### PR TITLE
Add CMake presets and update build configuration

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -81,20 +81,15 @@ jobs:
       - name: Install build tools
         run: sudo apt-get update && sudo apt-get install -y libfuse2 xvfb libxcb-cursor0 zsync
 
+      - name: Configure
+        run: cmake --preset release
+
       - name: Build
-        run: |
-          mkdir build
-          cd build
-          CMAKE_BUILD_PARALLEL_LEVEL=$(nproc)
-          export CMAKE_BUILD_PARALLEL_LEVEL
-          cmake -DCMAKE_BUILD_TYPE=Release ..
-          cmake --build .
+        run: cmake --build --preset release
 
       - name: Run unit tests
-        run: |
-          cd build
-          export QT_QPA_PLATFORM=offscreen
-          ctest --output-on-failure -C Release
+        # ctest preset already sets QT_QPA_PLATFORM=offscreen.
+        run: ctest --preset release
 
       - name: Install linuxdeploy and plugin
         run: |
@@ -115,8 +110,8 @@ jobs:
           mkdir -p $APP_DIR/usr/lib
           mkdir -p $APP_DIR/usr/share/applications
           mkdir -p $APP_DIR/usr/share/icons/hicolor/256x256/apps
-          cp build/bin/Release/${{ env.APP_NAME }} $APP_DIR/usr/bin/
-          cp -r build/bin/Release/tzdata $APP_DIR/usr/share/
+          cp build/release/bin/Release/${{ env.APP_NAME }} $APP_DIR/usr/bin/
+          cp -r build/release/bin/Release/tzdata $APP_DIR/usr/share/
           cp resources/icon-white.png $APP_DIR/usr/share/icons/hicolor/256x256/apps/${{ env.APP_NAME }}.png
           cp resources/app.desktop $APP_DIR/usr/share/applications/${{ env.APP_NAME }}.desktop
           ./linuxdeploy-x86_64.AppImage --appdir=$APP_DIR --plugin qt --output appimage
@@ -171,30 +166,30 @@ jobs:
       - name: Install CMake and Ninja
         uses: lukka/get-cmake@latest
 
+      - name: Configure
+        shell: cmd
+        run: |
+          call "C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Auxiliary\Build\vcvarsall.bat" amd64
+          cmake --preset release
+
       - name: Build
         shell: cmd
         run: |
-          mkdir build
-          cd build
           call "C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Auxiliary\Build\vcvarsall.bat" amd64
-          set CMAKE_BUILD_PARALLEL_LEVEL=%NUMBER_OF_PROCESSORS%
-          cmake -G "Ninja" -DCMAKE_BUILD_TYPE=Release ..
-          cmake --build .
+          cmake --build --preset release
 
       - name: Run unit tests
+        # ctest preset already sets QT_QPA_PLATFORM=offscreen.
         shell: cmd
-        run: |
-          cd build
-          call "C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Auxiliary\Build\vcvarsall.bat" amd64
-          ctest --output-on-failure -C Release
+        run: ctest --preset release
 
       - name: Package application
         shell: powershell
         run: |
           mkdir ${{ env.APP_NAME }}
           cd ${{ env.APP_NAME }}
-          mv ../build/bin/Release/${{ env.APP_NAME }}.exe .
-          mv ../build/bin/Release/tzdata .
+          mv ../build/release/bin/Release/${{ env.APP_NAME }}.exe .
+          mv ../build/release/bin/Release/tzdata .
           windeployqt --release ${{ env.APP_NAME }}.exe
           Compress-Archive -Path . -DestinationPath ../${{ env.APP_NAME }}.zip
 
@@ -244,24 +239,19 @@ jobs:
       - name: Install CMake and Ninja
         uses: lukka/get-cmake@latest
 
+      - name: Configure
+        run: cmake --preset release
+
       - name: Build
-        run: |
-          mkdir build
-          cd build
-          CMAKE_BUILD_PARALLEL_LEVEL=$(sysctl -n hw.ncpu)
-          export CMAKE_BUILD_PARALLEL_LEVEL
-          cmake -G Ninja -DCMAKE_BUILD_TYPE=Release ..
-          cmake --build .
+        run: cmake --build --preset release
 
       - name: Run unit tests
-        run: |
-          cd build
-          export QT_QPA_PLATFORM=offscreen
-          ctest --output-on-failure -C Release
+        # ctest preset already sets QT_QPA_PLATFORM=offscreen.
+        run: ctest --preset release
 
       - name: Package application
         run: |
-          cd build/bin/Release
+          cd build/release/bin/Release
           # tzdata is copied into the bundle's Contents/Resources by the CMake
           # POST_BUILD step; verify it's there before deploying.
           if [ ! -d "${{ env.APP_NAME }}.app/Contents/Resources/tzdata" ]; then

--- a/.gitignore
+++ b/.gitignore
@@ -39,6 +39,9 @@ Thumbs.db
 *.pro.user*
 CMakeLists.txt.user*
 
