### PR TITLE
Update documentation and improve user guide for Structured Log Viewer

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,14 +4,14 @@ Thanks for your interest in contributing! This document covers building from sou
 
 ## Prerequisites
 
-- **CMake** 3.19 or newer
+- **CMake** 3.28 or newer
 - **Qt** 6.1 or newer (Qt 6.8 is used in CI)
 - A C++23-capable toolchain:
   - Linux: GCC 13+ or Clang 17+
   - Windows: MSVC 2022 (Visual Studio 2022)
   - macOS: Xcode 15+ / Apple Clang
 
-Most third-party C++ dependencies (`date`, `fmt`, `Catch2`, `mio`, `glaze`, `simdjson`, `robin-map`) are fetched automatically via `FetchContent`. To use system copies instead, pass e.g. `-DUSE_SYSTEM_FMT=ON` when configuring.
+Most third-party C++ dependencies (`date`, `fmt`, `Catch2`, `mio`, `glaze`, `simdjson`, `robin-map`) are fetched automatically via `FetchContent`. To use system copies instead, pass the corresponding option when configuring — one of `USE_SYSTEM_DATE`, `USE_SYSTEM_FMT`, `USE_SYSTEM_CATCH2`, `USE_SYSTEM_MIO`, `USE_SYSTEM_GLAZE`, `USE_SYSTEM_SIMDJSON`, `USE_SYSTEM_ROBIN_MAP` (e.g. `-DUSE_SYSTEM_FMT=ON`). See [`cmake/FetchDependencies.cmake`](cmake/FetchDependencies.cmake) for the pinned versions.
 
 ## Building
 

--- a/README.md
+++ b/README.md
@@ -5,107 +5,124 @@
 
 ## Overview
 
-Structured Log Viewer is a C++ application that consists of a library for handling structured log data and a Qt-based GUI application for viewing and interacting with the log data.
+Structured Log Viewer is a C++ application consisting of a reusable library (`loglib`) for handling structured log data and a Qt-based GUI (`StructuredLogViewer`) for viewing, searching, and filtering the logs.
 
-Currently, only JSON logs are supported.
+Currently, only JSON Lines (one JSON object per line) logs are supported.
 
 ## Application
 
 ### Supported Platforms
 
-- **Linux**
-- **Windows**
+- **Linux** (Ubuntu 22.04+ / compatible; AppImage)
+- **Windows** (Windows 10/11; standalone ZIP)
+- **macOS** (macOS 12+; DMG)
 
 ### Installation
 
 #### Linux
 
