### PR TITLE
Improve Speed by Using Faster Hash Maps

### DIFF
--- a/cmake/FetchDependencies.cmake
+++ b/cmake/FetchDependencies.cmake
@@ -7,6 +7,7 @@ option(USE_SYSTEM_CATCH2 "Use system catchorg Catch2 library" OFF)
 option(USE_SYSTEM_MIO "Use system mandreyel mio library" OFF)
 option(USE_SYSTEM_GLAZE "Use system stephenberry Glaze library" OFF)
 option(USE_SYSTEM_SIMDJSON "Use system simdjson library" OFF)
+option(USE_SYSTEM_ROBIN_MAP "Use system Tessil robin-map library" OFF)
 
 if(NOT USE_SYSTEM_DATE)
     fetchcontent_declare(
@@ -98,4 +99,14 @@ if(NOT USE_SYSTEM_SIMDJSON)
     fetchcontent_makeavailable(simdjson)
 else()
     find_package(simdjson REQUIRED)
+endif()
+
+if(NOT USE_SYSTEM_ROBIN_MAP)
+    fetchcontent_declare(
+        robin_map
+        GIT_REPOSITORY https://github.com/Tessil/robin-map.git
+        GIT_TAG v1.4.0)
+    fetchcontent_makeavailable(robin_map)
+else()
+    find_package(robin_map REQUIRED)
 endif()

--- a/library/CMakeLists.txt
+++ b/library/CMakeLists.txt
@@ -15,7 +15,8 @@ target_include_directories(loglib PUBLIC ./include)
 
 target_link_libraries(
     loglib
-    PUBLIC mio
+    PUBLIC robin_map
+           mio
            simdjson::simdjson
            glaze::glaze
            date::date

--- a/library/include/loglib/json_parser.hpp
+++ b/library/include/loglib/json_parser.hpp
@@ -3,9 +3,7 @@
 #include "log_parser.hpp"
 
 #include <simdjson.h>
-
-#include <unordered_map>
-#include <unordered_set>
+#include <tsl/robin_map.h>
 
 namespace loglib
 {
@@ -50,8 +48,8 @@ private:
      */
     struct ParseCache
     {
-        std::unordered_map<std::string, simdjson::ondemand::json_type> keyTypes;
-        std::unordered_map<std::string, simdjson::ondemand::number_type> numberTypes;
+        tsl::robin_map<std::string, simdjson::ondemand::json_type> keyTypes;
+        tsl::robin_map<std::string, simdjson::ondemand::number_type> numberTypes;
     };
 
     /**

--- a/library/include/loglib/log_line.hpp
+++ b/library/include/loglib/log_line.hpp
@@ -2,9 +2,10 @@
 
 #include "loglib/log_file.hpp"
 
+#include <tsl/robin_map.h>
+
 #include <chrono>
 #include <string>
-#include <unordered_map>
 #include <variant>
 #include <vector>
 
@@ -31,7 +32,7 @@ using LogValue = std::variant<std::string, int64_t, uint64_t, double, bool, Time
  * @brief Map of string keys to their corresponding log values.
  *
  */
-using LogMap = std::unordered_map<std::string, LogValue>;
+using LogMap = tsl::robin_map<std::string, LogValue>;
 
 /**
  * @brief Represents a single line in a log or a single log record, consisting of key-value pairs.

--- a/library/src/json_parser.cpp
+++ b/library/src/json_parser.cpp
@@ -221,7 +221,7 @@ LogMap JsonParser::ParseLine(simdjson::ondemand::object &object, ParseCache &cac
     {
         return result;
     }
-    result.reserve(std::ceil(countFieldsResult.value() / result.max_load_factor()));
+    result.rehash(countFieldsResult.value());
 
     // Iterate through all key-value pairs in the JSON object
     for (auto field : object)

--- a/library/src/log_data.cpp
+++ b/library/src/log_data.cpp
@@ -2,7 +2,7 @@
 
 #include <iterator>
 #include <set>
-#include <unordered_set>
+#include <tsl/robin_set.h>
 
 namespace loglib
 {
@@ -59,7 +59,7 @@ void LogData::Merge(LogData &&other)
         std::back_inserter(mLines)
     );
 
-    std::unordered_set<std::string> existingKeys(mKeys.begin(), mKeys.end());
+    tsl::robin_set<std::string> existingKeys(mKeys.begin(), mKeys.end());
     for (auto &&key : other.mKeys)
     {
         if (existingKeys.find(key) == existingKeys.end())


### PR DESCRIPTION
Use [Tessil robin-map](https://github.com/Tessil/robin-map) for faster hash maps and has sets.

Improved speed for the benchmark from 25 ms to 22 ms.

Now my computer can parse JSON logs with about 80 MB/s.