+# Personal CMake preset overrides (machine-specific paths, e.g. Qt location)
+CMakeUserPresets.json
+
 # xemacs temporary files
 *.flc
 

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -17,6 +17,7 @@ repos:
     rev: v19.1.3
     hooks:
       - id: clang-format
+        types_or: [c, c++]
 
   - repo: https://github.com/BlankSpruce/gersemi-pre-commit
     rev: 0.27.2

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -1,0 +1,84 @@
+{
+    "version": 6,
+    "cmakeMinimumRequired": { "major": 3, "minor": 25 },
+
+    "configurePresets": [
+        {
+            "name": "_base",
+            "hidden": true,
+            "binaryDir": "${sourceDir}/build/${presetName}",
+            "generator": "Ninja",
+            "cacheVariables": {
+                "CMAKE_EXPORT_COMPILE_COMMANDS": "ON"
+            }
+        },
+        {
+            "name": "release",
+            "displayName": "Release (Ninja)",
+            "description": "Optimized build, no debug info, assertions stripped.",
+            "inherits": "_base",
+            "cacheVariables": { "CMAKE_BUILD_TYPE": "Release" }
+        },
+        {
+            "name": "debug",
+            "displayName": "Debug (Ninja)",
+            "description": "Debug build with full symbols and assertions.",
+            "inherits": "_base",
+            "cacheVariables": { "CMAKE_BUILD_TYPE": "Debug" }
+        },
+        {
+            "name": "relwithdebinfo",
+            "displayName": "RelWithDebInfo (Ninja)",
+            "description": "Release optimizations + debug info, suitable for profiling.",
+            "inherits": "_base",
+            "cacheVariables": { "CMAKE_BUILD_TYPE": "RelWithDebInfo" }
+        }
+    ],
+
+    "buildPresets": [
+        { "name": "release",        "configurePreset": "release" },
+        { "name": "debug",          "configurePreset": "debug" },
+        { "name": "relwithdebinfo", "configurePreset": "relwithdebinfo" }
+    ],
+
+    "testPresets": [
+        {
+            "name": "release",
+            "configurePreset": "release",
+            "output":      { "outputOnFailure": true },
+            "execution":   { "noTestsAction": "error", "stopOnFailure": false },
+            "environment": { "QT_QPA_PLATFORM": "offscreen" }
+        },
+        {
+            "name": "debug",
+            "inherits": "release",
+            "configurePreset": "debug"
+        },
+        {
+            "name": "relwithdebinfo",
+            "inherits": "release",
+            "configurePreset": "relwithdebinfo"
+        }
+    ],
+
+    "workflowPresets": [
+        {
+            "name": "release",
+            "displayName": "Release: configure + build + test",
+            "steps": [
+                { "type": "configure", "name": "release" },
+                { "type": "build",     "name": "release" },
+                { "type": "test",      "name": "release" }
+            ]
+        },
+        {
+            "name": "debug",
+            "displayName": "Debug: configure + build + test",
+            "steps": [
+                { "type": "configure", "name": "debug" },
+                { "type": "build",     "name": "debug" },
+                { "type": "test",      "name": "debug" }
+            ]
+        }
+    ]
+}

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -15,41 +15,98 @@ Most third-party C++ dependencies (`date`, `fmt`, `Catch2`, `mio`, `glaze`, `sim
 
 ## Building
 
-### Linux / macOS
+All build configurations are defined in [`CMakePresets.json`](CMakePresets.json) (CMake 3.25+). The shared presets are:
+
+| Preset           | Build type       | Purpose                                    |
+| ---------------- | ---------------- | ------------------------------------------ |
+| `release`        | `Release`        | Optimized build, used by CI and releases.  |
+| `debug`          | `Debug`          | Full debug info and assertions.            |
+| `relwithdebinfo` | `RelWithDebInfo` | Release optimizations + debug info (perf). |
+
+Each preset uses the **Ninja** generator and writes to `build/<presetName>/`. They also enable `CMAKE_EXPORT_COMPILE_COMMANDS` so `clangd`, `clang-tidy`, and other tools work out of the box. Matching `buildPresets`, `testPresets`, and `workflowPresets` are defined with the same names.
+
+### Quick start
+
+Configure, build, and test in one shot:
 
 ```sh
-mkdir build
-cd build
-cmake -DCMAKE_BUILD_TYPE=Release ..
-cmake --build . -j
+cmake --workflow --preset release
+```
+
+Or run the steps individually (handy for iterative development — CI does this too):
+
+```sh
+cmake --preset release           # configure
+cmake --build --preset release   # build
+ctest --preset release           # test (sets QT_QPA_PLATFORM=offscreen)
 ```
 
 ### Windows
 
-Open the **Developer PowerShell for VS 2022** or Developer Command Prompt and run:
+Run the same commands from the **Developer PowerShell for VS 2022** (or Developer Command Prompt) so that `cl.exe` and Ninja are on `PATH`.
 
-```powershell
-mkdir build
-cd build
-cmake -G Ninja -DCMAKE_BUILD_TYPE=Release ..
-cmake --build .
+### Machine-specific overrides (`CMakeUserPresets.json`)
+
+For paths that differ between machines (typically your Qt install), add a `CMakeUserPresets.json` at the repo root — it is gitignored and merged with `CMakePresets.json` automatically. Example:
+
+```json
+{
+    "version": 6,
+    "cmakeMinimumRequired": { "major": 3, "minor": 25 },
+    "include": ["CMakePresets.json"],
+    "configurePresets": [
+        {
+            "name": "local",
+            "inherits": "release",
+            "cacheVariables": {
+                "CMAKE_PREFIX_PATH": "C:/Qt/6.8.0/msvc2022_64"
+            }
+        }
+    ],
+    "buildPresets": [{ "name": "local", "configurePreset": "local" }],
+    "testPresets":  [
+        {
+            "name": "local",
+            "configurePreset": "local",
+            "output":      { "outputOnFailure": true },
+            "environment": { "QT_QPA_PLATFORM": "offscreen" }
+        }
+    ],
+    "workflowPresets": [
+        {
+            "name": "local",
+            "steps": [
+                { "type": "configure", "name": "local" },
+                { "type": "build",     "name": "local" },
+                { "type": "test",      "name": "local" }
+            ]
+        }
+    ]
+}
 ```
 
-Qt Creator works out of the box with the top-level `CMakeLists.txt`.
+Then `cmake --workflow --preset local` (or `cmake --preset local` + `cmake --build --preset local`) uses your local Qt.
+
+### Enabling system packages
+
+To use system copies of dependencies instead of `FetchContent`, pass the relevant option at configure time — for example:
+
+```sh
+cmake --preset release -DUSE_SYSTEM_FMT=ON -DUSE_SYSTEM_SIMDJSON=ON
+```
+
+The full list of `USE_SYSTEM_*` options is in [`cmake/FetchDependencies.cmake`](cmake/FetchDependencies.cmake).
+
+### IDE integration
+
+Qt Creator, CLion, Visual Studio, and VS Code (with the CMake Tools extension) all detect `CMakePresets.json` / `CMakeUserPresets.json` automatically — just open the repository folder and pick a preset.
 
 ## Running tests
 
-From the `build/` directory:
+`ctest --preset <name>` runs the full suite and automatically sets `QT_QPA_PLATFORM=offscreen` for headless GUI tests:
 
 ```sh
-ctest --output-on-failure -C Release
-```
-
-On headless environments (CI, remote VMs), set the Qt platform to offscreen first:
-
-```sh
-export QT_QPA_PLATFORM=offscreen   # Linux / macOS
-$env:QT_QPA_PLATFORM = "offscreen" # Windows PowerShell
+ctest --preset release
 ```
 
 The suite contains:

--- a/README.md
+++ b/README.md
@@ -107,18 +107,17 @@ Most third-party C++ dependencies are fetched automatically via `FetchContent`. 
 
 #### Building
 
-It is recommended to use Qt Creator for development (open the top-level `CMakeLists.txt`).
-
-To build manually:
+The project ships a [`CMakePresets.json`](CMakePresets.json) that defines shared configure/build/test/workflow presets, so a single command can configure, build, and run the test suite:
 
 ```sh
-mkdir build
-cd build
-cmake -DCMAKE_BUILD_TYPE=Release ..
-cmake --build . -j
+cmake --workflow --preset release
 ```
 
-On Windows, use the Developer PowerShell or Developer Command Prompt for VS 2022. See [CONTRIBUTING.md](CONTRIBUTING.md#building) for platform-specific notes and test instructions.
+Available workflows are `release`, `debug`, and `relwithdebinfo`; each writes to its own `build/<preset>/` directory. All presets use the Ninja generator, so `ninja` must be on your `PATH` (installed by default with modern Qt / Visual Studio, or available via your system package manager).
+
+On Windows, run the command from the **Developer PowerShell** (or **Developer Command Prompt**) for Visual Studio 2022 so MSVC is on `PATH`.
+
+For machine-specific overrides (e.g. pinning `CMAKE_PREFIX_PATH` to your Qt install), create a personal `CMakeUserPresets.json` at the repo root — it is gitignored. Qt Creator, CLion, and VS Code all discover these presets automatically. See [CONTRIBUTING.md](CONTRIBUTING.md#building) for a worked example and per-step commands.
 
 ### Contributing
 


### PR DESCRIPTION
- Introduced CMakePresets.json to define shared configure, build, and test presets for streamlined workflows.
- Updated CONTRIBUTING.md and README.md to reflect new build instructions using presets.
- Added CMakeUserPresets.json to allow for machine-specific overrides, enhancing flexibility.
- Modified .pre-commit-config.yaml to include support for C and C++ file types in clang-format.
- Updated GitHub Actions workflow to utilize the new CMake presets for building and testing.