-1. Download the latest release of `StructuredLogViewer.AppImage`.
+1. Download the latest `StructuredLogViewer-x86_64.AppImage` from the [Releases page](https://github.com/jan-moravec/structured_log_viewer/releases).
 
 1. Make the AppImage executable:
 
    ```sh
-   chmod +x StructuredLogViewer.AppImage
+   chmod +x StructuredLogViewer-x86_64.AppImage
    ```
 
 1. Run the AppImage:
 
    ```sh
-   ./StructuredLogViewer.AppImage
+   ./StructuredLogViewer-x86_64.AppImage
    ```
+
+   The AppImage supports delta updates via [`appimageupdate`](https://github.com/AppImageCommunity/AppImageUpdate); see [CONTRIBUTING.md](CONTRIBUTING.md#appimage-delta-updates-zsync) for details.
 
 #### Windows
 
-1. Download the latest release of `StructuredLogViewer.zip`.
+1. Download the latest `StructuredLogViewer.zip`.
 1. Unzip the archive.
-1. Run the `StructuredLogViewer.exe` executable.
+1. Run `StructuredLogViewer.exe`.
+
+#### macOS
+
+1. Download the latest `StructuredLogViewer.dmg`.
+1. Open the DMG and drag `StructuredLogViewer.app` into `/Applications`.
+1. Launch it from Launchpad or Spotlight.
+
+> The macOS build is not notarized. On first launch you may need to right-click the app and choose **Open** to bypass Gatekeeper.
+
+Each release is accompanied by SHA-256 checksums; see [Verifying a release](CONTRIBUTING.md#verifying-a-release) for instructions.
 
 ### Usage
 
-For information regarding using the application, see [README](doc/README.md).
+For information regarding using the application, see the [user guide](doc/README.md).
 
 ## Development
 
 ### Project Structure
 
-The project is organized into two main components: the `library` and the `gui` application.
+The project is organized into two main components: the `library` and the GUI `app`.
 
 ```plaintext
 structured_log_viewer/
-├── library/
-│   ├── include/
-│   │   └── loglib/
-│   │       └── // Library headers
-│   ├── src/
-│   │   └── // Library source files
+├── library/               # loglib: core log handling (no Qt dependency)
+│   ├── include/loglib/    # Public library headers
+│   ├── src/               # Library implementation
 │   └── CMakeLists.txt
-├── gui/
-│   ├── include/
-│   │   └── // GUI headers
-│   ├── src/
-│   │   └── // GUI source files
+├── app/                   # Qt6 GUI application (StructuredLogViewer)
+│   ├── include/           # GUI headers
+│   ├── src/               # GUI implementation (including main_window.ui)
 │   └── CMakeLists.txt
-├── .github/
-│   └── workflows/
-│       └── // GitHub workflows
+├── test/
+│   ├── lib/               # Catch2 unit tests and benchmarks for loglib
+│   └── app/               # Qt Test smoke tests for MainWindow
+├── cmake/                 # Shared CMake modules (warnings, FetchContent)
+├── resources/             # Icons, .desktop entry, Qt resource file
+├── doc/                   # End-user documentation
+├── .github/workflows/     # CI: build + test on Linux / Windows / macOS
 ├── CMakeLists.txt
 └── README.md
 ```
 
 ### Library
 
-The `library` component provides the core functionality for handling structured log data. It includes classes such as `LogLine` and `LogTable` for managing log entries and tables of log data.
+The `library` component (`loglib`) provides the core functionality for handling structured log data. It defines types such as `LogLine`, `LogTable`, `LogData`, and `LogConfiguration` for representing log entries and their presentation, plus pluggable parsers (currently `JsonParser`). It has no Qt dependency and can be reused in other applications.
 
 ### GUI Application
 
-The `gui` component is a Qt-based application that provides a graphical interface for viewing and interacting with the log data. It uses the `library` component to manage the log data and display it in a user-friendly format.
+The `app` component is a Qt 6 Widgets application. It uses `loglib` for parsing and data management, and exposes the data through `QAbstractTableModel`/`QSortFilterProxyModel` subclasses with support for sorting, filtering, searching, and configurable columns.
 
 ### Build Instructions
 
 #### Prerequisites
 
-- **CMake**: Used for configuring and building the project.
-- **Qt5**: Required for the GUI application.
-- **C++ Build Tools**
+- **CMake** 3.28 or newer
+- **Qt** 6.1 or newer (CI uses Qt 6.8)
+- A **C++23** toolchain:
+  - Linux: GCC 13+ or Clang 17+
+  - Windows: MSVC 2022 (Visual Studio 2022)
+  - macOS: Xcode 15+ / Apple Clang
+
+Most third-party C++ dependencies are fetched automatically via `FetchContent`. To use system copies, pass the corresponding option (e.g. `-DUSE_SYSTEM_FMT=ON`) when configuring. See [`cmake/FetchDependencies.cmake`](cmake/FetchDependencies.cmake) for the full list.
 
 #### Building
 
-It is recommended to use Qt Creator for development and building.
+It is recommended to use Qt Creator for development (open the top-level `CMakeLists.txt`).
 
-To manually build the project, use the usual CMake commands:
+To build manually:
 
 ```sh
 mkdir build
 cd build
-cmake ..
-cmake --build .
+cmake -DCMAKE_BUILD_TYPE=Release ..
+cmake --build . -j
 ```
 
-On Windows, use the Developer PowerShell or Command Prompt.
+On Windows, use the Developer PowerShell or Developer Command Prompt for VS 2022. See [CONTRIBUTING.md](CONTRIBUTING.md#building) for platform-specific notes and test instructions.
 
 ### Contributing
 
-Contributions are welcome! See [CONTRIBUTING.md](CONTRIBUTING.md) for build instructions, code style, test setup, and the release process.
+Contributions are welcome! See [CONTRIBUTING.md](CONTRIBUTING.md) for detailed build instructions, test setup, coding style, and the release process.
 
 ## License
 
@@ -113,8 +130,11 @@ This project is licensed under the MIT License. See the [LICENSE](LICENSE) file 
 
 ## Acknowledgments
 
-- <https://github.com/nlohmann/json>
-- <https://github.com/HowardHinnant/date>
-- <https://github.com/fmtlib/fmt>
-- <https://github.com/catchorg/Catch2.git>
+- [HowardHinnant/date](https://github.com/HowardHinnant/date) — timezone-aware timestamp parsing/formatting
+- [fmtlib/fmt](https://github.com/fmtlib/fmt) — formatting library
+- [simdjson/simdjson](https://github.com/simdjson/simdjson) — fast JSON parsing
+- [stephenberry/glaze](https://github.com/stephenberry/glaze) — JSON serialization for configuration
+- [mandreyel/mio](https://github.com/mandreyel/mio) — header-only memory-mapped file I/O
+- [Tessil/robin-map](https://github.com/Tessil/robin-map) — fast hash map
+- [catchorg/Catch2](https://github.com/catchorg/Catch2) — unit testing and benchmarking
 - [Icon by Ilham Fitrotul Hayat](https://www.freepik.com/icon/file_5392654)

--- a/doc/README.md
+++ b/doc/README.md
@@ -1,32 +1,128 @@
-# Structured Log Viewer GUI
+# Structured Log Viewer — User Guide
 
 ## Overview
 
-The Structured Log Viewer GUI is a Qt-based application that allows users to open, view, search, and filter JSON log files. It provides a user-friendly interface for interacting with structured log data.
+Structured Log Viewer is a Qt 6 desktop application for inspecting JSON Lines log files. It displays each record as a row in a sortable, filterable table, auto-detects timestamp columns, and lets you search records using plain text, wildcards, or regular expressions.
 
-## Features
+## Supported Input Format
 
-- **Open JSON Log Files**: Load and display JSON log files.
-- **View Log Entries**: Display log entries in a tabular format.
-- **Search**: Search through log entries using keywords.
-- **Filter**: Apply filters to display only relevant log entries.
+The application currently reads **JSON Lines** (also known as NDJSON): one JSON object per line, for example:
 
-## Usage
+```json
+{"timestamp":"2025-01-15T12:34:56.789Z","level":"info","component":"app","message":"started"}
+{"timestamp":"2025-01-15T12:34:57.000Z","level":"error","component":"db","message":"connection refused"}
+```
 
-### Opening a Log File
+Empty lines are skipped. Lines that fail to parse are reported as errors but do not abort loading — valid records are still shown. Nested objects and arrays are preserved as their compact JSON string.
 
-1. Click on the "Open" button in the toolbar or select "File > Open" from the menu.
-1. Navigate to the JSON log file you want to open and select it.
-1. The log entries will be displayed in the main table.
+## Opening Log Files
 
-### Searching Log Entries
+You can open a log file in three ways:
 
-1. Enter a keyword in the search bar at the top of the window.
-1. Press "Enter" or click the "Search" button.
-1. The table will update to show only the log entries that match the search keyword.
+1. **File → Open…** (`Ctrl+O`) — opens a file picker that auto-detects whether the selected file is a log or a [configuration](#configurations) file.
+1. **File → Open JSON Logs…** — forces the JSON parser regardless of content. Use this if auto-detection mistakenly treats a log as a configuration.
+1. **Drag & drop** one or more files onto the main window.
 
-### Filtering Log Entries
+Opening multiple files at once **merges** their records into a single table. If parsing errors occur, the first 20 are shown in a dialog; the rest are summarized as "… and N more error(s)".
 
-1. Click on the "Filter" button in the toolbar or select "View > Filter" from the menu.
-1. Enter the filter criteria in the dialog that appears.
-1. Click "Apply" to filter the log entries based on the criteria.
+### Automatic Column Detection
+
+The first time you open a file, Structured Log Viewer builds the column list from the keys it sees in the JSON records:
+
+- Any key named `timestamp`, `time`, or `t` (case-insensitive) is treated as a **timestamp column**. Its values are parsed with the ISO 8601 formats `%FT%T%Ez`, `%F %T%Ez`, `%FT%T`, `%F %T` and displayed with the format `%F %H:%M:%S` in the local timezone. Timestamp columns are moved to the front of the table.
+- All other keys become generic columns with the format `{}` (pass-through).
+
+You can persist a customized column layout and filter set via [configurations](#configurations).
+
+## Navigating the Table
+
+- **Sorting**: click a column header to sort ascending/descending. Click again to toggle direction. The initial load is unsorted (records appear in file order).
+- **Column resizing**: drag the column header dividers. The last column stretches automatically to fill remaining space.
+- **Smooth scrolling** is enabled by default (per-pixel) both vertically and horizontally.
+- **Alternating row colors** improve readability on dense logs. The table respects the application's light/dark palette.
+
+### Selecting and Copying Rows
+
+- Click a row to select it. Hold `Ctrl`/`Shift` to extend the selection.
+- **Edit → Copy** (`Ctrl+C`) copies the selected rows as the **original JSON text** (one line per row), so you can paste them back into another tool. Cell-level copy is not performed — rows are always copied whole.
+
+## Searching
+
+Open the Find bar with **Edit → Find** (`Ctrl+F`). It appears at the bottom of the window with:
+
+- A text field for the search term
+- **Wildcards** checkbox — interprets `*` and `?` in the term
+- **Regular Expressions** checkbox — interprets the term as a Qt `QRegularExpression`
+- **Next** / **Previous** buttons — walk forward or backward from the current selection
+- **X** to close the bar
+
+Search matches any cell in any visible column. Results wrap at the end/beginning of the table. The found row is selected and scrolled into view.
+
+> Only one of *Wildcards* or *Regular Expressions* should be enabled at a time. Leaving both off performs a case-sensitive substring search.
+
+## Filtering
+
+Structured Log Viewer supports any number of simultaneous filters. A row is shown only if it matches **all** active filters.
+
+### Adding a Filter
+
+1. Choose **Filters → Add** to open the **Filter Editor** dialog.
+1. Pick the column to filter in the **Row to filter** dropdown.
+1. Depending on the column type:
+   - **Text columns** — enter a filter string and pick a match mode: *Exactly*, *Contains*, *Regular Expression*, or *Wildcards*.
+   - **Timestamp columns** — pick a **Begin** and **End** date/time. The dialog constrains the two so Begin ≤ End, and pre-fills them with the range of values present in the table.
+1. Click **Ok**. The active filter is added as an entry in the **Filters** menu, titled with its value (or timestamp range).
+
+### Editing or Clearing a Filter
+
+Each filter entry in the Filters menu has **Edit** and **Clear** sub-actions:
+
+- **Edit** re-opens the Filter Editor pre-populated with the current values.
+- **Clear** removes just that filter.
+- **Filters → Clear All** removes every filter at once.
+
+Filters are live: the table updates immediately when a filter is added, edited, or cleared.
+
+## Configurations
+
+A *configuration* captures the current column layout (headers, keys, print format, timestamp parse formats). Configurations are saved as JSON files, and can be loaded into future sessions to skip auto-detection and to enforce a consistent layout across teammates.
+
+- **File → Save Configuration…** (`Ctrl+S`) — writes the current layout to a `.json` file.
+- **File → Load Configuration…** — loads a configuration file and clears any open logs. Open logs again afterwards to apply the layout.
+
+Because `Open…` auto-detects configurations, double-clicking a saved configuration file also works (it loads the layout without opening any logs).
+
+> Filters are not currently persisted in configurations.
+
+## Preferences
+
+Open **Settings → Preferences…** to change the application's appearance:
+
+- **Style** — the Qt widget style (e.g. `fusion`, `windows11`, `macOS`). Styles available depend on your platform.
+- **Font** — the application-wide UI font family.
+- **Font size** — 6 to 72 pt.
+
+Changes preview live. Click **Ok** to persist them (stored via `QSettings` under the organization `jan-moravec` / application `StructuredLogViewer`), or **Cancel** to revert to the last saved values. The previous configuration is automatically restored the next time you launch the application.
+
+## Keyboard Shortcuts
+
+| Action                     | Shortcut |
+| -------------------------- | -------- |
+| Open file(s)               | `Ctrl+O` |
+| Save configuration         | `Ctrl+S` |
+| Find                       | `Ctrl+F` |
+| Copy selected rows as JSON | `Ctrl+C` |
+
+## Troubleshooting
+
+### "Failed to parse …" or "No valid JSON data found"
+
+The selected file is not valid JSON Lines, or every line failed to parse. Check the error dialog for the first few offending line numbers.
+
+### Timestamps show as raw strings
+
+Your timestamp key is not named `timestamp`, `time`, or `t`, or its format is not ISO 8601. Save a configuration, open it in a text editor, and add your column's key to the `keys` array of the timestamp column. You can also add additional patterns to `parseFormats` (e.g. `"%Y-%m-%d %H:%M:%S.%f"`). Reload the configuration and re-open the log.
+
+### Timezone-related errors on first launch
+
+On startup the application loads the IANA timezone database from a `tzdata/` folder shipped alongside the executable (or inside `Contents/Resources/tzdata` on macOS). If this folder is missing, a dialog reports the error and the application exits. Re-installing from the official release archive should resolve it.


### PR DESCRIPTION
- Bump minimum CMake version requirement to 3.28 in CONTRIBUTING.md.
- Clarify supported platforms and installation instructions in README.md, including macOS support.
- Enhance user guide in doc/README.md to detail JSON Lines format, file opening methods, automatic column detection, and filtering features.
- Improve descriptions of application components and functionalities for better user understanding.