### PR TITLE
Clang-Tidy and Sanitizers

### DIFF
--- a/.ci/lsan.supp
+++ b/.ci/lsan.supp
@@ -1,0 +1,33 @@
+# LeakSanitizer suppressions for the Clang ASan+UBSan CI job.
+#
+# Pattern syntax: `leak:<token>` matches stack frames whose symbol name
+# (or library path) contains <token>. See:
+# https://clang.llvm.org/docs/AddressSanitizer.html#issue-suppression
+#
+# Add an entry here only when the leak is a *one-shot* allocation in a
+# system library that we don't control, NOT when it's our own code. Each
+# entry should carry a one-line comment explaining where it came from so
+# the next reader can audit and prune it.
+
+# Qt initialises a handful of process-global singletons (icon engines,
+# theme database, plugin registry) that are intentionally never torn
+# down before exit. These show up as definite leaks under LSan even
+# though Qt is using them correctly.
+leak:libQt6Core
+leak:libQt6Gui
+leak:libQt6Widgets
+leak:libQt6Test
+
+# fontconfig caches a process-global FcConfig that survives until exit.
+# The Qt platform plugin pulls it in indirectly.
+leak:libfontconfig
+
+# glibc's dlopen path keeps internal bookkeeping alive across the
+# process lifetime; the typical fingerprint is `_dl_init` /
+# `_dl_close_worker` showing up as the leak root.
+leak:_dl_init
+leak:_dl_close_worker
+
+# oneTBB's task arena lazily allocates a worker pool that's reused for
+# the whole process and torn down by an exit handler LSan can't see.
+leak:tbb::detail

--- a/.ci/tsan.supp
+++ b/.ci/tsan.supp
@@ -1,0 +1,17 @@
+# ThreadSanitizer suppressions for the Clang TSan CI job.
+#
+# Pattern syntax: `<type>:<symbol-or-path>`. See:
+# https://github.com/google/sanitizers/wiki/ThreadSanitizerSuppressions
+#
+# Common types we use:
+#   race:        suppress data-race reports rooted at <symbol>
+#   thread:      suppress thread-leak reports
+#   mutex:       suppress mutex misuse reports
+#   deadlock:    suppress lock-order reports
+#
+# Keep this file empty by default; add an entry only when an upstream
+# library produces a documented false positive that we cannot fix.
+# Every entry should carry a one-line comment with a link or rationale
+# so the next reader can audit and prune it.
+
+# (none yet)

--- a/.clang-format
+++ b/.clang-format
@@ -188,7 +188,7 @@ PenaltyIndentedWhitespace: 0
 PenaltyReturnTypeOnItsOwnLine: 1000
 PointerAlignment: Right
 PPIndentWidth:   -1
-QualifierAlignment: Leave
+QualifierAlignment: Left
 ReferenceAlignment: Pointer
 ReflowComments:  true
 RemoveBracesLLVM: false

--- a/.clang-tidy
+++ b/.clang-tidy
@@ -68,6 +68,7 @@ CheckOptions:
   - { key: cppcoreguidelines-special-member-functions.AllowSoleDefaultDtor, value: true }
   - { key: cppcoreguidelines-special-member-functions.AllowMissingMoveFunctionsWhenCopyIsDeleted, value: true }
   - { key: misc-include-cleaner.MissingIncludes, value: false }
+  - { key: misc-include-cleaner.UnusedIncludes,  value: false }
   - { key: modernize-avoid-c-arrays.AllowStringArrays, value: false }
 
   # ------- Identifier naming -------

--- a/.clang-tidy
+++ b/.clang-tidy
@@ -13,6 +13,8 @@
 #   -readability-function-cognitive-complexity: Noisy for complex functions.
 #   -cppcoreguidelines-pro-type-reinterpret-cast: Necessary for low-level buffer code.
 #   -cppcoreguidelines-pro-bounds-*: Too strict for pointer/array operations.
+#   -cppcoreguidelines-pro-bounds-avoid-unchecked-container-access: Same family;
+#        flags every `vec[i]` in tests/macros and nlohmann/json `operator[]`.
 #   -cppcoreguidelines-avoid-c-arrays: C arrays sometimes needed for constexpr.
 #   -modernize-avoid-c-arrays: Alias for the above.
 #   -cppcoreguidelines-macro-usage: Some macros are necessary.
@@ -47,6 +49,7 @@ Checks: >
   -cppcoreguidelines-pro-bounds-array-to-pointer-decay,
   -cppcoreguidelines-pro-bounds-constant-array-index,
   -cppcoreguidelines-pro-bounds-pointer-arithmetic,
+  -cppcoreguidelines-pro-bounds-avoid-unchecked-container-access,
   -cppcoreguidelines-avoid-c-arrays,
   -modernize-avoid-c-arrays,
   -cppcoreguidelines-macro-usage,

--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,0 +1,121 @@
+# Configure clang-tidy checks
+#
+# Each check has a name and the checks to run can be chosen with the Checks list,
+# which specifies a comma-separated list of positive and negative (prefixed with -) globs.
+# Positive globs add subsets of checks, and negative globs remove them.
+
+# First disable all checks, then enable the groups we like,
+# finally disable again specific checks.
+#
+# Disabled checks:
+#   -modernize-use-trailing-return-type: Stylistic preference only.
+#   -modernize-use-nodiscard: Too noisy; flags every function with a return value.
+#   -readability-function-cognitive-complexity: Noisy for complex functions.
+#   -cppcoreguidelines-pro-type-reinterpret-cast: Necessary for low-level buffer code.
+#   -cppcoreguidelines-pro-bounds-*: Too strict for pointer/array operations.
+#   -cppcoreguidelines-avoid-c-arrays: C arrays sometimes needed for constexpr.
+#   -modernize-avoid-c-arrays: Alias for the above.
+#   -cppcoreguidelines-macro-usage: Some macros are necessary.
+#   -readability-identifier-length: Short names often appropriate (i, rd).
+#   -bugprone-easily-swappable-parameters: Too noisy.
+#   -performance-enum-size: Micro-optimization, not worth the noise.
+#   -portability-avoid-pragma-once: pragma once is supported by all modern compilers.
+#   -bugprone-implicit-widening-of-multiplication-result: Fires on size_t = int*int
+#        idioms; suppressing avoids sprinkling static_cast<size_t> everywhere.
+#   -cppcoreguidelines-narrowing-conversions: Dozens of false positives on
+#        size_t -> difference_type iterator arithmetic.
+#   -readability-uppercase-literal-suffix: Cosmetic (1u vs 1U).
+#   -readability-implicit-bool-conversion: Noisy on Qt pointer `if (mWidget)` idioms.
+# Note: misc-include-cleaner is left enabled but its "MissingIncludes"
+# pass is turned off via CheckOptions below (transitive-include noise).
+Checks: >
+  -*,
+  bugprone-*,
+  cert-*,
+  clang-analyzer-*,
+  concurrency-*,
+  cppcoreguidelines-*,
+  misc-*,
+  modernize-*,
+  performance-*,
+  portability-*,
+  readability-*,
+  -modernize-use-trailing-return-type,
+  -modernize-use-nodiscard,
+  -readability-function-cognitive-complexity,
+  -cppcoreguidelines-pro-type-reinterpret-cast,
+  -cppcoreguidelines-pro-bounds-array-to-pointer-decay,
+  -cppcoreguidelines-pro-bounds-constant-array-index,
+  -cppcoreguidelines-pro-bounds-pointer-arithmetic,
+  -cppcoreguidelines-avoid-c-arrays,
+  -modernize-avoid-c-arrays,
+  -cppcoreguidelines-macro-usage,
+  -readability-identifier-length,
+  -bugprone-easily-swappable-parameters,
+  -performance-enum-size,
+  -portability-avoid-pragma-once,
+  -bugprone-implicit-widening-of-multiplication-result,
+  -cppcoreguidelines-narrowing-conversions,
+  -readability-uppercase-literal-suffix,
+  -readability-implicit-bool-conversion
+
+WarningsAsErrors: ""
+FormatStyle: "file"
+
+# Additional options for checks.
+# Includes the style naming conventions.
+CheckOptions:
+  - { key: cppcoreguidelines-special-member-functions.AllowSoleDefaultDtor, value: true }
+  - { key: cppcoreguidelines-special-member-functions.AllowMissingMoveFunctionsWhenCopyIsDeleted, value: true }
+  - { key: misc-include-cleaner.MissingIncludes, value: false }
+  - { key: modernize-avoid-c-arrays.AllowStringArrays, value: false }
+
+  # ------- Identifier naming -------
+  # Types and type-like constructs: CamelCase.
+  - { key: readability-identifier-naming.NamespaceCase,          value: lower_case }
+  - { key: readability-identifier-naming.ClassCase,              value: CamelCase }
+  - { key: readability-identifier-naming.StructCase,             value: CamelCase }
+  - { key: readability-identifier-naming.UnionCase,              value: CamelCase }
+  - { key: readability-identifier-naming.EnumCase,               value: CamelCase }
+  - { key: readability-identifier-naming.TypeAliasCase,          value: CamelCase }
+  - { key: readability-identifier-naming.TypedefCase,            value: CamelCase }
+  - { key: readability-identifier-naming.ConceptCase,            value: CamelCase }
+  - { key: readability-identifier-naming.TemplateParameterCase,  value: CamelCase }
+
+  # Functions / methods: CamelCase. Qt-forced camelBack names (overrides,
+  # signals, public slots) are allowed via app/.clang-tidy which relaxes
+  # PublicMethodCase to aNy_CasE for the GUI code only.
+  - { key: readability-identifier-naming.FunctionCase,           value: CamelCase }
+  - { key: readability-identifier-naming.MethodCase,             value: CamelCase }
+  - { key: readability-identifier-naming.ClassMethodCase,        value: CamelCase }
+
+  # Enum constants: CamelCase. Scoped and unscoped both. This matches Qt's
+  # style (Qt::UserRole etc.) and avoids UPPER_CASE collisions with
+  # Windows macros (ERROR, FAILED, IN, OUT, MIN, MAX, ...).
+  - { key: readability-identifier-naming.EnumConstantCase,       value: CamelCase }
+  - { key: readability-identifier-naming.ScopedEnumConstantCase, value: CamelCase }
+
+  # Data members. Struct fields are plain camelBack (value-type aggregates);
+  # class fields are private-with-m-prefix by default.
+  - { key: readability-identifier-naming.StructMemberCase,       value: camelBack }
+  - { key: readability-identifier-naming.ClassMemberCase,        value: CamelCase }
+  - { key: readability-identifier-naming.PrivateMemberCase,      value: CamelCase }
+  - { key: readability-identifier-naming.PrivateMemberPrefix,    value: m }
+  - { key: readability-identifier-naming.ProtectedMemberCase,    value: CamelCase }
+  - { key: readability-identifier-naming.ProtectedMemberPrefix,  value: m }
+
+  # Local variables, parameters: camelBack. Local const (non-constexpr) is
+  # just a local variable in the clang-tidy sense, not a "constant".
+  - { key: readability-identifier-naming.ParameterCase,          value: camelBack }
+  - { key: readability-identifier-naming.LocalVariableCase,      value: camelBack }
+  - { key: readability-identifier-naming.LocalConstantCase,      value: camelBack }
+  - { key: readability-identifier-naming.VariableCase,           value: camelBack }
+
+  # True compile-time constants: UPPER_CASE. Covers constexpr (local and
+  # namespace), global const, static const at namespace or class scope,
+  # and macros.
+  - { key: readability-identifier-naming.MacroDefinitionCase,    value: UPPER_CASE }
+  - { key: readability-identifier-naming.ConstexprVariableCase,  value: UPPER_CASE }
+  - { key: readability-identifier-naming.GlobalConstantCase,     value: UPPER_CASE }
+  - { key: readability-identifier-naming.StaticConstantCase,     value: UPPER_CASE }
+  - { key: readability-identifier-naming.ClassConstantCase,      value: UPPER_CASE }

--- a/.clang-tidy
+++ b/.clang-tidy
@@ -28,8 +28,8 @@
 #        size_t -> difference_type iterator arithmetic.
 #   -readability-uppercase-literal-suffix: Cosmetic (1u vs 1U).
 #   -readability-implicit-bool-conversion: Noisy on Qt pointer `if (mWidget)` idioms.
-# Note: misc-include-cleaner is left enabled but its "MissingIncludes"
-# pass is turned off via CheckOptions below (transitive-include noise).
+#   -misc-include-cleaner: With MissingIncludes/UnusedIncludes off it only prints
+#        a no-op banner per TU; disabling avoids noise until include-cleaner is adopted.
 Checks: >
   -*,
   bugprone-*,
@@ -60,7 +60,8 @@ Checks: >
   -bugprone-implicit-widening-of-multiplication-result,
   -cppcoreguidelines-narrowing-conversions,
   -readability-uppercase-literal-suffix,
-  -readability-implicit-bool-conversion
+  -readability-implicit-bool-conversion,
+  -misc-include-cleaner
 
 WarningsAsErrors: ""
 FormatStyle: "file"
@@ -70,8 +71,6 @@ FormatStyle: "file"
 CheckOptions:
   - { key: cppcoreguidelines-special-member-functions.AllowSoleDefaultDtor, value: true }
   - { key: cppcoreguidelines-special-member-functions.AllowMissingMoveFunctionsWhenCopyIsDeleted, value: true }
-  - { key: misc-include-cleaner.MissingIncludes, value: false }
-  - { key: misc-include-cleaner.UnusedIncludes,  value: false }
   - { key: modernize-avoid-c-arrays.AllowStringArrays, value: false }
 
   # ------- Identifier naming -------

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,9 +13,8 @@ on:
 permissions:
   contents: read
 
-# Cancel superseded PR runs; let push and tag runs finish so we never abort a
-# half-published release. On `push` events `head_ref` is empty, so the
-# `run_id` fallback gives each push its own group.
+# Cancel superseded PR runs; let push/tag runs finish so we never abort a
+# half-published release. `run_id` fallback gives each push its own group.
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
@@ -40,7 +39,7 @@ jobs:
           python-version: "3.x"
 
       - name: Cache pre-commit environments
-        # Resolved Python version is in the key so a runner-image 3.12 -> 3.13
+        # Resolved Python version in the key so a runner-image 3.12 -> 3.13
         # bump invalidates venvs with stale interpreter paths.
         uses: actions/cache@v4
         with:
@@ -57,23 +56,18 @@ jobs:
         run: pre-commit run --all-files --show-diff-on-failure --color=always
 
   clang-ci:
-    # Three Clang 22 matrix legs:
+    # Clang 22 matrix:
     #   asan-ubsan -> AddressSanitizer + UBSan
-    #   tsan       -> ThreadSanitizer (excludes apptest; Qt internals trip it)
+    #   tsan       -> ThreadSanitizer (excludes apptest; Qt trips it)
     #   coverage   -> source-based coverage + Codecov upload; also runs
-    #                 cpp-linter-action *after* the build (Qt AUTOMOC/AUTOUIC
-    #                 outputs must exist before clang-tidy can parse the TUs)
-    #                 but before tests/coverage so a tidy hit still skips the
-    #                 long-running Codecov path.
-    # Coverage requires a CODECOV_TOKEN repo secret; without it the upload
-    # fails the leg by design (fail_ci_if_error=true).
+    #                 cpp-linter-action against the build's compile_commands.json.
+    # Coverage requires a CODECOV_TOKEN repo secret (fail_ci_if_error=true).
     needs: pre-commit
     runs-on: ubuntu-24.04
     timeout-minutes: 60
     permissions:
-      # contents: read inherited from the workflow scope is enough for
-      # cpp-linter-action's PR-files API call. pull-requests: write is what
-      # lets it post the inline tidy-review + rolling thread comment on PRs.
+      # pull-requests: write lets cpp-linter-action post inline tidy review
+      # comments on PRs; contents: read is inherited.
       contents: read
       pull-requests: write
     strategy:
@@ -82,15 +76,12 @@ jobs:
         mode: [asan-ubsan, tsan, coverage]
     steps:
       - name: Checkout code
-        # cpp-linter-action gets the changed-files list from the GitHub API,
-        # so the default shallow checkout is fine for every leg.
         uses: actions/checkout@v5
 
       - name: Install Clang 22 + LLVM tools
-        # `llvm.sh 22 all` -> clang-22, clang-tidy-22, clang-tools-22
-        # (clang-tidy-diff-22.py), llvm-profdata-22, llvm-cov-22, sanitizer
-        # runtimes, libc++-22-dev. The compiler is pinned via the preset's
-        # CMAKE_C(XX)_COMPILER, not via apt's default `clang` symlink.
+        # llvm.sh 22 all installs clang-22, clang-tidy-22, llvm-profdata/cov-22,
+        # sanitizer runtimes, libc++-22-dev. The compiler is pinned via the
+        # preset's CMAKE_C(XX)_COMPILER, not apt's default `clang` symlink.
         run: |
           set -euo pipefail
           wget --quiet https://apt.llvm.org/llvm.sh
@@ -118,35 +109,17 @@ jobs:
         run: sudo apt-get update && sudo apt-get install -y libssl-dev libxcb-cursor0
 
       - name: Configure
-        # TLS pinned ON so TcpServerProducer + asio::ssl is in scope for
-        # sanitizers / coverage / tidy.
+        # TLS pinned ON so TcpServerProducer + asio::ssl is in scope for tidy/sanitizers.
         run: cmake --preset clang-${{ matrix.mode }} -DLOGLIB_NETWORK_TLS=ON
 
       - name: Build
         run: cmake --build --preset clang-${{ matrix.mode }}
 
       - name: Run clang-tidy on PR changes
-        # Coverage leg only, *after* the build so Qt's AUTOMOC/AUTOUIC/AUTORCC
-        # outputs (moc_*.cpp, *.moc, ui_*.h, qrc_*.cpp) are on disk; without
-        # them clang-tidy fails the entire TU with "<file>.moc: file not
-        # found" before any real check can run. We still gate the test run +
-        # Codecov upload on the result, so a tidy hit short-circuits the leg.
-        #
-        # cpp-linter-action drives clang-tidy-22 against the PR diff using
-        # this build's compile_commands.json (CMAKE_EXPORT_COMPILE_COMMANDS=ON
-        # in the preset). Findings are surfaced as inline PR review comments
-        # and a step-summary; no YAML artifact to chase down.
-        #
-        # clang-format is intentionally skipped (`style: ''`): pre-commit
-        # already enforces formatting, and we don't want this leg to start
-        # double-reporting it.
-        # `tidy-checks: ''` defers entirely to .clang-tidy.
-        # `lines-changed-only: true` matches the previous clang-tidy-diff
-        # behaviour: only diagnostics on lines added by the PR fail the leg.
-        #
-        # SHA-pinned to v2.18.0 so a tag re-cut can't silently change what
-        # we run; bump deliberately. Resolved SHA verified against
-        # https://api.github.com/repos/cpp-linter/cpp-linter-action/git/ref/tags/v2.18.0
+        # Coverage leg only, after the build so AUTOMOC/AUTOUIC/AUTORCC outputs
+        # exist (without them clang-tidy fails with "<file>.moc: file not found").
+        # style/tidy-checks empty -> defer to pre-commit and .clang-tidy.
+        # SHA-pinned so a tag re-cut can't change what we run.
         if: matrix.mode == 'coverage'
         id: cpp-linter
         uses: cpp-linter/cpp-linter-action@77c390c5ba9c947ebc185a3e49cc754f1558abb5 # v2.18.0
@@ -165,24 +138,20 @@ jobs:
           step-summary: true
 
       - name: Fail leg if clang-tidy reported issues
-        # cpp-linter-action itself never fails the workflow; gate on its
-        # output so a tidy hit aborts before the expensive test/codecov work
-        # and CI status reflects the lint result.
+        # cpp-linter-action never fails the workflow itself; gate on its
+        # output so a tidy hit aborts before the expensive test/codecov work.
         if: matrix.mode == 'coverage' && steps.cpp-linter.outputs.checks-failed > 0
         run: |
           echo "::error title=clang-tidy::clang-tidy reported issues on changed lines. See the PR review comments and the job's step summary for details."
           exit 1
 
       - name: Run tests
-        # ASAN/UBSAN/TSAN/LSAN_OPTIONS + LLVM_PROFILE_FILE come from the
-        # preset's `environment` block, so local `ctest --preset` matches CI.
+        # Sanitizer + LLVM_PROFILE_FILE env comes from the preset.
         run: ctest --preset clang-${{ matrix.mode }}
 
       - name: Merge coverage profiles + export lcov
-        # Merge the per-(PID,binary) .profraw files written by the test
-        # step into one .profdata, then export lcov for the binaries
-        # ctest actually ran. ignore-filename-regex drops _deps/ (FetchContent),
-        # build/ (generated headers), and test/ (we want library+app coverage).
+        # Drop _deps/ (FetchContent), build/ (generated headers) and test/
+        # so the report covers only library + app source.
         if: matrix.mode == 'coverage'
         run: |
           set -euo pipefail
@@ -208,8 +177,8 @@ jobs:
           echo "::endgroup::"
 
       - name: Upload coverage to Codecov
-        # fail_ci_if_error: a missing/expired CODECOV_TOKEN fails the leg
-        # loudly instead of silently producing zero-coverage runs.
+        # fail_ci_if_error: missing/expired token fails the leg loudly
+        # instead of silently producing zero-coverage runs.
         if: matrix.mode == 'coverage'
         uses: codecov/codecov-action@v5
         with:
@@ -258,25 +227,21 @@ jobs:
         run: sudo apt-get update && sudo apt-get install -y libfuse2 libxcb-cursor0 zsync libssl-dev
 
       - name: Configure
-        # TLS pinned ON so a future project-default flip can't silently
-        # disable it in the published AppImage.
+        # TLS pinned ON so the published AppImage can't silently lose it.
         run: cmake --preset release -DLOGLIB_NETWORK_TLS=ON
 
       - name: Build
         run: cmake --build --preset release
 
       - name: Run unit tests
-        # `release` preset excludes the `benchmark` label; benchmarks run below.
+        # release preset excludes the `benchmark` label; benchmarks run below.
         run: ctest --preset release
 
       - name: Run parser benchmarks
-        # `release-benchmark` runs only the `benchmark` label, verbose, so the
-        # WARN-line throughput numbers show up in the CI log. See
-        # CONTRIBUTING.md `## Benchmarking` for the regression-gate convention.
         run: ctest --preset release-benchmark
 
       - name: Install linuxdeploy and plugin
-        # Tagged releases (not `continuous`) so two runs of the same commit
+        # Pinned tags (not `continuous`) so two runs of the same commit
         # produce identical AppImages. Bump deliberately.
         env:
           LINUXDEPLOY_TAG: "1-alpha-20251107-1"
@@ -290,8 +255,8 @@ jobs:
 
       - name: Package application
         env:
-          # Enables delta/zsync updates; linuxdeploy embeds this and writes a
-          # sibling .zsync file. https://docs.appimage.org/packaging-guide/optional/updates.html
+          # Enables delta/zsync updates; linuxdeploy embeds this entry and
+          # writes a sibling .zsync file.
           UPDATE_INFORMATION: "gh-releases-zsync|${{ github.repository_owner }}|${{ github.event.repository.name }}|latest|${{ env.APP_NAME }}-*x86_64.AppImage.zsync"
         run: |
           APP_DIR="${{ env.APP_NAME }}.AppDir"
@@ -303,8 +268,6 @@ jobs:
           cp -r build/release/bin/Release/tzdata $APP_DIR/usr/share/
           cp resources/icon-white.png $APP_DIR/usr/share/icons/hicolor/256x256/apps/${{ env.APP_NAME }}.png
           cp resources/app.desktop $APP_DIR/usr/share/applications/${{ env.APP_NAME }}.desktop
-          # Third-party licenses + LICENSE: stage under usr/ so linuxdeploy
-          # preserves them in the AppImage.
           mkdir -p $APP_DIR/usr/share/doc/${{ env.APP_NAME }}
           cp build/release/bin/Release/THIRD_PARTY_LICENSES.txt \
              build/release/bin/Release/LICENSE \
@@ -312,9 +275,8 @@ jobs:
           ./linuxdeploy-x86_64.AppImage --appdir=$APP_DIR --plugin qt --output appimage
 
       - name: Smoke-test packaged AppImage
-        # Launches the AppImage headlessly so a missing bundled Qt plugin /
-        # shared library fails CI before we ship a broken release. ctest
-        # only exercises the build tree, not the packaged artifact.
+        # Headless launch so a missing bundled plugin / shared library fails
+        # CI before we ship a broken release. ctest only covers the build tree.
         run: |
           set -euo pipefail
           shopt -s nullglob
@@ -327,7 +289,6 @@ jobs:
           chmod +x "$APPIMAGE"
           QT_QPA_PLATFORM=offscreen "./$APPIMAGE" &
           PID=$!
-          # 5s: a missing shared library aborts almost immediately.
           sleep 5
           if ! kill -0 "$PID" 2>/dev/null; then
             RC=0
@@ -347,8 +308,8 @@ jobs:
           done
 
       - name: Upload artifact
-        # No `if: always()`: combined with `if-no-files-found: error` it would
-        # pile a noisy second failure on top of an earlier build failure.
+        # No `if: always()`: with `if-no-files-found: error` it would pile a
+        # second failure on top of an earlier build failure.
         uses: actions/upload-artifact@v4
         with:
           name: ${{ env.APP_NAME }}-linux
@@ -395,25 +356,21 @@ jobs:
         uses: lukka/get-cmake@v4.3.2
 
       - name: Set up MSVC environment
-        # Adds cl.exe + INCLUDE/LIB to the job env via vswhere, so we don't
-        # hard-code `vcvarsall.bat` against a specific VS edition path
+        # vswhere-based discovery so we don't hard-code a VS edition path
         # (the hosted image has flipped Community <-> Enterprise before).
         uses: ilammy/msvc-dev-cmd@v1
         with:
           arch: x64
 
       - name: Install OpenSSL
-        # Strawberry Perl's openssl on PATH lacks import libraries, so it's
-        # unusable for find_package. Install the full SLP build via choco;
-        # the install path varies between bundles, so the next step probes.
+        # Strawberry Perl's openssl lacks import libraries; use the full
+        # SLP build via choco. Install path varies, so the next step probes.
         shell: powershell
         run: choco install openssl --version=$env:OPENSSL_VERSION --yes --no-progress
 
       - name: Locate OpenSSL and export OPENSSL_ROOT_DIR
-        # Probe the SLP / choco install roots for openssl.exe + include/openssl/
-        # (find_package needs both) and export the match into GITHUB_ENV.
-        # Fails loud with a directory listing so installer-layout drift is
-        # diagnosable without reproducing the CI run locally.
+        # Probe known SLP / choco install roots for openssl.exe + headers
+        # and export the match into GITHUB_ENV for find_package(OpenSSL).
         shell: powershell
         run: |
           $ErrorActionPreference = "Stop"
@@ -436,50 +393,50 @@ jobs:
           }
           $version = & "$found\bin\openssl.exe" version
           Write-Host "Located OpenSSL: $version at $found"
-          # List the runtime DLLs (libssl-<major>-x64.dll convention) that
-          # the LOGLIB_NETWORK_TLS POST_BUILD rule will copy next to the exe.
           Get-ChildItem "$found\bin" -Filter "libssl*.dll"
           Get-ChildItem "$found\bin" -Filter "libcrypto*.dll"
           "OPENSSL_ROOT_DIR=$found" | Out-File -FilePath $env:GITHUB_ENV -Append -Encoding utf8
 
       - name: Configure
-        # TLS pinned ON so a future project-default flip can't silently
-        # disable it in the published binary.
+        # TLS pinned ON so the published binary can't silently lose it.
         run: cmake --preset release -DLOGLIB_NETWORK_TLS=ON
 
       - name: Build
         run: cmake --build --preset release
 
       - name: Run unit tests
-        # `release` preset excludes the `benchmark` label; benchmarks run below.
         run: ctest --preset release
 
       - name: Run parser benchmarks
-        # `release-benchmark` runs only the `benchmark` label, verbose.
         run: ctest --preset release-benchmark
 
       - name: Package application
+        # All runtime DLLs (TBB, MSVC CRT, OpenSSL) and license files are
+        # staged next to the .exe by POST_BUILD rules in app/CMakeLists.txt.
+        # `--no-compiler-runtime` skips the ~25 MB vc_redist.x64.exe installer;
+        # we ship the individual CRT DLLs instead so the zip is portable.
         shell: powershell
         run: |
           mkdir ${{ env.APP_NAME }}
           cd ${{ env.APP_NAME }}
           mv ../build/release/bin/Release/${{ env.APP_NAME }}.exe .
           mv ../build/release/bin/Release/tzdata .
-          # tbb*.dll: oneTBB runtime, copied next to the exe by app/CMakeLists.txt.
           Move-Item ../build/release/bin/Release/tbb*.dll .
-          # libssl-*/libcrypto-*: OpenSSL runtime, also placed by the
-          # LOGLIB_NETWORK_TLS POST_BUILD rule. Missing -> STATUS_DLL_NOT_FOUND.
+          Move-Item ../build/release/bin/Release/msvcp*.dll .
+          Move-Item ../build/release/bin/Release/vcruntime*.dll .
+          if (Test-Path ../build/release/bin/Release/concrt*.dll) {
+              Move-Item ../build/release/bin/Release/concrt*.dll .
+          }
           Move-Item ../build/release/bin/Release/libssl-*.dll .
           Move-Item ../build/release/bin/Release/libcrypto-*.dll .
-          # Third-party licenses + LICENSE staged by the BundleLicenses rule.
           Move-Item ../build/release/bin/Release/THIRD_PARTY_LICENSES.txt .
           Move-Item ../build/release/bin/Release/LICENSE .
-          windeployqt --release ${{ env.APP_NAME }}.exe
+          windeployqt --release --no-compiler-runtime ${{ env.APP_NAME }}.exe
           Compress-Archive -Path . -DestinationPath ../${{ env.APP_NAME }}.zip
 
       - name: Smoke-test packaged binary
-        # Headless launch so a missing tbb12.dll (STATUS_DLL_NOT_FOUND,
-        # 0xc0000135) fails CI before we ship a broken zip.
+        # Headless launch so a missing DLL (STATUS_DLL_NOT_FOUND, 0xc0000135)
+        # fails CI before we ship a broken zip.
         shell: powershell
         run: |
           $env:QT_QPA_PLATFORM = "offscreen"
@@ -541,12 +498,10 @@ jobs:
         uses: lukka/get-cmake@v4.3.2
 
       - name: Install OpenSSL
-        # `brew install openssl@3` is a no-op when present. The keg prefix
-        # differs between arm64 and Intel runners; resolved in the next step.
+        # No-op when present. Keg prefix varies by arch; resolved next step.
         run: brew install openssl@3
 
       - name: Locate OpenSSL and export OPENSSL_ROOT_DIR
-        # `brew --prefix openssl@3` works on both arm64 and Intel runners.
         run: |
           set -euo pipefail
           OPENSSL_PREFIX="$(brew --prefix openssl@3)"
@@ -559,31 +514,27 @@ jobs:
           echo "OPENSSL_ROOT_DIR=$OPENSSL_PREFIX" >> "$GITHUB_ENV"
 
       - name: Configure
-        # TLS pinned ON so a future project-default flip can't silently
-        # disable it in the published DMG.
+        # TLS pinned ON so the published DMG can't silently lose it.
         run: cmake --preset release -DLOGLIB_NETWORK_TLS=ON
 
       - name: Build
         run: cmake --build --preset release
 
       - name: Run unit tests
-        # `release` preset excludes the `benchmark` label; benchmarks run below.
         run: ctest --preset release
 
       - name: Run parser benchmarks
-        # `release-benchmark` runs only the `benchmark` label, verbose.
         run: ctest --preset release-benchmark
 
       - name: Package application
+        # POST_BUILD rules (app/CMakeLists.txt) stage tzdata + licenses into
+        # the bundle's Resources/. Verify before macdeployqt rewrites @rpaths.
         run: |
           cd build/release/bin/Release
-          # tzdata is staged into the bundle by the app's POST_BUILD step.
           if [ ! -d "${{ env.APP_NAME }}.app/Contents/Resources/tzdata" ]; then
             echo "ERROR: tzdata missing from bundle Resources" >&2
             exit 1
           fi
-          # Same POST_BUILD step stages the licenses; fail loud rather than
-          # ship a non-compliant DMG.
           if [ ! -f "${{ env.APP_NAME }}.app/Contents/Resources/THIRD_PARTY_LICENSES.txt" ]; then
             echo "ERROR: THIRD_PARTY_LICENSES.txt missing from bundle Resources" >&2
             exit 1
@@ -592,9 +543,8 @@ jobs:
           mv ${{ env.APP_NAME }}.dmg "$GITHUB_WORKSPACE/${{ env.APP_NAME }}.dmg"
 
       - name: Smoke-test packaged .app bundle
-        # Headless launch of the macdeployqt-rewritten .app so a missing
-        # bundled framework / plugin or a broken @rpath fails CI before
-        # we ship a broken DMG.
+        # Headless launch so a missing bundled framework / plugin or broken
+        # @rpath fails CI before we ship a broken DMG.
         run: |
           set -euo pipefail
           APP_BUNDLE="build/release/bin/Release/${{ env.APP_NAME }}.app"
@@ -605,7 +555,6 @@ jobs:
           fi
           QT_QPA_PLATFORM=offscreen "$EXE" &
           PID=$!
-          # 5s: a missing dylib / unresolved @rpath aborts almost immediately.
           sleep 5
           if ! kill -0 "$PID" 2>/dev/null; then
             RC=0

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -117,16 +117,24 @@ jobs:
       - name: Run clang-tidy-diff on PR changes
         # Coverage leg only, *before* the build so style hits fail fast.
         # Empty diff -> no-op; non-empty tidy-fixes.yaml -> fail + upload.
+        # We use pull_request.base.sha rather than `origin/<base>` because
+        # actions/checkout doesn't set up a remote-tracking ref for the base
+        # branch even with fetch-depth: 0. The base SHA is reachable via the
+        # merge commit's first-parent history, so no extra fetch is needed.
         if: matrix.mode == 'coverage'
         shell: bash
+        env:
+          PR_BASE_SHA: ${{ github.event.pull_request.base.sha }}
         run: |
           set -euo pipefail
           if [ "${GITHUB_EVENT_NAME}" = "pull_request" ]; then
-            BASE="origin/${GITHUB_BASE_REF}"
+            BASE="${PR_BASE_SHA}"
           else
             BASE="HEAD^"
           fi
-          DIFF=$(git diff -U0 "$BASE"...HEAD -- '*.cpp' '*.hpp' '*.h' '*.cc' || true)
+          # No `|| true`: a failed `git diff` previously yielded an empty DIFF
+          # and silently disabled clang-tidy on every PR. Let it fail loud.
+          DIFF=$(git diff -U0 "$BASE"...HEAD -- '*.cpp' '*.hpp' '*.h' '*.cc')
           if [ -z "$DIFF" ]; then
             echo "No C/C++ changes in this diff; skipping clang-tidy-diff."
             exit 0

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,6 +13,13 @@ on:
 permissions:
   contents: read
 
+# Cancel superseded PR runs; let push and tag runs finish so we never abort a
+# half-published release. On `push` events `head_ref` is empty, so the
+# `run_id` fallback gives each push its own group.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 env:
   QT_VERSION: "6.8.*"
   APP_NAME: "StructuredLogViewer"
@@ -27,16 +34,20 @@ jobs:
         uses: actions/checkout@v5
 
       - name: Set up Python
+        id: python
         uses: actions/setup-python@v5
         with:
           python-version: "3.x"
 
       - name: Cache pre-commit environments
+        # Resolved Python version is in the key so a runner-image 3.12 -> 3.13
+        # bump invalidates venvs with stale interpreter paths.
         uses: actions/cache@v4
         with:
           path: ~/.cache/pre-commit
-          key: pre-commit-${{ runner.os }}-${{ hashFiles('.pre-commit-config.yaml') }}
+          key: pre-commit-${{ runner.os }}-py${{ steps.python.outputs.python-version }}-${{ hashFiles('.pre-commit-config.yaml') }}
           restore-keys: |
+            pre-commit-${{ runner.os }}-py${{ steps.python.outputs.python-version }}-
             pre-commit-${{ runner.os }}-
 
       - name: Install pre-commit
@@ -46,19 +57,13 @@ jobs:
         run: pre-commit run --all-files --show-diff-on-failure --color=always
 
   clang-ci:
-    # Three Clang 22 matrix legs that gate every PR alongside the platform
-    # build jobs:
-    #   - asan-ubsan  -> AddressSanitizer + UndefinedBehaviorSanitizer
-    #   - tsan        -> ThreadSanitizer (excludes apptest; Qt internals
-    #                    generate false positives that drown the signal)
-    #   - coverage    -> source-based coverage + Codecov upload, and also
-    #                    runs clang-tidy-diff on the PR's C/C++ changes
-    #                    before the build so a tidy hit fails fast.
-    #
-    # The Codecov upload step requires a CODECOV_TOKEN repo secret. Without
-    # it the step fails (fail_ci_if_error=true) and the coverage matrix leg
-    # blocks merge - that's intentional. Set the secret once at:
-    #   Settings -> Secrets and variables -> Actions -> CODECOV_TOKEN
+    # Three Clang 22 matrix legs:
+    #   asan-ubsan -> AddressSanitizer + UBSan
+    #   tsan       -> ThreadSanitizer (excludes apptest; Qt internals trip it)
+    #   coverage   -> source-based coverage + Codecov upload; also runs
+    #                 clang-tidy-diff before the build so style hits fail fast.
+    # Coverage requires a CODECOV_TOKEN repo secret; without it the upload
+    # fails the leg by design (fail_ci_if_error=true).
     needs: pre-commit
     runs-on: ubuntu-24.04
     timeout-minutes: 60
@@ -70,19 +75,14 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v5
         with:
-          # The coverage leg's clang-tidy-diff needs the merge base to
-          # exist locally; fetch-depth: 0 is the simplest way to guarantee
-          # that for both push and pull_request triggers without per-event
-          # branching here. The other two legs don't care.
-          fetch-depth: 0
+          # Only coverage's clang-tidy-diff needs the merge base; shallow elsewhere.
+          fetch-depth: ${{ matrix.mode == 'coverage' && 0 || 1 }}
 
       - name: Install Clang 22 + LLVM tools
-        # `llvm.sh 22 all` pulls clang-22, clang-tidy-22, clang-tools-22
-        # (provides clang-tidy-diff-22.py), llvm-22 (llvm-profdata-22,
-        # llvm-cov-22), libclang-rt-22-dev (sanitizer runtimes), and
-        # libc++-22-dev. Pinned to clang-22 explicitly via the preset's
-        # CMAKE_C(XX)_COMPILER so a future apt-default flip doesn't
-        # silently change which compiler we run.
+        # `llvm.sh 22 all` -> clang-22, clang-tidy-22, clang-tools-22
+        # (clang-tidy-diff-22.py), llvm-profdata-22, llvm-cov-22, sanitizer
+        # runtimes, libc++-22-dev. The compiler is pinned via the preset's
+        # CMAKE_C(XX)_COMPILER, not via apt's default `clang` symlink.
         run: |
           set -euo pipefail
           wget --quiet https://apt.llvm.org/llvm.sh
@@ -103,25 +103,20 @@ jobs:
           cache: true
 
       - name: Install CMake and Ninja
-        uses: lukka/get-cmake@latest
+        uses: lukka/get-cmake@v4.3.2
 
       - name: Install build tools
-        # libssl-dev for find_package(OpenSSL) (LOGLIB_NETWORK_TLS=ON
-        # default), libxcb-cursor0 for the offscreen Qt platform plugin.
+        # libssl-dev: find_package(OpenSSL); libxcb-cursor0: offscreen QPA.
         run: sudo apt-get update && sudo apt-get install -y libssl-dev libxcb-cursor0
 
       - name: Configure
-        # LOGLIB_NETWORK_TLS=ON pinned explicitly so the TLS code path
-        # (TcpServerProducer + asio::ssl) is in scope for sanitizers /
-        # coverage / tidy. Matches the platform build jobs.
+        # TLS pinned ON so TcpServerProducer + asio::ssl is in scope for
+        # sanitizers / coverage / tidy.
         run: cmake --preset clang-${{ matrix.mode }} -DLOGLIB_NETWORK_TLS=ON
 
       - name: Run clang-tidy-diff on PR changes
-        # Coverage leg only. Runs *before* the build so a tidy hit fails
-        # fast - we don't waste a full instrumented build + test run +
-        # Codecov upload on a style issue. Empty diff -> no-op, succeeds.
-        # Non-empty `tidy-fixes.yaml` -> at least one warning was reported,
-        # job fails and the YAML is uploaded as an artifact below.
+        # Coverage leg only, *before* the build so style hits fail fast.
+        # Empty diff -> no-op; non-empty tidy-fixes.yaml -> fail + upload.
         if: matrix.mode == 'coverage'
         shell: bash
         run: |
@@ -148,10 +143,8 @@ jobs:
           fi
 
       - name: Upload clang-tidy fixes
-        # Surface the YAML so reviewers / authors can apply it locally
-        # via `clang-apply-replacements`. Only relevant when the previous
-        # step failed; if-no-files-found silences the upload when there's
-        # nothing to upload (e.g. build failed before tidy ran).
+        # Surface the YAML so authors can apply it via clang-apply-replacements.
+        # if-no-files-found: ignore covers builds that failed before tidy ran.
         if: failure() && matrix.mode == 'coverage'
         uses: actions/upload-artifact@v4
         with:
@@ -165,21 +158,15 @@ jobs:
         run: cmake --build --preset clang-${{ matrix.mode }}
 
       - name: Run tests
-        # ASAN_OPTIONS / UBSAN_OPTIONS / TSAN_OPTIONS / LSAN_OPTIONS /
-        # LLVM_PROFILE_FILE all come from the matching test preset's
-        # `environment` block in CMakePresets.json - keeps local repro
-        # via `ctest --preset clang-<mode>` exactly equivalent to CI.
+        # ASAN/UBSAN/TSAN/LSAN_OPTIONS + LLVM_PROFILE_FILE come from the
+        # preset's `environment` block, so local `ctest --preset` matches CI.
         run: ctest --preset clang-${{ matrix.mode }}
 
       - name: Merge coverage profiles + export lcov
-        # The test step writes one .profraw per (PID, binary) under
-        # build/clang-coverage/profiles/ via LLVM_PROFILE_FILE in the
-        # preset. Merge them, then export lcov for the three test
-        # binaries that ctest actually ran (apptest_bench is excluded
-        # by the `benchmark` label; log_generator isn't a test).
-        # The ignore-filename-regex drops _deps/ (FetchContent), build/
-        # (generated headers), and test/ (test code itself; we only
-        # care about library + app coverage).
+        # Merge the per-(PID,binary) .profraw files written by the test
+        # step into one .profdata, then export lcov for the binaries
+        # ctest actually ran. ignore-filename-regex drops _deps/ (FetchContent),
+        # build/ (generated headers), and test/ (we want library+app coverage).
         if: matrix.mode == 'coverage'
         run: |
           set -euo pipefail
@@ -205,10 +192,8 @@ jobs:
           echo "::endgroup::"
 
       - name: Upload coverage to Codecov
-        # Requires CODECOV_TOKEN repo secret (see top-of-job comment).
-        # fail_ci_if_error makes a failed upload block the PR so a
-        # missing token surfaces immediately rather than silently
-        # producing zero-coverage runs.
+        # fail_ci_if_error: a missing/expired CODECOV_TOKEN fails the leg
+        # loudly instead of silently producing zero-coverage runs.
         if: matrix.mode == 'coverage'
         uses: codecov/codecov-action@v5
         with:
@@ -219,9 +204,10 @@ jobs:
 
   build-linux:
     needs: pre-commit
-    # Pinned to the oldest supported runner so the AppImage links against an
-    # older glibc and stays compatible with Ubuntu 22.04 / equivalent distros.
+    # Oldest supported runner so the AppImage links against an older glibc
+    # and stays compatible with Ubuntu 22.04 / equivalent distros.
     runs-on: ubuntu-22.04
+    timeout-minutes: 60
     permissions:
       contents: write
     env:
@@ -248,51 +234,48 @@ jobs:
           cache: true
 
       - name: Install CMake
-        uses: lukka/get-cmake@latest
+        uses: lukka/get-cmake@v4.3.2
 
       - name: Install build tools
-        # libssl-dev satisfies find_package(OpenSSL) for the
-        # LOGLIB_NETWORK_TLS code path (TcpServerProducer + asio::ssl).
-        # Other entries: libfuse2 (AppImage runtime), xvfb / libxcb-cursor0
-        # (Qt's offscreen QPA), zsync (linuxdeploy delta updates).
-        run: sudo apt-get update && sudo apt-get install -y libfuse2 xvfb libxcb-cursor0 zsync libssl-dev
+        # libssl-dev: find_package(OpenSSL); libfuse2: AppImage runtime;
+        # libxcb-cursor0: still loaded by the offscreen QPA; zsync: delta updates.
+        run: sudo apt-get update && sudo apt-get install -y libfuse2 libxcb-cursor0 zsync libssl-dev
 
       - name: Configure
-        # LOGLIB_NETWORK_TLS=ON is the project default but pinned here
-        # explicitly so a future default flip doesn't silently disable
-        # TLS in the published AppImage.
+        # TLS pinned ON so a future project-default flip can't silently
+        # disable it in the published AppImage.
         run: cmake --preset release -DLOGLIB_NETWORK_TLS=ON
 
       - name: Build
         run: cmake --build --preset release
 
       - name: Run unit tests
-        # ctest preset already sets QT_QPA_PLATFORM=offscreen. The `release`
-        # test preset filters out the `benchmark` CTest label so this step
-        # only runs the functional/parity tests; the parser benchmarks in
-        # `test/lib/src/benchmark_json.cpp` run in the dedicated step below.
+        # `release` preset excludes the `benchmark` label; benchmarks run below.
         run: ctest --preset release
 
       - name: Run parser benchmarks
-        # The `release-benchmark` test preset includes only the `benchmark`
-        # CTest label and runs verbosely so the WARN-line throughput / latency
-        # numbers from `test/lib/src/benchmark_json.cpp` show up in the CI log.
-        # See CONTRIBUTING.md `## Benchmarking` for the regression-gate
-        # convention these numbers feed into.
+        # `release-benchmark` runs only the `benchmark` label, verbose, so the
+        # WARN-line throughput numbers show up in the CI log. See
+        # CONTRIBUTING.md `## Benchmarking` for the regression-gate convention.
         run: ctest --preset release-benchmark
 
       - name: Install linuxdeploy and plugin
+        # Tagged releases (not `continuous`) so two runs of the same commit
+        # produce identical AppImages. Bump deliberately.
+        env:
+          LINUXDEPLOY_TAG: "1-alpha-20251107-1"
+          LINUXDEPLOY_PLUGIN_QT_TAG: "1-alpha-20250213-1"
         run: |
-          wget https://github.com/linuxdeploy/linuxdeploy/releases/download/continuous/linuxdeploy-x86_64.AppImage
+          set -euo pipefail
+          wget --quiet "https://github.com/linuxdeploy/linuxdeploy/releases/download/${LINUXDEPLOY_TAG}/linuxdeploy-x86_64.AppImage"
           chmod +x linuxdeploy-x86_64.AppImage
-          wget https://github.com/linuxdeploy/linuxdeploy-plugin-qt/releases/download/continuous/linuxdeploy-plugin-qt-x86_64.AppImage
+          wget --quiet "https://github.com/linuxdeploy/linuxdeploy-plugin-qt/releases/download/${LINUXDEPLOY_PLUGIN_QT_TAG}/linuxdeploy-plugin-qt-x86_64.AppImage"
           chmod +x linuxdeploy-plugin-qt-x86_64.AppImage
 
       - name: Package application
         env:
-          # Enables delta/zsync updates: linuxdeploy embeds this entry into the
-          # AppImage and writes a sibling .zsync file. See:
-          # https://docs.appimage.org/packaging-guide/optional/updates.html
+          # Enables delta/zsync updates; linuxdeploy embeds this and writes a
+          # sibling .zsync file. https://docs.appimage.org/packaging-guide/optional/updates.html
           UPDATE_INFORMATION: "gh-releases-zsync|${{ github.repository_owner }}|${{ github.event.repository.name }}|latest|${{ env.APP_NAME }}-*x86_64.AppImage.zsync"
         run: |
           APP_DIR="${{ env.APP_NAME }}.AppDir"
@@ -304,15 +287,41 @@ jobs:
           cp -r build/release/bin/Release/tzdata $APP_DIR/usr/share/
           cp resources/icon-white.png $APP_DIR/usr/share/icons/hicolor/256x256/apps/${{ env.APP_NAME }}.png
           cp resources/app.desktop $APP_DIR/usr/share/applications/${{ env.APP_NAME }}.desktop
-          # Stage the aggregated third-party license bundle and the
-          # project's own LICENSE alongside the binary so they survive
-          # the AppImage packaging step (linuxdeploy preserves
-          # everything under usr/).
+          # Third-party licenses + LICENSE: stage under usr/ so linuxdeploy
+          # preserves them in the AppImage.
           mkdir -p $APP_DIR/usr/share/doc/${{ env.APP_NAME }}
           cp build/release/bin/Release/THIRD_PARTY_LICENSES.txt \
              build/release/bin/Release/LICENSE \
              $APP_DIR/usr/share/doc/${{ env.APP_NAME }}/
           ./linuxdeploy-x86_64.AppImage --appdir=$APP_DIR --plugin qt --output appimage
+
+      - name: Smoke-test packaged AppImage
+        # Launches the AppImage headlessly so a missing bundled Qt plugin /
+        # shared library fails CI before we ship a broken release. ctest
+        # only exercises the build tree, not the packaged artifact.
+        run: |
+          set -euo pipefail
+          shopt -s nullglob
+          APPIMAGES=( ${{ env.APP_NAME }}-*.AppImage )
+          if [ "${#APPIMAGES[@]}" -eq 0 ]; then
+            echo "No AppImage produced by linuxdeploy" >&2
+            exit 1
+          fi
+          APPIMAGE="${APPIMAGES[0]}"
+          chmod +x "$APPIMAGE"
+          QT_QPA_PLATFORM=offscreen "./$APPIMAGE" &
+          PID=$!
+          # 5s: a missing shared library aborts almost immediately.
+          sleep 5
+          if ! kill -0 "$PID" 2>/dev/null; then
+            RC=0
+            wait "$PID" || RC=$?
+            echo "Packaged AppImage exited prematurely with code $RC" >&2
+            exit 1
+          fi
+          kill "$PID" 2>/dev/null || true
+          wait "$PID" 2>/dev/null || true
+          echo "Packaged AppImage launched successfully and was terminated after 5s."
 
       - name: Compute SHA256 checksums
         run: |
@@ -322,8 +331,9 @@ jobs:
           done
 
       - name: Upload artifact
+        # No `if: always()`: combined with `if-no-files-found: error` it would
+        # pile a noisy second failure on top of an earlier build failure.
         uses: actions/upload-artifact@v4
-        if: always()
         with:
           name: ${{ env.APP_NAME }}-linux
           path: |
@@ -346,8 +356,12 @@ jobs:
   build-windows:
     needs: pre-commit
     runs-on: windows-latest
+    timeout-minutes: 60
     permissions:
       contents: write
+    env:
+      # Single source for the choco install version and the path probe.
+      OPENSSL_VERSION: "3.6.2"
     steps:
       - name: Checkout code
         uses: actions/checkout@v5
@@ -362,38 +376,35 @@ jobs:
           cache: true
 
       - name: Install CMake and Ninja
-        uses: lukka/get-cmake@latest
+        uses: lukka/get-cmake@v4.3.2
+
+      - name: Set up MSVC environment
+        # Adds cl.exe + INCLUDE/LIB to the job env via vswhere, so we don't
+        # hard-code `vcvarsall.bat` against a specific VS edition path
+        # (the hosted image has flipped Community <-> Enterprise before).
+        uses: ilammy/msvc-dev-cmd@v1
+        with:
+          arch: x64
 
       - name: Install OpenSSL
-        # The Windows runner has Strawberry Perl's openssl on PATH but
-        # without import libraries, so it's unusable for find_package.
-        # Install the full (dev headers + .lib + DLLs) Shining Light
-        # Productions build via chocolatey, pinned to the same 3.x
-        # version we tested with locally. Subsequent versions of the
-        # SLP installer have shipped to `C:\Program Files\OpenSSL-Win64`,
-        # `C:\Program Files\OpenSSL`, or
-        # `C:\Program Files\OpenSSL-Win64-<ver>` depending on the
-        # bundle, so the next step probes both rather than hard-coding
-        # one path that may silently disagree with what choco installed.
+        # Strawberry Perl's openssl on PATH lacks import libraries, so it's
+        # unusable for find_package. Install the full SLP build via choco;
+        # the install path varies between bundles, so the next step probes.
         shell: powershell
-        run: choco install openssl --version=3.6.2 --yes --no-progress
+        run: choco install openssl --version=$env:OPENSSL_VERSION --yes --no-progress
 
       - name: Locate OpenSSL and export OPENSSL_ROOT_DIR
-        # Probe the well-known SLP / chocolatey install roots for an
-        # `openssl.exe` paired with a populated `include/openssl/`
-        # directory (find_package(OpenSSL) needs both). Export the
-        # match into $GITHUB_ENV so every following step inherits the
-        # right root regardless of which path the installer used.
-        # Fails loud with a directory listing if nothing matches, so
-        # diagnosing future installer-layout changes does not require
-        # reproducing the CI run locally.
+        # Probe the SLP / choco install roots for openssl.exe + include/openssl/
+        # (find_package needs both) and export the match into GITHUB_ENV.
+        # Fails loud with a directory listing so installer-layout drift is
+        # diagnosable without reproducing the CI run locally.
         shell: powershell
         run: |
           $ErrorActionPreference = "Stop"
           $candidates = @(
             "C:\Program Files\OpenSSL-Win64",
             "C:\Program Files\OpenSSL",
-            "C:\Program Files\OpenSSL-Win64-3.6.2"
+            "C:\Program Files\OpenSSL-Win64-$env:OPENSSL_VERSION"
           )
           $found = $null
           foreach ($c in $candidates) {
@@ -409,38 +420,26 @@ jobs:
           }
           $version = & "$found\bin\openssl.exe" version
           Write-Host "Located OpenSSL: $version at $found"
-          # Sanity-check the runtime DLLs the build's POST_BUILD step
-          # will copy next to the executable. Names follow OpenSSL's
-          # SONAME convention (libssl-<major>-x64.dll on Windows).
+          # List the runtime DLLs (libssl-<major>-x64.dll convention) that
+          # the LOGLIB_NETWORK_TLS POST_BUILD rule will copy next to the exe.
           Get-ChildItem "$found\bin" -Filter "libssl*.dll"
           Get-ChildItem "$found\bin" -Filter "libcrypto*.dll"
           "OPENSSL_ROOT_DIR=$found" | Out-File -FilePath $env:GITHUB_ENV -Append -Encoding utf8
 
       - name: Configure
-        shell: cmd
-        run: |
-          call "C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Auxiliary\Build\vcvarsall.bat" amd64
-          cmake --preset release -DLOGLIB_NETWORK_TLS=ON
+        # TLS pinned ON so a future project-default flip can't silently
+        # disable it in the published binary.
+        run: cmake --preset release -DLOGLIB_NETWORK_TLS=ON
 
       - name: Build
-        shell: cmd
-        run: |
-          call "C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Auxiliary\Build\vcvarsall.bat" amd64
-          cmake --build --preset release
+        run: cmake --build --preset release
 
       - name: Run unit tests
-        # ctest preset already sets QT_QPA_PLATFORM=offscreen. The `release`
-        # test preset filters out the `benchmark` CTest label so this step
-        # only runs the functional/parity tests; benchmarks live in the
-        # dedicated step below.
-        shell: cmd
+        # `release` preset excludes the `benchmark` label; benchmarks run below.
         run: ctest --preset release
 
       - name: Run parser benchmarks
-        # The `release-benchmark` test preset includes only the `benchmark`
-        # CTest label and runs verbosely so the WARN-line throughput / latency
-        # numbers from `test/lib/src/benchmark_json.cpp` show up in the CI log.
-        shell: cmd
+        # `release-benchmark` runs only the `benchmark` label, verbose.
         run: ctest --preset release-benchmark
 
       - name: Package application
@@ -450,28 +449,21 @@ jobs:
           cd ${{ env.APP_NAME }}
           mv ../build/release/bin/Release/${{ env.APP_NAME }}.exe .
           mv ../build/release/bin/Release/tzdata .
-          # Carry oneTBB's runtime DLL alongside the executable. The CMake
-          # POST_BUILD rule in app/CMakeLists.txt already copies it next to
-          # StructuredLogViewer.exe, so the file is present in the build tree.
+          # tbb*.dll: oneTBB runtime, copied next to the exe by app/CMakeLists.txt.
           Move-Item ../build/release/bin/Release/tbb*.dll .
-          # OpenSSL runtime DLLs (libssl-3-x64.dll, libcrypto-3-x64.dll)
-          # are placed by the LOGLIB_NETWORK_TLS POST_BUILD rule in
-          # app/CMakeLists.txt. Without them, StructuredLogViewer.exe
-          # would fail at startup with STATUS_DLL_NOT_FOUND.
+          # libssl-*/libcrypto-*: OpenSSL runtime, also placed by the
+          # LOGLIB_NETWORK_TLS POST_BUILD rule. Missing -> STATUS_DLL_NOT_FOUND.
           Move-Item ../build/release/bin/Release/libssl-*.dll .
           Move-Item ../build/release/bin/Release/libcrypto-*.dll .
-          # Stage the aggregated third-party license bundle and the
-          # project's own LICENSE next to the executable. They are the
-          # same files the BundleLicenses POST_BUILD rule copied into
-          # bin/Release/, so just move them across.
+          # Third-party licenses + LICENSE staged by the BundleLicenses rule.
           Move-Item ../build/release/bin/Release/THIRD_PARTY_LICENSES.txt .
           Move-Item ../build/release/bin/Release/LICENSE .
           windeployqt --release ${{ env.APP_NAME }}.exe
           Compress-Archive -Path . -DestinationPath ../${{ env.APP_NAME }}.zip
 
       - name: Smoke-test packaged binary
-        # Launches the packaged executable headlessly so a missing tbb12.dll
-        # (STATUS_DLL_NOT_FOUND, 0xc0000135) fails CI before we ship a broken zip.
+        # Headless launch so a missing tbb12.dll (STATUS_DLL_NOT_FOUND,
+        # 0xc0000135) fails CI before we ship a broken zip.
         shell: powershell
         run: |
           $env:QT_QPA_PLATFORM = "offscreen"
@@ -493,8 +485,8 @@ jobs:
           "$hash  $file" | Out-File -FilePath "$file.sha256" -Encoding ascii
 
       - name: Upload artifact
+        # See build-linux for why no `if: always()` here.
         uses: actions/upload-artifact@v4
-        if: always()
         with:
           name: ${{ env.APP_NAME }}-windows
           path: |
@@ -513,6 +505,7 @@ jobs:
   build-macos:
     needs: pre-commit
     runs-on: macos-latest
+    timeout-minutes: 60
     permissions:
       contents: write
     steps:
@@ -529,21 +522,15 @@ jobs:
           cache: true
 
       - name: Install CMake and Ninja
-        uses: lukka/get-cmake@latest
+        uses: lukka/get-cmake@v4.3.2
 
       - name: Install OpenSSL
-        # macos-latest ships openssl@3 via Homebrew; re-running
-        # `brew install` is a cheap no-op when already present. The
-        # keg lives under `$(brew --prefix openssl@3)`, which differs
-        # between Apple Silicon (`/opt/homebrew/opt/openssl@3`) and
-        # Intel (`/usr/local/opt/openssl@3`) runners. The next step
-        # resolves it dynamically rather than hard-coding either path.
+        # `brew install openssl@3` is a no-op when present. The keg prefix
+        # differs between arm64 and Intel runners; resolved in the next step.
         run: brew install openssl@3
 
       - name: Locate OpenSSL and export OPENSSL_ROOT_DIR
-        # Resolve the keg prefix from Homebrew so we work on both
-        # arm64 (default for macos-latest today) and Intel runners,
-        # then export it so subsequent steps inherit the right root.
+        # `brew --prefix openssl@3` works on both arm64 and Intel runners.
         run: |
           set -euo pipefail
           OPENSSL_PREFIX="$(brew --prefix openssl@3)"
@@ -556,36 +543,31 @@ jobs:
           echo "OPENSSL_ROOT_DIR=$OPENSSL_PREFIX" >> "$GITHUB_ENV"
 
       - name: Configure
+        # TLS pinned ON so a future project-default flip can't silently
+        # disable it in the published DMG.
         run: cmake --preset release -DLOGLIB_NETWORK_TLS=ON
 
       - name: Build
         run: cmake --build --preset release
 
       - name: Run unit tests
-        # ctest preset already sets QT_QPA_PLATFORM=offscreen. The `release`
-        # test preset filters out the `benchmark` CTest label so this step
-        # only runs the functional/parity tests; benchmarks live in the
-        # dedicated step below.
+        # `release` preset excludes the `benchmark` label; benchmarks run below.
         run: ctest --preset release
 
       - name: Run parser benchmarks
-        # The `release-benchmark` test preset includes only the `benchmark`
-        # CTest label and runs verbosely so the WARN-line throughput / latency
-        # numbers from `test/lib/src/benchmark_json.cpp` show up in the CI log.
+        # `release-benchmark` runs only the `benchmark` label, verbose.
         run: ctest --preset release-benchmark
 
       - name: Package application
         run: |
           cd build/release/bin/Release
-          # tzdata is copied into the bundle's Contents/Resources by the CMake
-          # POST_BUILD step; verify it's there before deploying.
+          # tzdata is staged into the bundle by the app's POST_BUILD step.
           if [ ! -d "${{ env.APP_NAME }}.app/Contents/Resources/tzdata" ]; then
             echo "ERROR: tzdata missing from bundle Resources" >&2
             exit 1
           fi
-          # Aggregated third-party licenses + project LICENSE. Same
-          # POST_BUILD step that handles tzdata copies them in; verify
-          # so we fail loud instead of shipping a non-compliant DMG.
+          # Same POST_BUILD step stages the licenses; fail loud rather than
+          # ship a non-compliant DMG.
           if [ ! -f "${{ env.APP_NAME }}.app/Contents/Resources/THIRD_PARTY_LICENSES.txt" ]; then
             echo "ERROR: THIRD_PARTY_LICENSES.txt missing from bundle Resources" >&2
             exit 1
@@ -593,12 +575,38 @@ jobs:
           macdeployqt ${{ env.APP_NAME }}.app -dmg
           mv ${{ env.APP_NAME }}.dmg "$GITHUB_WORKSPACE/${{ env.APP_NAME }}.dmg"
 
+      - name: Smoke-test packaged .app bundle
+        # Headless launch of the macdeployqt-rewritten .app so a missing
+        # bundled framework / plugin or a broken @rpath fails CI before
+        # we ship a broken DMG.
+        run: |
+          set -euo pipefail
+          APP_BUNDLE="build/release/bin/Release/${{ env.APP_NAME }}.app"
+          EXE="$APP_BUNDLE/Contents/MacOS/${{ env.APP_NAME }}"
+          if [ ! -x "$EXE" ]; then
+            echo "Packaged .app is missing executable at $EXE" >&2
+            exit 1
+          fi
+          QT_QPA_PLATFORM=offscreen "$EXE" &
+          PID=$!
+          # 5s: a missing dylib / unresolved @rpath aborts almost immediately.
+          sleep 5
+          if ! kill -0 "$PID" 2>/dev/null; then
+            RC=0
+            wait "$PID" || RC=$?
+            echo "Packaged .app exited prematurely with code $RC" >&2
+            exit 1
+          fi
+          kill "$PID" 2>/dev/null || true
+          wait "$PID" 2>/dev/null || true
+          echo "Packaged .app launched successfully and was terminated after 5s."
+
       - name: Compute SHA256 checksums
         run: shasum -a 256 ${{ env.APP_NAME }}.dmg > ${{ env.APP_NAME }}.dmg.sha256
 
       - name: Upload artifact
+        # See build-linux for why no `if: always()` here.
         uses: actions/upload-artifact@v4
-        if: always()
         with:
           name: ${{ env.APP_NAME }}-macos
           path: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -61,22 +61,27 @@ jobs:
     #   asan-ubsan -> AddressSanitizer + UBSan
     #   tsan       -> ThreadSanitizer (excludes apptest; Qt internals trip it)
     #   coverage   -> source-based coverage + Codecov upload; also runs
-    #                 clang-tidy-diff before the build so style hits fail fast.
+    #                 cpp-linter-action before the build so style hits fail fast.
     # Coverage requires a CODECOV_TOKEN repo secret; without it the upload
     # fails the leg by design (fail_ci_if_error=true).
     needs: pre-commit
     runs-on: ubuntu-24.04
     timeout-minutes: 60
+    permissions:
+      # contents: read inherited from the workflow scope is enough for
+      # cpp-linter-action's PR-files API call. pull-requests: write is what
+      # lets it post the inline tidy-review + rolling thread comment on PRs.
+      contents: read
+      pull-requests: write
     strategy:
       fail-fast: false
       matrix:
         mode: [asan-ubsan, tsan, coverage]
     steps:
       - name: Checkout code
+        # cpp-linter-action gets the changed-files list from the GitHub API,
+        # so the default shallow checkout is fine for every leg.
         uses: actions/checkout@v5
-        with:
-          # Only coverage's clang-tidy-diff needs the merge base; shallow elsewhere.
-          fetch-depth: ${{ matrix.mode == 'coverage' && 0 || 1 }}
 
       - name: Install Clang 22 + LLVM tools
         # `llvm.sh 22 all` -> clang-22, clang-tidy-22, clang-tools-22
@@ -114,53 +119,48 @@ jobs:
         # sanitizers / coverage / tidy.
         run: cmake --preset clang-${{ matrix.mode }} -DLOGLIB_NETWORK_TLS=ON
 
-      - name: Run clang-tidy-diff on PR changes
+      - name: Run clang-tidy on PR changes
         # Coverage leg only, *before* the build so style hits fail fast.
-        # Empty diff -> no-op; non-empty tidy-fixes.yaml -> fail + upload.
-        # We use pull_request.base.sha rather than `origin/<base>` because
-        # actions/checkout doesn't set up a remote-tracking ref for the base
-        # branch even with fetch-depth: 0. The base SHA is reachable via the
-        # merge commit's first-parent history, so no extra fetch is needed.
+        # cpp-linter-action drives clang-tidy-22 against the PR diff using
+        # this build's compile_commands.json (CMAKE_EXPORT_COMPILE_COMMANDS=ON
+        # in the preset). Findings are surfaced as inline PR review comments
+        # and a step-summary; no YAML artifact to chase down.
+        #
+        # clang-format is intentionally skipped (`style: ''`): pre-commit
+        # already enforces formatting, and we don't want this leg to start
+        # double-reporting it.
+        # `tidy-checks: ''` defers entirely to .clang-tidy.
+        # `lines-changed-only: true` matches the previous clang-tidy-diff
+        # behaviour: only diagnostics on lines added by the PR fail the leg.
+        #
+        # SHA-pinned to v2.18.0 so a tag re-cut can't silently change what
+        # we run; bump deliberately. Resolved SHA verified against
+        # https://api.github.com/repos/cpp-linter/cpp-linter-action/git/ref/tags/v2.18.0
         if: matrix.mode == 'coverage'
-        shell: bash
+        id: cpp-linter
+        uses: cpp-linter/cpp-linter-action@77c390c5ba9c947ebc185a3e49cc754f1558abb5 # v2.18.0
         env:
-          PR_BASE_SHA: ${{ github.event.pull_request.base.sha }}
-        run: |
-          set -euo pipefail
-          if [ "${GITHUB_EVENT_NAME}" = "pull_request" ]; then
-            BASE="${PR_BASE_SHA}"
-          else
-            BASE="HEAD^"
-          fi
-          # No `|| true`: a failed `git diff` previously yielded an empty DIFF
-          # and silently disabled clang-tidy on every PR. Let it fail loud.
-          DIFF=$(git diff -U0 "$BASE"...HEAD -- '*.cpp' '*.hpp' '*.h' '*.cc')
-          if [ -z "$DIFF" ]; then
-            echo "No C/C++ changes in this diff; skipping clang-tidy-diff."
-            exit 0
-          fi
-          echo "$DIFF" \
-            | clang-tidy-diff-22.py -p1 -path build/clang-coverage \
-                -clang-tidy-binary clang-tidy-22 \
-                -j"$(nproc)" -fix=false -quiet \
-                -export-fixes tidy-fixes.yaml \
-            | tee tidy-report.txt
-          if [ -s tidy-fixes.yaml ]; then
-            echo "::error title=clang-tidy-diff::clang-tidy reported issues on changed lines. Download the clang-tidy-fixes artifact for the YAML diff to apply."
-            exit 1
-          fi
-
-      - name: Upload clang-tidy fixes
-        # Surface the YAML so authors can apply it via clang-apply-replacements.
-        # if-no-files-found: ignore covers builds that failed before tidy ran.
-        if: failure() && matrix.mode == 'coverage'
-        uses: actions/upload-artifact@v4
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
-          name: clang-tidy-fixes
-          path: |
-            tidy-fixes.yaml
-            tidy-report.txt
-          if-no-files-found: ignore
+          version: "22"
+          style: ""
+          tidy-checks: ""
+          database: build/clang-coverage
+          extensions: cpp,hpp,h,cc
+          files-changed-only: true
+          lines-changed-only: true
+          tidy-review: true
+          thread-comments: update
+          step-summary: true
+
+      - name: Fail leg if clang-tidy reported issues
+        # cpp-linter-action itself never fails the workflow; gate on its
+        # output so a tidy hit aborts before the expensive build/test/codecov
+        # work and CI status reflects the lint result.
+        if: matrix.mode == 'coverage' && steps.cpp-linter.outputs.checks-failed > 0
+        run: |
+          echo "::error title=clang-tidy::clang-tidy reported issues on changed lines. See the PR review comments and the job's step summary for details."
+          exit 1
 
       - name: Build
         run: cmake --build --preset clang-${{ matrix.mode }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -45,6 +45,178 @@ jobs:
       - name: Run pre-commit
         run: pre-commit run --all-files --show-diff-on-failure --color=always
 
+  clang-ci:
+    # Three Clang 22 matrix legs that gate every PR alongside the platform
+    # build jobs:
+    #   - asan-ubsan  -> AddressSanitizer + UndefinedBehaviorSanitizer
+    #   - tsan        -> ThreadSanitizer (excludes apptest; Qt internals
+    #                    generate false positives that drown the signal)
+    #   - coverage    -> source-based coverage + Codecov upload, and also
+    #                    runs clang-tidy-diff on the PR's C/C++ changes
+    #                    before the build so a tidy hit fails fast.
+    #
+    # The Codecov upload step requires a CODECOV_TOKEN repo secret. Without
+    # it the step fails (fail_ci_if_error=true) and the coverage matrix leg
+    # blocks merge - that's intentional. Set the secret once at:
+    #   Settings -> Secrets and variables -> Actions -> CODECOV_TOKEN
+    needs: pre-commit
+    runs-on: ubuntu-24.04
+    timeout-minutes: 60
+    strategy:
+      fail-fast: false
+      matrix:
+        mode: [asan-ubsan, tsan, coverage]
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v5
+        with:
+          # The coverage leg's clang-tidy-diff needs the merge base to
+          # exist locally; fetch-depth: 0 is the simplest way to guarantee
+          # that for both push and pull_request triggers without per-event
+          # branching here. The other two legs don't care.
+          fetch-depth: 0
+
+      - name: Install Clang 22 + LLVM tools
+        # `llvm.sh 22 all` pulls clang-22, clang-tidy-22, clang-tools-22
+        # (provides clang-tidy-diff-22.py), llvm-22 (llvm-profdata-22,
+        # llvm-cov-22), libclang-rt-22-dev (sanitizer runtimes), and
+        # libc++-22-dev. Pinned to clang-22 explicitly via the preset's
+        # CMAKE_C(XX)_COMPILER so a future apt-default flip doesn't
+        # silently change which compiler we run.
+        run: |
+          set -euo pipefail
+          wget --quiet https://apt.llvm.org/llvm.sh
+          chmod +x llvm.sh
+          sudo ./llvm.sh 22 all
+          clang-22 --version
+          clang-tidy-22 --version
+          llvm-cov-22 --version
+          which clang-tidy-diff-22.py
+
+      - name: Install Qt
+        uses: jurplel/install-qt-action@v4
+        with:
+          version: ${{ env.QT_VERSION }}
+          host: "linux"
+          target: "desktop"
+          arch: "linux_gcc_64"
+          cache: true
+
+      - name: Install CMake and Ninja
+        uses: lukka/get-cmake@latest
+
+      - name: Install build tools
+        # libssl-dev for find_package(OpenSSL) (LOGLIB_NETWORK_TLS=ON
+        # default), libxcb-cursor0 for the offscreen Qt platform plugin.
+        run: sudo apt-get update && sudo apt-get install -y libssl-dev libxcb-cursor0
+
+      - name: Configure
+        # LOGLIB_NETWORK_TLS=ON pinned explicitly so the TLS code path
+        # (TcpServerProducer + asio::ssl) is in scope for sanitizers /
+        # coverage / tidy. Matches the platform build jobs.
+        run: cmake --preset clang-${{ matrix.mode }} -DLOGLIB_NETWORK_TLS=ON
+
+      - name: Run clang-tidy-diff on PR changes
+        # Coverage leg only. Runs *before* the build so a tidy hit fails
+        # fast - we don't waste a full instrumented build + test run +
+        # Codecov upload on a style issue. Empty diff -> no-op, succeeds.
+        # Non-empty `tidy-fixes.yaml` -> at least one warning was reported,
+        # job fails and the YAML is uploaded as an artifact below.
+        if: matrix.mode == 'coverage'
+        shell: bash
+        run: |
+          set -euo pipefail
+          if [ "${GITHUB_EVENT_NAME}" = "pull_request" ]; then
+            BASE="origin/${GITHUB_BASE_REF}"
+          else
+            BASE="HEAD^"
+          fi
+          DIFF=$(git diff -U0 "$BASE"...HEAD -- '*.cpp' '*.hpp' '*.h' '*.cc' || true)
+          if [ -z "$DIFF" ]; then
+            echo "No C/C++ changes in this diff; skipping clang-tidy-diff."
+            exit 0
+          fi
+          echo "$DIFF" \
+            | clang-tidy-diff-22.py -p1 -path build/clang-coverage \
+                -clang-tidy-binary clang-tidy-22 \
+                -j"$(nproc)" -fix=false -quiet \
+                -export-fixes tidy-fixes.yaml \
+            | tee tidy-report.txt
+          if [ -s tidy-fixes.yaml ]; then
+            echo "::error title=clang-tidy-diff::clang-tidy reported issues on changed lines. Download the clang-tidy-fixes artifact for the YAML diff to apply."
+            exit 1
+          fi
+
+      - name: Upload clang-tidy fixes
+        # Surface the YAML so reviewers / authors can apply it locally
+        # via `clang-apply-replacements`. Only relevant when the previous
+        # step failed; if-no-files-found silences the upload when there's
+        # nothing to upload (e.g. build failed before tidy ran).
+        if: failure() && matrix.mode == 'coverage'
+        uses: actions/upload-artifact@v4
+        with:
+          name: clang-tidy-fixes
+          path: |
+            tidy-fixes.yaml
+            tidy-report.txt
+          if-no-files-found: ignore
+
+      - name: Build
+        run: cmake --build --preset clang-${{ matrix.mode }}
+
+      - name: Run tests
+        # ASAN_OPTIONS / UBSAN_OPTIONS / TSAN_OPTIONS / LSAN_OPTIONS /
+        # LLVM_PROFILE_FILE all come from the matching test preset's
+        # `environment` block in CMakePresets.json - keeps local repro
+        # via `ctest --preset clang-<mode>` exactly equivalent to CI.
+        run: ctest --preset clang-${{ matrix.mode }}
+
+      - name: Merge coverage profiles + export lcov
+        # The test step writes one .profraw per (PID, binary) under
+        # build/clang-coverage/profiles/ via LLVM_PROFILE_FILE in the
+        # preset. Merge them, then export lcov for the three test
+        # binaries that ctest actually ran (apptest_bench is excluded
+        # by the `benchmark` label; log_generator isn't a test).
+        # The ignore-filename-regex drops _deps/ (FetchContent), build/
+        # (generated headers), and test/ (test code itself; we only
+        # care about library + app coverage).
+        if: matrix.mode == 'coverage'
+        run: |
+          set -euo pipefail
+          BIN_DIR=build/clang-coverage/bin/RelWithDebInfo
+          llvm-profdata-22 merge -sparse \
+            build/clang-coverage/profiles/*.profraw \
+            -o build/clang-coverage/merged.profdata
+          OBJECTS=(
+            "$BIN_DIR/tests"
+            -object "$BIN_DIR/apptest"
+            -object "$BIN_DIR/apptest_queue"
+          )
+          llvm-cov-22 export -format=lcov \
+            -instr-profile=build/clang-coverage/merged.profdata \
+            -ignore-filename-regex='(_deps|build|test)/' \
+            "${OBJECTS[@]}" \
+            > coverage.lcov
+          echo "::group::Coverage summary (library + app only)"
+          llvm-cov-22 report \
+            -instr-profile=build/clang-coverage/merged.profdata \
+            -ignore-filename-regex='(_deps|build|test)/' \
+            "${OBJECTS[@]}"
+          echo "::endgroup::"
+
+      - name: Upload coverage to Codecov
+        # Requires CODECOV_TOKEN repo secret (see top-of-job comment).
+        # fail_ci_if_error makes a failed upload block the PR so a
+        # missing token surfaces immediately rather than silently
+        # producing zero-coverage runs.
+        if: matrix.mode == 'coverage'
+        uses: codecov/codecov-action@v5
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          files: ./coverage.lcov
+          fail_ci_if_error: true
+          verbose: true
+
   build-linux:
     needs: pre-commit
     # Pinned to the oldest supported runner so the AppImage links against an

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -61,7 +61,10 @@ jobs:
     #   asan-ubsan -> AddressSanitizer + UBSan
     #   tsan       -> ThreadSanitizer (excludes apptest; Qt internals trip it)
     #   coverage   -> source-based coverage + Codecov upload; also runs
-    #                 cpp-linter-action before the build so style hits fail fast.
+    #                 cpp-linter-action *after* the build (Qt AUTOMOC/AUTOUIC
+    #                 outputs must exist before clang-tidy can parse the TUs)
+    #                 but before tests/coverage so a tidy hit still skips the
+    #                 long-running Codecov path.
     # Coverage requires a CODECOV_TOKEN repo secret; without it the upload
     # fails the leg by design (fail_ci_if_error=true).
     needs: pre-commit
@@ -119,8 +122,16 @@ jobs:
         # sanitizers / coverage / tidy.
         run: cmake --preset clang-${{ matrix.mode }} -DLOGLIB_NETWORK_TLS=ON
 
+      - name: Build
+        run: cmake --build --preset clang-${{ matrix.mode }}
+
       - name: Run clang-tidy on PR changes
-        # Coverage leg only, *before* the build so style hits fail fast.
+        # Coverage leg only, *after* the build so Qt's AUTOMOC/AUTOUIC/AUTORCC
+        # outputs (moc_*.cpp, *.moc, ui_*.h, qrc_*.cpp) are on disk; without
+        # them clang-tidy fails the entire TU with "<file>.moc: file not
+        # found" before any real check can run. We still gate the test run +
+        # Codecov upload on the result, so a tidy hit short-circuits the leg.
+        #
         # cpp-linter-action drives clang-tidy-22 against the PR diff using
         # this build's compile_commands.json (CMAKE_EXPORT_COMPILE_COMMANDS=ON
         # in the preset). Findings are surfaced as inline PR review comments
@@ -155,15 +166,12 @@ jobs:
 
       - name: Fail leg if clang-tidy reported issues
         # cpp-linter-action itself never fails the workflow; gate on its
-        # output so a tidy hit aborts before the expensive build/test/codecov
-        # work and CI status reflects the lint result.
+        # output so a tidy hit aborts before the expensive test/codecov work
+        # and CI status reflects the lint result.
         if: matrix.mode == 'coverage' && steps.cpp-linter.outputs.checks-failed > 0
         run: |
           echo "::error title=clang-tidy::clang-tidy reported issues on changed lines. See the PR review comments and the job's step summary for details."
           exit 1
-
-      - name: Build
-        run: cmake --build --preset clang-${{ matrix.mode }}
 
       - name: Run tests
         # ASAN/UBSAN/TSAN/LSAN_OPTIONS + LLVM_PROFILE_FILE come from the

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -74,7 +74,7 @@
         {
             "name": "clang-coverage",
             "displayName": "Clang source-based coverage",
-            "description": "Clang 22 RelWithDebInfo + -fprofile-instr-generate -fcoverage-mapping. The CI coverage job also runs `clang-tidy-diff-22.py` against this build's `compile_commands.json` (no separate tidy preset needed). Local repro: `cmake --workflow --preset clang-coverage` then `llvm-profdata-22 merge build/clang-coverage/profiles/*.profraw -o merged.profdata` + `llvm-cov-22 export -format=lcov ...`.",
+            "description": "Clang 22 RelWithDebInfo + -fprofile-instr-generate -fcoverage-mapping. The CI coverage job also runs `cpp-linter-action` against this build's `compile_commands.json` (no separate tidy preset needed). Local repro: `cmake --workflow --preset clang-coverage` then `llvm-profdata-22 merge build/clang-coverage/profiles/*.profraw -o merged.profdata` + `llvm-cov-22 export -format=lcov ...`.",
             "inherits": "_clang_ci_base",
             "cacheVariables": {
                 "CMAKE_CXX_FLAGS": "-fprofile-instr-generate -fcoverage-mapping",

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -32,13 +32,67 @@
             "description": "Release optimizations + debug info, suitable for profiling.",
             "inherits": "_base",
             "cacheVariables": { "CMAKE_BUILD_TYPE": "RelWithDebInfo" }
+        },
+        {
+            "name": "_clang_ci_base",
+            "hidden": true,
+            "inherits": "_base",
+            "description": "Shared base for the Clang sanitizer / coverage CI presets. Pins clang-22, RelWithDebInfo, and disables IPO/LTO (LTO breaks sanitizer stack traces and skews coverage line mapping).",
+            "cacheVariables": {
+                "CMAKE_BUILD_TYPE": "RelWithDebInfo",
+                "CMAKE_C_COMPILER": "clang-22",
+                "CMAKE_CXX_COMPILER": "clang++-22",
+                "CMAKE_INTERPROCEDURAL_OPTIMIZATION_RELWITHDEBINFO": "OFF"
+            }
+        },
+        {
+            "name": "clang-asan-ubsan",
+            "displayName": "Clang AddressSanitizer + UndefinedBehaviorSanitizer",
+            "description": "Clang 22 RelWithDebInfo + ASan + UBSan. -fno-sanitize-recover=all makes the first hit fail the test binary so CTest turns it into a job failure. Mutually exclusive with TSan (cannot link both into one binary).",
+            "inherits": "_clang_ci_base",
+            "cacheVariables": {
+                "CMAKE_CXX_FLAGS": "-fsanitize=address,undefined -fno-omit-frame-pointer -fno-sanitize-recover=all",
+                "CMAKE_C_FLAGS": "-fsanitize=address,undefined -fno-omit-frame-pointer -fno-sanitize-recover=all",
+                "CMAKE_EXE_LINKER_FLAGS": "-fsanitize=address,undefined",
+                "CMAKE_SHARED_LINKER_FLAGS": "-fsanitize=address,undefined",
+                "CMAKE_MODULE_LINKER_FLAGS": "-fsanitize=address,undefined"
+            }
+        },
+        {
+            "name": "clang-tsan",
+            "displayName": "Clang ThreadSanitizer",
+            "description": "Clang 22 RelWithDebInfo + TSan for the loglib threading code (TBB pipeline, StreamLineSource, TailingBytesProducer, LogModel teardown). The matching test preset excludes the Qt-coupled `apptest` because Qt's private mutexes generate false positives; `apptest_queue` (pure C++ BoundedBatchQueue) still runs.",
+            "inherits": "_clang_ci_base",
+            "cacheVariables": {
+                "CMAKE_CXX_FLAGS": "-fsanitize=thread -fno-omit-frame-pointer",
+                "CMAKE_C_FLAGS": "-fsanitize=thread -fno-omit-frame-pointer",
+                "CMAKE_EXE_LINKER_FLAGS": "-fsanitize=thread",
+                "CMAKE_SHARED_LINKER_FLAGS": "-fsanitize=thread",
+                "CMAKE_MODULE_LINKER_FLAGS": "-fsanitize=thread"
+            }
+        },
+        {
+            "name": "clang-coverage",
+            "displayName": "Clang source-based coverage",
+            "description": "Clang 22 RelWithDebInfo + -fprofile-instr-generate -fcoverage-mapping. The CI coverage job also runs `clang-tidy-diff-22.py` against this build's `compile_commands.json` (no separate tidy preset needed). Local repro: `cmake --workflow --preset clang-coverage` then `llvm-profdata-22 merge build/clang-coverage/profiles/*.profraw -o merged.profdata` + `llvm-cov-22 export -format=lcov ...`.",
+            "inherits": "_clang_ci_base",
+            "cacheVariables": {
+                "CMAKE_CXX_FLAGS": "-fprofile-instr-generate -fcoverage-mapping",
+                "CMAKE_C_FLAGS": "-fprofile-instr-generate -fcoverage-mapping",
+                "CMAKE_EXE_LINKER_FLAGS": "-fprofile-instr-generate -fcoverage-mapping",
+                "CMAKE_SHARED_LINKER_FLAGS": "-fprofile-instr-generate -fcoverage-mapping",
+                "CMAKE_MODULE_LINKER_FLAGS": "-fprofile-instr-generate -fcoverage-mapping"
+            }
         }
     ],
 
     "buildPresets": [
-        { "name": "release",        "configurePreset": "release" },
-        { "name": "debug",          "configurePreset": "debug" },
-        { "name": "relwithdebinfo", "configurePreset": "relwithdebinfo" }
+        { "name": "release",          "configurePreset": "release" },
+        { "name": "debug",            "configurePreset": "debug" },
+        { "name": "relwithdebinfo",   "configurePreset": "relwithdebinfo" },
+        { "name": "clang-asan-ubsan", "configurePreset": "clang-asan-ubsan" },
+        { "name": "clang-tsan",       "configurePreset": "clang-tsan" },
+        { "name": "clang-coverage",   "configurePreset": "clang-coverage" }
     ],
 
     "testPresets": [
@@ -82,6 +136,46 @@
             "description": "Same as `release-benchmark` but against the `relwithdebinfo` build (release optimisations + debug info, useful when attaching a profiler to the benchmark fixtures).",
             "configurePreset": "relwithdebinfo",
             "inherits": "release-benchmark"
+        },
+        {
+            "name": "clang-asan-ubsan",
+            "displayName": "ASan + UBSan tests (excludes benchmarks)",
+            "description": "Runs unit + Qt smoke tests under AddressSanitizer + UndefinedBehaviorSanitizer. ASAN_OPTIONS / UBSAN_OPTIONS halt on first hit so CTest reports the failure; LSAN_OPTIONS points at the project's suppression file for known Qt / fontconfig / oneTBB one-shot allocations.",
+            "configurePreset": "clang-asan-ubsan",
+            "inherits": "_test_base",
+            "filter": { "exclude": { "label": "benchmark" } },
+            "environment": {
+                "ASAN_OPTIONS": "detect_leaks=1:halt_on_error=1:abort_on_error=1:strict_string_checks=1:detect_stack_use_after_return=1",
+                "UBSAN_OPTIONS": "halt_on_error=1:print_stacktrace=1:abort_on_error=1",
+                "LSAN_OPTIONS": "suppressions=${sourceDir}/.ci/lsan.supp:print_suppressions=0"
+            }
+        },
+        {
+            "name": "clang-tsan",
+            "displayName": "TSan tests (excludes benchmarks and apptest)",
+            "description": "Runs the loglib unit tests + apptest_queue under ThreadSanitizer. Excludes apptest by name regex because Qt's internal mutexes generate false positives that drown the signal; the threading code worth testing (TBB pipeline, StreamLineSource, TailingBytesProducer, LogModel::Reset teardown, BoundedBatchQueue) lives in the tests that still run.",
+            "configurePreset": "clang-tsan",
+            "inherits": "_test_base",
+            "filter": {
+                "exclude": {
+                    "label": "benchmark",
+                    "name": "^apptest$"
+                }
+            },
+            "environment": {
+                "TSAN_OPTIONS": "halt_on_error=1:second_deadlock_stack=1:history_size=7:suppressions=${sourceDir}/.ci/tsan.supp"
+            }
+        },
+        {
+            "name": "clang-coverage",
+            "displayName": "Coverage tests (excludes benchmarks)",
+            "description": "Runs unit + Qt smoke tests under -fprofile-instr-generate. Each test binary writes its own .profraw under build/clang-coverage/profiles/; merge with `llvm-profdata-22 merge -sparse` and export with `llvm-cov-22 export -format=lcov` for upload.",
+            "configurePreset": "clang-coverage",
+            "inherits": "_test_base",
+            "filter": { "exclude": { "label": "benchmark" } },
+            "environment": {
+                "LLVM_PROFILE_FILE": "${sourceDir}/build/clang-coverage/profiles/%p-%m.profraw"
+            }
         }
     ],
 
@@ -102,6 +196,33 @@
                 { "type": "configure", "name": "debug" },
                 { "type": "build",     "name": "debug" },
                 { "type": "test",      "name": "debug" }
+            ]
+        },
+        {
+            "name": "clang-asan-ubsan",
+            "displayName": "Clang ASan+UBSan: configure + build + test",
+            "steps": [
+                { "type": "configure", "name": "clang-asan-ubsan" },
+                { "type": "build",     "name": "clang-asan-ubsan" },
+                { "type": "test",      "name": "clang-asan-ubsan" }
+            ]
+        },
+        {
+            "name": "clang-tsan",
+            "displayName": "Clang TSan: configure + build + test",
+            "steps": [
+                { "type": "configure", "name": "clang-tsan" },
+                { "type": "build",     "name": "clang-tsan" },
+                { "type": "test",      "name": "clang-tsan" }
+            ]
+        },
+        {
+            "name": "clang-coverage",
+            "displayName": "Clang coverage: configure + build + test",
+            "steps": [
+                { "type": "configure", "name": "clang-coverage" },
+                { "type": "build",     "name": "clang-coverage" },
+                { "type": "test",      "name": "clang-coverage" }
             ]
         }
     ]

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -334,11 +334,14 @@ When adding a new third-party dependency to `cmake/FetchDependencies.cmake`, app
 
 All build configurations are defined in [`CMakePresets.json`](CMakePresets.json) (CMake 3.28+). The shared presets are:
 
-| Preset           | Build type       | Purpose                                    |
-| ---------------- | ---------------- | ------------------------------------------ |
-| `release`        | `Release`        | Optimized build, used by CI and releases.  |
-| `debug`          | `Debug`          | Full debug info and assertions.            |
-| `relwithdebinfo` | `RelWithDebInfo` | Release optimizations + debug info (perf). |
+| Preset             | Build type       | Purpose                                                                                                                                     |
+| ------------------ | ---------------- | ------------------------------------------------------------------------------------------------------------------------------------------- |
+| `release`          | `Release`        | Optimized build, used by CI and releases.                                                                                                   |
+| `debug`            | `Debug`          | Full debug info and assertions.                                                                                                             |
+| `relwithdebinfo`   | `RelWithDebInfo` | Release optimizations + debug info (perf).                                                                                                  |
+| `clang-asan-ubsan` | `RelWithDebInfo` | Clang 22 + AddressSanitizer + UndefinedBehaviorSanitizer. CI gating; see [Sanitizers and coverage](#sanitizers-and-coverage).               |
+| `clang-tsan`       | `RelWithDebInfo` | Clang 22 + ThreadSanitizer (excludes `apptest` for Qt-internal false positives). CI gating; same section.                                   |
+| `clang-coverage`   | `RelWithDebInfo` | Clang 22 + source-based coverage. CI leg also runs `clang-tidy-diff` against this build's `compile_commands.json`; no separate tidy preset. |
 
 Each preset uses the **Ninja** generator and writes to `build/<presetName>/`. They also enable `CMAKE_EXPORT_COMPILE_COMMANDS` so `clangd`, `clang-tidy`, and other tools work out of the box. Matching `buildPresets`, `testPresets`, and `workflowPresets` are defined with the same names. Two extra benchmark-only test presets — `release-benchmark` and `relwithdebinfo-benchmark` — opt into the long-running parser benchmarks (see [Benchmarking](#benchmarking)).
 
@@ -410,6 +413,49 @@ cmake --preset release -DUSE_SYSTEM_FMT=ON -DUSE_SYSTEM_SIMDJSON=ON
 ```
 
 The full list of `USE_SYSTEM_*` options is in [`cmake/FetchDependencies.cmake`](cmake/FetchDependencies.cmake).
+
+### Sanitizers and coverage
+
+The `clang-asan-ubsan`, `clang-tsan`, and `clang-coverage` presets pin Clang 22 (`clang-22` / `clang++-22`), build `RelWithDebInfo` with IPO/LTO disabled (LTO breaks sanitizer stack traces and skews coverage line mapping), and feed the matching CI matrix legs in [`build.yml`](.github/workflows/build.yml). All three are required to pass on every PR.
+
+Local repro is one command per preset — same shape as `release`:
+
+```sh
+cmake --workflow --preset clang-asan-ubsan   # configure + build + test under ASan + UBSan
+cmake --workflow --preset clang-tsan         # ditto under TSan (excludes apptest by name regex)
+cmake --workflow --preset clang-coverage     # coverage-instrumented build + test
+```
+
+The runtime knobs CI uses come from the test presets' `environment` blocks, so a `ctest --preset clang-<mode>` invocation matches the CI behaviour exactly. The most relevant ones:
+
+- **ASan / UBSan / LSan:**
+  - `ASAN_OPTIONS=detect_leaks=1:halt_on_error=1:abort_on_error=1:strict_string_checks=1:detect_stack_use_after_return=1` — the first hit aborts so CTest reports the failure.
+  - `UBSAN_OPTIONS=halt_on_error=1:print_stacktrace=1:abort_on_error=1`.
+  - `LSAN_OPTIONS=suppressions=${sourceDir}/.ci/lsan.supp:print_suppressions=0` — Qt / fontconfig / oneTBB process-global one-shot allocations are suppressed via [`.ci/lsan.supp`](.ci/lsan.supp). Add an entry there only when the leak is in a system library you don't control; each entry should carry a one-line comment explaining where it came from.
+- **TSan:** `TSAN_OPTIONS=halt_on_error=1:second_deadlock_stack=1:history_size=7:suppressions=${sourceDir}/.ci/tsan.supp`. The matching `clang-tsan` test preset excludes `apptest` (the Qt smoke test) because Qt's private mutexes generate false positives that drown the signal; `apptest_queue` (pure C++ `BoundedBatchQueue` tests) and the `loglib` unit tests cover the threading worth checking — TBB pipeline, `StreamLineSource`, `TailingBytesProducer`, and the `LogModel::Reset()` teardown sequence (`BytesProducer::Stop()` → sink `RequestStop()` → worker join). [`.ci/tsan.supp`](.ci/tsan.supp) starts empty; add entries with a rationale comment as upstream-library false positives surface.
+- **Coverage:** `LLVM_PROFILE_FILE=${sourceDir}/build/clang-coverage/profiles/%p-%m.profraw` — one `.profraw` per (PID, binary) so the eventual `llvm-profdata-22 merge` is unambiguous. After running the tests:
+
+```sh
+llvm-profdata-22 merge -sparse build/clang-coverage/profiles/*.profraw \
+    -o build/clang-coverage/merged.profdata
+llvm-cov-22 report \
+    -instr-profile=build/clang-coverage/merged.profdata \
+    -ignore-filename-regex='(_deps|build|test)/' \
+    build/clang-coverage/bin/RelWithDebInfo/tests \
+    -object build/clang-coverage/bin/RelWithDebInfo/apptest \
+    -object build/clang-coverage/bin/RelWithDebInfo/apptest_queue
+```
+
+The CI coverage leg also runs `clang-tidy-diff-22.py` against this build's `compile_commands.json` *before* the build step, so a tidy hit fails fast without paying for the instrumented build + test run + Codecov upload. To run the same diff-only tidy check locally before pushing:
+
+```sh
+cmake --preset clang-coverage
+git diff -U0 origin/main...HEAD -- '*.cpp' '*.hpp' '*.h' '*.cc' \
+    | clang-tidy-diff-22.py -p1 -path build/clang-coverage \
+        -clang-tidy-binary clang-tidy-22 -j"$(nproc)" -fix=false -quiet
+```
+
+Coverage uploads land on [Codecov](https://codecov.io); the CI leg fails the PR if the upload fails, so the `CODECOV_TOKEN` repo secret must be set (Settings → Secrets and variables → Actions). The Codecov badge in the README links to the latest result.
 
 ### IDE integration
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -334,14 +334,14 @@ When adding a new third-party dependency to `cmake/FetchDependencies.cmake`, app
 
 All build configurations are defined in [`CMakePresets.json`](CMakePresets.json) (CMake 3.28+). The shared presets are:
 
-| Preset             | Build type       | Purpose                                                                                                                                     |
-| ------------------ | ---------------- | ------------------------------------------------------------------------------------------------------------------------------------------- |
-| `release`          | `Release`        | Optimized build, used by CI and releases.                                                                                                   |
-| `debug`            | `Debug`          | Full debug info and assertions.                                                                                                             |
-| `relwithdebinfo`   | `RelWithDebInfo` | Release optimizations + debug info (perf).                                                                                                  |
-| `clang-asan-ubsan` | `RelWithDebInfo` | Clang 22 + AddressSanitizer + UndefinedBehaviorSanitizer. CI gating; see [Sanitizers and coverage](#sanitizers-and-coverage).               |
-| `clang-tsan`       | `RelWithDebInfo` | Clang 22 + ThreadSanitizer (excludes `apptest` for Qt-internal false positives). CI gating; same section.                                   |
-| `clang-coverage`   | `RelWithDebInfo` | Clang 22 + source-based coverage. CI leg also runs `clang-tidy-diff` against this build's `compile_commands.json`; no separate tidy preset. |
+| Preset             | Build type       | Purpose                                                                                                                                       |
+| ------------------ | ---------------- | --------------------------------------------------------------------------------------------------------------------------------------------- |
+| `release`          | `Release`        | Optimized build, used by CI and releases.                                                                                                     |
+| `debug`            | `Debug`          | Full debug info and assertions.                                                                                                               |
+| `relwithdebinfo`   | `RelWithDebInfo` | Release optimizations + debug info (perf).                                                                                                    |
+| `clang-asan-ubsan` | `RelWithDebInfo` | Clang 22 + AddressSanitizer + UndefinedBehaviorSanitizer. CI gating; see [Sanitizers and coverage](#sanitizers-and-coverage).                 |
+| `clang-tsan`       | `RelWithDebInfo` | Clang 22 + ThreadSanitizer (excludes `apptest` for Qt-internal false positives). CI gating; same section.                                     |
+| `clang-coverage`   | `RelWithDebInfo` | Clang 22 + source-based coverage. CI leg also runs `cpp-linter-action` against this build's `compile_commands.json`; no separate tidy preset. |
 
 Each preset uses the **Ninja** generator and writes to `build/<presetName>/`. They also enable `CMAKE_EXPORT_COMPILE_COMMANDS` so `clangd`, `clang-tidy`, and other tools work out of the box. Matching `buildPresets`, `testPresets`, and `workflowPresets` are defined with the same names. Two extra benchmark-only test presets — `release-benchmark` and `relwithdebinfo-benchmark` — opt into the long-running parser benchmarks (see [Benchmarking](#benchmarking)).
 
@@ -446,7 +446,7 @@ llvm-cov-22 report \
     -object build/clang-coverage/bin/RelWithDebInfo/apptest_queue
 ```
 
-The CI coverage leg also runs `clang-tidy-diff-22.py` against this build's `compile_commands.json` *before* the build step, so a tidy hit fails fast without paying for the instrumented build + test run + Codecov upload. To run the same diff-only tidy check locally before pushing:
+The CI coverage leg also runs [`cpp-linter-action`](https://github.com/cpp-linter/cpp-linter-action) against this build's `compile_commands.json` *before* the build step, so a tidy hit fails fast without paying for the instrumented build + test run + Codecov upload. The action posts inline review comments and a rolling thread comment on the PR — no YAML artifact to download and replay locally. To reproduce the same diff-only tidy check at the command line before pushing:
 
 ```sh
 cmake --preset clang-coverage

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -446,10 +446,13 @@ llvm-cov-22 report \
     -object build/clang-coverage/bin/RelWithDebInfo/apptest_queue
 ```
 
-The CI coverage leg also runs [`cpp-linter-action`](https://github.com/cpp-linter/cpp-linter-action) against this build's `compile_commands.json` *before* the build step, so a tidy hit fails fast without paying for the instrumented build + test run + Codecov upload. The action posts inline review comments and a rolling thread comment on the PR — no YAML artifact to download and replay locally. To reproduce the same diff-only tidy check at the command line before pushing:
+The CI coverage leg also runs [`cpp-linter-action`](https://github.com/cpp-linter/cpp-linter-action) against this build's `compile_commands.json` *after* the build step (Qt's AUTOMOC/AUTOUIC/AUTORCC outputs must exist for clang-tidy to parse the touched translation units) but *before* the test run + Codecov upload, so a tidy hit short-circuits the long tail of the leg. The action posts inline review comments and a rolling thread comment on the PR — no YAML artifact to download and replay locally. To reproduce the same diff-only tidy check at the command line before pushing:
 
 ```sh
+# Configure + build so Qt's AUTOMOC/AUTOUIC/AUTORCC outputs exist; without
+# them clang-tidy fails the affected TUs with "*.moc / ui_*.h: file not found".
 cmake --preset clang-coverage
+cmake --build --preset clang-coverage
 git diff -U0 origin/main...HEAD -- '*.cpp' '*.hpp' '*.h' '*.cc' \
     | clang-tidy-diff-22.py -p1 -path build/clang-coverage \
         -clang-tidy-binary clang-tidy-22 -j"$(nproc)" -fix=false -quiet

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # Structured Log Viewer
 
 [![Build](https://github.com/jan-moravec/structured_log_viewer/workflows/Build/badge.svg)](https://github.com/jan-moravec/structured_log_viewer/actions?query=workflow%3ABuild)
+[![Coverage](https://codecov.io/gh/jan-moravec/structured_log_viewer/branch/main/graph/badge.svg)](https://codecov.io/gh/jan-moravec/structured_log_viewer)
 [![GitHub Releases](https://img.shields.io/github/release/jan-moravec/structured_log_viewer.svg)](https://github.com/jan-moravec/structured_log_viewer/releases)
 
 ## Overview

--- a/app/.clang-tidy
+++ b/app/.clang-tidy
@@ -1,0 +1,29 @@
+# App-level overrides for the Qt GUI.
+#
+# Qt forces camelBack on a lot of public API that we cannot rename:
+#   - Overrides from QAbstractTableModel / QObject (`rowCount`,
+#     `columnCount`, `data`, `headerData`, `flags`, ...).
+#   - Signals and public slots declared under `signals:` / `public slots:`
+#     (`errorCountChanged`, `streamingFinished`, `rotationDetected`, ...).
+#
+# Relax the public-method naming rule to accept either CamelCase (our
+# own helpers) or camelBack (Qt-mandated names). Private/protected
+# methods still inherit the project-wide `MethodCase: CamelCase` so our
+# own helpers stay consistent.
+#
+# We also disable a few core-guidelines checks that fight Qt idioms:
+#   -cppcoreguidelines-owning-memory: Qt's parent-owned `new Widget(this)`
+#        pattern is the whole point of QObject. Every widget construction
+#        fires this check otherwise.
+#   -cppcoreguidelines-prefer-member-initializer: Forcing Qt widget
+#        construction into initializer lists reorders setup and fights
+#        Qt's `setCentralWidget` / `addWidget` flow.
+
+InheritParentConfig: true
+
+Checks: >
+  -cppcoreguidelines-owning-memory,
+  -cppcoreguidelines-prefer-member-initializer
+
+CheckOptions:
+  - { key: readability-identifier-naming.PublicMethodCase, value: aNy_CasE }

--- a/app/.clang-tidy
+++ b/app/.clang-tidy
@@ -18,12 +18,23 @@
 #   -cppcoreguidelines-prefer-member-initializer: Forcing Qt widget
 #        construction into initializer lists reorders setup and fights
 #        Qt's `setCentralWidget` / `addWidget` flow.
+#   -readability-redundant-access-specifiers
+#   (and its `cppcoreguidelines-redundant-access-specifiers` alias):
+#        Qt's moc uses the next access specifier as the slot-list
+#        boundary, so the `private:` after `private slots:` is required.
+#        Both names are listed because the root config enables both
+#        `readability-*` and `cppcoreguidelines-*`.
+#   -readability-convert-member-functions-to-static:
+#        Qt slots / signals / overrides must stay non-static for moc.
 
 InheritParentConfig: true
 
 Checks: >
   -cppcoreguidelines-owning-memory,
-  -cppcoreguidelines-prefer-member-initializer
+  -cppcoreguidelines-prefer-member-initializer,
+  -readability-redundant-access-specifiers,
+  -cppcoreguidelines-redundant-access-specifiers,
+  -readability-convert-member-functions-to-static
 
 CheckOptions:
   - { key: readability-identifier-naming.PublicMethodCase, value: aNy_CasE }

--- a/app/CMakeLists.txt
+++ b/app/CMakeLists.txt
@@ -104,17 +104,38 @@ if(WIN32)
     install(FILES $<TARGET_FILE:TBB::tbb> DESTINATION ${CMAKE_INSTALL_BINDIR})
 endif()
 
-# Windows + LOGLIB_NETWORK_TLS=ON requires the OpenSSL runtime DLLs
-# (libssl-3-x64.dll, libcrypto-3-x64.dll on a 64-bit OpenSSL 3 install)
-# to sit next to StructuredLogViewer.exe. `find_package(OpenSSL)` only
-# locates the import libraries; the runtime DLLs live under the
-# `bin/` subdir of the OpenSSL install root. We derive that root from
-# `OPENSSL_INCLUDE_DIR` (which CMake fills out reliably) and probe a
-# couple of common file-name variants. CI-side: the GitHub Actions
-# Windows job points OPENSSL_ROOT_DIR at the chocolatey-installed
-# OpenSSL so this discovery succeeds; on a developer machine without
-# OpenSSL we silently fall through (LOGLIB_NETWORK_TLS=OFF on dev
-# builds is the documented default).
+# Ship the MSVC runtime DLLs (msvcp140*, vcruntime140*, concrt140*)
+# app-locally so the zip is portable without the user installing the
+# VC++ redist. `_LIBS_SKIP=TRUE` suppresses the module's own install
+# rule — we stage via POST_BUILD and install ourselves so the layout
+# matches the other runtime DLLs (TBB, OpenSSL).
+if(WIN32 AND MSVC)
+    set(CMAKE_INSTALL_SYSTEM_RUNTIME_LIBS_SKIP TRUE)
+    set(CMAKE_INSTALL_DEBUG_LIBRARIES FALSE)
+    include(InstallRequiredSystemLibraries)
+    if(CMAKE_INSTALL_SYSTEM_RUNTIME_LIBS)
+        message(STATUS "MSVC runtime DLLs (staged next to ${PROJECT_NAME}): ${CMAKE_INSTALL_SYSTEM_RUNTIME_LIBS}")
+        add_custom_command(
+            TARGET StructuredLogViewer
+            POST_BUILD
+            COMMAND
+                ${CMAKE_COMMAND} -E copy_if_different ${CMAKE_INSTALL_SYSTEM_RUNTIME_LIBS}
+                $<TARGET_FILE_DIR:StructuredLogViewer>
+            COMMENT "Copying MSVC runtime DLLs next to StructuredLogViewer.exe"
+            VERBATIM
+        )
+        install(PROGRAMS ${CMAKE_INSTALL_SYSTEM_RUNTIME_LIBS} DESTINATION ${CMAKE_INSTALL_BINDIR})
+    else()
+        message(
+            WARNING
+            "InstallRequiredSystemLibraries resolved no MSVC runtime DLLs; binary will require system VC++ redist."
+        )
+    endif()
+endif()
+
+# With LOGLIB_NETWORK_TLS=ON, ship libssl/libcrypto next to the exe.
+# find_package(OpenSSL) only locates the import libraries; the
+# runtime DLLs live in `<root>/bin`, derived from OPENSSL_INCLUDE_DIR.
 if(WIN32 AND LOGLIB_NETWORK_TLS)
     get_filename_component(OPENSSL_BIN_HINT "${OPENSSL_INCLUDE_DIR}/../bin" ABSOLUTE)
     find_file(
@@ -130,10 +151,7 @@ if(WIN32 AND LOGLIB_NETWORK_TLS)
         NO_DEFAULT_PATH
     )
     if(OPENSSL_DLL_LIBSSL AND OPENSSL_DLL_LIBCRYPTO)
-        message(
-            STATUS
-            "OpenSSL runtime DLLs: ${OPENSSL_DLL_LIBSSL}, ${OPENSSL_DLL_LIBCRYPTO} (will be staged next to ${PROJECT_NAME})"
-        )
+        message(STATUS "OpenSSL runtime DLLs: ${OPENSSL_DLL_LIBSSL}, ${OPENSSL_DLL_LIBCRYPTO}")
         add_custom_command(
             TARGET StructuredLogViewer
             POST_BUILD
@@ -147,19 +165,15 @@ if(WIN32 AND LOGLIB_NETWORK_TLS)
     else()
         message(
             WARNING
-            "LOGLIB_NETWORK_TLS=ON but OpenSSL runtime DLLs were not found under ${OPENSSL_BIN_HINT}; the binary "
-            "will fail at startup with STATUS_DLL_NOT_FOUND. Set OPENSSL_ROOT_DIR or rebuild with "
-            "-DLOGLIB_NETWORK_TLS=OFF for a plaintext-only build."
+            "LOGLIB_NETWORK_TLS=ON but OpenSSL runtime DLLs not found under ${OPENSSL_BIN_HINT}; "
+            "binary will fail at startup with STATUS_DLL_NOT_FOUND. Set OPENSSL_ROOT_DIR or rebuild "
+            "with -DLOGLIB_NETWORK_TLS=OFF."
         )
     endif()
 endif()
 
-# Bundle every third-party license text plus the project's own
-# LICENSE next to the StructuredLogViewer executable. Closes a
-# pre-existing compliance gap where the packaged artifacts shipped
-# without any third-party attribution. `BundleLicenses.cmake` writes
-# the aggregated `THIRD_PARTY_LICENSES.txt` at configure time and
-# stages it (plus `LICENSE`) via POST_BUILD copy + install rules.
+# Aggregate third-party license texts + project LICENSE next to the
+# binary. See cmake/BundleLicenses.cmake for the dep list.
 bundle_third_party_licenses(StructuredLogViewer)
 
 qt_finalize_executable(StructuredLogViewer)

--- a/app/include/log_filter_model.hpp
+++ b/app/include/log_filter_model.hpp
@@ -55,5 +55,5 @@ private:
     std::vector<std::unique_ptr<FilterRule>> mFilterRules;
 
 private:
-    bool Matches(const QVariant &data, const QVariant &value, Qt::MatchFlags flags) const;
+    static bool Matches(const QVariant &data, const QVariant &value, Qt::MatchFlags flags);
 };

--- a/app/include/main_window.hpp
+++ b/app/include/main_window.hpp
@@ -100,7 +100,7 @@ private slots:
     void FindRecords(const QString &text, bool next, bool wildcards, bool regularExpressions);
 
     void AddFilter(
-        const QString filterId, const std::optional<loglib::LogConfiguration::LogFilter> &filter = std::nullopt
+        const QString &filterId, const std::optional<loglib::LogConfiguration::LogFilter> &filter = std::nullopt
     );
     void ClearAllFilters();
     void ClearFilter(const QString &filterID);

--- a/app/include/qt_streaming_log_sink.hpp
+++ b/app/include/qt_streaming_log_sink.hpp
@@ -136,7 +136,7 @@ private:
     /// Concatenates the batches into one. The first batch's
     /// `firstLineNumber` is preserved; all other vectors are appended.
     /// Used by `Resume()`, `TakePausedBuffer()`, and `DrainGeneration`.
-    static loglib::StreamedBatch CoalesceLocked(std::vector<loglib::StreamedBatch> &&batches);
+    static loglib::StreamedBatch CoalesceLocked(std::vector<loglib::StreamedBatch> batches);
 
     /// Total row count across `mPausedBatches`. Caller must hold
     /// `mPausedMutex`.

--- a/app/src/appearance_control.cpp
+++ b/app/src/appearance_control.cpp
@@ -17,8 +17,8 @@ AppearanceControl::Configuration AppearanceControl::mConfiguration;
 
 bool AppearanceControl::IsDarkTheme()
 {
-    QColor bgColor = qApp->palette().color(QPalette::Window);
-    int brightness = (bgColor.red() * 299 + bgColor.green() * 587 + bgColor.blue() * 114) / 1000;
+    const QColor bgColor = qApp->palette().color(QPalette::Window);
+    const int brightness = ((bgColor.red() * 299) + (bgColor.green() * 587) + (bgColor.blue() * 114)) / 1000;
     return brightness < 128;
 }
 

--- a/app/src/appearance_control.cpp
+++ b/app/src/appearance_control.cpp
@@ -2,6 +2,7 @@
 
 #include <QApplication>
 #include <QFont>
+#include <QLatin1String>
 #include <QPalette>
 #include <QSettings>
 #include <QStyle>
@@ -9,10 +10,10 @@
 
 namespace
 {
-const QString CONFIGURATION_STYLE = QStringLiteral("appearance/style");
-const QString CONFIGURATION_FONT = QStringLiteral("appearance/font");
+constexpr char CONFIGURATION_STYLE[] = "appearance/style";
+constexpr char CONFIGURATION_FONT[] = "appearance/font";
 
-constexpr int kMidGrayBrightness = 128;
+constexpr int K_MID_GRAY_BRIGHTNESS = 128;
 } // namespace
 
 AppearanceControl::Configuration AppearanceControl::mConfiguration;
@@ -21,7 +22,7 @@ bool AppearanceControl::IsDarkTheme()
 {
     const QColor bgColor = qApp->palette().color(QPalette::Window);
     const int brightness = ((bgColor.red() * 299) + (bgColor.green() * 587) + (bgColor.blue() * 114)) / 1000;
-    return brightness < kMidGrayBrightness;
+    return brightness < K_MID_GRAY_BRIGHTNESS;
 }
 
 void AppearanceControl::SaveConfiguration()
@@ -30,16 +31,15 @@ void AppearanceControl::SaveConfiguration()
     mConfiguration.font = qApp->font().toString();
 
     QSettings settings;
-    settings.setValue(CONFIGURATION_STYLE, mConfiguration.style);
-    settings.setValue(CONFIGURATION_FONT, mConfiguration.font);
+    settings.setValue(QLatin1String(CONFIGURATION_STYLE), mConfiguration.style);
+    settings.setValue(QLatin1String(CONFIGURATION_FONT), mConfiguration.font);
 }
 
 void AppearanceControl::LoadConfiguration()
 {
     if (mConfiguration.style.isEmpty())
     {
-        static const QString DEFAULT_STYLE = "fusion";
-        mConfiguration.style = DEFAULT_STYLE;
+        mConfiguration.style = QStringLiteral("fusion");
     }
     if (mConfiguration.font.isEmpty())
     {
@@ -47,11 +47,11 @@ void AppearanceControl::LoadConfiguration()
     }
 
     QSettings settings;
-    if (const QVariant value = settings.value(CONFIGURATION_STYLE); value.isValid())
+    if (const QVariant value = settings.value(QLatin1String(CONFIGURATION_STYLE)); value.isValid())
     {
         mConfiguration.style = value.toString();
     }
-    if (const QVariant value = settings.value(CONFIGURATION_FONT); value.isValid())
+    if (const QVariant value = settings.value(QLatin1String(CONFIGURATION_FONT)); value.isValid())
     {
         mConfiguration.font = value.toString();
     }
@@ -65,7 +65,7 @@ void AppearanceControl::LoadConfiguration()
         }
         else
         {
-            settings.remove(CONFIGURATION_STYLE);
+            settings.remove(QLatin1String(CONFIGURATION_STYLE));
             mConfiguration.style.clear();
         }
     }
@@ -78,7 +78,7 @@ void AppearanceControl::LoadConfiguration()
         }
         else
         {
-            settings.remove(CONFIGURATION_FONT);
+            settings.remove(QLatin1String(CONFIGURATION_FONT));
             mConfiguration.font.clear();
         }
     }

--- a/app/src/appearance_control.cpp
+++ b/app/src/appearance_control.cpp
@@ -9,8 +9,10 @@
 
 namespace
 {
-const QString CONFIGURATION_STYLE = "appearance/style";
-const QString CONFIGURATION_FONT = "appearance/font";
+const QString CONFIGURATION_STYLE = QStringLiteral("appearance/style");
+const QString CONFIGURATION_FONT = QStringLiteral("appearance/font");
+
+constexpr int kMidGrayBrightness = 128;
 } // namespace
 
 AppearanceControl::Configuration AppearanceControl::mConfiguration;
@@ -19,7 +21,7 @@ bool AppearanceControl::IsDarkTheme()
 {
     const QColor bgColor = qApp->palette().color(QPalette::Window);
     const int brightness = ((bgColor.red() * 299) + (bgColor.green() * 587) + (bgColor.blue() * 114)) / 1000;
-    return brightness < 128;
+    return brightness < kMidGrayBrightness;
 }
 
 void AppearanceControl::SaveConfiguration()

--- a/app/src/filter_editor.cpp
+++ b/app/src/filter_editor.cpp
@@ -92,23 +92,23 @@ int FilterEditor::GetMatchType() const
 
 void FilterEditor::SetupLayout()
 {
-    QVBoxLayout *mainLayout = new QVBoxLayout(this);
+    auto *mainLayout = new QVBoxLayout(this);
 
-    QHBoxLayout *rowLayout = new QHBoxLayout();
+    auto *rowLayout = new QHBoxLayout();
     rowLayout->addWidget(new QLabel("Row to filter:", this));
     rowLayout->addWidget(mRowComboBox);
     mainLayout->addLayout(rowLayout);
 
-    QHBoxLayout *stringLayout = new QHBoxLayout();
+    auto *stringLayout = new QHBoxLayout();
     stringLayout->addWidget(new QLabel("String to filter:", this));
     stringLayout->addWidget(mStringLineEdit);
 
-    QHBoxLayout *matchLayout = new QHBoxLayout();
+    auto *matchLayout = new QHBoxLayout();
     matchLayout->addWidget(new QLabel("Match type:", this));
     matchLayout->addWidget(mMatchTypeComboBox);
 
-    QWidget *firstPage = new QWidget(this);
-    QVBoxLayout *firstLayout = new QVBoxLayout(firstPage);
+    auto *firstPage = new QWidget(this);
+    auto *firstLayout = new QVBoxLayout(firstPage);
     firstLayout->addLayout(stringLayout);
     firstLayout->addLayout(matchLayout);
     firstPage->setLayout(firstLayout);
@@ -116,14 +116,14 @@ void FilterEditor::SetupLayout()
     mBeginTimeEdit->setDisplayFormat("HH:mm:ss.zzz");
     mEndTimeEdit->setDisplayFormat("HH:mm:ss.zzz");
 
-    QWidget *secondPage = new QWidget(this);
-    QVBoxLayout *secondPageLayout = new QVBoxLayout(secondPage);
-    QHBoxLayout *beginLayout = new QHBoxLayout;
+    auto *secondPage = new QWidget(this);
+    auto *secondPageLayout = new QVBoxLayout(secondPage);
+    auto *beginLayout = new QHBoxLayout;
     beginLayout->addWidget(new QLabel("Begin Date and Time:", this));
     beginLayout->addWidget(mBeginDateEdit);
     beginLayout->addWidget(mBeginTimeEdit);
 
-    QHBoxLayout *endLayout = new QHBoxLayout;
+    auto *endLayout = new QHBoxLayout;
     endLayout->addWidget(new QLabel("End Date and Time:", this));
     endLayout->addWidget(mEndDateEdit);
     endLayout->addWidget(mEndTimeEdit);
@@ -135,7 +135,7 @@ void FilterEditor::SetupLayout()
     mStackedWidget->addWidget(secondPage);
     mainLayout->addWidget(mStackedWidget);
 
-    QHBoxLayout *buttonLayout = new QHBoxLayout();
+    auto *buttonLayout = new QHBoxLayout();
     buttonLayout->addWidget(mOkButton);
     buttonLayout->addWidget(mCancelButton);
     mainLayout->addStretch(1);

--- a/app/src/filter_editor.cpp
+++ b/app/src/filter_editor.cpp
@@ -165,8 +165,9 @@ QDateTime FilterEditor::ConvertToQDateTime(qint64 timestamp)
 
 qint64 FilterEditor::ConvertToTimeStamp(const QDate &date, const QTime &time)
 {
+    constexpr qint64 MICROSECONDS_PER_MILLISECOND = 1000;
     const QDateTime dateTime(date, time, QTimeZone::systemTimeZone());
-    return dateTime.toMSecsSinceEpoch() * 1000;
+    return dateTime.toMSecsSinceEpoch() * MICROSECONDS_PER_MILLISECOND;
 }
 
 void FilterEditor::OnOkClicked()

--- a/app/src/find_record_widget.cpp
+++ b/app/src/find_record_widget.cpp
@@ -9,7 +9,7 @@
 FindRecordWidget::FindRecordWidget(QWidget *parent)
     : QWidget{parent}
 {
-    QHBoxLayout *hLayout = new QHBoxLayout(this);
+    auto *hLayout = new QHBoxLayout(this);
 
     mEdit = new QLineEdit(this);
     hLayout->addWidget(mEdit);

--- a/app/src/log_filter_model.cpp
+++ b/app/src/log_filter_model.cpp
@@ -19,7 +19,7 @@ QList<QModelIndex> LogFilterModel::MatchRow(
     const int rowCount = this->rowCount(start.parent());
     const int columnCount = this->columnCount(start.parent());
 
-    bool wrap = flags.testFlag(Qt::MatchWrap);
+    const bool wrap = flags.testFlag(Qt::MatchWrap);
     const int startRow = start.row();
     const int startColumn = start.column();
 
@@ -27,13 +27,13 @@ QList<QModelIndex> LogFilterModel::MatchRow(
     {
         for (int row = skipFirstN; row < rowCount; ++row)
         {
-            int actualRow = (startRow + row) % rowCount;
+            const int actualRow = (startRow + row) % rowCount;
 
             for (int col = 0; col < columnCount; ++col)
             {
-                int actualColumn = (startColumn + col) % columnCount;
-                QModelIndex index = this->index(actualRow, actualColumn, start.parent());
-                QVariant data = this->data(index, role);
+                const int actualColumn = (startColumn + col) % columnCount;
+                const QModelIndex index = this->index(actualRow, actualColumn, start.parent());
+                const QVariant data = this->data(index, role);
 
                 if (Matches(data, value, flags))
                 {
@@ -64,9 +64,9 @@ QList<QModelIndex> LogFilterModel::MatchRow(
 
             for (int col = 0; col < columnCount; ++col)
             {
-                int actualColumn = (startColumn + col) % columnCount;
-                QModelIndex index = this->index(actualRow, actualColumn, start.parent());
-                QVariant data = this->data(index, role);
+                const int actualColumn = (startColumn + col) % columnCount;
+                const QModelIndex index = this->index(actualRow, actualColumn, start.parent());
+                const QVariant data = this->data(index, role);
 
                 if (Matches(data, value, flags))
                 {
@@ -89,7 +89,7 @@ QList<QModelIndex> LogFilterModel::MatchRow(
     return result;
 }
 
-bool LogFilterModel::Matches(const QVariant &data, const QVariant &value, Qt::MatchFlags flags) const
+bool LogFilterModel::Matches(const QVariant &data, const QVariant &value, Qt::MatchFlags flags)
 {
     if (flags.testFlag(Qt::MatchExactly))
     {
@@ -109,12 +109,12 @@ bool LogFilterModel::Matches(const QVariant &data, const QVariant &value, Qt::Ma
     }
     if (flags.testFlag(Qt::MatchRegularExpression))
     {
-        QRegularExpression regex(value.toString());
+        const QRegularExpression regex(value.toString());
         return regex.match(data.toString()).hasMatch();
     }
     if (flags.testFlag(Qt::MatchWildcard))
     {
-        QRegularExpression regex(QRegularExpression::wildcardToRegularExpression(value.toString()));
+        const QRegularExpression regex(QRegularExpression::wildcardToRegularExpression(value.toString()));
         return regex.match(data.toString()).hasMatch();
     }
     return false;

--- a/app/src/log_model.cpp
+++ b/app/src/log_model.cpp
@@ -22,6 +22,7 @@
 #include <QVariant>
 #include <QtConcurrent/QtConcurrent>
 
+#include <algorithm>
 #include <cstddef>
 #include <memory>
 #include <optional>
@@ -280,11 +281,11 @@ loglib::StopToken LogModel::BeginStreaming(
 
     QtStreamingLogSink *sinkForWorker = mSink;
     auto callable = std::move(parseCallable);
-    QFuture<void> future = QtConcurrent::run([sinkForWorker, stopToken, callable = std::move(callable)]() {
+    const QFuture<void> future = QtConcurrent::run([sinkForWorker, stopToken, callable = std::move(callable)]() {
         RunParserWorkerWithBoundary(sinkForWorker, [&] { callable(stopToken); });
     });
 
-    mStreamingWatcher->setFuture(std::move(future));
+    mStreamingWatcher->setFuture(future);
     return stopToken;
 }
 
@@ -314,11 +315,11 @@ loglib::StopToken LogModel::AppendStreaming(
 
     QtStreamingLogSink *sinkForWorker = mSink;
     auto callable = std::move(parseCallable);
-    QFuture<void> future = QtConcurrent::run([sinkForWorker, stopToken, callable = std::move(callable)]() {
+    const QFuture<void> future = QtConcurrent::run([sinkForWorker, stopToken, callable = std::move(callable)]() {
         RunParserWorkerWithBoundary(sinkForWorker, [&] { callable(stopToken); });
     });
 
-    mStreamingWatcher->setFuture(std::move(future));
+    mStreamingWatcher->setFuture(future);
     return stopToken;
 }
 
@@ -361,7 +362,7 @@ loglib::StopToken LogModel::BeginStreaming(
     // synchronously from this thread); re-emit via a queued connection
     // so the GUI receives them on the model's thread. `QPointer` makes
     // destruction mid-hop a graceful no-op.
-    QPointer<LogModel> self(this);
+    const QPointer<LogModel> self(this);
     if (loglib::BytesProducer *producer = streamSourcePtr->Producer(); producer != nullptr)
     {
         producer->SetRotationCallback([self]() {
@@ -398,22 +399,22 @@ loglib::StopToken LogModel::BeginStreaming(
         });
     }
 
-    QFuture<void> future =
+    const QFuture<void> future =
         QtConcurrent::run([sinkForWorker, streamSourcePtr, capturedOptions = std::move(options)]() mutable {
             RunParserWorkerWithBoundary(sinkForWorker, [&] {
-                loglib::JsonParser parser;
+                const loglib::JsonParser parser;
                 parser.ParseStreaming(*streamSourcePtr, *sinkForWorker, std::move(capturedOptions));
             });
         });
 
-    mStreamingWatcher->setFuture(std::move(future));
+    mStreamingWatcher->setFuture(future);
     return stopToken;
 }
 
 void LogModel::AppendBatch(loglib::StreamedBatch batch)
 {
     // Capture errors before `LogTable::AppendBatch` swallows them.
-    const qsizetype capturedErrorCount = static_cast<qsizetype>(batch.errors.size());
+    const auto capturedErrorCount = static_cast<qsizetype>(batch.errors.size());
     if (!batch.errors.empty())
     {
         mStreamingErrors.reserve(mStreamingErrors.size() + batch.errors.size());
@@ -442,20 +443,17 @@ void LogModel::AppendBatch(loglib::StreamedBatch batch)
     // counts, fire `beginInsert*`, then commit. Columns first so
     // headers are live when inserted rows query `data()`.
     const auto preview = mLogTable.PreviewAppend(batch);
-    int newColumnCount = static_cast<int>(preview.newColumnCount);
+    const int newColumnCount = static_cast<int>(preview.newColumnCount);
     int newRowCount = static_cast<int>(preview.newRowCount);
 
     // FIFO eviction: drop the oldest rows before inserting the new
     // batch so the visible model stays within the cap. Order is
     // remove → insert.
     int dropCount = 0;
-    if (mRetentionCap != 0 && newRowCount > 0 && static_cast<size_t>(newRowCount) > mRetentionCap)
+    if (mRetentionCap != 0 && newRowCount > 0 && std::cmp_greater(newRowCount, mRetentionCap))
     {
         dropCount = newRowCount - static_cast<int>(mRetentionCap);
-        if (dropCount > oldRowCount)
-        {
-            dropCount = oldRowCount;
-        }
+        dropCount = std::min(dropCount, oldRowCount);
     }
 
     if (dropCount > 0)
@@ -520,7 +518,7 @@ void LogModel::AppendBatch(loglib::StreamedBatch batch)
         // Process low-to-high: each move targets index 0, and because
         // every source index is > 0 the unprocessed (higher) indices do
         // not shift.
-        for (int srcIndex : newTimestampColumnIndices)
+        for (const int srcIndex : newTimestampColumnIndices)
         {
             if (srcIndex == 0)
             {
@@ -566,7 +564,7 @@ QVariant LogModel::headerData(int section, Qt::Orientation orientation, int role
 {
     if (role != Qt::DisplayRole)
     {
-        return QVariant();
+        return {};
     }
 
     if (orientation == Qt::Horizontal && section >= 0 && section < columnCount())
@@ -574,14 +572,14 @@ QVariant LogModel::headerData(int section, Qt::Orientation orientation, int role
         return QString::fromStdString(mLogTable.GetHeader(static_cast<size_t>(section)));
     }
 
-    return QVariant();
+    return {};
 }
 
 QVariant LogModel::data(const QModelIndex &index, int role) const
 {
     if (!index.isValid() || index.row() >= rowCount() || index.column() >= columnCount())
     {
-        return QVariant();
+        return {};
     }
 
     if (role == Qt::DisplayRole)
@@ -590,7 +588,7 @@ QVariant LogModel::data(const QModelIndex &index, int role) const
             mLogTable.GetFormattedValue(static_cast<size_t>(index.row()), static_cast<size_t>(index.column()))
         );
     }
-    else if (role == LogModelItemDataRole::SortRole)
+    if (role == LogModelItemDataRole::SortRole)
     {
         loglib::LogValue value =
             mLogTable.GetValue(static_cast<size_t>(index.row()), static_cast<size_t>(index.column()));
@@ -628,7 +626,7 @@ QVariant LogModel::data(const QModelIndex &index, int role) const
                 }
                 else if constexpr (std::is_same_v<T, std::monostate>)
                 {
-                    return QVariant();
+                    return {};
                 }
                 else
                 {
@@ -638,28 +636,28 @@ QVariant LogModel::data(const QModelIndex &index, int role) const
             value
         );
     }
-    else if (role == LogModelItemDataRole::InsertionOrderRole)
+    if (role == LogModelItemDataRole::InsertionOrderRole)
     {
         // Bare source row index, column-independent (see the role's
         // declaration). Historically `StreamOrderProxyModel` sorted by
         // it for newest-first mode; the role is retained for tests that
         // need the source-side row index, and for the `LogFilterModel`
         // sort tie-break.
-        return QVariant(index.row());
+        return {index.row()};
     }
-    else if (role == LogModelItemDataRole::CopyLine)
+    if (role == LogModelItemDataRole::CopyLine)
     {
         // The `LineSource *` on each `LogLine` disambiguates between
         // the mmap arena (file path) and per-line owned bytes
         // (live-tail path).
-        const size_t row = static_cast<size_t>(index.row());
+        const auto row = static_cast<size_t>(index.row());
         const auto &line = mLogTable.Data().Lines()[row];
         const loglib::LineSource *source = line.Source();
         const std::string raw = source != nullptr ? source->RawLine(line.LineId()) : std::string{};
         return QVariant(QString::fromStdString(raw));
     }
 
-    return QVariant();
+    return {};
 }
 
 template <typename T> std::optional<std::pair<T, T>> LogModel::GetMinMaxValues(int column) const

--- a/app/src/log_model.cpp
+++ b/app/src/log_model.cpp
@@ -182,10 +182,11 @@ void LogModel::BeginStreamingShared(std::unique_ptr<loglib::LineSource> source)
     // FileLineSource fast path: pre-reserve per-line offsets so per-batch
     // inserts stay amortised O(1). ~100 bytes/line matches the benchmark
     // fixture. The hint is a no-op for stream sources.
+    constexpr size_t BYTES_PER_LINE_RESERVE_HINT = 100;
     std::optional<size_t> reserveCount;
     if (auto *fileSource = dynamic_cast<loglib::FileLineSource *>(source.get()); fileSource != nullptr)
     {
-        reserveCount = fileSource->File().Size() / 100;
+        reserveCount = fileSource->File().Size() / BYTES_PER_LINE_RESERVE_HINT;
     }
 
     mLogTable.BeginStreaming(std::move(source));
@@ -612,13 +613,9 @@ QVariant LogModel::data(const QModelIndex &index, int role) const
                 {
                     return QVariant::fromValue<qulonglong>(arg);
                 }
-                else if constexpr (std::is_same_v<T, double>)
+                else if constexpr (std::is_same_v<T, double> || std::is_same_v<T, bool>)
                 {
-                    return QVariant(arg);
-                }
-                else if constexpr (std::is_same_v<T, bool>)
-                {
-                    return QVariant(arg);
+                    return {arg};
                 }
                 else if constexpr (std::is_same_v<T, loglib::TimeStamp>)
                 {
@@ -654,7 +651,7 @@ QVariant LogModel::data(const QModelIndex &index, int role) const
         const auto &line = mLogTable.Data().Lines()[row];
         const loglib::LineSource *source = line.Source();
         const std::string raw = source != nullptr ? source->RawLine(line.LineId()) : std::string{};
-        return QVariant(QString::fromStdString(raw));
+        return {QString::fromStdString(raw)};
     }
 
     return {};

--- a/app/src/log_table_view.cpp
+++ b/app/src/log_table_view.cpp
@@ -17,7 +17,7 @@ LogTableView::LogTableView(QWidget *parent)
 {
     setAcceptDrops(true);
 
-    QScrollBar *vbar = verticalScrollBar();
+    const QScrollBar *vbar = verticalScrollBar();
 
     // Edge-triggered scroll detection gated on `mNextValueChangeIsUser`
     // so non-user changes (programmatic `scrollTo`, `endInsertRows`
@@ -104,7 +104,7 @@ void LogTableView::wheelEvent(QWheelEvent *event)
 
 bool LogTableView::ComputeAtTailEdge(int value) const
 {
-    QScrollBar *bar = verticalScrollBar();
+    const QScrollBar *bar = verticalScrollBar();
     if (mTailEdge == TailEdge::Bottom)
     {
         return value >= bar->maximum();
@@ -184,7 +184,7 @@ void LogTableView::SaveAnchorIfShouldPreserve()
         return;
     }
 
-    QAbstractItemModel *m = model();
+    const QAbstractItemModel *m = model();
     if (m == nullptr || m->rowCount() == 0)
     {
         return;

--- a/app/src/main.cpp
+++ b/app/src/main.cpp
@@ -6,7 +6,7 @@
 
 int main(int argc, char *argv[])
 {
-    QApplication a(argc, argv);
+    const QApplication a(argc, argv);
 
     QCoreApplication::setOrganizationName("jan-moravec");
     QCoreApplication::setApplicationName("StructuredLogViewer");
@@ -16,5 +16,5 @@ int main(int argc, char *argv[])
     MainWindow w;
     w.show();
 
-    return a.exec();
+    return QApplication::exec();
 }

--- a/app/src/main_window.cpp
+++ b/app/src/main_window.cpp
@@ -367,7 +367,7 @@ MainWindow::MainWindow(QWidget *parent)
     ApplyStreamingRetention();
     ApplyDisplayOrder();
 
-    QTimer::singleShot(0, [this] {
+    QTimer::singleShot(0, [] {
         // qCritical() instead of a modal dialog: offscreen Qt (CI / apptest) hangs on modals.
         std::vector<std::filesystem::path> searched;
         const auto tzdata = FindTzdata(searched);

--- a/app/src/main_window.cpp
+++ b/app/src/main_window.cpp
@@ -578,6 +578,8 @@ void MainWindow::StreamNextPendingFile()
         loglib::ParserOptions options;
         options.configuration = std::move(cfg);
 
+        // NOLINTNEXTLINE(clang-analyzer-cplusplus.NewDeleteLeaks): false positive; `parseCallable` is moved into the
+        // model and invoked; `cfg` is consumed by `options`.
         auto parseCallable = [sink, fileSourcePtr, options = std::move(options)](const loglib::StopToken &stopToken
                              ) mutable {
             options.stopToken = stopToken;
@@ -775,10 +777,11 @@ void MainWindow::StopStream()
 
 void MainWindow::OnRotationDetected()
 {
+    constexpr int ROTATION_STATUS_FLASH_MS = 3000;
     // Brief 3 s `— rotated` flash on the status label.
     mRotationFlashActive = true;
     UpdateStreamingStatus();
-    QTimer::singleShot(3000, this, [this]() {
+    QTimer::singleShot(ROTATION_STATUS_FLASH_MS, this, [this]() {
         mRotationFlashActive = false;
         UpdateStreamingStatus();
     });
@@ -1254,6 +1257,8 @@ void MainWindow::AddLogFilter(const QString &id, const loglib::LogConfiguration:
     menuItem->menuAction()->setData(QVariant(id));
 
     const QAction *editAction = menuItem->addAction("Edit");
+    // NOLINTNEXTLINE(bugprone-exception-escape): Qt slot; `AddFilter` uses normal exception-throwing STL; failures
+    // surface as usual.
     connect(editAction, &QAction::triggered, this, [this, id, filter]() { AddFilter(id, filter); });
 
     const QAction *clearAction = menuItem->addAction("Clear");

--- a/app/src/main_window.cpp
+++ b/app/src/main_window.cpp
@@ -578,9 +578,10 @@ void MainWindow::StreamNextPendingFile()
         loglib::ParserOptions options;
         options.configuration = std::move(cfg);
 
-        auto parseCallable = [sink, fileSourcePtr, options = std::move(options)](loglib::StopToken stopToken) mutable {
+        auto parseCallable = [sink, fileSourcePtr, options = std::move(options)](const loglib::StopToken &stopToken
+                             ) mutable {
             options.stopToken = stopToken;
-            loglib::JsonParser parser;
+            const loglib::JsonParser parser;
             parser.ParseStreaming(*fileSourcePtr, *sink, options);
         };
 
@@ -618,7 +619,7 @@ void MainWindow::OpenLogStream()
     const size_t retention =
         (mModel->RetentionCap() != 0) ? mModel->RetentionCap() : StreamingControl::RetentionLines();
 
-    std::filesystem::path filePath(file.toStdString());
+    const std::filesystem::path filePath(file.toStdString());
     std::unique_ptr<loglib::TailingBytesProducer> source;
     try
     {
@@ -1062,7 +1063,8 @@ void MainWindow::ShowParseErrors(const QString &title, const std::vector<std::st
 
 void MainWindow::SaveConfiguration()
 {
-    QString file = QFileDialog::getSaveFileName(this, "Save Configuration", QString(), "JSON (*.json);;All Files (*)");
+    const QString file =
+        QFileDialog::getSaveFileName(this, "Save Configuration", QString(), "JSON (*.json);;All Files (*)");
     if (!file.isEmpty())
     {
         mModel->ConfigurationManager().Save(file.toStdString());
@@ -1071,7 +1073,8 @@ void MainWindow::SaveConfiguration()
 
 void MainWindow::LoadConfiguration()
 {
-    QString file = QFileDialog::getOpenFileName(this, "Load Configuration", QString(), "JSON (*.json);;All Files (*)");
+    const QString file =
+        QFileDialog::getOpenFileName(this, "Load Configuration", QString(), "JSON (*.json);;All Files (*)");
     if (!file.isEmpty())
     {
         try
@@ -1134,11 +1137,11 @@ void MainWindow::FindRecords(const QString &text, bool next, bool wildcards, boo
     }
 }
 
-void MainWindow::AddFilter(const QString filterId, const std::optional<loglib::LogConfiguration::LogFilter> &filter)
+void MainWindow::AddFilter(const QString &filterId, const std::optional<loglib::LogConfiguration::LogFilter> &filter)
 {
     if (mModel->rowCount() > 0)
     {
-        auto filterEditor = new FilterEditor(*mModel, filterId, this);
+        auto *filterEditor = new FilterEditor(*mModel, filterId, this);
         connect(filterEditor, &FilterEditor::FilterSubmitted, this, &MainWindow::FilterSubmitted);
         connect(filterEditor, &FilterEditor::FilterTimeStampSubmitted, this, &MainWindow::FilterTimeStampSubmitted);
         if (filter.has_value())
@@ -1250,10 +1253,10 @@ void MainWindow::AddLogFilter(const QString &id, const loglib::LogConfiguration:
     QMenu *menuItem = ui->menuFilters->addMenu(title);
     menuItem->menuAction()->setData(QVariant(id));
 
-    QAction *editAction = menuItem->addAction("Edit");
+    const QAction *editAction = menuItem->addAction("Edit");
     connect(editAction, &QAction::triggered, this, [this, id, filter]() { AddFilter(id, filter); });
 
-    QAction *clearAction = menuItem->addAction("Clear");
+    const QAction *clearAction = menuItem->addAction("Clear");
     connect(clearAction, &QAction::triggered, this, [this, id]() { ClearFilter(id); });
     ui->actionClearAllFilters->setDisabled(false);
 }

--- a/app/src/preferences_editor.cpp
+++ b/app/src/preferences_editor.cpp
@@ -12,12 +12,20 @@
 
 #include <cstddef>
 
+namespace
+{
+constexpr int PREFERENCES_MIN_WIDTH_PX = 300;
+constexpr int FONT_POINT_SIZE_MIN = 6;
+constexpr int FONT_POINT_SIZE_MAX = 72;
+constexpr int RETENTION_LINES_SPIN_SINGLE_STEP = 1000;
+} // namespace
+
 PreferencesEditor::PreferencesEditor(QWidget *parent)
     : QWidget{parent}
 {
     setWindowFlags(Qt::Window);
     setWindowTitle("Preferences");
-    setMinimumWidth(300);
+    setMinimumWidth(PREFERENCES_MIN_WIDTH_PX);
 
     mFontComboBox = new QFontComboBox(this);
     mSizeSpinBox = new QSpinBox(this);
@@ -26,12 +34,12 @@ PreferencesEditor::PreferencesEditor(QWidget *parent)
     mStreamNewestFirstCheckBox = new QCheckBox("Show newest lines first", this);
     mStaticNewestFirstCheckBox = new QCheckBox("Show newest lines first", this);
 
-    mSizeSpinBox->setRange(6, 72);
+    mSizeSpinBox->setRange(FONT_POINT_SIZE_MIN, FONT_POINT_SIZE_MAX);
 
     mStreamRetentionSpinBox->setRange(
         static_cast<int>(StreamingControl::MIN_RETENTION_LINES), static_cast<int>(StreamingControl::MAX_RETENTION_LINES)
     );
-    mStreamRetentionSpinBox->setSingleStep(1000);
+    mStreamRetentionSpinBox->setSingleStep(RETENTION_LINES_SPIN_SINGLE_STEP);
     mStreamRetentionSpinBox->setValue(static_cast<int>(StreamingControl::DEFAULT_RETENTION_LINES));
     mStreamRetentionSpinBox->setToolTip(
         "Maximum number of streamed lines kept in memory. Oldest lines are dropped when the cap "

--- a/app/src/preferences_editor.cpp
+++ b/app/src/preferences_editor.cpp
@@ -95,8 +95,8 @@ PreferencesEditor::PreferencesEditor(QWidget *parent)
     layout->addWidget(streamingGroup);
     layout->addWidget(staticGroup);
 
-    QPushButton *okButton = new QPushButton("Ok", this);
-    QPushButton *cancelButton = new QPushButton("Cancel", this);
+    auto *okButton = new QPushButton("Ok", this);
+    auto *cancelButton = new QPushButton("Cancel", this);
 
     connect(okButton, &QPushButton::clicked, this, [this]() {
         AppearanceControl::SaveConfiguration();
@@ -133,7 +133,7 @@ PreferencesEditor::PreferencesEditor(QWidget *parent)
         close();
     });
 
-    QHBoxLayout *buttonLayout = new QHBoxLayout();
+    auto *buttonLayout = new QHBoxLayout();
     buttonLayout->addWidget(okButton);
     buttonLayout->addWidget(cancelButton);
     layout->addStretch(1);

--- a/app/src/qt_streaming_log_sink.cpp
+++ b/app/src/qt_streaming_log_sink.cpp
@@ -2,13 +2,12 @@
 
 #include "log_model.hpp"
 
-#include <loglib/log_data.hpp>
 #include <loglib/log_table.hpp>
+#include <algorithm>
 
 #include <QMetaObject>
 #include <QThread>
 
-#include <algorithm>
 #include <iterator>
 #include <utility>
 
@@ -23,7 +22,7 @@ loglib::StopToken QtStreamingLogSink::Arm()
     mGeneration.fetch_add(1, std::memory_order_acq_rel);
     mStopSource.emplace();
     {
-        std::lock_guard<std::mutex> lock(mPausedMutex);
+        const std::scoped_lock lock(mPausedMutex);
         mPausedBatches.clear();
     }
     // Re-arm the bounded queue: clear leftover items and the stopped
@@ -60,7 +59,7 @@ void QtStreamingLogSink::DropPendingBatches()
     // can capture the new generation.
     mGeneration.fetch_add(1, std::memory_order_acq_rel);
     {
-        std::lock_guard<std::mutex> lock(mPausedMutex);
+        const std::scoped_lock lock(mPausedMutex);
         mPausedBatches.clear();
     }
     // Drain-and-discard anything the worker enqueued before exiting.
@@ -94,7 +93,7 @@ void QtStreamingLogSink::Resume()
     // below, preserving FIFO order.
     std::vector<loglib::StreamedBatch> drained;
     {
-        std::lock_guard<std::mutex> lock(mPausedMutex);
+        const std::scoped_lock lock(mPausedMutex);
         if (!mPaused.load(std::memory_order_acquire))
         {
             return;
@@ -117,7 +116,7 @@ bool QtStreamingLogSink::IsPaused() const noexcept
 
 size_t QtStreamingLogSink::PausedLineCount() const
 {
-    std::lock_guard<std::mutex> lock(mPausedMutex);
+    const std::scoped_lock lock(mPausedMutex);
     return PausedLineCountLocked();
 }
 
@@ -133,8 +132,8 @@ void QtStreamingLogSink::SetRetentionCap(size_t cap) noexcept
 
 void QtStreamingLogSink::TrimPausedBufferTo(size_t maxBufferedLines)
 {
-    std::lock_guard<std::mutex> lock(mPausedMutex);
-    size_t total = PausedLineCountLocked();
+    const std::scoped_lock lock(mPausedMutex);
+    const size_t total = PausedLineCountLocked();
     if (total <= maxBufferedLines)
     {
         return;
@@ -171,7 +170,7 @@ std::optional<loglib::StreamedBatch> QtStreamingLogSink::TakePausedBuffer()
 {
     std::vector<loglib::StreamedBatch> drained;
     {
-        std::lock_guard<std::mutex> lock(mPausedMutex);
+        const std::scoped_lock lock(mPausedMutex);
         drained.swap(mPausedBatches);
     }
     if (drained.empty())
@@ -201,7 +200,7 @@ void QtStreamingLogSink::OnBatch(loglib::StreamedBatch batch)
     if (mPaused.load(std::memory_order_acquire))
     {
         const size_t cap = mRetentionCap.load(std::memory_order_acquire);
-        std::lock_guard<std::mutex> lock(mPausedMutex);
+        const std::scoped_lock lock(mPausedMutex);
         // Re-check under the lock; a concurrent Resume could have
         // already swapped the buffer out.
         if (mPaused.load(std::memory_order_acquire))
@@ -212,7 +211,7 @@ void QtStreamingLogSink::OnBatch(loglib::StreamedBatch batch)
             // `LogModel::AppendBatch`'s FIFO eviction.
             if (cap != 0)
             {
-                size_t total = PausedLineCountLocked();
+                const size_t total = PausedLineCountLocked();
                 if (total > cap)
                 {
                     size_t toDrop = total - cap;
@@ -358,12 +357,10 @@ loglib::StreamedBatch QtStreamingLogSink::CoalesceLocked(std::vector<loglib::Str
     out.firstLineNumber = batches.front().firstLineNumber;
     for (auto &batch : batches)
     {
-        std::move(batch.lines.begin(), batch.lines.end(), std::back_inserter(out.lines));
-        std::move(
-            batch.localLineOffsets.begin(), batch.localLineOffsets.end(), std::back_inserter(out.localLineOffsets)
-        );
-        std::move(batch.errors.begin(), batch.errors.end(), std::back_inserter(out.errors));
-        std::move(batch.newKeys.begin(), batch.newKeys.end(), std::back_inserter(out.newKeys));
+        std::ranges::move(batch.lines, std::back_inserter(out.lines));
+        std::ranges::move(batch.localLineOffsets, std::back_inserter(out.localLineOffsets));
+        std::ranges::move(batch.errors, std::back_inserter(out.errors));
+        std::ranges::move(batch.newKeys, std::back_inserter(out.newKeys));
     }
     return out;
 }

--- a/app/src/qt_streaming_log_sink.cpp
+++ b/app/src/qt_streaming_log_sink.cpp
@@ -196,7 +196,6 @@ void QtStreamingLogSink::OnBatch(loglib::StreamedBatch batch)
     // While paused, route batches into the paused buffer instead of
     // posting them across threads, so the Qt event queue does not
     // become a third unbounded memory pool.
-    bool routedToPausedBuffer = false;
     if (mPaused.load(std::memory_order_acquire))
     {
         const size_t cap = mRetentionCap.load(std::memory_order_acquire);
@@ -245,12 +244,8 @@ void QtStreamingLogSink::OnBatch(loglib::StreamedBatch batch)
                     mPausedDropCount.fetch_add(linesDropped, std::memory_order_acq_rel);
                 }
             }
-            routedToPausedBuffer = true;
+            return;
         }
-    }
-    if (routedToPausedBuffer)
-    {
-        return;
     }
 
     // Park the worker once the bounded queue is full. The drain on the
@@ -331,7 +326,7 @@ std::size_t QtStreamingLogSink::BatchesDroppedDuringShutdown() const noexcept
     return mPending.BatchesDroppedDuringShutdown();
 }
 
-loglib::StreamedBatch QtStreamingLogSink::CoalesceLocked(std::vector<loglib::StreamedBatch> &&batches)
+loglib::StreamedBatch QtStreamingLogSink::CoalesceLocked(std::vector<loglib::StreamedBatch> batches)
 {
     loglib::StreamedBatch out;
     if (batches.empty())

--- a/app/src/row_order_proxy_model.cpp
+++ b/app/src/row_order_proxy_model.cpp
@@ -236,14 +236,14 @@ QModelIndex RowOrderProxyModel::index(int row, int column, const QModelIndex &pa
 {
     if (parent.isValid())
     {
-        return QModelIndex();
+        return {};
     }
     return createIndex(row, column);
 }
 
 QModelIndex RowOrderProxyModel::parent(const QModelIndex & /*child*/) const
 {
-    return QModelIndex();
+    return {};
 }
 
 int RowOrderProxyModel::rowCount(const QModelIndex &parent) const
@@ -268,11 +268,11 @@ QModelIndex RowOrderProxyModel::mapFromSource(const QModelIndex &sourceIndex) co
 {
     if (!sourceIndex.isValid() || sourceModel() == nullptr)
     {
-        return QModelIndex();
+        return {};
     }
     if (sourceIndex.parent().isValid())
     {
-        return QModelIndex();
+        return {};
     }
     if (!mReversed)
     {
@@ -281,7 +281,7 @@ QModelIndex RowOrderProxyModel::mapFromSource(const QModelIndex &sourceIndex) co
     const int rows = sourceModel()->rowCount(QModelIndex());
     if (rows == 0)
     {
-        return QModelIndex();
+        return {};
     }
     return createIndex(rows - 1 - sourceIndex.row(), sourceIndex.column());
 }
@@ -290,7 +290,7 @@ QModelIndex RowOrderProxyModel::mapToSource(const QModelIndex &proxyIndex) const
 {
     if (!proxyIndex.isValid() || sourceModel() == nullptr)
     {
-        return QModelIndex();
+        return {};
     }
     if (!mReversed)
     {
@@ -299,7 +299,7 @@ QModelIndex RowOrderProxyModel::mapToSource(const QModelIndex &proxyIndex) const
     const int rows = sourceModel()->rowCount(QModelIndex());
     if (rows == 0)
     {
-        return QModelIndex();
+        return {};
     }
     return sourceModel()->index(rows - 1 - proxyIndex.row(), proxyIndex.column(), QModelIndex());
 }

--- a/app/src/streaming_control.cpp
+++ b/app/src/streaming_control.cpp
@@ -7,9 +7,9 @@
 
 namespace
 {
-const QString CONFIGURATION_RETENTION_LINES = "streaming/retentionLines";
-const QString CONFIGURATION_NEWEST_FIRST = "streaming/newestFirst";
-const QString CONFIGURATION_STATIC_NEWEST_FIRST = "static/newestFirst";
+const QString CONFIGURATION_RETENTION_LINES = QStringLiteral("streaming/retentionLines");
+const QString CONFIGURATION_NEWEST_FIRST = QStringLiteral("streaming/newestFirst");
+const QString CONFIGURATION_STATIC_NEWEST_FIRST = QStringLiteral("static/newestFirst");
 } // namespace
 
 StreamingControl::Configuration StreamingControl::mConfiguration;

--- a/app/src/streaming_control.cpp
+++ b/app/src/streaming_control.cpp
@@ -1,5 +1,6 @@
 #include "streaming_control.hpp"
 
+#include <QLatin1String>
 #include <QSettings>
 #include <QVariant>
 
@@ -7,9 +8,9 @@
 
 namespace
 {
-const QString CONFIGURATION_RETENTION_LINES = QStringLiteral("streaming/retentionLines");
-const QString CONFIGURATION_NEWEST_FIRST = QStringLiteral("streaming/newestFirst");
-const QString CONFIGURATION_STATIC_NEWEST_FIRST = QStringLiteral("static/newestFirst");
+constexpr char CONFIGURATION_RETENTION_LINES[] = "streaming/retentionLines";
+constexpr char CONFIGURATION_NEWEST_FIRST[] = "streaming/newestFirst";
+constexpr char CONFIGURATION_STATIC_NEWEST_FIRST[] = "static/newestFirst";
 } // namespace
 
 StreamingControl::Configuration StreamingControl::mConfiguration;
@@ -17,15 +18,17 @@ StreamingControl::Configuration StreamingControl::mConfiguration;
 void StreamingControl::SaveConfiguration()
 {
     QSettings settings;
-    settings.setValue(CONFIGURATION_RETENTION_LINES, static_cast<qulonglong>(mConfiguration.retentionLines));
-    settings.setValue(CONFIGURATION_NEWEST_FIRST, mConfiguration.newestFirst);
-    settings.setValue(CONFIGURATION_STATIC_NEWEST_FIRST, mConfiguration.staticNewestFirst);
+    settings.setValue(
+        QLatin1String(CONFIGURATION_RETENTION_LINES), static_cast<qulonglong>(mConfiguration.retentionLines)
+    );
+    settings.setValue(QLatin1String(CONFIGURATION_NEWEST_FIRST), mConfiguration.newestFirst);
+    settings.setValue(QLatin1String(CONFIGURATION_STATIC_NEWEST_FIRST), mConfiguration.staticNewestFirst);
 }
 
 void StreamingControl::LoadConfiguration()
 {
     QSettings settings;
-    if (const QVariant value = settings.value(CONFIGURATION_RETENTION_LINES); value.isValid())
+    if (const QVariant value = settings.value(QLatin1String(CONFIGURATION_RETENTION_LINES)); value.isValid())
     {
         bool ok = false;
         const qulonglong raw = value.toULongLong(&ok);
@@ -37,7 +40,7 @@ void StreamingControl::LoadConfiguration()
         {
             // Drop a corrupt / out-of-range value so it can't wedge
             // the spinbox.
-            settings.remove(CONFIGURATION_RETENTION_LINES);
+            settings.remove(QLatin1String(CONFIGURATION_RETENTION_LINES));
             mConfiguration.retentionLines = DEFAULT_RETENTION_LINES;
         }
     }
@@ -46,7 +49,7 @@ void StreamingControl::LoadConfiguration()
         mConfiguration.retentionLines = DEFAULT_RETENTION_LINES;
     }
 
-    if (const QVariant value = settings.value(CONFIGURATION_NEWEST_FIRST); value.isValid())
+    if (const QVariant value = settings.value(QLatin1String(CONFIGURATION_NEWEST_FIRST)); value.isValid())
     {
         mConfiguration.newestFirst = value.toBool();
     }
@@ -55,7 +58,7 @@ void StreamingControl::LoadConfiguration()
         mConfiguration.newestFirst = DEFAULT_NEWEST_FIRST;
     }
 
-    if (const QVariant value = settings.value(CONFIGURATION_STATIC_NEWEST_FIRST); value.isValid())
+    if (const QVariant value = settings.value(QLatin1String(CONFIGURATION_STATIC_NEWEST_FIRST)); value.isValid())
     {
         mConfiguration.staticNewestFirst = value.toBool();
     }

--- a/library/include/loglib/bytes_producer.hpp
+++ b/library/include/loglib/bytes_producer.hpp
@@ -75,12 +75,12 @@ public:
     /// Rotation-event callback, invoked from the producer's worker
     /// thread on detected rotations. Default no-op for non-rotating
     /// producers; an empty callback clears any previous installation.
-    virtual void SetRotationCallback(std::function<void()> callback);
+    virtual void SetRotationCallback(const std::function<void()> &callback);
 
     /// Status-change callback, invoked on edge transitions between
     /// `Running` and `Waiting`. Default no-op; an empty callback
     /// clears any previous installation.
-    virtual void SetStatusCallback(std::function<void(SourceStatus)> callback);
+    virtual void SetStatusCallback(const std::function<void(SourceStatus)> &callback);
 };
 
 } // namespace loglib

--- a/library/include/loglib/log_data.hpp
+++ b/library/include/loglib/log_data.hpp
@@ -76,7 +76,7 @@ public:
 
     /// Merges @p other in place, rewiring back-pointers and remapping KeyIds
     /// to this side's canonical `KeyIndex`.
-    void Merge(LogData &&other);
+    void Merge(LogData other);
 
     /// Append a parsed batch. `lineOffsets` populates
     /// `LogFile::mLineOffsets` for file sources; the live-tail path

--- a/library/include/loglib/log_data.hpp
+++ b/library/include/loglib/log_data.hpp
@@ -81,7 +81,7 @@ public:
     /// Append a parsed batch. `lineOffsets` populates
     /// `LogFile::mLineOffsets` for file sources; the live-tail path
     /// passes an empty vector (the source owns its per-line storage).
-    void AppendBatch(std::vector<LogLine> lines, std::vector<uint64_t> lineOffsets);
+    void AppendBatch(std::vector<LogLine> lines, const std::vector<uint64_t> &lineOffsets);
 
 private:
     std::vector<std::unique_ptr<LineSource>> mSources;

--- a/library/include/loglib/log_line.hpp
+++ b/library/include/loglib/log_line.hpp
@@ -59,15 +59,15 @@ public:
 
     /// Debug builds assert @p value is not a `string_view`. Owned
     /// strings are appended to the source's arena.
-    void SetValue(KeyId id, LogValue value);
+    void SetValue(KeyId id, const LogValue &value);
 
     /// Caller promises any view in @p value outlives the `LogLine`.
     /// Views inside `StableBytes()` are stored zero-copy; others are
     /// copied into the arena.
-    void SetValue(KeyId id, LogValue value, LogValueTrustView trust);
+    void SetValue(KeyId id, const LogValue &value, LogValueTrustView trust);
 
     /// Throws if @p key is unknown.
-    void SetValue(const std::string &key, LogValue value);
+    void SetValue(const std::string &key, const LogValue &value);
 
     std::vector<std::string> GetKeys() const;
 

--- a/library/include/loglib/parsers/json_parser.hpp
+++ b/library/include/loglib/parsers/json_parser.hpp
@@ -36,14 +36,17 @@ public:
 
     /// Static-file overload exposing internal tuning knobs (used by
     /// benchmarks / bisects).
-    void ParseStreaming(
-        FileLineSource &source, LogParseSink &sink, ParserOptions options, internal::AdvancedParserOptions advanced
-    ) const;
+    static void ParseStreaming(
+        FileLineSource &source,
+        LogParseSink &sink,
+        const ParserOptions &options,
+        internal::AdvancedParserOptions advanced
+    );
 
     std::string ToString(const LogLine &line) const override;
 
     /// Convenience for `LogMap` (tests, debug dumps).
-    std::string ToString(const LogMap &values) const;
+    static std::string ToString(const LogMap &values);
 };
 
 } // namespace loglib

--- a/library/include/loglib/tailing_bytes_producer.hpp
+++ b/library/include/loglib/tailing_bytes_producer.hpp
@@ -100,9 +100,9 @@ public:
 
     [[nodiscard]] std::string DisplayName() const override;
 
-    void SetRotationCallback(std::function<void()> callback) override;
+    void SetRotationCallback(const std::function<void()> &callback) override;
 
-    void SetStatusCallback(std::function<void(SourceStatus)> callback) override;
+    void SetStatusCallback(const std::function<void(SourceStatus)> &callback) override;
 
     /// Total rotations the worker has observed since construction.
     /// Used by tests to assert debounce coalescing (the user-visible

--- a/library/include/loglib/tcp_server_producer.hpp
+++ b/library/include/loglib/tcp_server_producer.hpp
@@ -132,7 +132,7 @@ public:
     /// `Options::port == 0`.
     [[nodiscard]] std::string DisplayName() const override;
 
-    void SetStatusCallback(std::function<void(SourceStatus)> callback) override;
+    void SetStatusCallback(const std::function<void(SourceStatus)> &callback) override;
 
     /// Actual port the listener is bound to.
     [[nodiscard]] uint16_t BoundPort() const noexcept;

--- a/library/include/loglib/udp_server_producer.hpp
+++ b/library/include/loglib/udp_server_producer.hpp
@@ -93,7 +93,7 @@ public:
     /// port when `Options::port == 0`.
     [[nodiscard]] std::string DisplayName() const override;
 
-    void SetStatusCallback(std::function<void(SourceStatus)> callback) override;
+    void SetStatusCallback(const std::function<void(SourceStatus)> &callback) override;
 
     /// Actual port the socket is bound to. Equals `Options::port`
     /// unless that was 0, in which case it returns the kernel-chosen

--- a/library/src/batch_coalescer.cpp
+++ b/library/src/batch_coalescer.cpp
@@ -37,7 +37,7 @@ void BatchCoalescer::DrainNewKeysInto(StreamedBatch &out)
         out.newKeys.reserve(out.newKeys.size() + (currentKeyCount - mPrevKeyCount));
         for (size_t i = mPrevKeyCount; i < currentKeyCount; ++i)
         {
-            out.newKeys.emplace_back(std::string(mKeys.KeyOf(static_cast<KeyId>(i))));
+            out.newKeys.emplace_back(mKeys.KeyOf(static_cast<KeyId>(i)));
         }
         mPrevKeyCount = currentKeyCount;
     }

--- a/library/src/buffering_sink.cpp
+++ b/library/src/buffering_sink.cpp
@@ -66,7 +66,7 @@ LogData BufferingSink::TakeData()
         mSource->File().AppendLineOffsets(mLineOffsets);
         mLineOffsets.clear();
     }
-    return LogData(std::move(mSource), std::move(mLines), std::move(mKeys));
+    return {std::move(mSource), std::move(mLines), std::move(mKeys)};
 }
 
 std::vector<std::string> BufferingSink::TakeErrors()

--- a/library/src/bytes_producer.cpp
+++ b/library/src/bytes_producer.cpp
@@ -3,12 +3,12 @@
 namespace loglib
 {
 
-void BytesProducer::SetRotationCallback(std::function<void()> /*callback*/)
+void BytesProducer::SetRotationCallback(const std::function<void()> & /*callback*/)
 {
     // No-op: finite producers never rotate.
 }
 
-void BytesProducer::SetStatusCallback(std::function<void(SourceStatus)> /*callback*/)
+void BytesProducer::SetStatusCallback(const std::function<void(SourceStatus)> & /*callback*/)
 {
     // No-op: producers that never become unavailable stay `Running`.
 }

--- a/library/src/compact_log_value.cpp
+++ b/library/src/compact_log_value.cpp
@@ -341,7 +341,8 @@ void CompactLineFields::AssignSorted(const value_type *values, uint32_t count)
 
 void CompactLineFields::AssignSorted(std::vector<value_type> &&values)
 {
-    AssignSorted(values.data(), static_cast<uint32_t>(values.size()));
+    std::vector<value_type> local = std::move(values);
+    AssignSorted(local.data(), static_cast<uint32_t>(local.size()));
 }
 
 void CompactLineFields::EmplaceBack(KeyId key, CompactLogValue value)

--- a/library/src/compact_log_value.cpp
+++ b/library/src/compact_log_value.cpp
@@ -1,7 +1,6 @@
 #include "loglib/internal/compact_log_value.hpp"
 
 #include "loglib/line_source.hpp"
-#include "loglib/log_file.hpp"
 #include "loglib/log_line.hpp"
 
 #include <algorithm>
@@ -257,17 +256,14 @@ uint32_t GrowCapacity(uint32_t current, uint32_t needed) noexcept
     // Geometric growth (×1.5 rounded up). Matches `std::vector`'s
     // amortised cost while keeping capacity tighter than ×2.
     uint32_t target = current == 0 ? 4U : current + (current / 2U) + 1U;
-    if (target < needed)
-    {
-        target = needed;
-    }
+    target = std::max(target, needed);
     return target;
 }
 
 } // namespace
 
 CompactLineFields::CompactLineFields(uint32_t initialCapacity)
-    : mData(AllocatePairs(initialCapacity)), mSize(0), mCapacity(initialCapacity)
+    : mData(AllocatePairs(initialCapacity)), mCapacity(initialCapacity)
 {
 }
 

--- a/library/src/file_identity.cpp
+++ b/library/src/file_identity.cpp
@@ -21,11 +21,14 @@ namespace
 {
 
 #ifdef _WIN32
+constexpr unsigned kFileIndexHighShift = 32U;
+
 FileIdentity FromBhfi(const BY_HANDLE_FILE_INFORMATION &info) noexcept
 {
     FileIdentity identity;
     identity.high = static_cast<uint64_t>(info.dwVolumeSerialNumber);
-    identity.low = (static_cast<uint64_t>(info.nFileIndexHigh) << 32) | static_cast<uint64_t>(info.nFileIndexLow);
+    identity.low = (static_cast<uint64_t>(info.nFileIndexHigh) << kFileIndexHighShift) |
+                     static_cast<uint64_t>(info.nFileIndexLow);
     identity.valid = true;
     return identity;
 }
@@ -47,7 +50,7 @@ FileIdentity FromPath(const std::filesystem::path &path) noexcept
 #ifdef _WIN32
     // Full sharing so we don't disturb a concurrent producer.
     // FILE_FLAG_BACKUP_SEMANTICS lets the call also work on directories.
-    const HANDLE handle = ::CreateFileW(
+    HANDLE const handle = ::CreateFileW(
         path.c_str(),
         0, // metadata only
         FILE_SHARE_READ | FILE_SHARE_WRITE | FILE_SHARE_DELETE,

--- a/library/src/file_identity.cpp
+++ b/library/src/file_identity.cpp
@@ -3,7 +3,7 @@
 #include <cstdint>
 #include <filesystem>
 
-#if defined(_WIN32)
+#ifdef _WIN32
 #ifndef WIN32_LEAN_AND_MEAN
 #define WIN32_LEAN_AND_MEAN
 #endif
@@ -20,7 +20,7 @@ namespace loglib::internal
 namespace
 {
 
-#if defined(_WIN32)
+#ifdef _WIN32
 FileIdentity FromBhfi(const BY_HANDLE_FILE_INFORMATION &info) noexcept
 {
     FileIdentity identity;
@@ -44,7 +44,7 @@ FileIdentity FromStat(const struct stat &st) noexcept
 
 FileIdentity FromPath(const std::filesystem::path &path) noexcept
 {
-#if defined(_WIN32)
+#ifdef _WIN32
     // Full sharing so we don't disturb a concurrent producer.
     // FILE_FLAG_BACKUP_SEMANTICS lets the call also work on directories.
     const HANDLE handle = ::CreateFileW(
@@ -80,7 +80,7 @@ FileIdentity FromPath(const std::filesystem::path &path) noexcept
 
 FileIdentity FromOpenHandle(NativeFileHandle handle) noexcept
 {
-#if defined(_WIN32)
+#ifdef _WIN32
     if (handle == INVALID_HANDLE_VALUE || handle == nullptr)
     {
         return FileIdentity{};

--- a/library/src/file_identity.cpp
+++ b/library/src/file_identity.cpp
@@ -21,14 +21,14 @@ namespace
 {
 
 #ifdef _WIN32
-constexpr unsigned kFileIndexHighShift = 32U;
+constexpr unsigned K_FILE_INDEX_HIGH_SHIFT = 32U;
 
 FileIdentity FromBhfi(const BY_HANDLE_FILE_INFORMATION &info) noexcept
 {
     FileIdentity identity;
     identity.high = static_cast<uint64_t>(info.dwVolumeSerialNumber);
-    identity.low = (static_cast<uint64_t>(info.nFileIndexHigh) << kFileIndexHighShift) |
-                     static_cast<uint64_t>(info.nFileIndexLow);
+    identity.low = (static_cast<uint64_t>(info.nFileIndexHigh) << K_FILE_INDEX_HIGH_SHIFT) |
+                   static_cast<uint64_t>(info.nFileIndexLow);
     identity.valid = true;
     return identity;
 }
@@ -50,7 +50,7 @@ FileIdentity FromPath(const std::filesystem::path &path) noexcept
 #ifdef _WIN32
     // Full sharing so we don't disturb a concurrent producer.
     // FILE_FLAG_BACKUP_SEMANTICS lets the call also work on directories.
-    HANDLE const handle = ::CreateFileW(
+    HANDLE handle = ::CreateFileW(
         path.c_str(),
         0, // metadata only
         FILE_SHARE_READ | FILE_SHARE_WRITE | FILE_SHARE_DELETE,

--- a/library/src/file_line_source.cpp
+++ b/library/src/file_line_source.cpp
@@ -38,7 +38,7 @@ std::string_view FileLineSource::ResolveMmapBytes(uint64_t offset, uint32_t leng
     {
         return {};
     }
-    return std::string_view(data + offset, length);
+    return {data + offset, length};
 }
 
 std::string_view FileLineSource::ResolveOwnedBytes(uint64_t offset, uint32_t length, size_t /*lineId*/) const noexcept

--- a/library/src/file_line_source.cpp
+++ b/library/src/file_line_source.cpp
@@ -59,7 +59,7 @@ std::span<const char> FileLineSource::StableBytes() const noexcept
     {
         return {};
     }
-    return std::span<const char>(data, size);
+    return {data, size};
 }
 
 uint64_t FileLineSource::AppendOwnedBytes(size_t /*lineId*/, std::string_view bytes)

--- a/library/src/key_index.cpp
+++ b/library/src/key_index.cpp
@@ -10,7 +10,6 @@
 #include <cassert>
 #include <cstddef>
 #include <deque>
-#include <limits>
 #include <mutex>
 #include <shared_mutex>
 #include <string>
@@ -74,14 +73,14 @@ KeyId KeyIndex::GetOrInsert(std::string_view key)
     Impl::Shard &shard = mImpl->shards[Impl::ShardIndex(key)];
 
     {
-        std::shared_lock<std::shared_mutex> lock(shard.mutex);
+        const std::shared_lock<std::shared_mutex> lock(shard.mutex);
         if (auto it = shard.map.find(key); it != shard.map.end())
         {
             return it->second;
         }
     }
 
-    std::scoped_lock locks(shard.mutex, mImpl->reverseMutex);
+    const std::scoped_lock locks(shard.mutex, mImpl->reverseMutex);
 
     if (auto it = shard.map.find(key); it != shard.map.end())
     {
@@ -92,7 +91,7 @@ KeyId KeyIndex::GetOrInsert(std::string_view key)
     // other thread can observe the new id. The assert pins the 2^32 cap:
     // wrapping past it would collide with `INVALID_KEY_ID`.
     assert(static_cast<uint64_t>(mImpl->reverse.size()) < static_cast<uint64_t>(INVALID_KEY_ID));
-    const KeyId id = static_cast<KeyId>(mImpl->reverse.size());
+    const auto id = static_cast<KeyId>(mImpl->reverse.size());
     mImpl->reverse.emplace_back(key);
     shard.map.emplace(mImpl->reverse.back(), id);
 
@@ -107,7 +106,7 @@ KeyId KeyIndex::Find(std::string_view key) const
 #endif
 
     const Impl::Shard &shard = mImpl->shards[Impl::ShardIndex(key)];
-    std::shared_lock<std::shared_mutex> lock(shard.mutex);
+    const std::shared_lock<std::shared_mutex> lock(shard.mutex);
     if (auto it = shard.map.find(key); it != shard.map.end())
     {
         return it->second;
@@ -120,7 +119,7 @@ std::string_view KeyIndex::KeyOf(KeyId id) const
     // Shared lock excludes `GetOrInsert`'s `emplace_back` from racing with
     // `operator[]`. The returned view remains valid after release because
     // deque element addresses are stable across inserts.
-    std::shared_lock<std::shared_mutex> lock(mImpl->reverseMutex);
+    const std::shared_lock<std::shared_mutex> lock(mImpl->reverseMutex);
     return mImpl->reverse[id];
 }
 
@@ -131,9 +130,9 @@ size_t KeyIndex::Size() const noexcept
 
 std::vector<std::string> KeyIndex::SortedKeys() const
 {
-    std::shared_lock<std::shared_mutex> lock(mImpl->reverseMutex);
+    const std::shared_lock<std::shared_mutex> lock(mImpl->reverseMutex);
     std::vector<std::string> result(mImpl->reverse.begin(), mImpl->reverse.end());
-    std::sort(result.begin(), result.end());
+    std::ranges::sort(result);
     return result;
 }
 
@@ -146,7 +145,7 @@ size_t KeyIndex::EstimatedMemoryBytes() const
     size_t bytes = 0;
     for (const auto &shard : mImpl->shards)
     {
-        std::shared_lock<std::shared_mutex> lock(shard.mutex);
+        const std::shared_lock<std::shared_mutex> lock(shard.mutex);
         bytes += shard.map.bucket_count() * (sizeof(std::string) + sizeof(KeyId));
         for (const auto &kv : shard.map)
         {
@@ -157,7 +156,7 @@ size_t KeyIndex::EstimatedMemoryBytes() const
         }
     }
     {
-        std::shared_lock<std::shared_mutex> lock(mImpl->reverseMutex);
+        const std::shared_lock<std::shared_mutex> lock(mImpl->reverseMutex);
         // `std::deque` typically uses fixed-size chunks; approximate by the
         // string objects' size. The chunk-pointer map overhead is negligible
         // relative to the strings themselves for any realistic key count.

--- a/library/src/log_configuration.cpp
+++ b/library/src/log_configuration.cpp
@@ -14,18 +14,16 @@ namespace
 std::string ToLower(const std::string &str)
 {
     std::string lower = str;
-    std::transform(lower.begin(), lower.end(), lower.begin(), [](auto c) {
-        return static_cast<unsigned char>(std::tolower(c));
-    });
+    std::ranges::transform(lower, lower.begin(), [](auto c) { return static_cast<unsigned char>(std::tolower(c)); });
     return lower;
 }
 
 bool IsTimestampKey(const std::string &key)
 {
     static const std::vector<std::string> TIMESTAMP_KEYS = {"timestamp", "time", "t"};
-    return std::any_of(
-        TIMESTAMP_KEYS.begin(),
-        TIMESTAMP_KEYS.end(),
+    return std::ranges::any_of(
+        TIMESTAMP_KEYS,
+
         [lowerKey = ToLower(key)](const std::string &value) { return (lowerKey == value); }
     );
 }
@@ -44,7 +42,7 @@ namespace loglib
 
 void LogConfigurationManager::Load(const std::filesystem::path &path)
 {
-    std::ifstream file(path);
+    const std::ifstream file(path);
     if (file.is_open())
     {
         std::ostringstream buffer;
@@ -93,7 +91,11 @@ void LogConfigurationManager::Update(const LogData &logData)
             if (IsTimestampKey(key))
             {
                 mConfiguration.columns.push_back(LogConfiguration::Column{
-                    key, {key}, "%F %H:%M:%S", LogConfiguration::Type::time, {"%FT%T%Ez", "%F %T%Ez", "%FT%T", "%F %T"}
+                    .header = key,
+                    .keys = {key},
+                    .printFormat = "%F %H:%M:%S",
+                    .type = LogConfiguration::Type::time,
+                    .parseFormats = {"%FT%T%Ez", "%F %T%Ez", "%FT%T", "%F %T"}
                 });
                 // Timestamps land in the first column; shift everything else right.
                 for (size_t i = mConfiguration.columns.size() - 1; i > 0; --i)
@@ -103,9 +105,13 @@ void LogConfigurationManager::Update(const LogData &logData)
             }
             else
             {
-                mConfiguration.columns.push_back(
-                    LogConfiguration::Column{key, {key}, "{}", LogConfiguration::Type::any, {}}
-                );
+                mConfiguration.columns.push_back(LogConfiguration::Column{
+                    .header = key,
+                    .keys = {key},
+                    .printFormat = "{}",
+                    .type = LogConfiguration::Type::any,
+                    .parseFormats = {}
+                });
             }
             mKeysInColumns.insert(key);
         }
@@ -125,13 +131,22 @@ void LogConfigurationManager::AppendKeys(const std::vector<std::string> &newKeys
         if (IsTimestampKey(key))
         {
             mConfiguration.columns.push_back(LogConfiguration::Column{
-                key, {key}, "%F %H:%M:%S", LogConfiguration::Type::time, {"%FT%T%Ez", "%F %T%Ez", "%FT%T", "%F %T"}
+                .header = key,
+                .keys = {key},
+                .printFormat = "%F %H:%M:%S",
+                .type = LogConfiguration::Type::time,
+                .parseFormats = {"%FT%T%Ez", "%F %T%Ez", "%FT%T", "%F %T"}
             });
         }
         else
         {
-            mConfiguration.columns.push_back(LogConfiguration::Column{key, {key}, "{}", LogConfiguration::Type::any, {}}
-            );
+            mConfiguration.columns.push_back(LogConfiguration::Column{
+                .header = key,
+                .keys = {key},
+                .printFormat = "{}",
+                .type = LogConfiguration::Type::any,
+                .parseFormats = {}
+            });
         }
         mKeysInColumns.insert(key);
     }
@@ -207,7 +222,7 @@ void LogConfigurationManager::EnsureKeyCacheBuilt() const
 bool LogConfigurationManager::IsKeyInAnyColumnCached(const std::string &key) const
 {
     EnsureKeyCacheBuilt();
-    return mKeysInColumns.find(key) != mKeysInColumns.end();
+    return mKeysInColumns.contains(key);
 }
 
 } // namespace loglib

--- a/library/src/log_configuration.cpp
+++ b/library/src/log_configuration.cpp
@@ -6,6 +6,7 @@
 
 #include <algorithm>
 #include <fstream>
+#include <iterator>
 #include <sstream>
 
 namespace
@@ -159,14 +160,23 @@ void LogConfigurationManager::MoveColumn(size_t srcIndex, size_t destIndex)
     {
         return;
     }
+    using Diff = std::vector<LogConfiguration::Column>::difference_type;
     auto begin = mConfiguration.columns.begin();
     if (srcIndex > destIndex)
     {
-        std::rotate(begin + destIndex, begin + srcIndex, begin + srcIndex + 1);
+        std::rotate(
+            std::next(begin, static_cast<Diff>(destIndex)),
+            std::next(begin, static_cast<Diff>(srcIndex)),
+            std::next(begin, static_cast<Diff>(srcIndex + 1))
+        );
     }
     else
     {
-        std::rotate(begin + srcIndex, begin + srcIndex + 1, begin + destIndex + 1);
+        std::rotate(
+            std::next(begin, static_cast<Diff>(srcIndex)),
+            std::next(begin, static_cast<Diff>(srcIndex + 1)),
+            std::next(begin, static_cast<Diff>(destIndex + 1))
+        );
     }
     // The cached key set is unchanged by a pure reorder.
 }

--- a/library/src/log_data.cpp
+++ b/library/src/log_data.cpp
@@ -165,7 +165,7 @@ void LogData::MarkTimestampsParsed()
     mTimestampsAlreadyParsed = true;
 }
 
-void LogData::Merge(LogData &&other)
+void LogData::Merge(LogData other)
 {
     // Splice sources first: each `LogLine` already points at a heap
     // `LineSource` inside `other.mSources`; moving the `unique_ptr`s

--- a/library/src/log_data.cpp
+++ b/library/src/log_data.cpp
@@ -199,7 +199,7 @@ void LogData::Merge(LogData &&other)
         {
             remapped.emplace_back(remap[entry.first], entry.second);
         }
-        std::sort(remapped.begin(), remapped.end(), [](const auto &a, const auto &b) { return a.first < b.first; });
+        std::ranges::sort(remapped, [](const auto &a, const auto &b) { return a.first < b.first; });
 
         assert(line.Source() != nullptr);
         LogLine rebuilt(std::move(remapped), mKeys, *line.Source(), line.LineId());
@@ -212,7 +212,7 @@ void LogData::Merge(LogData &&other)
     }
 }
 
-void LogData::AppendBatch(std::vector<LogLine> lines, std::vector<uint64_t> lineOffsets)
+void LogData::AppendBatch(std::vector<LogLine> lines, const std::vector<uint64_t> &lineOffsets)
 {
     // No per-batch `reserve` — rely on geometric push_back growth
     // (some STL impls take `reserve(size+n)` as exact = O(N^2/B)).

--- a/library/src/log_file.cpp
+++ b/library/src/log_file.cpp
@@ -9,7 +9,7 @@
 #include <utility>
 #include <vector>
 
-#if defined(_WIN32)
+#ifdef _WIN32
 #ifndef WIN32_LEAN_AND_MEAN
 #define WIN32_LEAN_AND_MEAN
 #endif
@@ -30,12 +30,12 @@ namespace
 /// Windows `PrefetchVirtualMemory`). Best-effort; failures are ignored.
 void HintSequential(const mio::mmap_source &mmap)
 {
-    if (mmap.size() == 0)
+    if (mmap.empty())
     {
         return;
     }
 
-#if defined(_WIN32)
+#ifdef _WIN32
     WIN32_MEMORY_RANGE_ENTRY range;
     range.VirtualAddress = const_cast<char *>(mmap.data());
     range.NumberOfBytes = mmap.size();

--- a/library/src/log_file.cpp
+++ b/library/src/log_file.cpp
@@ -37,10 +37,13 @@ void HintSequential(const mio::mmap_source &mmap)
 
 #ifdef _WIN32
     WIN32_MEMORY_RANGE_ENTRY range;
+    // NOLINTNEXTLINE(cppcoreguidelines-pro-type-const-cast): Win32 `PrefetchVirtualMemory` takes non-const `void*`;
+    // mapping is read-only.
     range.VirtualAddress = const_cast<char *>(mmap.data());
     range.NumberOfBytes = mmap.size();
     (void)::PrefetchVirtualMemory(::GetCurrentProcess(), 1, &range, 0);
 #elif defined(__unix__) || defined(__APPLE__)
+    // NOLINTNEXTLINE(cppcoreguidelines-pro-type-const-cast): POSIX API takes non-const `void*`; mapping is read-only.
     (void)::posix_madvise(const_cast<char *>(mmap.data()), mmap.size(), POSIX_MADV_SEQUENTIAL);
 #else
     (void)mmap;

--- a/library/src/log_line.cpp
+++ b/library/src/log_line.cpp
@@ -128,9 +128,7 @@ LogLine::LogLine(
     : mValues(static_cast<uint32_t>(sortedValues.size())), mKeys(&keys), mSource(&source), mLineId(lineId)
 {
 #ifndef NDEBUG
-    assert(std::is_sorted(sortedValues.begin(), sortedValues.end(), [](const auto &a, const auto &b) {
-        return a.first < b.first;
-    }));
+    assert(std::ranges::is_sorted(sortedValues, [](const auto &a, const auto &b) { return a.first < b.first; }));
 #endif
     for (auto &entry : sortedValues)
     {
@@ -147,9 +145,7 @@ LogLine::LogLine(
     : mKeys(&keys), mSource(&source), mLineId(lineId)
 {
 #ifndef NDEBUG
-    assert(std::is_sorted(sortedValues.begin(), sortedValues.end(), [](const auto &a, const auto &b) {
-        return a.first < b.first;
-    }));
+    assert(std::ranges::is_sorted(sortedValues, [](const auto &a, const auto &b) { return a.first < b.first; }));
 #endif
     // Exact-fit copy: drops the temporary vector's `reserve(16)` capacity
     // waste in one go, so each `LogLine` carries only `size * 16` bytes
@@ -167,7 +163,7 @@ LogLine::LogLine(const LogMap &values, KeyIndex &keys, LineSource &source, size_
     {
         staging.emplace_back(keys.GetOrInsert(key), MakeCompactFromVariant(source, lineId, value));
     }
-    std::sort(staging.begin(), staging.end(), [](const auto &a, const auto &b) { return a.first < b.first; });
+    std::ranges::sort(staging, [](const auto &a, const auto &b) { return a.first < b.first; });
     mValues.AssignSorted(staging.data(), static_cast<uint32_t>(staging.size()));
 }
 
@@ -215,27 +211,27 @@ LogValue LogLine::GetValue(const std::string &key) const
     return GetValue(id);
 }
 
-void LogLine::SetValue(KeyId id, LogValue value)
+void LogLine::SetValue(KeyId id, const LogValue &value)
 {
 #ifndef NDEBUG
     // Untagged setter is for owned values; callers passing a `string_view`
     // must use the `LogValueTrustView` overload to declare the lifetime.
     assert(!std::holds_alternative<std::string_view>(value));
 #endif
-    SetValue(id, std::move(value), LogValueTrustView{});
+    SetValue(id, value, LogValueTrustView{});
 }
 
-void LogLine::SetValue(KeyId id, LogValue value, LogValueTrustView /*trust*/)
+void LogLine::SetValue(KeyId id, const LogValue &value, LogValueTrustView /*trust*/)
 {
     assert(mSource != nullptr);
-    internal::CompactLogValue compact = MakeCompactFromVariant(*mSource, mLineId, value);
+    const internal::CompactLogValue compact = MakeCompactFromVariant(*mSource, mLineId, value);
     auto *data = mValues.Data();
     const uint32_t size = mValues.Size();
     uint32_t lo = 0;
     uint32_t hi = size;
     while (lo < hi)
     {
-        const uint32_t mid = lo + (hi - lo) / 2U;
+        const uint32_t mid = lo + ((hi - lo) / 2U);
         if (data[mid].first < id)
         {
             lo = mid + 1U;
@@ -255,7 +251,7 @@ void LogLine::SetValue(KeyId id, LogValue value, LogValueTrustView /*trust*/)
     mValues.Insert(lo, id, compact);
 }
 
-void LogLine::SetValue(const std::string &key, LogValue value)
+void LogLine::SetValue(const std::string &key, const LogValue &value)
 {
     if (mKeys == nullptr)
     {
@@ -266,7 +262,7 @@ void LogLine::SetValue(const std::string &key, LogValue value)
     {
         throw std::runtime_error("LogLine::SetValue(string): key '" + key + "' is not registered in the KeyIndex");
     }
-    SetValue(id, std::move(value));
+    SetValue(id, value);
 }
 
 std::vector<std::string> LogLine::GetKeys() const
@@ -298,7 +294,7 @@ std::vector<std::pair<KeyId, LogValue>> LogLine::IndexedValues() const
 
 std::span<const std::pair<KeyId, internal::CompactLogValue>> LogLine::CompactValues() const noexcept
 {
-    return std::span<const std::pair<KeyId, internal::CompactLogValue>>(mValues.Data(), mValues.Size());
+    return {mValues.Data(), mValues.Size()};
 }
 
 LogMap LogLine::Values() const

--- a/library/src/log_processing.cpp
+++ b/library/src/log_processing.cpp
@@ -20,6 +20,22 @@ namespace loglib
 namespace
 {
 
+constexpr int DECIMAL_RADIX = 10;
+constexpr size_t ISO_DASH1_INDEX = 4;
+constexpr size_t MONTH_DIGITS_OFFSET = 5;
+constexpr size_t ISO_DASH2_INDEX = 7;
+constexpr size_t DAY_DIGITS_OFFSET = 8;
+constexpr size_t DATE_TIME_SEPARATOR_INDEX = 10;
+constexpr size_t HOUR_DIGITS_OFFSET = 11;
+constexpr size_t TIME_COLON1_INDEX = 13;
+constexpr size_t MINUTE_DIGITS_OFFSET = 14;
+constexpr size_t TIME_COLON2_INDEX = 16;
+constexpr size_t SECOND_DIGITS_OFFSET = 17;
+constexpr size_t FRACTION_DIGITS_SCALE = 6;
+constexpr int MAX_HOUR_INCLUSIVE = 23;
+constexpr int MAX_MINUTE_INCLUSIVE = 59;
+constexpr int MAX_SECOND_INCLUSIVE_LEAP = 60;
+
 bool ParseFixedDigits(const char *p, size_t n, int &out)
 {
     int value = 0;
@@ -30,7 +46,7 @@ bool ParseFixedDigits(const char *p, size_t n, int &out)
         {
             return false;
         }
-        value = (value * 10) + (c - '0');
+        value = (value * DECIMAL_RADIX) + (c - '0');
     }
     out = value;
     return true;
@@ -72,43 +88,43 @@ bool TryParseIsoTimestamp(std::string_view sv, char dateTimeSep, TimeStamp &out)
     {
         return false;
     }
-    if (sv[4] != '-')
+    if (sv[ISO_DASH1_INDEX] != '-')
     {
         return false;
     }
-    if (!ParseFixedDigits(sv.data() + 5, 2, month))
+    if (!ParseFixedDigits(sv.data() + MONTH_DIGITS_OFFSET, 2, month))
     {
         return false;
     }
-    if (sv[7] != '-')
+    if (sv[ISO_DASH2_INDEX] != '-')
     {
         return false;
     }
-    if (!ParseFixedDigits(sv.data() + 8, 2, day))
+    if (!ParseFixedDigits(sv.data() + DAY_DIGITS_OFFSET, 2, day))
     {
         return false;
     }
-    if (sv[10] != dateTimeSep)
+    if (sv[DATE_TIME_SEPARATOR_INDEX] != dateTimeSep)
     {
         return false;
     }
-    if (!ParseFixedDigits(sv.data() + 11, 2, hour))
+    if (!ParseFixedDigits(sv.data() + HOUR_DIGITS_OFFSET, 2, hour))
     {
         return false;
     }
-    if (sv[13] != ':')
+    if (sv[TIME_COLON1_INDEX] != ':')
     {
         return false;
     }
-    if (!ParseFixedDigits(sv.data() + 14, 2, minute))
+    if (!ParseFixedDigits(sv.data() + MINUTE_DIGITS_OFFSET, 2, minute))
     {
         return false;
     }
-    if (sv[16] != ':')
+    if (sv[TIME_COLON2_INDEX] != ':')
     {
         return false;
     }
-    if (!ParseFixedDigits(sv.data() + 17, 2, second))
+    if (!ParseFixedDigits(sv.data() + SECOND_DIGITS_OFFSET, 2, second))
     {
         return false;
     }
@@ -121,7 +137,7 @@ bool TryParseIsoTimestamp(std::string_view sv, char dateTimeSep, TimeStamp &out)
             return false;
         }
         const size_t fractionStart = PREFIX_LEN + 1;
-        const size_t maxFractionEnd = std::min(sv.size(), fractionStart + 6);
+        const size_t maxFractionEnd = std::min(sv.size(), fractionStart + FRACTION_DIGITS_SCALE);
         size_t fractionEnd = fractionStart;
         while (fractionEnd < maxFractionEnd && sv[fractionEnd] >= '0' && sv[fractionEnd] <= '9')
         {
@@ -135,16 +151,16 @@ bool TryParseIsoTimestamp(std::string_view sv, char dateTimeSep, TimeStamp &out)
         }
         for (size_t i = fractionStart; i < fractionEnd; ++i)
         {
-            fractionalUs = (fractionalUs * 10) + (sv[i] - '0');
+            fractionalUs = (fractionalUs * DECIMAL_RADIX) + (sv[i] - '0');
         }
-        for (size_t i = fractionLen; i < 6; ++i)
+        for (size_t i = fractionLen; i < FRACTION_DIGITS_SCALE; ++i)
         {
-            fractionalUs *= 10;
+            fractionalUs *= DECIMAL_RADIX;
         }
     }
 
     // Accept second == 60 to match `date::parse("%T")` leap-second handling.
-    if (hour > 23 || minute > 59 || second > 60)
+    if (hour > MAX_HOUR_INCLUSIVE || minute > MAX_MINUTE_INCLUSIVE || second > MAX_SECOND_INCLUSIVE_LEAP)
     {
         return false;
     }

--- a/library/src/log_processing.cpp
+++ b/library/src/log_processing.cpp
@@ -1,8 +1,6 @@
 #include "loglib/log_processing.hpp"
 
 #include "loglib/internal/timestamp_promotion.hpp"
-#include "loglib/line_source.hpp"
-#include "loglib/log_file.hpp"
 
 #include <date/date.h>
 #include <date/tz.h>
@@ -32,7 +30,7 @@ bool ParseFixedDigits(const char *p, size_t n, int &out)
         {
             return false;
         }
-        value = value * 10 + (c - '0');
+        value = (value * 10) + (c - '0');
     }
     out = value;
     return true;
@@ -137,7 +135,7 @@ bool TryParseIsoTimestamp(std::string_view sv, char dateTimeSep, TimeStamp &out)
         }
         for (size_t i = fractionStart; i < fractionEnd; ++i)
         {
-            fractionalUs = fractionalUs * 10 + (sv[i] - '0');
+            fractionalUs = (fractionalUs * 10) + (sv[i] - '0');
         }
         for (size_t i = fractionLen; i < 6; ++i)
         {
@@ -160,11 +158,11 @@ bool TryParseIsoTimestamp(std::string_view sv, char dateTimeSep, TimeStamp &out)
     }
 
     const auto days = date::sys_days{ymd};
-    const auto totalUs =
-        std::chrono::duration_cast<std::chrono::microseconds>(days.time_since_epoch()) +
-        std::chrono::duration_cast<std::chrono::microseconds>(std::chrono::seconds{hour * 3600 + minute * 60 + second}
-        ) +
-        std::chrono::microseconds{fractionalUs};
+    const auto totalUs = std::chrono::duration_cast<std::chrono::microseconds>(days.time_since_epoch()) +
+                         std::chrono::duration_cast<std::chrono::microseconds>(
+                             std::chrono::seconds{(hour * 3600) + (minute * 60) + second}
+                         ) +
+                         std::chrono::microseconds{fractionalUs};
     out = TimeStamp{totalUs};
     // Syntactically valid Y/M/D/H/M/S/fraction is success; the POSIX epoch
     // and pre-1970 timestamps are valid outputs, not failures.
@@ -179,7 +177,12 @@ bool TryParseGenericTimestamp(
     scratch.stream.clear();
     scratch.stream.str(scratch.str);
     out = TimeStamp{};
-    scratch.stream >> date::parse(format, out);
+    // Call `date::from_stream` directly rather than using
+    // `scratch.stream >> date::parse(format, out)`. The latter expands inside
+    // `date::parse` to an unqualified `from_stream(...)` call, which becomes
+    // ambiguous in C++20+/libc++ where `std::chrono::from_stream` is also a
+    // viable overload for `std::chrono::time_point<system_clock, microseconds>`.
+    date::from_stream(scratch.stream, format.c_str(), out);
     // Stream-fail bit alone is the success signal: the POSIX epoch and
     // pre-1970 timestamps are valid outputs.
     return !scratch.stream.fail();
@@ -326,16 +329,15 @@ std::vector<std::string> ParseTimestamps(LogData &logData, const LogConfiguratio
 {
     std::vector<std::string> errors;
 
-    for (size_t i = 0; i < configuration.columns.size(); ++i)
+    for (const auto &column : configuration.columns)
     {
-        const LogConfiguration::Column &column = configuration.columns[i];
         if (column.type == LogConfiguration::Type::time)
         {
             auto columnErrors = BackfillTimestampColumn(column, logData.Lines());
             if (!columnErrors.empty())
             {
                 errors.reserve(errors.size() + columnErrors.size());
-                std::move(columnErrors.begin(), columnErrors.end(), std::back_inserter(errors));
+                std::ranges::move(columnErrors, std::back_inserter(errors));
             }
         }
     }

--- a/library/src/log_table.cpp
+++ b/library/src/log_table.cpp
@@ -7,7 +7,9 @@
 #include <date/tz.h>
 #include <fmt/format.h>
 
+#include <algorithm>
 #include <cassert>
+#include <iterator>
 #include <span>
 #include <string>
 #include <string_view>
@@ -214,14 +216,23 @@ void LogTable::MoveColumn(size_t srcIndex, size_t destIndex)
         return;
     }
     mConfiguration.MoveColumn(srcIndex, destIndex);
+    using Diff = std::vector<std::vector<KeyId>>::difference_type;
     auto begin = mColumnKeyIds.begin();
     if (srcIndex > destIndex)
     {
-        std::rotate(begin + destIndex, begin + srcIndex, begin + srcIndex + 1);
+        std::rotate(
+            std::next(begin, static_cast<Diff>(destIndex)),
+            std::next(begin, static_cast<Diff>(srcIndex)),
+            std::next(begin, static_cast<Diff>(srcIndex + 1))
+        );
     }
     else
     {
-        std::rotate(begin + srcIndex, begin + srcIndex + 1, begin + destIndex + 1);
+        std::rotate(
+            std::next(begin, static_cast<Diff>(srcIndex)),
+            std::next(begin, static_cast<Diff>(srcIndex + 1)),
+            std::next(begin, static_cast<Diff>(destIndex + 1))
+        );
     }
 }
 

--- a/library/src/log_table.cpp
+++ b/library/src/log_table.cpp
@@ -102,7 +102,7 @@ void LogTable::AppendBatch(StreamedBatch batch)
 
     if (!batch.lines.empty() || !batch.localLineOffsets.empty())
     {
-        mData.AppendBatch(std::move(batch.lines), std::move(batch.localLineOffsets));
+        mData.AppendBatch(std::move(batch.lines), batch.localLineOffsets);
     }
 
     if (!batch.newKeys.empty())
@@ -179,7 +179,9 @@ void LogTable::AppendBatch(StreamedBatch batch)
         {
             if (oldLineCount < mData.Lines().size())
             {
-                std::span<LogLine> slice(mData.Lines().data() + oldLineCount, mData.Lines().size() - oldLineCount);
+                const std::span<LogLine> slice(
+                    mData.Lines().data() + oldLineCount, mData.Lines().size() - oldLineCount
+                );
                 BackfillTimestampColumn(column, slice, BackfillErrors::Discard);
             }
         }
@@ -281,7 +283,7 @@ std::string LogTable::GetFormattedValue(size_t row, size_t column) const
         {
             continue;
         }
-        LogValue value = line.GetValue(id);
+        const LogValue value = line.GetValue(id);
         if (!std::holds_alternative<std::monostate>(value))
         {
             return FormatLogValue(printFormat, value);
@@ -409,7 +411,7 @@ void LogTable::RefreshColumnKeyIdsForKeys(const std::vector<std::string> &newKey
         {
             for (const std::string &key : column.keys)
             {
-                if (newKeySet.find(std::string_view(key)) != newKeySet.end())
+                if (newKeySet.contains(std::string_view(key)))
                 {
                     affected = true;
                     break;
@@ -483,12 +485,12 @@ std::string LogTable::FormatLogValue(const std::string &format, const LogValue &
             }
             else if constexpr (std::is_same_v<T, TimeStamp>)
             {
-                const date::zoned_time local_time{CurrentZone(), std::chrono::round<std::chrono::milliseconds>(arg)};
-                return date::format(format, local_time);
+                const date::zoned_time localTime{CurrentZone(), std::chrono::round<std::chrono::milliseconds>(arg)};
+                return date::format(format, localTime);
             }
             else if constexpr (std::is_same_v<T, std::monostate>)
             {
-                return std::string();
+                return {};
             }
             else
             {

--- a/library/src/log_table.cpp
+++ b/library/src/log_table.cpp
@@ -478,19 +478,8 @@ std::string LogTable::FormatLogValue(const std::string &format, const LogValue &
             {
                 return std::string(arg);
             }
-            else if constexpr (std::is_same_v<T, int64_t>)
-            {
-                return fmt::vformat(format, fmt::make_format_args(arg));
-            }
-            else if constexpr (std::is_same_v<T, uint64_t>)
-            {
-                return fmt::vformat(format, fmt::make_format_args(arg));
-            }
-            else if constexpr (std::is_same_v<T, double>)
-            {
-                return fmt::vformat(format, fmt::make_format_args(arg));
-            }
-            else if constexpr (std::is_same_v<T, bool>)
+            else if constexpr (std::is_same_v<T, int64_t> || std::is_same_v<T, uint64_t> || std::is_same_v<T, double> ||
+                               std::is_same_v<T, bool>)
             {
                 return fmt::vformat(format, fmt::make_format_args(arg));
             }

--- a/library/src/parse_file.cpp
+++ b/library/src/parse_file.cpp
@@ -39,7 +39,7 @@ ParseResult ParseFile(const LogParser &parser, const std::filesystem::path &file
 
     LogData data = sink.TakeData();
     std::vector<std::string> errors = sink.TakeErrors();
-    return ParseResult{std::move(data), std::move(errors)};
+    return ParseResult{.data = std::move(data), .errors = std::move(errors)};
 }
 
 ParseResult ParseFile(const std::filesystem::path &file)

--- a/library/src/parsers/json_parser.cpp
+++ b/library/src/parsers/json_parser.cpp
@@ -72,6 +72,8 @@ template <class Field> FastFieldKey ExtractFieldKey(Field &field)
 /// Crossover at which `InsertSorted` switches from a linear back-scan to
 /// `std::lower_bound`. Tuned for the `[wide]` benchmark.
 constexpr size_t INSERT_SORTED_LOWER_BOUND_THRESHOLD = 8;
+constexpr size_t INITIAL_OBJECT_FIELD_CAPACITY = 16;
+constexpr size_t LINE_PADDED_EXTRA_SLACK_BYTES = 64;
 
 void InsertSorted(
     std::vector<std::pair<KeyId, internal::CompactLogValue>> &out, KeyId id, internal::CompactLogValue value
@@ -231,7 +233,7 @@ std::vector<std::pair<KeyId, internal::CompactLogValue>> ParseJsonLine(
 )
 {
     std::vector<std::pair<KeyId, internal::CompactLogValue>> result;
-    result.reserve(16);
+    result.reserve(INITIAL_OBJECT_FIELD_CAPACITY);
 
     for (auto field : object)
     {
@@ -437,8 +439,6 @@ std::vector<std::pair<KeyId, internal::CompactLogValue>> ParseJsonLine(
             break;
         }
         case simdjson::ondemand::json_type::null:
-            InsertSorted(result, keyId, internal::CompactLogValue::MakeMonostate());
-            break;
         default:
             InsertSorted(result, keyId, internal::CompactLogValue::MakeMonostate());
             break;
@@ -562,7 +562,9 @@ void DecodeJsonBatch(
                     if (line.size() > worker.user.maxLineSize || worker.user.linePadded.size() < needed)
                     {
                         worker.user.maxLineSize = std::max(worker.user.maxLineSize, line.size());
-                        worker.user.linePadded.resize(worker.user.maxLineSize + simdjson::SIMDJSON_PADDING + 64);
+                        worker.user.linePadded.resize(
+                            worker.user.maxLineSize + simdjson::SIMDJSON_PADDING + LINE_PADDED_EXTRA_SLACK_BYTES
+                        );
                     }
                     std::memcpy(worker.user.linePadded.data(), line.data(), line.size());
                     std::memset(worker.user.linePadded.data() + line.size(), 0, simdjson::SIMDJSON_PADDING);
@@ -730,7 +732,7 @@ public:
             if (line.size() > mMaxLineSize || mLinePadded.size() < needed)
             {
                 mMaxLineSize = std::max(mMaxLineSize, line.size());
-                mLinePadded.resize(mMaxLineSize + simdjson::SIMDJSON_PADDING + 64);
+                mLinePadded.resize(mMaxLineSize + simdjson::SIMDJSON_PADDING + LINE_PADDED_EXTRA_SLACK_BYTES);
             }
             std::memcpy(mLinePadded.data(), line.data(), line.size());
             std::memset(mLinePadded.data() + line.size(), 0, simdjson::SIMDJSON_PADDING);

--- a/library/src/parsers/json_parser.cpp
+++ b/library/src/parsers/json_parser.cpp
@@ -1,6 +1,5 @@
 #include "loglib/parsers/json_parser.hpp"
 
-#include "loglib/bytes_producer.hpp"
 #include "loglib/file_line_source.hpp"
 #include "loglib/internal/advanced_parser_options.hpp"
 #include "loglib/internal/compact_log_value.hpp"
@@ -8,7 +7,6 @@
 #include "loglib/internal/static_parser_pipeline.hpp"
 #include "loglib/internal/streaming_parse_loop.hpp"
 #include "loglib/internal/timestamp_promotion.hpp"
-#include "loglib/log_configuration.hpp"
 #include "loglib/log_file.hpp"
 #include "loglib/log_line.hpp"
 #include "loglib/log_processing.hpp"
@@ -17,16 +15,13 @@
 #include <date/date.h>
 #include <fmt/format.h>
 #include <glaze/glaze.hpp>
+#include <algorithm>
 
 #include <simdjson.h>
 
-#include <algorithm>
-#include <bit>
-#include <chrono>
 #include <cstdint>
 #include <cstring>
 #include <fstream>
-#include <iterator>
 #include <stdexcept>
 #include <string>
 #include <string_view>
@@ -58,7 +53,7 @@ template <class Field> FastFieldKey ExtractFieldKey(Field &field)
         return result;
     }
 
-    if (escaped.find('\\') == std::string_view::npos)
+    if (!escaped.contains('\\'))
     {
         result.isView = true;
         result.view = escaped;
@@ -103,6 +98,8 @@ void InsertSorted(
         return;
     }
 
+    // Asymmetric comparator: std::ranges::lower_bound rejects it.
+    // NOLINTNEXTLINE(modernize-use-ranges)
     auto it = std::lower_bound(
         out.begin(),
         out.end(),
@@ -147,11 +144,11 @@ internal::CompactLogValue ExtractStringValue(
     // benchmark's fast-path fraction is the regression signal).
     if (sourceIsStable)
     {
-        std::string_view rawToken(value.raw_json_token());
+        const std::string_view rawToken(value.raw_json_token());
         if (rawToken.size() >= 2 && rawToken.front() == '"' && rawToken.back() == '"')
         {
-            std::string_view inner = rawToken.substr(1, rawToken.size() - 2);
-            if (inner.find('\\') == std::string_view::npos)
+            const std::string_view inner = rawToken.substr(1, rawToken.size() - 2);
+            if (!inner.contains('\\'))
             {
                 return MakeStringCompact(inner, fileBegin, fileSize, ownedArena);
             }
@@ -238,7 +235,7 @@ std::vector<std::pair<KeyId, internal::CompactLogValue>> ParseJsonLine(
 
     for (auto field : object)
     {
-        FastFieldKey fk = ExtractFieldKey(field);
+        const FastFieldKey fk = ExtractFieldKey(field);
         if (!fk.isView && fk.owned.empty())
         {
             continue;
@@ -256,7 +253,7 @@ std::vector<std::pair<KeyId, internal::CompactLogValue>> ParseJsonLine(
             {
             case simdjson::ondemand::json_type::boolean:
             {
-                bool b;
+                bool b = false;
                 if (!value.get(b))
                 {
                     InsertSorted(result, keyId, internal::CompactLogValue::MakeBool(b));
@@ -272,7 +269,7 @@ std::vector<std::pair<KeyId, internal::CompactLogValue>> ParseJsonLine(
                     {
                     case simdjson::ondemand::number_type::signed_integer:
                     {
-                        int64_t i;
+                        int64_t i = 0;
                         if (!value.get(i))
                         {
                             InsertSorted(result, keyId, internal::CompactLogValue::MakeInt64(i));
@@ -282,7 +279,7 @@ std::vector<std::pair<KeyId, internal::CompactLogValue>> ParseJsonLine(
                     }
                     case simdjson::ondemand::number_type::unsigned_integer:
                     {
-                        uint64_t u;
+                        uint64_t u = 0;
                         if (!value.get(u))
                         {
                             InsertSorted(result, keyId, internal::CompactLogValue::MakeUint64(u));
@@ -292,7 +289,7 @@ std::vector<std::pair<KeyId, internal::CompactLogValue>> ParseJsonLine(
                     }
                     case simdjson::ondemand::number_type::floating_point_number:
                     {
-                        double d;
+                        double d = NAN;
                         if (!value.get(d))
                         {
                             InsertSorted(result, keyId, internal::CompactLogValue::MakeDouble(d));
@@ -308,7 +305,7 @@ std::vector<std::pair<KeyId, internal::CompactLogValue>> ParseJsonLine(
             }
             case simdjson::ondemand::json_type::string:
             {
-                internal::CompactLogValue stringValue =
+                const internal::CompactLogValue stringValue =
                     ExtractStringValue(value, sourceIsStable, fileBegin, fileSize, ownedArena);
                 if (stringValue.tag != internal::CompactTag::Monostate)
                 {
@@ -320,7 +317,7 @@ std::vector<std::pair<KeyId, internal::CompactLogValue>> ParseJsonLine(
             case simdjson::ondemand::json_type::array:
             case simdjson::ondemand::json_type::object:
             {
-                internal::CompactLogValue rawValue =
+                const internal::CompactLogValue rawValue =
                     ExtractRawJsonValue(value, sourceIsStable, fileBegin, fileSize, ownedArena);
                 if (rawValue.tag != internal::CompactTag::Monostate)
                 {
@@ -356,7 +353,7 @@ std::vector<std::pair<KeyId, internal::CompactLogValue>> ParseJsonLine(
         {
         case simdjson::ondemand::json_type::boolean:
         {
-            bool b;
+            bool b = false;
             if (!value.get(b))
             {
                 InsertSorted(result, keyId, internal::CompactLogValue::MakeBool(b));
@@ -381,7 +378,7 @@ std::vector<std::pair<KeyId, internal::CompactLogValue>> ParseJsonLine(
             {
             case simdjson::ondemand::number_type::signed_integer:
             {
-                int64_t i;
+                int64_t i = 0;
                 if (!value.get(i))
                 {
                     InsertSorted(result, keyId, internal::CompactLogValue::MakeInt64(i));
@@ -394,7 +391,7 @@ std::vector<std::pair<KeyId, internal::CompactLogValue>> ParseJsonLine(
             }
             case simdjson::ondemand::number_type::unsigned_integer:
             {
-                uint64_t u;
+                uint64_t u = 0;
                 if (!value.get(u))
                 {
                     InsertSorted(result, keyId, internal::CompactLogValue::MakeUint64(u));
@@ -407,7 +404,7 @@ std::vector<std::pair<KeyId, internal::CompactLogValue>> ParseJsonLine(
             }
             case simdjson::ondemand::number_type::floating_point_number:
             {
-                double d;
+                double d = NAN;
                 if (!value.get(d))
                 {
                     InsertSorted(result, keyId, internal::CompactLogValue::MakeDouble(d));
@@ -426,7 +423,7 @@ std::vector<std::pair<KeyId, internal::CompactLogValue>> ParseJsonLine(
         }
         case simdjson::ondemand::json_type::string:
         {
-            internal::CompactLogValue stringValue =
+            const internal::CompactLogValue stringValue =
                 ExtractStringValue(value, sourceIsStable, fileBegin, fileSize, ownedArena);
             InsertSorted(result, keyId, stringValue);
             break;
@@ -434,7 +431,7 @@ std::vector<std::pair<KeyId, internal::CompactLogValue>> ParseJsonLine(
         case simdjson::ondemand::json_type::array:
         case simdjson::ondemand::json_type::object:
         {
-            internal::CompactLogValue rawValue =
+            const internal::CompactLogValue rawValue =
                 ExtractRawJsonValue(value, sourceIsStable, fileBegin, fileSize, ownedArena);
             InsertSorted(result, keyId, rawValue);
             break;
@@ -522,8 +519,8 @@ void DecodeJsonBatch(
     const char *fileEnd = batch.fileEnd;
     const char *fileBegin = source.File().Data();
 
-    const size_t batchBytes = static_cast<size_t>(end - cursor);
-    const size_t estimatedLines = batchBytes / 64 + 1;
+    const auto batchBytes = static_cast<size_t>(end - cursor);
+    const size_t estimatedLines = (batchBytes / 64) + 1;
     parsed.lines.reserve(estimatedLines);
     parsed.localLineOffsets.reserve(estimatedLines);
 
@@ -557,7 +554,7 @@ void DecodeJsonBatch(
         {
             // mmap fast path needs SIMDJSON_PADDING bytes of slack past
             // lineEnd; otherwise fall back to a padded scratch copy.
-            const size_t remaining = static_cast<size_t>(fileEnd - lineEnd);
+            const auto remaining = static_cast<size_t>(fileEnd - lineEnd);
             const bool sourceIsStable = remaining >= simdjson::SIMDJSON_PADDING;
             auto result =
                 sourceIsStable ? worker.user.parser.iterate(line.data(), line.size(), line.size() + remaining) : [&]() {
@@ -575,9 +572,9 @@ void DecodeJsonBatch(
                 }();
             if (result.error())
             {
-                parsed.errors.push_back(
-                    internal::ParsedLineError{relativeLineNumber, std::string(simdjson::error_message(result.error()))}
-                );
+                parsed.errors.push_back(internal::ParsedLineError{
+                    .relativeLine = relativeLineNumber, .body = std::string(simdjson::error_message(result.error()))
+                });
                 relativeLineNumber++;
                 continue;
             }
@@ -585,13 +582,15 @@ void DecodeJsonBatch(
             auto object = result.get_object();
             if (object.error())
             {
-                parsed.errors.push_back(internal::ParsedLineError{relativeLineNumber, "Not a JSON object."});
+                parsed.errors.push_back(
+                    internal::ParsedLineError{.relativeLine = relativeLineNumber, .body = "Not a JSON object."}
+                );
                 relativeLineNumber++;
                 continue;
             }
 
             auto objectValue = object.value();
-            const size_t fileSize = static_cast<size_t>(fileEnd - fileBegin);
+            const auto fileSize = static_cast<size_t>(fileEnd - fileBegin);
             auto values = ParseJsonLine(
                 objectValue,
                 keys,
@@ -618,7 +617,9 @@ void DecodeJsonBatch(
         }
         catch (const std::exception &e)
         {
-            parsed.errors.push_back(internal::ParsedLineError{relativeLineNumber, std::string(e.what())});
+            parsed.errors.push_back(
+                internal::ParsedLineError{.relativeLine = relativeLineNumber, .body = std::string(e.what())}
+            );
         }
 
         relativeLineNumber++;
@@ -674,7 +675,7 @@ std::string JsonParser::ToString(const LogLine &line) const
     return SerializeJson(json);
 }
 
-std::string JsonParser::ToString(const LogMap &values) const
+std::string JsonParser::ToString(const LogMap &values)
 {
     if (values.empty())
     {
@@ -793,14 +794,14 @@ void JsonParser::ParseStreaming(StreamLineSource &source, LogParseSink &sink, Pa
 
 void JsonParser::ParseStreaming(FileLineSource &source, LogParseSink &sink, ParserOptions options) const
 {
-    ParseStreaming(source, sink, std::move(options), internal::AdvancedParserOptions{});
+    ParseStreaming(source, sink, options, internal::AdvancedParserOptions{});
 }
 
 void JsonParser::ParseStreaming(
-    FileLineSource &source, LogParseSink &sink, ParserOptions options, internal::AdvancedParserOptions advanced
-) const
+    FileLineSource &source, LogParseSink &sink, const ParserOptions &options, internal::AdvancedParserOptions advanced
+)
 {
-    LogFile &file = source.File();
+    const LogFile &file = source.File();
     const size_t batchSize = advanced.batchSizeBytes != 0 ? advanced.batchSizeBytes
                                                           : internal::AdvancedParserOptions::DEFAULT_BATCH_SIZE_BYTES;
 
@@ -817,7 +818,7 @@ void JsonParser::ParseStreaming(
         }
         const char *batchBegin = cursor;
         // Bounded advance: `cursor + batchSize` past one-past-end is UB.
-        const size_t remaining = static_cast<size_t>(fileEnd - cursor);
+        const auto remaining = static_cast<size_t>(fileEnd - cursor);
         const size_t advance = std::min(batchSize, remaining);
         const char *target = cursor + advance;
         if (advance < remaining)

--- a/library/src/static_parser_pipeline.cpp
+++ b/library/src/static_parser_pipeline.cpp
@@ -17,7 +17,7 @@ ResolvedPipelineSettings ResolvePipelineSettings(const AdvancedParserOptions &ad
     {
         out.effectiveThreads = 1;
     }
-    out.ntokens = static_cast<size_t>(2 * out.effectiveThreads);
+    out.ntokens = size_t{2} * static_cast<size_t>(out.effectiveThreads);
     return out;
 }
 

--- a/library/src/stream_line_source.cpp
+++ b/library/src/stream_line_source.cpp
@@ -55,7 +55,7 @@ std::string_view StreamLineSource::ResolveOwnedBytes(uint64_t offset, uint32_t l
     // Deque entries are reference-stable until evicted, so the view
     // outlives the lock release. Callers must not retain it past the
     // next `EvictBefore` for this line id.
-    return std::string_view(arena.data() + offset, length);
+    return {arena.data() + offset, length};
 }
 
 std::span<const char> StreamLineSource::StableBytes() const noexcept

--- a/library/src/stream_line_source.cpp
+++ b/library/src/stream_line_source.cpp
@@ -24,7 +24,7 @@ const std::filesystem::path &StreamLineSource::Path() const noexcept
 
 std::string StreamLineSource::RawLine(size_t lineId) const
 {
-    std::lock_guard<std::mutex> guard(mLock);
+    const std::scoped_lock guard(mLock);
     if (!LineIsLiveLocked(lineId))
     {
         throw std::out_of_range("StreamLineSource::RawLine: lineId " + std::to_string(lineId) + " is not available");
@@ -42,7 +42,7 @@ std::string_view StreamLineSource::ResolveMmapBytes(
 
 std::string_view StreamLineSource::ResolveOwnedBytes(uint64_t offset, uint32_t length, size_t lineId) const noexcept
 {
-    std::lock_guard<std::mutex> guard(mLock);
+    const std::scoped_lock guard(mLock);
     if (!LineIsLiveLocked(lineId))
     {
         return {};
@@ -67,7 +67,7 @@ std::span<const char> StreamLineSource::StableBytes() const noexcept
 
 uint64_t StreamLineSource::AppendOwnedBytes(size_t lineId, std::string_view bytes)
 {
-    std::lock_guard<std::mutex> guard(mLock);
+    const std::scoped_lock guard(mLock);
     if (!LineIsLiveLocked(lineId))
     {
         throw std::out_of_range(
@@ -87,7 +87,7 @@ bool StreamLineSource::SupportsEviction() const noexcept
 
 void StreamLineSource::EvictBefore(size_t firstSurvivingLineId)
 {
-    std::lock_guard<std::mutex> guard(mLock);
+    const std::scoped_lock guard(mLock);
     if (firstSurvivingLineId <= mFirstAvailableLineId)
     {
         return;
@@ -106,7 +106,7 @@ void StreamLineSource::EvictBefore(size_t firstSurvivingLineId)
 
 size_t StreamLineSource::FirstAvailableLineId() const noexcept
 {
-    std::lock_guard<std::mutex> guard(mLock);
+    const std::scoped_lock guard(mLock);
     return mFirstAvailableLineId;
 }
 
@@ -122,7 +122,7 @@ const BytesProducer *StreamLineSource::Producer() const noexcept
 
 size_t StreamLineSource::AppendLine(std::string rawLine, std::string ownedBytes)
 {
-    std::lock_guard<std::mutex> guard(mLock);
+    const std::scoped_lock guard(mLock);
     const size_t lineId = mNextLineId++;
     mLines.push_back(std::move(rawLine));
     mLineOwnedBytes.push_back(std::move(ownedBytes));
@@ -131,13 +131,13 @@ size_t StreamLineSource::AppendLine(std::string rawLine, std::string ownedBytes)
 
 size_t StreamLineSource::Size() const noexcept
 {
-    std::lock_guard<std::mutex> guard(mLock);
+    const std::scoped_lock guard(mLock);
     return mLines.size();
 }
 
 size_t StreamLineSource::OwnedMemoryBytes() const noexcept
 {
-    std::lock_guard<std::mutex> guard(mLock);
+    const std::scoped_lock guard(mLock);
     // STRICT LOWER BOUND: this counts the per-string control block
     // (`sizeof(std::string)` per element) plus each string's heap
     // `capacity()`. It does NOT count `std::deque`'s per-block

--- a/library/src/tailing_bytes_producer.cpp
+++ b/library/src/tailing_bytes_producer.cpp
@@ -186,7 +186,7 @@ SsizeType ReadAtOffset(internal::NativeFileHandle handle, void *out, size_t size
 #else
     SsizeType total = 0;
     char *outChars = static_cast<char *>(out);
-    while (total < static_cast<SsizeType>(size))
+    while (std::cmp_less(total, size))
     {
         const auto pos = static_cast<off_t>(offset + static_cast<uint64_t>(total));
         const ssize_t n = ::pread(handle, outChars + total, size - static_cast<size_t>(total), pos);

--- a/library/src/tailing_bytes_producer.cpp
+++ b/library/src/tailing_bytes_producer.cpp
@@ -188,7 +188,8 @@ SsizeType ReadAtOffset(internal::NativeFileHandle handle, void *out, size_t size
     char *outChars = static_cast<char *>(out);
     while (total < static_cast<SsizeType>(size))
     {
-        const ssize_t n = ::pread(handle, outChars + total, size - static_cast<size_t>(total), offset + total);
+        const auto pos = static_cast<off_t>(offset + static_cast<uint64_t>(total));
+        const ssize_t n = ::pread(handle, outChars + total, size - static_cast<size_t>(total), pos);
         if (n == 0)
         {
             break; // EOF

--- a/library/src/tailing_bytes_producer.cpp
+++ b/library/src/tailing_bytes_producer.cpp
@@ -882,7 +882,8 @@ void TailingBytesProducerImpl::CompactReadyBufferIfNeededLocked()
     constexpr size_t MIN_COMPACT_BYTES = 64 * 1024;
     if (mReadyConsumed >= MIN_COMPACT_BYTES && mReadyConsumed * 2 >= mReadyBuffer.size())
     {
-        const auto eraseEnd = std::next(mReadyBuffer.begin(), static_cast<std::vector<char>::difference_type>(mReadyConsumed));
+        const auto eraseEnd =
+            std::next(mReadyBuffer.begin(), static_cast<std::vector<char>::difference_type>(mReadyConsumed));
         mReadyBuffer.erase(mReadyBuffer.begin(), eraseEnd);
         mReadyConsumed = 0;
     }

--- a/library/src/tailing_bytes_producer.cpp
+++ b/library/src/tailing_bytes_producer.cpp
@@ -13,6 +13,7 @@
 #include <cstring>
 #include <filesystem>
 #include <functional>
+#include <iterator>
 #include <limits>
 #include <memory>
 #include <mutex>
@@ -142,6 +143,22 @@ std::optional<uint64_t> SizeOfOpenHandle(internal::NativeFileHandle handle) noex
 #endif
 }
 
+#ifdef _WIN32
+/// Split a 64-bit file offset into `OVERLAPPED::Offset` / `OffsetHigh`.
+/// `OVERLAPPED` stores these fields in a union; this is the documented
+/// Win32 pattern for overlapped reads.
+constexpr DWORD K_OVERLAPPED_OFFSET_LOW_MASK = 0xFFFFFFFFu;
+constexpr unsigned K_OVERLAPPED_OFFSET_HIGH_SHIFT = 32U;
+
+void SetOverlappedFileOffset(OVERLAPPED &ov, uint64_t offset) noexcept
+{
+    // NOLINTNEXTLINE(cppcoreguidelines-pro-type-union-access): Win32 API layout
+    ov.Offset = static_cast<DWORD>(offset & K_OVERLAPPED_OFFSET_LOW_MASK);
+    // NOLINTNEXTLINE(cppcoreguidelines-pro-type-union-access)
+    ov.OffsetHigh = static_cast<DWORD>(offset >> K_OVERLAPPED_OFFSET_HIGH_SHIFT);
+}
+#endif
+
 /// Pread-style read: up to @p size bytes from @p offset, without
 /// advancing a persistent file pointer. Short reads at EOF are normal.
 /// Returns -1 on hard error.
@@ -153,8 +170,7 @@ SsizeType ReadAtOffset(internal::NativeFileHandle handle, void *out, size_t size
     }
 #ifdef _WIN32
     OVERLAPPED ov{};
-    ov.Offset = static_cast<DWORD>(offset & 0xFFFFFFFFu);
-    ov.OffsetHigh = static_cast<DWORD>(offset >> 32);
+    SetOverlappedFileOffset(ov, offset);
     DWORD bytesRead = 0;
     const DWORD toRead = static_cast<DWORD>(std::min<size_t>(size, std::numeric_limits<DWORD>::max()));
     if (!::ReadFile(handle, out, toRead, &bytesRead, &ov))
@@ -198,6 +214,9 @@ namespace internal
 
 class TailingBytesProducerImpl;
 
+namespace
+{
+
 /// efsw listener glue. Filters parent-directory events down to the
 /// basename of our open file and forwards to the source.
 class TailingBytesProducerWatcherListener final : public efsw::FileWatchListener
@@ -221,6 +240,8 @@ private:
     std::string mFilename;
 };
 
+} // namespace
+
 /// Pimpl for `TailingBytesProducer`. Owns the worker thread, the mutex /
 /// cv pair guarding the byte queue, and the efsw watcher.
 class TailingBytesProducerImpl
@@ -240,8 +261,8 @@ public:
     void Stop() noexcept;
     [[nodiscard]] bool IsClosed() const noexcept;
     [[nodiscard]] std::string DisplayName() const;
-    void SetRotationCallback(std::function<void()> callback);
-    void SetStatusCallback(std::function<void(SourceStatus)> callback);
+    void SetRotationCallback(const std::function<void()> &callback);
+    void SetStatusCallback(const std::function<void(SourceStatus)> &callback);
     [[nodiscard]] size_t RotationCount() const noexcept;
 
     /// Called from the efsw thread. Wakes the worker.
@@ -314,6 +335,9 @@ private:
     std::thread mWorker;
 };
 
+namespace
+{
+
 void TailingBytesProducerWatcherListener::handleFileAction(
     efsw::WatchID /*watchid*/,
     const std::string & /*dir*/,
@@ -331,6 +355,8 @@ void TailingBytesProducerWatcherListener::handleFileAction(
         mImpl->OnWatcherEvent();
     }
 }
+
+} // namespace
 
 TailingBytesProducerImpl::TailingBytesProducerImpl(
     std::filesystem::path path, size_t retentionLines, TailingBytesProducer::Options options
@@ -474,13 +500,13 @@ std::string TailingBytesProducerImpl::DisplayName() const
     return mDisplayName;
 }
 
-void TailingBytesProducerImpl::SetRotationCallback(std::function<void()> callback)
+void TailingBytesProducerImpl::SetRotationCallback(const std::function<void()> &callback)
 {
     const std::scoped_lock lock(mCallbackMutex);
-    mRotationCallback = std::move(callback);
+    mRotationCallback = callback;
 }
 
-void TailingBytesProducerImpl::SetStatusCallback(std::function<void(SourceStatus)> callback)
+void TailingBytesProducerImpl::SetStatusCallback(const std::function<void(SourceStatus)> &callback)
 {
     // Mirror `TcpServerProducer` / `UdpServerProducer`: snapshot the
     // last-reported status under the lock and replay it once outside
@@ -494,7 +520,7 @@ void TailingBytesProducerImpl::SetStatusCallback(std::function<void(SourceStatus
     SourceStatus current{};
     {
         const std::scoped_lock lock(mCallbackMutex);
-        mStatusCallback = std::move(callback);
+        mStatusCallback = callback;
         snapshot = mStatusCallback;
         current = mLastReportedStatus;
     }
@@ -625,7 +651,8 @@ void TailingBytesProducerImpl::Prefill()
         scannedBytes += static_cast<uint64_t>(n);
         for (auto i = static_cast<size_t>(n); i > 0; --i)
         {
-            if (chunk[i - 1] == '\n')
+            const size_t idx = i - 1U;
+            if (chunk.at(idx) == '\n')
             {
                 ++newlinesSeen;
                 if (newlinesSeen == targetNewlines)
@@ -829,7 +856,8 @@ void TailingBytesProducerImpl::AppendBytesAndSplitLocked(const char *data, size_
         return;
     }
     const size_t completeBytes = lastNewline + 1;
-    mReadyBuffer.insert(mReadyBuffer.end(), mPartialLine.begin(), mPartialLine.begin() + completeBytes);
+    const auto completeEnd = std::next(mPartialLine.begin(), static_cast<std::string::difference_type>(completeBytes));
+    mReadyBuffer.insert(mReadyBuffer.end(), mPartialLine.begin(), completeEnd);
     mPartialLine.erase(0, completeBytes);
 }
 
@@ -854,7 +882,8 @@ void TailingBytesProducerImpl::CompactReadyBufferIfNeededLocked()
     constexpr size_t MIN_COMPACT_BYTES = 64 * 1024;
     if (mReadyConsumed >= MIN_COMPACT_BYTES && mReadyConsumed * 2 >= mReadyBuffer.size())
     {
-        mReadyBuffer.erase(mReadyBuffer.begin(), mReadyBuffer.begin() + mReadyConsumed);
+        const auto eraseEnd = std::next(mReadyBuffer.begin(), static_cast<std::vector<char>::difference_type>(mReadyConsumed));
+        mReadyBuffer.erase(mReadyBuffer.begin(), eraseEnd);
         mReadyConsumed = 0;
     }
 }
@@ -935,14 +964,14 @@ std::string TailingBytesProducer::DisplayName() const
     return mImpl->DisplayName();
 }
 
-void TailingBytesProducer::SetRotationCallback(std::function<void()> callback)
+void TailingBytesProducer::SetRotationCallback(const std::function<void()> &callback)
 {
-    mImpl->SetRotationCallback(std::move(callback));
+    mImpl->SetRotationCallback(callback);
 }
 
-void TailingBytesProducer::SetStatusCallback(std::function<void(SourceStatus)> callback)
+void TailingBytesProducer::SetStatusCallback(const std::function<void(SourceStatus)> &callback)
 {
-    mImpl->SetStatusCallback(std::move(callback));
+    mImpl->SetStatusCallback(callback);
 }
 
 size_t TailingBytesProducer::RotationCount() const noexcept

--- a/library/src/tailing_bytes_producer.cpp
+++ b/library/src/tailing_bytes_producer.cpp
@@ -18,14 +18,13 @@
 #include <mutex>
 #include <optional>
 #include <span>
-#include <stdexcept>
 #include <string>
 #include <system_error>
 #include <thread>
 #include <utility>
 #include <vector>
 
-#if defined(_WIN32)
+#ifdef _WIN32
 #ifndef WIN32_LEAN_AND_MEAN
 #define WIN32_LEAN_AND_MEAN
 #endif
@@ -41,7 +40,7 @@ namespace
 {
 // `ssize_t` is POSIX-only; alias to a portable signed type so the I/O
 // helpers below have a single signature on all platforms.
-using ssize_type = std::int64_t;
+using SsizeType = std::int64_t;
 } // namespace
 
 namespace loglib
@@ -50,7 +49,7 @@ namespace loglib
 namespace
 {
 
-#if defined(_WIN32)
+#ifdef _WIN32
 // `INVALID_HANDLE_VALUE` is a reinterpret_cast and not a constant
 // expression in MSVC's C++23 mode (C2131); use a plain `const` global.
 const internal::NativeFileHandle INVALID_HANDLE = INVALID_HANDLE_VALUE;
@@ -60,7 +59,7 @@ constexpr internal::NativeFileHandle INVALID_HANDLE = -1;
 
 bool IsValidHandle(internal::NativeFileHandle handle) noexcept
 {
-#if defined(_WIN32)
+#ifdef _WIN32
     return handle != INVALID_HANDLE_VALUE && handle != nullptr;
 #else
     return handle >= 0;
@@ -73,7 +72,7 @@ void CloseNativeHandle(internal::NativeFileHandle handle) noexcept
     {
         return;
     }
-#if defined(_WIN32)
+#ifdef _WIN32
     ::CloseHandle(handle);
 #else
     ::close(handle);
@@ -100,7 +99,7 @@ std::filesystem::path CanonicalizeWatchedPath(std::filesystem::path path)
 /// Returns `INVALID_HANDLE` on failure.
 internal::NativeFileHandle OpenForTail(const std::filesystem::path &path) noexcept
 {
-#if defined(_WIN32)
+#ifdef _WIN32
     // FILE_SHARE_DELETE is critical: without it the producer cannot
     // rename or unlink the file. FILE_FLAG_SEQUENTIAL_SCAN hints the
     // cache manager to read ahead.
@@ -126,7 +125,7 @@ std::optional<uint64_t> SizeOfOpenHandle(internal::NativeFileHandle handle) noex
     {
         return std::nullopt;
     }
-#if defined(_WIN32)
+#ifdef _WIN32
     LARGE_INTEGER li{};
     if (!::GetFileSizeEx(handle, &li))
     {
@@ -146,13 +145,13 @@ std::optional<uint64_t> SizeOfOpenHandle(internal::NativeFileHandle handle) noex
 /// Pread-style read: up to @p size bytes from @p offset, without
 /// advancing a persistent file pointer. Short reads at EOF are normal.
 /// Returns -1 on hard error.
-ssize_type ReadAtOffset(internal::NativeFileHandle handle, void *out, size_t size, uint64_t offset) noexcept
+SsizeType ReadAtOffset(internal::NativeFileHandle handle, void *out, size_t size, uint64_t offset) noexcept
 {
     if (!IsValidHandle(handle) || size == 0)
     {
         return 0;
     }
-#if defined(_WIN32)
+#ifdef _WIN32
     OVERLAPPED ov{};
     ov.Offset = static_cast<DWORD>(offset & 0xFFFFFFFFu);
     ov.OffsetHigh = static_cast<DWORD>(offset >> 32);
@@ -167,11 +166,11 @@ ssize_type ReadAtOffset(internal::NativeFileHandle handle, void *out, size_t siz
         }
         return -1;
     }
-    return static_cast<ssize_type>(bytesRead);
+    return static_cast<SsizeType>(bytesRead);
 #else
-    ssize_type total = 0;
+    SsizeType total = 0;
     char *outChars = static_cast<char *>(out);
-    while (total < static_cast<ssize_type>(size))
+    while (total < static_cast<SsizeType>(size))
     {
         const ssize_t n = ::pread(handle, outChars + total, size - static_cast<size_t>(total), offset + total);
         if (n == 0)
@@ -186,7 +185,7 @@ ssize_type ReadAtOffset(internal::NativeFileHandle handle, void *out, size_t siz
             }
             return -1;
         }
-        total += static_cast<ssize_type>(n);
+        total += static_cast<SsizeType>(n);
     }
     return total;
 #endif
@@ -297,7 +296,7 @@ private:
     mutable std::mutex mCallbackMutex;
     std::function<void()> mRotationCallback;
     std::function<void(SourceStatus)> mStatusCallback;
-    std::chrono::steady_clock::time_point mLastRotationFireTime{};
+    std::chrono::steady_clock::time_point mLastRotationFireTime;
     SourceStatus mLastReportedStatus = SourceStatus::Running;
 
     // Worker-thread-only state (no lock needed):
@@ -342,11 +341,12 @@ TailingBytesProducerImpl::TailingBytesProducerImpl(
       mFileName(mPath.filename().string()),
       mDisplayName(mPath.string()),
       mRetentionLines(std::max<size_t>(retentionLines, 1)),
-      mOptions(options)
+      mOptions(options),
+      mHandle(OpenForTail(mPath))
 {
     // Open synchronously. Transient ENOENT during tailing is handled by
     // the worker's rotation branch (ii), not here.
-    mHandle = OpenForTail(mPath);
+
     if (!IsValidHandle(mHandle))
     {
         const std::error_code ec(errno, std::generic_category());
@@ -419,7 +419,7 @@ size_t TailingBytesProducerImpl::Read(std::span<char> buffer)
         return 0;
     }
 
-    std::lock_guard<std::mutex> lock(mMutex);
+    const std::scoped_lock lock(mMutex);
     const size_t available = mReadyBuffer.size() - mReadyConsumed;
     if (available == 0)
     {
@@ -453,7 +453,7 @@ void TailingBytesProducerImpl::Stop() noexcept
         return; // already stopped
     }
     {
-        std::lock_guard<std::mutex> lock(mMutex);
+        const std::scoped_lock lock(mMutex);
         mWatcherEventPending = true;
     }
     mCv.notify_all();
@@ -465,7 +465,7 @@ bool TailingBytesProducerImpl::IsClosed() const noexcept
     {
         return false;
     }
-    std::lock_guard<std::mutex> lock(mMutex);
+    const std::scoped_lock lock(mMutex);
     return (mReadyBuffer.size() - mReadyConsumed) == 0;
 }
 
@@ -476,7 +476,7 @@ std::string TailingBytesProducerImpl::DisplayName() const
 
 void TailingBytesProducerImpl::SetRotationCallback(std::function<void()> callback)
 {
-    std::lock_guard<std::mutex> lock(mCallbackMutex);
+    const std::scoped_lock lock(mCallbackMutex);
     mRotationCallback = std::move(callback);
 }
 
@@ -493,7 +493,7 @@ void TailingBytesProducerImpl::SetStatusCallback(std::function<void(SourceStatus
     std::function<void(SourceStatus)> snapshot;
     SourceStatus current{};
     {
-        std::lock_guard<std::mutex> lock(mCallbackMutex);
+        const std::scoped_lock lock(mCallbackMutex);
         mStatusCallback = std::move(callback);
         snapshot = mStatusCallback;
         current = mLastReportedStatus;
@@ -512,7 +512,7 @@ size_t TailingBytesProducerImpl::RotationCount() const noexcept
 void TailingBytesProducerImpl::OnWatcherEvent() noexcept
 {
     {
-        std::lock_guard<std::mutex> lock(mMutex);
+        const std::scoped_lock lock(mMutex);
         mWatcherEventPending = true;
     }
     mCv.notify_all();
@@ -562,7 +562,7 @@ void TailingBytesProducerImpl::WorkerMain()
         }
         else
         {
-            std::lock_guard<std::mutex> lock(mMutex);
+            const std::scoped_lock lock(mMutex);
             mWatcherEventPending = false;
         }
     }
@@ -570,7 +570,7 @@ void TailingBytesProducerImpl::WorkerMain()
     // Flush the partial-line buffer as a synthetic final line, unless
     // we're mid-rotation.
     {
-        std::lock_guard<std::mutex> lock(mMutex);
+        const std::scoped_lock lock(mMutex);
         if (!mRotationInProgress)
         {
             FlushPartialLineLocked();
@@ -615,7 +615,7 @@ void TailingBytesProducerImpl::Prefill()
     {
         const uint64_t chunkSize = std::min<uint64_t>(pos, mOptions.prefillChunkBytes);
         pos -= chunkSize;
-        const ssize_type n = ReadAtOffset(mHandle, chunk.data(), static_cast<size_t>(chunkSize), pos);
+        const SsizeType n = ReadAtOffset(mHandle, chunk.data(), static_cast<size_t>(chunkSize), pos);
         if (n <= 0)
         {
             // Read failed; abandon prefill and tail from file_size.
@@ -623,7 +623,7 @@ void TailingBytesProducerImpl::Prefill()
             return;
         }
         scannedBytes += static_cast<uint64_t>(n);
-        for (size_t i = static_cast<size_t>(n); i > 0; --i)
+        for (auto i = static_cast<size_t>(n); i > 0; --i)
         {
             if (chunk[i - 1] == '\n')
             {
@@ -648,10 +648,10 @@ void TailingBytesProducerImpl::Prefill()
     {
         const uint64_t toRead = fileSize - lineStart;
         std::vector<char> body(static_cast<size_t>(toRead));
-        const ssize_type n = ReadAtOffset(mHandle, body.data(), body.size(), lineStart);
+        const SsizeType n = ReadAtOffset(mHandle, body.data(), body.size(), lineStart);
         if (n > 0)
         {
-            std::lock_guard<std::mutex> lock(mMutex);
+            const std::scoped_lock lock(mMutex);
             AppendBytesAndSplitLocked(body.data(), static_cast<size_t>(n));
         }
     }
@@ -685,7 +685,7 @@ bool TailingBytesProducerImpl::DetectAndRecoverRotation()
         mWaiting = false;
 
         {
-            std::lock_guard<std::mutex> lock(mMutex);
+            const std::scoped_lock lock(mMutex);
             mPartialLine.clear();
         }
 
@@ -708,7 +708,7 @@ bool TailingBytesProducerImpl::DetectAndRecoverRotation()
         {
             mWaiting = true;
             {
-                std::lock_guard<std::mutex> lock(mMutex);
+                const std::scoped_lock lock(mMutex);
                 mPartialLine.clear();
             }
             FireStatusCallbackIfChanged(SourceStatus::Waiting);
@@ -728,7 +728,7 @@ bool TailingBytesProducerImpl::DetectAndRecoverRotation()
         mWaiting = false;
 
         {
-            std::lock_guard<std::mutex> lock(mMutex);
+            const std::scoped_lock lock(mMutex);
             mPartialLine.clear();
         }
 
@@ -759,7 +759,7 @@ bool TailingBytesProducerImpl::DetectAndRecoverRotation()
         mReadOffset = 0;
 
         {
-            std::lock_guard<std::mutex> lock(mMutex);
+            const std::scoped_lock lock(mMutex);
             mPartialLine.clear();
         }
 
@@ -785,10 +785,10 @@ size_t TailingBytesProducerImpl::ReadMoreBytes()
         return 0;
     }
     const uint64_t available = size - mReadOffset;
-    const size_t toRead = static_cast<size_t>(std::min<uint64_t>(available, mOptions.readChunkBytes));
+    const auto toRead = static_cast<size_t>(std::min<uint64_t>(available, mOptions.readChunkBytes));
 
     std::vector<char> scratch(toRead);
-    const ssize_type n = ReadAtOffset(mHandle, scratch.data(), toRead, mReadOffset);
+    const SsizeType n = ReadAtOffset(mHandle, scratch.data(), toRead, mReadOffset);
     if (n <= 0)
     {
         return 0;
@@ -796,7 +796,7 @@ size_t TailingBytesProducerImpl::ReadMoreBytes()
     mReadOffset += static_cast<uint64_t>(n);
 
     {
-        std::lock_guard<std::mutex> lock(mMutex);
+        const std::scoped_lock lock(mMutex);
         AppendBytesAndSplitLocked(scratch.data(), static_cast<size_t>(n));
     }
     mCv.notify_all();
@@ -864,7 +864,7 @@ void TailingBytesProducerImpl::FireRotationCallbackIfDebounced()
     const auto now = std::chrono::steady_clock::now();
     std::function<void()> cb;
     {
-        std::lock_guard<std::mutex> lock(mCallbackMutex);
+        const std::scoped_lock lock(mCallbackMutex);
         if (now - mLastRotationFireTime < mOptions.rotationDebounce)
         {
             return; // collapse rapid back-to-back rotations
@@ -882,7 +882,7 @@ void TailingBytesProducerImpl::FireStatusCallbackIfChanged(SourceStatus status)
 {
     std::function<void(SourceStatus)> cb;
     {
-        std::lock_guard<std::mutex> lock(mCallbackMutex);
+        const std::scoped_lock lock(mCallbackMutex);
         if (status == mLastReportedStatus)
         {
             return; // edge-triggered: only fire on transitions

--- a/library/src/tcp_server_producer.cpp
+++ b/library/src/tcp_server_producer.cpp
@@ -41,6 +41,8 @@ class TcpServerProducerImpl;
 /// `Stop()` without needing the templated session type at the call
 /// site. The vtable is tiny (one virtual: `Close`) so the indirection
 /// cost is negligible vs the network I/O each call wraps.
+// NOLINTNEXTLINE(misc-use-internal-linkage): `loglib::internal` TU-local implementation detail for
+// `TcpServerProducerImpl`.
 class SessionBase
 {
 public:
@@ -61,6 +63,7 @@ public:
 /// Per-connection state, ref-counted via `shared_ptr` so the in-flight
 /// Asio async chain keeps the session alive until the read completes
 /// and we explicitly drop it.
+// NOLINTNEXTLINE(misc-use-internal-linkage): TU-local async session type for `TcpServerProducerImpl`.
 template <class Stream> class Session : public SessionBase, public std::enable_shared_from_this<Session<Stream>>
 {
 public:
@@ -218,14 +221,17 @@ template <class Stream> void Session<Stream>::Start()
 #endif
 }
 
+// NOLINTNEXTLINE(misc-no-recursion): async continuation chain; not stack recursion.
 template <class Stream> void Session<Stream>::DoRead()
 {
     auto self = this->shared_from_this();
+    // NOLINTNEXTLINE(misc-no-recursion): Asio completion handler re-arms reads asynchronously.
     mStream.async_read_some(asio::buffer(mReadBuffer), [self](const asio::error_code &ec, std::size_t n) {
         self->OnRead(ec, n);
     });
 }
 
+// NOLINTNEXTLINE(misc-no-recursion): async continuation chain; not stack recursion.
 template <class Stream> void Session<Stream>::OnRead(const asio::error_code &ec, std::size_t bytes)
 {
     if (ec)
@@ -237,6 +243,7 @@ template <class Stream> void Session<Stream>::OnRead(const asio::error_code &ec,
     }
     if (bytes == 0)
     {
+        // NOLINTNEXTLINE(misc-no-recursion): async re-arm; not synchronous stack recursion.
         DoRead();
         return;
     }
@@ -255,6 +262,7 @@ template <class Stream> void Session<Stream>::OnRead(const asio::error_code &ec,
         mCarry.erase(0, lastNewline + 1);
     }
 
+    // NOLINTNEXTLINE(misc-no-recursion): async re-arm; not synchronous stack recursion.
     DoRead();
 }
 
@@ -448,6 +456,8 @@ void TcpServerProducerImpl::WaitForBytes(std::chrono::milliseconds timeout)
     });
 }
 
+// NOLINTNEXTLINE(bugprone-exception-escape): `asio::io_context::stop()` may throw in rare error paths; `noexcept`
+// matches producer contract; catch block is the safety net.
 void TcpServerProducerImpl::Stop() noexcept
 {
     if (mStopRequested.exchange(true, std::memory_order_acq_rel))
@@ -703,6 +713,7 @@ namespace loglib
 {
 
 TcpServerProducer::TcpServerProducer(Options options)
+    // NOLINTNEXTLINE(clang-analyzer-cplusplus.NewDelete): Asio `win_thread` false positive under MSVC headers.
     : mImpl(std::make_unique<internal::TcpServerProducerImpl>(std::move(options)))
 {
 }

--- a/library/src/tcp_server_producer.cpp
+++ b/library/src/tcp_server_producer.cpp
@@ -107,7 +107,7 @@ public:
     void Stop() noexcept;
     [[nodiscard]] bool IsClosed() const noexcept;
     [[nodiscard]] std::string DisplayName() const;
-    void SetStatusCallback(std::function<void(SourceStatus)> callback);
+    void SetStatusCallback(const std::function<void(SourceStatus)> &callback);
     [[nodiscard]] uint16_t BoundPort() const noexcept;
     [[nodiscard]] size_t ActiveClientCount() const noexcept;
     [[nodiscard]] size_t TotalClientsAccepted() const noexcept;
@@ -409,6 +409,7 @@ TcpServerProducerImpl::TcpServerProducerImpl(TcpServerProducer::Options options)
         catch (...)
         {
             // Asio handlers in this TU never throw; defensive only.
+            static_cast<void>(0);
         }
         mWorkerExited.store(true, std::memory_order_release);
         mCv.notify_all();
@@ -512,13 +513,13 @@ std::string TcpServerProducerImpl::DisplayName() const
     return mDisplayName;
 }
 
-void TcpServerProducerImpl::SetStatusCallback(std::function<void(SourceStatus)> callback)
+void TcpServerProducerImpl::SetStatusCallback(const std::function<void(SourceStatus)> &callback)
 {
     std::function<void(SourceStatus)> snapshot;
     SourceStatus current{};
     {
         const std::scoped_lock lock(mCallbackMutex);
-        mStatusCallback = std::move(callback);
+        mStatusCallback = callback;
         snapshot = mStatusCallback;
         current = mLastReportedStatus;
     }
@@ -733,9 +734,9 @@ std::string TcpServerProducer::DisplayName() const
     return mImpl->DisplayName();
 }
 
-void TcpServerProducer::SetStatusCallback(std::function<void(SourceStatus)> callback)
+void TcpServerProducer::SetStatusCallback(const std::function<void(SourceStatus)> &callback)
 {
-    mImpl->SetStatusCallback(std::move(callback));
+    mImpl->SetStatusCallback(callback);
 }
 
 uint16_t TcpServerProducer::BoundPort() const noexcept

--- a/library/src/tcp_server_producer.cpp
+++ b/library/src/tcp_server_producer.cpp
@@ -208,10 +208,14 @@ template <class Stream> void Session<Stream>::Start()
             }
             self->DoRead();
         });
-        return;
     }
-#endif
+    else
+    {
+        DoRead();
+    }
+#else
     DoRead();
+#endif
 }
 
 template <class Stream> void Session<Stream>::DoRead()
@@ -426,7 +430,7 @@ size_t TcpServerProducerImpl::Read(std::span<char> buffer)
     {
         return 0;
     }
-    std::lock_guard<std::mutex> lock(mMutex);
+    const std::scoped_lock lock(mMutex);
     return mReadyBuffer.Read(buffer);
 }
 
@@ -467,7 +471,7 @@ void TcpServerProducerImpl::Stop() noexcept
 
             std::vector<std::shared_ptr<SessionBase>> snapshot;
             {
-                std::lock_guard<std::mutex> lock(mMutex);
+                const std::scoped_lock lock(mMutex);
                 snapshot.reserve(mActiveSessions.size());
                 for (auto &kv : mActiveSessions)
                 {
@@ -499,7 +503,7 @@ bool TcpServerProducerImpl::IsClosed() const noexcept
     {
         return false;
     }
-    std::lock_guard<std::mutex> lock(mMutex);
+    const std::scoped_lock lock(mMutex);
     return mReadyBuffer.Empty();
 }
 
@@ -513,7 +517,7 @@ void TcpServerProducerImpl::SetStatusCallback(std::function<void(SourceStatus)> 
     std::function<void(SourceStatus)> snapshot;
     SourceStatus current{};
     {
-        std::lock_guard<std::mutex> lock(mCallbackMutex);
+        const std::scoped_lock lock(mCallbackMutex);
         mStatusCallback = std::move(callback);
         snapshot = mStatusCallback;
         current = mLastReportedStatus;
@@ -531,7 +535,7 @@ uint16_t TcpServerProducerImpl::BoundPort() const noexcept
 
 size_t TcpServerProducerImpl::ActiveClientCount() const noexcept
 {
-    std::lock_guard<std::mutex> lock(mMutex);
+    const std::scoped_lock lock(mMutex);
     return mActiveSessions.size();
 }
 
@@ -557,7 +561,7 @@ void TcpServerProducerImpl::OnSessionLines(std::string_view completeLines)
         return;
     }
     {
-        std::lock_guard<std::mutex> lock(mMutex);
+        const std::scoped_lock lock(mMutex);
         mReadyBuffer.Append(completeLines, mOptions.maxQueueBytes, mDroppedByteCount);
     }
     MarkRunning();
@@ -567,7 +571,7 @@ void TcpServerProducerImpl::OnSessionLines(std::string_view completeLines)
 void TcpServerProducerImpl::OnSessionEnded(size_t sessionId)
 {
     {
-        std::lock_guard<std::mutex> lock(mMutex);
+        const std::scoped_lock lock(mMutex);
         mActiveSessions.erase(sessionId);
     }
     mCv.notify_all();
@@ -577,7 +581,7 @@ void TcpServerProducerImpl::MarkRunning()
 {
     std::function<void(SourceStatus)> cb;
     {
-        std::lock_guard<std::mutex> lock(mCallbackMutex);
+        const std::scoped_lock lock(mCallbackMutex);
         if (mLastReportedStatus == SourceStatus::Running)
         {
             return;
@@ -613,7 +617,7 @@ void TcpServerProducerImpl::StartAccept()
 
 bool TcpServerProducerImpl::AdmitOrReject(asio::ip::tcp::socket &socket)
 {
-    std::lock_guard<std::mutex> lock(mMutex);
+    const std::scoped_lock lock(mMutex);
     if (mActiveSessions.size() >= mOptions.maxConcurrentClients)
     {
         asio::error_code closeEc;
@@ -646,7 +650,7 @@ void TcpServerProducerImpl::OnAcceptPlain(const asio::error_code &ec, asio::ip::
         size_t id = 0;
         std::shared_ptr<Session<asio::ip::tcp::socket>> session;
         {
-            std::lock_guard<std::mutex> lock(mMutex);
+            const std::scoped_lock lock(mMutex);
             id = mNextSessionId++;
             session =
                 std::make_shared<Session<asio::ip::tcp::socket>>(std::move(socket), this, id, mOptions.readChunkBytes);
@@ -679,7 +683,7 @@ void TcpServerProducerImpl::OnAcceptTls(const asio::error_code &ec, asio::ip::tc
         size_t id = 0;
         std::shared_ptr<Session<TlsStream>> session;
         {
-            std::lock_guard<std::mutex> lock(mMutex);
+            const std::scoped_lock lock(mMutex);
             id = mNextSessionId++;
             TlsStream stream(std::move(socket), *mSslContext);
             session = std::make_shared<Session<TlsStream>>(std::move(stream), this, id, mOptions.readChunkBytes);

--- a/library/src/timestamp_promotion.cpp
+++ b/library/src/timestamp_promotion.cpp
@@ -2,7 +2,6 @@
 
 #include "loglib/internal/compact_log_value.hpp"
 #include "loglib/line_source.hpp"
-#include "loglib/log_file.hpp"
 #include "loglib/log_line.hpp"
 
 #include <algorithm>
@@ -41,6 +40,8 @@ std::optional<std::string_view> ExtractStringBytes(
         return std::nullopt;
     }
     const auto compact = line.CompactValues();
+    // Asymmetric comparator: std::ranges::lower_bound rejects it.
+    // NOLINTNEXTLINE(modernize-use-ranges)
     auto it = std::lower_bound(compact.begin(), compact.end(), keyId, [](const auto &entry, KeyId target) {
         return entry.first < target;
     });
@@ -49,7 +50,7 @@ std::optional<std::string_view> ExtractStringBytes(
         return std::nullopt;
     }
     const CompactLogValue &value = it->second;
-    LineSource *source = line.Source();
+    const LineSource *source = line.Source();
     if (value.tag == CompactTag::MmapSlice)
     {
         if (source == nullptr)
@@ -184,7 +185,7 @@ bool PromoteLineTimestamps(
                     const TimestampFormatKind kind = spec.formatKinds[f];
                     if (tryPromote(keyId, format, kind, *sv))
                     {
-                        lv = LastValidTimestampParse{keyId, format, kind};
+                        lv = LastValidTimestampParse{.keyId = keyId, .format = format, .kind = kind};
                         promoted = true;
                         break;
                     }

--- a/library/src/udp_server_producer.cpp
+++ b/library/src/udp_server_producer.cpp
@@ -37,7 +37,7 @@ public:
     void Stop() noexcept;
     [[nodiscard]] bool IsClosed() const noexcept;
     [[nodiscard]] std::string DisplayName() const;
-    void SetStatusCallback(std::function<void(SourceStatus)> callback);
+    void SetStatusCallback(const std::function<void(SourceStatus)> &callback);
     [[nodiscard]] uint16_t BoundPort() const noexcept;
     [[nodiscard]] size_t DatagramCount() const noexcept;
     [[nodiscard]] size_t DroppedByteCount() const noexcept;
@@ -145,6 +145,7 @@ UdpServerProducerImpl::UdpServerProducerImpl(UdpServerProducer::Options options)
             // Asio handlers in this TU never throw, but defensive: if
             // a future change does, we want the worker to exit
             // gracefully rather than terminate the process.
+            static_cast<void>(0);
         }
         mWorkerExited.store(true, std::memory_order_release);
         mCv.notify_all();
@@ -229,13 +230,13 @@ std::string UdpServerProducerImpl::DisplayName() const
     return mDisplayName;
 }
 
-void UdpServerProducerImpl::SetStatusCallback(std::function<void(SourceStatus)> callback)
+void UdpServerProducerImpl::SetStatusCallback(const std::function<void(SourceStatus)> &callback)
 {
     std::function<void(SourceStatus)> snapshot;
     SourceStatus current{};
     {
         const std::scoped_lock lock(mCallbackMutex);
-        mStatusCallback = std::move(callback);
+        mStatusCallback = callback;
         snapshot = mStatusCallback;
         current = mLastReportedStatus;
     }
@@ -391,9 +392,9 @@ std::string UdpServerProducer::DisplayName() const
     return mImpl->DisplayName();
 }
 
-void UdpServerProducer::SetStatusCallback(std::function<void(SourceStatus)> callback)
+void UdpServerProducer::SetStatusCallback(const std::function<void(SourceStatus)> &callback)
 {
-    mImpl->SetStatusCallback(std::move(callback));
+    mImpl->SetStatusCallback(callback);
 }
 
 uint16_t UdpServerProducer::BoundPort() const noexcept

--- a/library/src/udp_server_producer.cpp
+++ b/library/src/udp_server_producer.cpp
@@ -4,7 +4,6 @@
 
 #include <asio.hpp>
 
-#include <algorithm>
 #include <atomic>
 #include <chrono>
 #include <condition_variable>
@@ -167,7 +166,7 @@ size_t UdpServerProducerImpl::Read(std::span<char> buffer)
     {
         return 0;
     }
-    std::lock_guard<std::mutex> lock(mMutex);
+    const std::scoped_lock lock(mMutex);
     return mReadyBuffer.Read(buffer);
 }
 
@@ -221,7 +220,7 @@ bool UdpServerProducerImpl::IsClosed() const noexcept
     {
         return false;
     }
-    std::lock_guard<std::mutex> lock(mMutex);
+    const std::scoped_lock lock(mMutex);
     return mReadyBuffer.Empty();
 }
 
@@ -235,7 +234,7 @@ void UdpServerProducerImpl::SetStatusCallback(std::function<void(SourceStatus)> 
     std::function<void(SourceStatus)> snapshot;
     SourceStatus current{};
     {
-        std::lock_guard<std::mutex> lock(mCallbackMutex);
+        const std::scoped_lock lock(mCallbackMutex);
         mStatusCallback = std::move(callback);
         snapshot = mStatusCallback;
         current = mLastReportedStatus;
@@ -270,7 +269,7 @@ void UdpServerProducerImpl::MarkRunning()
 {
     std::function<void(SourceStatus)> cb;
     {
-        std::lock_guard<std::mutex> lock(mCallbackMutex);
+        const std::scoped_lock lock(mCallbackMutex);
         if (mLastReportedStatus == SourceStatus::Running)
         {
             return;
@@ -315,7 +314,7 @@ void UdpServerProducerImpl::StartReceive()
             if (bytes > 0)
             {
                 {
-                    std::lock_guard<std::mutex> lock(mMutex);
+                    const std::scoped_lock lock(mMutex);
                     AppendDatagramLocked(mRecvBuffer.data(), bytes);
                 }
                 mDatagramCount.fetch_add(1, std::memory_order_acq_rel);

--- a/library/src/udp_server_producer.cpp
+++ b/library/src/udp_server_producer.cpp
@@ -184,6 +184,8 @@ void UdpServerProducerImpl::WaitForBytes(std::chrono::milliseconds timeout)
     });
 }
 
+// NOLINTNEXTLINE(bugprone-exception-escape): `asio::io_context::stop()` may throw in rare error paths; `noexcept`
+// matches producer contract; catch block is the safety net.
 void UdpServerProducerImpl::Stop() noexcept
 {
     if (mStopRequested.exchange(true, std::memory_order_acq_rel))
@@ -361,6 +363,7 @@ namespace loglib
 {
 
 UdpServerProducer::UdpServerProducer(Options options)
+    // NOLINTNEXTLINE(clang-analyzer-cplusplus.NewDelete): Asio `win_thread` false positive under MSVC headers.
     : mImpl(std::make_unique<internal::UdpServerProducerImpl>(std::move(options)))
 {
 }

--- a/test/.clang-tidy
+++ b/test/.clang-tidy
@@ -1,0 +1,19 @@
+# Test-level overrides.
+#
+# Magic numbers are common and acceptable in test code (expected values,
+# test data, etc.). `cert-err58-cpp` warns about static initialization
+# exceptions, acceptable in test utilities. Public member variables are
+# the norm in Catch2 fixtures / sink structs — `struct { ... }` with
+# exposed fields is idiomatic here. `cppcoreguidelines-owning-memory`
+# fires on the `FILE *fp = std::fopen(...)` / manual `fclose` dance that
+# the latency benchmark deliberately uses for direct-syscall control.
+
+InheritParentConfig: true
+
+Checks: >
+  -cppcoreguidelines-avoid-magic-numbers,
+  -readability-magic-numbers,
+  -cert-err58-cpp,
+  -misc-non-private-member-variables-in-classes,
+  -cppcoreguidelines-non-private-member-variables-in-classes,
+  -cppcoreguidelines-owning-memory

--- a/test/app/.clang-tidy
+++ b/test/app/.clang-tidy
@@ -1,0 +1,33 @@
+# Test-app-level overrides for Qt QTest test classes.
+#
+# Qt's QTest auto-invokes the camelBack lifecycle slots
+# `initTestCase`, `cleanupTestCase`, `init`, `cleanup` by exact name
+# match. Renaming them to CamelCase makes QTest silently skip them
+# (the test "passes" because nothing ran). The test methods themselves
+# live under `private slots:`, so the right knob is
+# `PrivateMethodCase` rather than `PublicMethodCase` -- the project's
+# `app/.clang-tidy` only relaxes the public side because the GUI's
+# Qt-forced camelBack names are signals / public slots / overrides.
+#
+# Public is also relaxed for parity with `app/.clang-tidy` (the test
+# binary calls into Qt's public surface as well).
+#
+# Also mirror the moc-related disables from `app/.clang-tidy`:
+#   -readability-redundant-access-specifiers (+ its cppcoreguidelines
+#        alias): the `private:` after `private slots:` is required so
+#        moc can find the slot-list boundary.
+#   -readability-convert-member-functions-to-static: QTest dispatches
+#        lifecycle slots through the metaobject as instance methods;
+#        marking them `static` also recategorises them under
+#        `ClassMethodCase`, rejecting the Qt-mandated camelBack names.
+
+InheritParentConfig: true
+
+Checks: >
+  -readability-redundant-access-specifiers,
+  -cppcoreguidelines-redundant-access-specifiers,
+  -readability-convert-member-functions-to-static
+
+CheckOptions:
+  - { key: readability-identifier-naming.PrivateMethodCase, value: aNy_CasE }
+  - { key: readability-identifier-naming.PublicMethodCase,  value: aNy_CasE }

--- a/test/app/src/benchmark_main_window.cpp
+++ b/test/app/src/benchmark_main_window.cpp
@@ -153,6 +153,7 @@ QString FormatThroughput(const QString &label, std::chrono::nanoseconds elapsed,
 
 } // namespace
 
+// NOLINTNEXTLINE(misc-use-internal-linkage): `Q_OBJECT` test fixture; moc + QTest registration expect this shape.
 class MainWindowBench : public QObject
 {
     Q_OBJECT

--- a/test/app/src/benchmark_main_window.cpp
+++ b/test/app/src/benchmark_main_window.cpp
@@ -116,8 +116,8 @@ RunResult RunOnce(const std::filesystem::path &logPath, bool reversed)
     const auto t0 = std::chrono::steady_clock::now();
     model->BeginStreaming(std::move(fileSource), [fileSourcePtr, sink = model->Sink()](loglib::StopToken token) {
         loglib::ParserOptions options;
-        options.stopToken = token;
-        loglib::JsonParser parser;
+        options.stopToken = std::move(token);
+        const loglib::JsonParser parser;
         parser.ParseStreaming(*fileSourcePtr, *sink, options);
     });
 
@@ -173,25 +173,25 @@ private slots:
         QVERIFY(mBytes > 0);
     }
 
-    void benchNewestFirstOff()
+    void BenchNewestFirstOff()
     {
-        runConfig(QStringLiteral("Qt path, newest-first OFF (default)"), false);
+        RunConfig(QStringLiteral("Qt path, newest-first OFF (default)"), false);
     }
 
-    void benchNewestFirstStreamMode()
+    void BenchNewestFirstStreamMode()
     {
-        runConfig(QStringLiteral("Qt path, newest-first ON (stream mode)"), true);
+        RunConfig(QStringLiteral("Qt path, newest-first ON (stream mode)"), true);
     }
 
-    void benchNewestFirstStaticMode()
+    void BenchNewestFirstStaticMode()
     {
-        runConfig(QStringLiteral("Qt path, newest-first ON (static mode)"), true);
+        RunConfig(QStringLiteral("Qt path, newest-first ON (static mode)"), true);
     }
 
 private:
     static constexpr std::size_t LINE_COUNT = 1'000'000;
 
-    void runConfig(const QString &label, bool reversed)
+    void RunConfig(const QString &label, bool reversed)
     {
         const RunResult run = RunOnce(mLogPath, reversed);
         QVERIFY2(run.finished, "streamingFinished must fire within the 180 s timeout");

--- a/test/app/src/main_window_test.cpp
+++ b/test/app/src/main_window_test.cpp
@@ -1994,8 +1994,7 @@ private slots:
         auto *model = mWindow->findChild<LogModel *>();
         QVERIFY(rowOrderProxy != nullptr);
         QVERIFY(model != nullptr);
-        // NOLINTNEXTLINE(clang-analyzer-core.CallAndMessage): false positive; prior `QVERIFY` aborts the test if
-        // pointers are null.
+        // NOLINTNEXTLINE(clang-analyzer-core.CallAndMessage): false positive; prior `QVERIFY` aborts on null.
         QVERIFY(!rowOrderProxy->IsReversed());
 
         // Drive a tiny streaming session with three rows so the proxy

--- a/test/app/src/main_window_test.cpp
+++ b/test/app/src/main_window_test.cpp
@@ -238,6 +238,7 @@ double LoadTestTimeScale() noexcept
 #pragma warning(push)
 #pragma warning(disable : 4996) // getenv
 #endif
+    // NOLINTNEXTLINE(concurrency-mt-unsafe): single-threaded test harness; read once per process.
     const char *raw = std::getenv("LOGLIB_TEST_TIME_SCALE");
 #ifdef _MSC_VER
 #pragma warning(pop)
@@ -398,6 +399,7 @@ QAction *FindActionByObjectName(QMainWindow *window, const QString &name)
 
 } // namespace
 
+// NOLINTNEXTLINE(misc-use-internal-linkage): `Q_OBJECT` QtTest fixture; moc expects this declaration shape.
 class MainWindowTest : public QObject
 {
     Q_OBJECT
@@ -1112,8 +1114,7 @@ private slots:
         const int linesPerBatch = 5;
         for (int b = 0; b < batchesWhilePaused; ++b)
         {
-            const auto firstLineId =
-                static_cast<size_t>(static_cast<size_t>(b) * static_cast<size_t>(linesPerBatch) + size_t{1});
+            const auto firstLineId = (static_cast<size_t>(b) * static_cast<size_t>(linesPerBatch)) + size_t{1};
             const bool declareNewKey = (b == 0);
             // Direct call to OnBatch from this thread mirrors the worker.
             sink->OnBatch(MakeSyntheticBatch(
@@ -1187,15 +1188,13 @@ private slots:
         for (int b = 0; b < batchesWhilePaused; ++b)
         {
             loglib::StreamedBatch batch;
-            batch.firstLineNumber =
-                static_cast<size_t>(static_cast<size_t>(b) * static_cast<size_t>(linesPerBatch) + size_t{1});
+            batch.firstLineNumber = (static_cast<size_t>(b) * static_cast<size_t>(linesPerBatch)) + size_t{1};
             batch.lines.reserve(linesPerBatch);
             batch.localLineOffsets.reserve(linesPerBatch);
             for (int i = 0; i < linesPerBatch; ++i)
             {
-                const auto lineNumber = static_cast<size_t>(
-                    static_cast<size_t>(b) * static_cast<size_t>(linesPerBatch) + static_cast<size_t>(i) + size_t{1}
-                );
+                const auto lineNumber =
+                    (static_cast<size_t>(b) * static_cast<size_t>(linesPerBatch)) + static_cast<size_t>(i) + size_t{1};
                 std::vector<std::pair<loglib::KeyId, loglib::LogValue>> values;
                 values.emplace_back(keyId, loglib::LogValue(static_cast<int64_t>(lineNumber)));
                 batch.lines.emplace_back(std::move(values), keys, *sourcePtr, lineNumber);
@@ -1995,6 +1994,8 @@ private slots:
         auto *model = mWindow->findChild<LogModel *>();
         QVERIFY(rowOrderProxy != nullptr);
         QVERIFY(model != nullptr);
+        // NOLINTNEXTLINE(clang-analyzer-core.CallAndMessage): false positive; prior `QVERIFY` aborts the test if
+        // pointers are null.
         QVERIFY(!rowOrderProxy->IsReversed());
 
         // Drive a tiny streaming session with three rows so the proxy

--- a/test/app/src/main_window_test.cpp
+++ b/test/app/src/main_window_test.cpp
@@ -42,7 +42,6 @@
 #include <QWheelEvent>
 #include <QtTest/QtTest>
 
-#include <algorithm>
 #include <atomic>
 #include <chrono>
 #include <condition_variable>
@@ -50,7 +49,6 @@
 #include <cstdint>
 #include <filesystem>
 #include <fstream>
-#include <map>
 #include <memory>
 #include <mutex>
 #include <string>
@@ -171,8 +169,8 @@ StreamingRun RunStreaming(const QString &fixturePath)
         loglib::internal::AdvancedParserOptions advanced;
         advanced.threads = 1;
 
-        loglib::JsonParser parser;
-        parser.ParseStreaming(*fileSourcePtr, *run.model->Sink(), options, advanced);
+        const loglib::JsonParser parser;
+        loglib::JsonParser::ParseStreaming(*fileSourcePtr, *run.model->Sink(), options, advanced);
     }
 
     if (finishedSpy.count() == 0)
@@ -204,7 +202,7 @@ public:
         mPath = mDir.filePath("live.jsonl");
         // Touch the file so `TailingBytesProducer`'s open() succeeds. Pre-fill
         // walks the existing content (zero bytes here) before tailing.
-        std::ofstream stream(mPath.toStdString(), std::ios::binary);
+        const std::ofstream stream(mPath.toStdString(), std::ios::binary);
         QVERIFY2(stream.is_open(), "live-tail fixture file must be openable");
     }
 
@@ -235,12 +233,12 @@ private:
 // still floor at 1 ms so a tight 25 ms budget never collapses to 0.
 double LoadTestTimeScale() noexcept
 {
-#if defined(_MSC_VER)
+#ifdef _MSC_VER
 #pragma warning(push)
 #pragma warning(disable : 4996) // getenv
 #endif
     const char *raw = std::getenv("LOGLIB_TEST_TIME_SCALE");
-#if defined(_MSC_VER)
+#ifdef _MSC_VER
 #pragma warning(pop)
 #endif
     if (raw == nullptr || *raw == '\0')
@@ -350,7 +348,7 @@ loglib::StreamedBatch MakeSyntheticBatch(
     batch.firstLineNumber = firstLineId;
     if (declareNewKey)
     {
-        batch.newKeys.emplace_back(std::string("value"));
+        batch.newKeys.emplace_back("value");
     }
     batch.lines.reserve(count);
     for (size_t i = 0; i < count; ++i)
@@ -419,30 +417,30 @@ private slots:
     void init()
     {
         // Called before each test function
-        window = new MainWindow();
+        mWindow = new MainWindow();
     }
 
     void cleanup()
     {
         // Called after each test function
-        delete window;
-        window = nullptr;
+        delete mWindow;
+        mWindow = nullptr;
     }
 
-    void testWindowTitle()
+    void TestWindowTitle()
     {
-        QCOMPARE(window->windowTitle(), QString("Structured Log Viewer"));
+        QCOMPARE(mWindow->windowTitle(), QString("Structured Log Viewer"));
     }
 
-    void testWindowIcon()
+    void TestWindowIcon()
     {
-        QVERIFY(!window->windowIcon().isNull());
+        QVERIFY(!mWindow->windowIcon().isNull());
     }
 
-    void testFixture_Empty()
+    static void TestFixtureEmpty()
     {
-        FixtureFile fixture(":/fixtures/empty.jsonl");
-        StreamingRun run = RunStreaming(fixture.Path());
+        const FixtureFile fixture(":/fixtures/empty.jsonl");
+        const StreamingRun run = RunStreaming(fixture.Path());
         QCOMPARE(run.finishedCount, 1);
         QCOMPARE(run.cancelled, false);
         QCOMPARE(run.model->rowCount(), 0);
@@ -450,10 +448,10 @@ private slots:
         QVERIFY(run.model->StreamingErrors().empty());
     }
 
-    void testFixture_SingleLine()
+    static void TestFixtureSingleLine()
     {
-        FixtureFile fixture(":/fixtures/single_line.jsonl");
-        StreamingRun run = RunStreaming(fixture.Path());
+        const FixtureFile fixture(":/fixtures/single_line.jsonl");
+        const StreamingRun run = RunStreaming(fixture.Path());
         QCOMPARE(run.finishedCount, 1);
         QCOMPARE(run.cancelled, false);
         QCOMPARE(run.model->rowCount(), 1);
@@ -463,9 +461,9 @@ private slots:
         QVERIFY(run.model->StreamingErrors().empty());
     }
 
-    void testFixture_ValueTypes()
+    static void TestFixtureValueTypes()
     {
-        FixtureFile fixture(":/fixtures/value_types.jsonl");
+        const FixtureFile fixture(":/fixtures/value_types.jsonl");
         StreamingRun run = RunStreaming(fixture.Path());
         QCOMPARE(run.finishedCount, 1);
         QCOMPARE(run.cancelled, false);
@@ -523,36 +521,36 @@ private slots:
         QCOMPARE(displayVal(2, colArr), QStringLiteral("[\"x\",\"y\"]"));
     }
 
-    void testFixture_IsoTTimestamp()
+    static void TestFixtureIsoTTimestamp()
     {
-        FixtureFile fixture(":/fixtures/iso_t_timestamp.jsonl");
+        const FixtureFile fixture(":/fixtures/iso_t_timestamp.jsonl");
         StreamingRun run = RunStreaming(fixture.Path());
         // 2024-04-28T07:14:30 UTC → 1714288470 seconds since epoch.
-        AssertTimestampFixture(run, qint64(1714288470000000), 3);
+        AssertTimestampFixture(run, static_cast<qint64>(1714288470000000), 3);
     }
 
-    void testFixture_IsoSpaceTimestamp()
+    static void TestFixtureIsoSpaceTimestamp()
     {
-        FixtureFile fixture(":/fixtures/iso_space_timestamp.jsonl");
+        const FixtureFile fixture(":/fixtures/iso_space_timestamp.jsonl");
         StreamingRun run = RunStreaming(fixture.Path());
         // 2024-04-28 07:14:30 UTC → 1714288470 seconds since epoch.
-        AssertTimestampFixture(run, qint64(1714288470000000), 3);
+        AssertTimestampFixture(run, static_cast<qint64>(1714288470000000), 3);
     }
 
-    void testFixture_IsoOffsetTimestamp()
+    static void TestFixtureIsoOffsetTimestamp()
     {
-        FixtureFile fixture(":/fixtures/iso_offset_timestamp.jsonl");
+        const FixtureFile fixture(":/fixtures/iso_offset_timestamp.jsonl");
         StreamingRun run = RunStreaming(fixture.Path());
         // 2024-04-28T07:14:30+02:00 → 2024-04-28T05:14:30 UTC → 1714281270 seconds.
-        AssertTimestampFixture(run, qint64(1714281270000000), 3);
+        AssertTimestampFixture(run, static_cast<qint64>(1714281270000000), 3);
     }
 
-    void testFixture_IsoFractionalTimestamp()
+    static void TestFixtureIsoFractionalTimestamp()
     {
-        FixtureFile fixture(":/fixtures/iso_fractional_timestamp.jsonl");
+        const FixtureFile fixture(":/fixtures/iso_fractional_timestamp.jsonl");
         StreamingRun run = RunStreaming(fixture.Path());
         // 2024-04-28T07:14:30.123 UTC → 1714288470.123 → 1714288470123000 µs.
-        AssertTimestampFixture(run, qint64(1714288470123000), 3);
+        AssertTimestampFixture(run, static_cast<qint64>(1714288470123000), 3);
 
         // Spot-check the µs and 0.5s rows separately so all three fractional
         // widths in the fixture are exercised.
@@ -563,10 +561,10 @@ private slots:
         QCOMPARE(row2Us, qint64(1714288470500000));
     }
 
-    void testFixture_AltTimestampKeys()
+    static void TestFixtureAltTimestampKeys()
     {
-        FixtureFile fixture(":/fixtures/alt_timestamp_keys.jsonl");
-        StreamingRun run = RunStreaming(fixture.Path());
+        const FixtureFile fixture(":/fixtures/alt_timestamp_keys.jsonl");
+        const StreamingRun run = RunStreaming(fixture.Path());
         QCOMPARE(run.finishedCount, 1);
         QCOMPARE(run.cancelled, false);
         QCOMPARE(run.model->rowCount(), 3);
@@ -607,9 +605,9 @@ private slots:
         QVERIFY(run.model->data(run.model->index(2, colTimestamp), LogModelItemDataRole::SortRole).isValid());
     }
 
-    void testFixture_MixedColumns()
+    static void TestFixtureMixedColumns()
     {
-        FixtureFile fixture(":/fixtures/mixed_columns.jsonl");
+        const FixtureFile fixture(":/fixtures/mixed_columns.jsonl");
         StreamingRun run = RunStreaming(fixture.Path());
         QCOMPARE(run.finishedCount, 1);
         QCOMPARE(run.cancelled, false);
@@ -642,10 +640,10 @@ private slots:
         QCOMPARE(displayVal(2, colC), QStringLiteral("c3"));
     }
 
-    void testFixture_InvalidLines()
+    static void TestFixtureInvalidLines()
     {
-        FixtureFile fixture(":/fixtures/invalid_lines.jsonl");
-        StreamingRun run = RunStreaming(fixture.Path());
+        const FixtureFile fixture(":/fixtures/invalid_lines.jsonl");
+        const StreamingRun run = RunStreaming(fixture.Path());
         QCOMPARE(run.finishedCount, 1);
         QCOMPARE(run.cancelled, false);
         QCOMPARE(run.model->rowCount(), 2);
@@ -664,10 +662,10 @@ private slots:
         QCOMPARE(run.model->data(run.model->index(1, colA), Qt::DisplayRole).toString(), QStringLiteral("valid_third"));
     }
 
-    void testFixture_MixedTzAndOrder()
+    static void TestFixtureMixedTzAndOrder()
     {
-        FixtureFile fixture(":/fixtures/mixed_tz_and_order.jsonl");
-        StreamingRun run = RunStreaming(fixture.Path());
+        const FixtureFile fixture(":/fixtures/mixed_tz_and_order.jsonl");
+        const StreamingRun run = RunStreaming(fixture.Path());
         QCOMPARE(run.finishedCount, 1);
         QCOMPARE(run.cancelled, false);
         QCOMPARE(run.model->rowCount(), 3);
@@ -717,10 +715,10 @@ private slots:
     // Regression: `LogModel::AppendBatch` must fire `beginInsertRows` /
     // `beginInsertColumns` *before* `LogTable::AppendBatch` mutates, so
     // proxies see the pre-mutation source count in `*AboutToBeInserted`.
-    void testAppendBatchFiresBeginsBeforeMutation()
+    static void TestAppendBatchFiresBeginsBeforeMutation()
     {
         const QStringList fixtureLines = MakeParityFixture();
-        TempJsonFile fixture(fixtureLines);
+        const TempJsonFile fixture(fixtureLines);
 
         LogModel model;
         LogFilterModel proxy;
@@ -760,8 +758,8 @@ private slots:
         loglib::internal::AdvancedParserOptions advanced;
         advanced.threads = 1;
 
-        loglib::JsonParser parser;
-        parser.ParseStreaming(*parseSource, *model.Sink(), options, advanced);
+        const loglib::JsonParser parser;
+        loglib::JsonParser::ParseStreaming(*parseSource, *model.Sink(), options, advanced);
 
         const bool finished = finishedSpy.count() > 0 || finishedSpy.wait(5000);
         QVERIFY2(finished, "streamingFinished must arrive within the timeout");
@@ -775,7 +773,7 @@ private slots:
         );
 
         int expectedRowCount = 0;
-        for (int snapshot : rowCountSnapshotsAtAboutToBeInserted)
+        for (const int snapshot : rowCountSnapshotsAtAboutToBeInserted)
         {
             QVERIFY2(
                 snapshot == expectedRowCount,
@@ -791,7 +789,7 @@ private slots:
         QCOMPARE(model.rowCount(), fixtureLines.size());
 
         int expectedColumnCount = 0;
-        for (int snapshot : columnCountSnapshotsAtAboutToBeInserted)
+        for (const int snapshot : columnCountSnapshotsAtAboutToBeInserted)
         {
             QVERIFY2(
                 snapshot >= expectedColumnCount,
@@ -813,11 +811,11 @@ private slots:
     // on a GUI-thread flag (`mStreamingActive`), not `isRunning()` — the
     // latter races with the queued `OnFinished` and would silently drop the
     // signal, leaving configuration menus disabled.
-    void testResetAfterBeginStreamingEmitsCompensatingFinished()
+    static void TestResetAfterBeginStreamingEmitsCompensatingFinished()
     {
         // Use a tiny in-memory file so BeginStreaming has a valid LogFile
         // to install on the model.
-        TempJsonFile fixture(QStringList{QStringLiteral(R"({"a": 1})")});
+        const TempJsonFile fixture(QStringList{QStringLiteral(R"({"a": 1})")});
 
         LogModel model;
         QSignalSpy finishedSpy(&model, &LogModel::streamingFinished);
@@ -847,9 +845,9 @@ private slots:
     // `RequestStop()`. Otherwise drain-phase queued lambdas pass the
     // mismatch check and run after `Reset()` has destroyed `mLogTable`
     // (use-after-free on dangling `LogFile*` + spurious second `streamingFinished`).
-    void testResetDuringStreamingDropsDrainPhaseBatch()
+    static void TestResetDuringStreamingDropsDrainPhaseBatch()
     {
-        TempJsonFile fixture(QStringList{QStringLiteral(R"({"a": 1})")});
+        const TempJsonFile fixture(QStringList{QStringLiteral(R"({"a": 1})")});
 
         LogModel model;
         QSignalSpy finishedSpy(&model, &LogModel::streamingFinished);
@@ -870,7 +868,7 @@ private slots:
 
         const loglib::StopToken stop = model.BeginStreaming(
             std::move(fileSource),
-            [sinkBeforeBegin, sourcePtr, &releaseMutex, &releaseCv, &released](loglib::StopToken stopToken) {
+            [sinkBeforeBegin, sourcePtr, &releaseMutex, &releaseCv, &released](const loglib::StopToken &stopToken) {
                 while (!stopToken.stop_requested())
                 {
                     std::this_thread::yield();
@@ -898,7 +896,7 @@ private slots:
         std::thread releaser([&]() {
             std::this_thread::sleep_for(std::chrono::milliseconds(10));
             {
-                std::lock_guard lock(releaseMutex);
+                const std::scoped_lock lock(releaseMutex);
                 released = true;
             }
             releaseCv.notify_all();
@@ -932,9 +930,9 @@ private slots:
     // assertion (the row must survive) and the signal-count assertion
     // (the drained `OnFinished` lambda emits the *only* terminal
     // signal — no compensating duplicate from the teardown helper).
-    void testStopAndKeepRowsPreservesDrainPhaseBatch()
+    static void TestStopAndKeepRowsPreservesDrainPhaseBatch()
     {
-        TempJsonFile fixture(QStringList{QStringLiteral(R"({"a": 1})")});
+        const TempJsonFile fixture(QStringList{QStringLiteral(R"({"a": 1})")});
 
         LogModel model;
         QSignalSpy finishedSpy(&model, &LogModel::streamingFinished);
@@ -952,7 +950,7 @@ private slots:
 
         const loglib::StopToken stop = model.BeginStreaming(
             std::move(fileSource),
-            [sinkBeforeBegin, sourcePtr, &releaseMutex, &releaseCv, &released](loglib::StopToken stopToken) {
+            [sinkBeforeBegin, sourcePtr, &releaseMutex, &releaseCv, &released](const loglib::StopToken &stopToken) {
                 while (!stopToken.stop_requested())
                 {
                     std::this_thread::yield();
@@ -978,7 +976,7 @@ private slots:
         std::thread releaser([&]() {
             std::this_thread::sleep_for(std::chrono::milliseconds(10));
             {
-                std::lock_guard lock(releaseMutex);
+                const std::scoped_lock lock(releaseMutex);
                 released = true;
             }
             releaseCv.notify_all();
@@ -1009,7 +1007,7 @@ private slots:
     //   - `beginRemoveRows`/`rowsRemoved` fire on the prefix as new lines arrive;
     //   - the surviving rows correspond to the *most recent* lines, not the
     //     oldest ones (FIFO drops oldest).
-    void testRetentionCapFifoEviction()
+    static void TestRetentionCapFifoEviction()
     {
         LogModel model;
         // Install a no-producer `StreamLineSource` so synthetic
@@ -1018,7 +1016,7 @@ private slots:
         loglib::StreamLineSource &streamSource = BeginSyntheticStreamSession(model);
         model.SetRetentionCap(100);
 
-        QSignalSpy rowsRemovedSpy(&model, &QAbstractItemModel::rowsRemoved);
+        const QSignalSpy rowsRemovedSpy(&model, &QAbstractItemModel::rowsRemoved);
         QVERIFY(rowsRemovedSpy.isValid());
 
         loglib::KeyIndex &keys = model.Sink()->Keys();
@@ -1058,7 +1056,7 @@ private slots:
     // exceeds the cap must collapse the head of the batch *before* it lands
     // in `LogTable`, so per-batch eviction stays O(cap) and the visible
     // model never breaches the cap.
-    void testRetentionCapGiantBatchCollapse()
+    static void TestRetentionCapGiantBatchCollapse()
     {
         LogModel model;
         loglib::StreamLineSource &streamSource = BeginSyntheticStreamSession(model);
@@ -1090,10 +1088,10 @@ private slots:
     // buffer instead of posting per-batch QueuedConnection lambdas; on
     // Resume the buffer is coalesced into a single batch and posted to
     // `LogModel::AppendBatch`.
-    void testSinkPauseResumeCoalescesBufferedBatches()
+    static void TestSinkPauseResumeCoalescesBufferedBatches()
     {
         LogModel model;
-        QSignalSpy lineCountSpy(&model, &LogModel::lineCountChanged);
+        const QSignalSpy lineCountSpy(&model, &LogModel::lineCountChanged);
         QVERIFY(lineCountSpy.isValid());
 
         loglib::StreamLineSource &streamSource = BeginSyntheticStreamSession(model);
@@ -1113,7 +1111,7 @@ private slots:
         const int linesPerBatch = 5;
         for (int b = 0; b < batchesWhilePaused; ++b)
         {
-            const size_t firstLineId = static_cast<size_t>(b * linesPerBatch + 1);
+            const auto firstLineId = static_cast<size_t>((b * linesPerBatch) + 1);
             const bool declareNewKey = (b == 0);
             // Direct call to OnBatch from this thread mirrors the worker.
             sink->OnBatch(MakeSyntheticBatch(
@@ -1147,21 +1145,21 @@ private slots:
     // payload that the static path emits, and `PausedLineCountLocked`
     // only summing `streamLines.size()` (so the status-bar `K buffered`
     // would read 0 even with rows queued).
-    void testSinkPauseResumePreservesStaticLineBatches()
+    static void TestSinkPauseResumePreservesStaticLineBatches()
     {
         // Need a real `LogFile` because the `FileLineSource` (and the
         // model's `LogTable::AppendBatch` path that consumes `lines`) hold
         // pointers into the file. The file's contents don't have to match
         // what we synthesise -- we never call `LogLine::GetValue()` on them
         // through the table -- but they must outlive the test.
-        TempJsonFile fixture(QStringList{
+        const TempJsonFile fixture(QStringList{
             QStringLiteral(R"({"a": 1})"),
             QStringLiteral(R"({"a": 2})"),
             QStringLiteral(R"({"a": 3})"),
         });
 
         LogModel model;
-        QSignalSpy lineCountSpy(&model, &LogModel::lineCountChanged);
+        const QSignalSpy lineCountSpy(&model, &LogModel::lineCountChanged);
         QVERIFY(lineCountSpy.isValid());
 
         auto file = std::make_unique<loglib::LogFile>(fixture.Path().toStdString());
@@ -1187,12 +1185,12 @@ private slots:
         for (int b = 0; b < batchesWhilePaused; ++b)
         {
             loglib::StreamedBatch batch;
-            batch.firstLineNumber = static_cast<size_t>(b * linesPerBatch + 1);
+            batch.firstLineNumber = static_cast<size_t>((b * linesPerBatch) + 1);
             batch.lines.reserve(linesPerBatch);
             batch.localLineOffsets.reserve(linesPerBatch);
             for (int i = 0; i < linesPerBatch; ++i)
             {
-                const size_t lineNumber = static_cast<size_t>(b * linesPerBatch + i + 1);
+                const auto lineNumber = static_cast<size_t>((b * linesPerBatch) + i + 1);
                 std::vector<std::pair<loglib::KeyId, loglib::LogValue>> values;
                 values.emplace_back(keyId, loglib::LogValue(static_cast<int64_t>(lineNumber)));
                 batch.lines.emplace_back(std::move(values), keys, *sourcePtr, lineNumber);
@@ -1225,7 +1223,7 @@ private slots:
     // Pause + cap-shrink interaction: while paused, lowering
     // the retention cap must trim the paused buffer to `cap - visible`
     // (preserving the visible rows). Verified via PausedLineCount().
-    void testPauseCapShrinkTrimsPausedBuffer()
+    static void TestPauseCapShrinkTrimsPausedBuffer()
     {
         LogModel model;
         loglib::StreamLineSource &streamSource = BeginSyntheticStreamSession(model);
@@ -1265,9 +1263,9 @@ private slots:
     // pause-freezes-view-with-buffer-keeps-growing, and resume-drains.
     // Retention cap is high (1000) so FIFO eviction stays inactive
     // here — the dedicated `testRetentionCap*` tests cover that.
-    void testStreamModeOpensTailFileAndAppends()
+    static void TestStreamModeOpensTailFileAndAppends()
     {
-        TempLiveTailFile fixture;
+        const TempLiveTailFile fixture;
 
         // Pre-fill: 100 lines on disk before the source opens.
         {
@@ -1280,9 +1278,9 @@ private slots:
         }
 
         LogModel model;
-        QSignalSpy lineCountSpy(&model, &LogModel::lineCountChanged);
+        const QSignalSpy lineCountSpy(&model, &LogModel::lineCountChanged);
         QVERIFY(lineCountSpy.isValid());
-        QSignalSpy finishedSpy(&model, &LogModel::streamingFinished);
+        const QSignalSpy finishedSpy(&model, &LogModel::streamingFinished);
         QVERIFY(finishedSpy.isValid());
 
         model.SetRetentionCap(1000);
@@ -1295,15 +1293,15 @@ private slots:
         sourceOptions.pollInterval = std::chrono::milliseconds(25);
         sourceOptions.rotationDebounce = std::chrono::milliseconds(250);
 
-        std::filesystem::path filePath(fixture.Path().toStdString());
+        const std::filesystem::path filePath(fixture.Path().toStdString());
         auto source = std::make_unique<loglib::TailingBytesProducer>(filePath, /*retentionLines=*/1000, sourceOptions);
         auto streamSource = std::make_unique<loglib::StreamLineSource>(filePath, std::move(source));
 
-        loglib::ParserOptions options;
+        const loglib::ParserOptions options;
         // Don't pass a configuration; the auto-promote heuristics aren't the
         // focus of this test. The model's `BeginStreaming(StreamLineSource)`
         // overrides `options.stopToken` with the sink's freshly-armed token.
-        loglib::StopToken stopToken = model.BeginStreaming(std::move(streamSource), options);
+        const loglib::StopToken stopToken = model.BeginStreaming(std::move(streamSource), options);
         Q_UNUSED(stopToken);
 
         QVERIFY(model.IsStreamingActive());
@@ -1379,7 +1377,7 @@ private slots:
     // `NetworkStreamDialog` (modal -> would hang offscreen QPA);
     // instead we wire the producer directly into the model the same
     // way `MainWindow::OpenNetworkStream` does.
-    void testStreamModeOpensUdpProducer()
+    static void TestStreamModeOpensUdpProducer()
     {
         loglib::UdpServerProducer::Options opts;
         opts.bindAddress = "127.0.0.1"; // ephemeral port
@@ -1389,13 +1387,13 @@ private slots:
         const std::string display = producer->DisplayName();
 
         LogModel model;
-        QSignalSpy lineCountSpy(&model, &LogModel::lineCountChanged);
+        const QSignalSpy lineCountSpy(&model, &LogModel::lineCountChanged);
         QVERIFY(lineCountSpy.isValid());
         model.SetRetentionCap(1000);
 
         auto streamSource =
             std::make_unique<loglib::StreamLineSource>(std::filesystem::path(display), std::move(producer));
-        loglib::ParserOptions options;
+        const loglib::ParserOptions options;
         Q_UNUSED(model.BeginStreaming(std::move(streamSource), options));
 
         QVERIFY(model.IsStreamingActive());
@@ -1404,7 +1402,7 @@ private slots:
         test_common::UdpLogClient client("127.0.0.1", port);
         for (int i = 0; i < 10; ++i)
         {
-            client.Send("{\"i\":" + std::to_string(i + 1) + ",\"phase\":\"udp\"}");
+            client.Send("{\"i\":" + std::to_string(i + 1) + R"(,"phase":"udp"})");
         }
 
         QVERIFY2(WaitForLineCount(model, 10, std::chrono::seconds(5)), "10 UDP lines must arrive within 5 s");
@@ -1420,7 +1418,7 @@ private slots:
     // `test_tcp_server_producer_tls.cpp` so the apptest does not need
     // to build OpenSSL into its link line when LOGLIB_NETWORK_TLS is
     // off on a developer build).
-    void testStreamModeOpensTcpProducer()
+    static void TestStreamModeOpensTcpProducer()
     {
         loglib::TcpServerProducer::Options opts;
         opts.bindAddress = "127.0.0.1"; // ephemeral port
@@ -1431,13 +1429,13 @@ private slots:
         QVERIFY(display.starts_with("tcp://127.0.0.1:"));
 
         LogModel model;
-        QSignalSpy lineCountSpy(&model, &LogModel::lineCountChanged);
+        const QSignalSpy lineCountSpy(&model, &LogModel::lineCountChanged);
         QVERIFY(lineCountSpy.isValid());
         model.SetRetentionCap(1000);
 
         auto streamSource =
             std::make_unique<loglib::StreamLineSource>(std::filesystem::path(display), std::move(producer));
-        loglib::ParserOptions options;
+        const loglib::ParserOptions options;
         Q_UNUSED(model.BeginStreaming(std::move(streamSource), options));
 
         QVERIFY(model.IsStreamingActive());
@@ -1445,7 +1443,7 @@ private slots:
         test_common::TcpLogClient client("127.0.0.1", port);
         for (int i = 0; i < 10; ++i)
         {
-            client.Send("{\"i\":" + std::to_string(i + 1) + ",\"phase\":\"tcp\"}");
+            client.Send("{\"i\":" + std::to_string(i + 1) + R"(,"phase":"tcp"})");
         }
 
         QVERIFY2(WaitForLineCount(model, 10, std::chrono::seconds(5)), "10 TCP lines must arrive within 5 s");
@@ -1461,12 +1459,12 @@ private slots:
     // `FindUiAction` so apptest harnesses can locate it without going
     // through the QObject tree (the workaround documented in
     // `MainWindow::FindUiAction`).
-    void testActionOpenNetworkStreamIsExposed()
+    static void TestActionOpenNetworkStreamIsExposed()
     {
         // Local variable name avoids the `MainWindowTest::window`
         // member-shadow C4458 warning under MSVC.
-        MainWindow mainWindow;
-        QAction *action = mainWindow.FindUiAction(QStringLiteral("actionOpenNetworkStream"));
+        const MainWindow mainWindow;
+        const QAction *action = mainWindow.FindUiAction(QStringLiteral("actionOpenNetworkStream"));
         QVERIFY2(action != nullptr, "actionOpenNetworkStream must be reachable via FindUiAction");
         // Sanity-check the keyboard accelerator the production UI ships.
         QCOMPARE(action->shortcut(), QKeySequence(QStringLiteral("Ctrl+Shift+N")));
@@ -1478,7 +1476,7 @@ private slots:
     // the pause. This test pauses, feeds enough live-tail batches to
     // overflow the cap, and asserts both that `PausedDropCount()` > 0
     // and that the visible+buffered total stayed within the cap.
-    void testPausedDropCountIsObservable()
+    static void TestPausedDropCountIsObservable()
     {
         LogModel model;
         loglib::StreamLineSource &streamSource = BeginSyntheticStreamSession(model);
@@ -1507,7 +1505,7 @@ private slots:
         {
             const bool firstBatch = (b == 0);
             sink->OnBatch(MakeSyntheticBatch(
-                streamSource, keys, valueKey, static_cast<size_t>(b) * batchLines + 1, batchLines, firstBatch
+                streamSource, keys, valueKey, (static_cast<size_t>(b) * batchLines) + 1, batchLines, firstBatch
             ));
         }
 
@@ -1546,7 +1544,7 @@ private slots:
     // counter, but never silently disappeared. Counterpart to
     // `testPausedDropCountIsObservable` (which exercises overflow);
     // this one exercises the under-cap normal-stop path.
-    void testStopAfterPauseFlushesPausedBufferToModel()
+    static void TestStopAfterPauseFlushesPausedBufferToModel()
     {
         LogModel model;
         loglib::StreamLineSource &streamSource = BeginSyntheticStreamSession(model);
@@ -1573,7 +1571,7 @@ private slots:
         {
             const bool firstBatch = (b == 0);
             sink->OnBatch(MakeSyntheticBatch(
-                streamSource, keys, valueKey, static_cast<size_t>(b) * batchLines + 1, batchLines, firstBatch
+                streamSource, keys, valueKey, (static_cast<size_t>(b) * batchLines) + 1, batchLines, firstBatch
             ));
         }
 
@@ -1591,7 +1589,7 @@ private slots:
         QCoreApplication::processEvents();
 
         const qsizetype visible = model.rowCount();
-        const qulonglong dropped = static_cast<qulonglong>(sink->PausedDropCount());
+        const auto dropped = static_cast<qulonglong>(sink->PausedDropCount());
         QVERIFY2(
             static_cast<qulonglong>(visible) + dropped == totalLines,
             qPrintable(QStringLiteral("rows accounting failed: visible=%1 + dropped=%2 != totalLines=%3")
@@ -1613,9 +1611,9 @@ private slots:
     // pre-fix counter snapshotted `toDrop` up front, under-reporting the
     // overshoot to the status-bar "dropped while paused" indicator. The
     // fix accumulates the *actual* lines evicted as the loop runs.
-    void testPausedDropCountReflectsStaticBatchOverEviction()
+    static void TestPausedDropCountReflectsStaticBatchOverEviction()
     {
-        TempJsonFile fixture(QStringList{
+        const TempJsonFile fixture(QStringList{
             QStringLiteral(R"({"a": 1})"),
             QStringLiteral(R"({"a": 2})"),
             QStringLiteral(R"({"a": 3})"),
@@ -1646,7 +1644,7 @@ private slots:
         {
             loglib::StreamedBatch batch;
             batch.firstLineNumber = 1;
-            batch.newKeys.emplace_back(std::string("value"));
+            batch.newKeys.emplace_back("value");
             batch.lines.reserve(staticBatchRows);
             batch.localLineOffsets.reserve(staticBatchRows);
             for (size_t i = 0; i < staticBatchRows; ++i)
@@ -1707,12 +1705,12 @@ private slots:
     // static snapshot of what was in memory at stop time). `StopAndKeepRows()`
     // is the API `MainWindow::StopStream` uses; `Reset()` (which fully
     // resets the model) is reserved for the "open a new session" paths.
-    void testStopAndKeepRowsPreservesRows()
+    static void TestStopAndKeepRowsPreservesRows()
     {
         LogModel model;
         QSignalSpy finishedSpy(&model, &LogModel::streamingFinished);
         QVERIFY(finishedSpy.isValid());
-        QSignalSpy lineCountSpy(&model, &LogModel::lineCountChanged);
+        const QSignalSpy lineCountSpy(&model, &LogModel::lineCountChanged);
         QVERIFY(lineCountSpy.isValid());
 
         loglib::StreamLineSource &streamSource = BeginSyntheticStreamSession(model);
@@ -1780,7 +1778,7 @@ private slots:
     // already in the model — so any later `OnBatch` (queued or direct)
     // necessarily lands after them. We don't try to win the worker race
     // here; the synchronous contract removes the race entirely.
-    void testResumeDeliversBufferedBatchSynchronouslyForOrdering()
+    static void TestResumeDeliversBufferedBatchSynchronouslyForOrdering()
     {
         LogModel model;
         loglib::StreamLineSource &streamSource = BeginSyntheticStreamSession(model);
@@ -1854,11 +1852,11 @@ private slots:
     // The fix disables the three Stream actions whenever the toolbar
     // is hidden, and force-unchecks `actionPauseStream` defensively so
     // a stuck checked state from any other path can never persist.
-    void testStreamMenuActionsDisabledWhileIdle()
+    void TestStreamMenuActionsDisabledWhileIdle()
     {
-        QAction *pauseAction = FindActionByObjectName(window, QStringLiteral("actionPauseStream"));
-        QAction *followAction = FindActionByObjectName(window, QStringLiteral("actionFollowTail"));
-        QAction *stopAction = FindActionByObjectName(window, QStringLiteral("actionStopStream"));
+        QAction *pauseAction = FindActionByObjectName(mWindow, QStringLiteral("actionPauseStream"));
+        const QAction *followAction = FindActionByObjectName(mWindow, QStringLiteral("actionFollowTail"));
+        const QAction *stopAction = FindActionByObjectName(mWindow, QStringLiteral("actionStopStream"));
         QVERIFY(pauseAction != nullptr);
         QVERIFY(followAction != nullptr);
         QVERIFY(stopAction != nullptr);
@@ -1887,9 +1885,9 @@ private slots:
     // next session boundary. This validates that my new disable-gate
     // in `UpdateStreamToolbarVisibility` did not interfere with the
     // existing Pause-toggle reset in the slot.
-    void testStaleCheckedPauseClearedOnTeardown()
+    void TestStaleCheckedPauseClearedOnTeardown()
     {
-        QAction *pauseAction = FindActionByObjectName(window, QStringLiteral("actionPauseStream"));
+        QAction *pauseAction = FindActionByObjectName(mWindow, QStringLiteral("actionPauseStream"));
         QVERIFY(pauseAction != nullptr);
 
         // Simulate the bug condition: forcibly enable the action and
@@ -1904,7 +1902,7 @@ private slots:
         // (in `MainWindow`) resets the Pause toggle and refreshes the
         // toolbar gating. This is the existing reset path that must
         // keep working alongside the new disabled-while-idle invariant.
-        LogModel *model = window->findChild<LogModel *>();
+        auto *model = mWindow->findChild<LogModel *>();
         QVERIFY(model != nullptr);
 
         static_cast<void>(model->BeginStreamingForSyncTest(std::unique_ptr<loglib::LineSource>{}));
@@ -1938,10 +1936,10 @@ private slots:
     // the range — the closest in-process simulation of a hover-
     // triggered internal scroll update — must therefore leave the
     // toggle alone.
-    void testFollowTailIgnoresProgrammaticScrollbarChanges()
+    void TestFollowTailIgnoresProgrammaticScrollbarChanges()
     {
-        QAction *followAction = FindActionByObjectName(window, QStringLiteral("actionFollowTail"));
-        LogTableView *tableView = window->findChild<LogTableView *>();
+        QAction *followAction = FindActionByObjectName(mWindow, QStringLiteral("actionFollowTail"));
+        const auto *tableView = mWindow->findChild<LogTableView *>();
         QVERIFY(followAction != nullptr);
         QVERIFY(tableView != nullptr);
 
@@ -1963,7 +1961,7 @@ private slots:
         scrollBar->setRange(0, 1000);
         scrollBar->setValue(scrollBar->maximum());
 
-        QSignalSpy awaySpy(tableView, &LogTableView::userScrolledAwayFromTail);
+        const QSignalSpy awaySpy(tableView, &LogTableView::userScrolledAwayFromTail);
         QVERIFY(awaySpy.isValid());
 
         // Programmatic value change to the middle of the range — the
@@ -1986,10 +1984,10 @@ private slots:
     // `RowOrderProxyModel::SetReversed` plus the persisted
     // `streaming/newestFirst` setting — exercising the proxy here
     // covers the contract that the GUI relies on.
-    void testNewestFirstReversesProxyOrder()
+    void TestNewestFirstReversesProxyOrder()
     {
-        RowOrderProxyModel *rowOrderProxy = window->findChild<RowOrderProxyModel *>();
-        LogModel *model = window->findChild<LogModel *>();
+        auto *rowOrderProxy = mWindow->findChild<RowOrderProxyModel *>();
+        auto *model = mWindow->findChild<LogModel *>();
         QVERIFY(rowOrderProxy != nullptr);
         QVERIFY(model != nullptr);
         QVERIFY(!rowOrderProxy->IsReversed());
@@ -2059,10 +2057,10 @@ private slots:
     // first** enables reversed mode before any data (matching session
     // startup); the second batch must land with its newest line at
     // proxy row 0, not stuck under the first batch.
-    void testNewestFirstIncrementalBatchesKeepNewestAtTop()
+    void TestNewestFirstIncrementalBatchesKeepNewestAtTop()
     {
-        RowOrderProxyModel *rowOrderProxy = window->findChild<RowOrderProxyModel *>();
-        LogModel *model = window->findChild<LogModel *>();
+        auto *rowOrderProxy = mWindow->findChild<RowOrderProxyModel *>();
+        auto *model = mWindow->findChild<LogModel *>();
         QVERIFY(rowOrderProxy != nullptr);
         QVERIFY(model != nullptr);
 
@@ -2113,10 +2111,10 @@ private slots:
     // blow. Set deliberately loose to absorb CI noise; the failing
     // implementation routinely lands at multiple seconds, while the
     // current one lands in single-digit ms.
-    void testNewestFirstToggleIsOPersistentIndices()
+    void TestNewestFirstToggleIsOPersistentIndices()
     {
-        RowOrderProxyModel *rowOrderProxy = window->findChild<RowOrderProxyModel *>();
-        LogModel *model = window->findChild<LogModel *>();
+        auto *rowOrderProxy = mWindow->findChild<RowOrderProxyModel *>();
+        auto *model = mWindow->findChild<LogModel *>();
         QVERIFY(rowOrderProxy != nullptr);
         QVERIFY(model != nullptr);
 
@@ -2124,17 +2122,17 @@ private slots:
         QtStreamingLogSink *sink = model->Sink();
         QVERIFY(sink != nullptr);
 
-        constexpr int kRows = 10'000;
+        constexpr int K_ROWS = 10'000;
         loglib::KeyIndex &keys = sink->Keys();
         const loglib::KeyId valueKey = keys.GetOrInsert(std::string("value"));
-        sink->OnBatch(MakeSyntheticBatch(streamSource, keys, valueKey, 1, kRows, /*declareNewKey=*/true));
+        sink->OnBatch(MakeSyntheticBatch(streamSource, keys, valueKey, 1, K_ROWS, /*declareNewKey=*/true));
         QCoreApplication::processEvents();
-        QCOMPARE(model->rowCount(), kRows);
+        QCOMPARE(model->rowCount(), K_ROWS);
 
         // Hold a single persistent index from somewhere in the
         // middle of the proxy. Toggling SetReversed must remap *this
         // one* via `changePersistentIndexList`; nothing else.
-        const QPersistentModelIndex pinned(rowOrderProxy->index(kRows / 2, 0));
+        const QPersistentModelIndex pinned(rowOrderProxy->index(K_ROWS / 2, 0));
         QVERIFY(pinned.isValid());
 
         rowOrderProxy->SetReversed(false);
@@ -2142,8 +2140,8 @@ private slots:
 
         QElapsedTimer timer;
         timer.start();
-        constexpr int kToggles = 100;
-        for (int i = 0; i < kToggles; ++i)
+        constexpr int K_TOGGLES = 100;
+        for (int i = 0; i < K_TOGGLES; ++i)
         {
             rowOrderProxy->SetReversed(i % 2 == 1);
         }
@@ -2157,7 +2155,7 @@ private slots:
             elapsedMs < 200,
             qPrintable(QStringLiteral("RowOrderProxyModel::SetReversed must be O(persistent indices), "
                                       "not O(rows); 100 toggles over %1 rows took %2 ms (budget 200 ms)")
-                           .arg(kRows)
+                           .arg(K_ROWS)
                            .arg(elapsedMs))
         );
 
@@ -2167,7 +2165,7 @@ private slots:
         // identity, which is what the constructor saw) should sit at
         // proxy row (kRows - 1 - kRows/2).
         QVERIFY(pinned.isValid());
-        QCOMPARE(pinned.row(), kRows - 1 - kRows / 2);
+        QCOMPARE(pinned.row(), K_ROWS - 1 - K_ROWS / 2);
 
         rowOrderProxy->SetReversed(false);
         model->EndStreaming(false);
@@ -2189,9 +2187,9 @@ private slots:
     // The companion `testFollowTailIgnoresProgrammaticScrollbarChanges`
     // already covers the bottom edge; this test pins down the top edge
     // contract introduced by the newest-first feature.
-    void testTailEdgeTopFollowsScrollbarMinimum()
+    void TestTailEdgeTopFollowsScrollbarMinimum()
     {
-        LogTableView *tableView = window->findChild<LogTableView *>();
+        auto *tableView = mWindow->findChild<LogTableView *>();
         QVERIFY(tableView != nullptr);
 
         tableView->SetTailEdge(LogTableView::TailEdge::Top);
@@ -2204,8 +2202,8 @@ private slots:
 
         // Programmatic value change to the middle: must not flip the
         // toggle (mirrors the bottom-edge programmatic-scroll test).
-        QSignalSpy awaySpy(tableView, &LogTableView::userScrolledAwayFromTail);
-        QSignalSpy toSpy(tableView, &LogTableView::userScrolledToTail);
+        const QSignalSpy awaySpy(tableView, &LogTableView::userScrolledAwayFromTail);
+        const QSignalSpy toSpy(tableView, &LogTableView::userScrolledToTail);
         QVERIFY(awaySpy.isValid());
         QVERIFY(toSpy.isValid());
 
@@ -2261,10 +2259,10 @@ private slots:
     // arrows, key press on the slider) ultimately call, so driving
     // it directly here is the closest in-process equivalent of the
     // user clicking the scrollbar.
-    void testFollowNewestDisengagesOnScrollbarAction()
+    void TestFollowNewestDisengagesOnScrollbarAction()
     {
-        QAction *followAction = FindActionByObjectName(window, QStringLiteral("actionFollowTail"));
-        LogTableView *tableView = window->findChild<LogTableView *>();
+        QAction *followAction = FindActionByObjectName(mWindow, QStringLiteral("actionFollowTail"));
+        const auto *tableView = mWindow->findChild<LogTableView *>();
         QVERIFY(followAction != nullptr);
         QVERIFY(tableView != nullptr);
 
@@ -2277,7 +2275,7 @@ private slots:
         scrollBar->setRange(0, 1000);
         scrollBar->setValue(scrollBar->maximum());
 
-        QSignalSpy awaySpy(tableView, &LogTableView::userScrolledAwayFromTail);
+        const QSignalSpy awaySpy(tableView, &LogTableView::userScrolledAwayFromTail);
         QVERIFY(awaySpy.isValid());
 
         // `triggerAction(SliderToMinimum)` mirrors a Home keypress on
@@ -2302,12 +2300,12 @@ private slots:
     // row + its pixel offset before the structural change and
     // re-aligns the scrollbar after, so the row stays at the same
     // pixel position from the user's perspective (chat-app pattern).
-    void testNewestFirstPreservesReadingPositionAcrossBatches()
+    void TestNewestFirstPreservesReadingPositionAcrossBatches()
     {
-        RowOrderProxyModel *rowOrderProxy = window->findChild<RowOrderProxyModel *>();
-        LogTableView *tableView = window->findChild<LogTableView *>();
-        LogModel *model = window->findChild<LogModel *>();
-        QAction *followAction = FindActionByObjectName(window, QStringLiteral("actionFollowTail"));
+        auto *rowOrderProxy = mWindow->findChild<RowOrderProxyModel *>();
+        auto *tableView = mWindow->findChild<LogTableView *>();
+        auto *model = mWindow->findChild<LogModel *>();
+        QAction *followAction = FindActionByObjectName(mWindow, QStringLiteral("actionFollowTail"));
         QVERIFY(rowOrderProxy != nullptr);
         QVERIFY(tableView != nullptr);
         QVERIFY(model != nullptr);
@@ -2413,35 +2411,35 @@ private slots:
     // `QTableView::alternatingRowColors`. The companion
     // `testAlternatingRowColoursDisabledInStaticNewestFirstMode`
     // asserts the same contract for static-mode sessions.
-    void testAlternatingRowColoursDisabledInNewestFirstMode()
+    void TestAlternatingRowColoursDisabledInNewestFirstMode()
     {
-        LogTableView *tableView = window->findChild<LogTableView *>();
-        LogModel *model = window->findChild<LogModel *>();
+        const auto *tableView = mWindow->findChild<LogTableView *>();
+        auto *model = mWindow->findChild<LogModel *>();
         QVERIFY(tableView != nullptr);
         QVERIFY(model != nullptr);
 
         const bool originalNewestFirst = StreamingControl::IsNewestFirst();
         auto restoreNewestFirst = qScopeGuard([this, originalNewestFirst]() {
             StreamingControl::SetNewestFirst(originalNewestFirst);
-            window->SetSessionModeForTest(MainWindow::TestSessionMode::Idle);
+            mWindow->SetSessionModeForTest(MainWindow::TestSessionMode::Idle);
         });
 
         // Stage a stream-mode session so `ApplyDisplayOrder` consults
         // `IsNewestFirst()` (and not `IsStaticNewestFirst()`).
         static_cast<void>(BeginSyntheticStreamSession(*model));
-        window->SetSessionModeForTest(MainWindow::TestSessionMode::LiveTail);
+        mWindow->SetSessionModeForTest(MainWindow::TestSessionMode::LiveTail);
 
         // Default-mode baseline: alternation is on so users still get
         // the lighter/darker reading aid while reading static logs or
         // a bottom-tail stream.
         StreamingControl::SetNewestFirst(false);
-        window->ApplyDisplayOrder();
+        mWindow->ApplyDisplayOrder();
         QVERIFY2(tableView->alternatingRowColors(), "default bottom-tail mode should keep alternating row colours on");
 
         // Newest-first flips the toggle off — see the comment in
         // `ApplyDisplayOrder` for the rationale.
         StreamingControl::SetNewestFirst(true);
-        window->ApplyDisplayOrder();
+        mWindow->ApplyDisplayOrder();
         QVERIFY2(
             !tableView->alternatingRowColors(),
             "newest-first mode should disable alternating row colours to avoid the "
@@ -2452,7 +2450,7 @@ private slots:
         // never enabled newest-first, but covers the "I tried it,
         // didn't like it, switched back" path).
         StreamingControl::SetNewestFirst(false);
-        window->ApplyDisplayOrder();
+        mWindow->ApplyDisplayOrder();
         QVERIFY2(
             tableView->alternatingRowColors(), "switching newest-first off should re-enable alternating row colours"
         );
@@ -2465,11 +2463,11 @@ private slots:
     // **static** preference (`StreamingControl::IsStaticNewestFirst`),
     // not the stream-mode one. Toggling only the stream-mode flag must
     // be a no-op while a static session is active.
-    void testStaticNewestFirstReversesProxyOrder()
+    void TestStaticNewestFirstReversesProxyOrder()
     {
-        RowOrderProxyModel *rowOrderProxy = window->findChild<RowOrderProxyModel *>();
-        LogTableView *tableView = window->findChild<LogTableView *>();
-        LogModel *model = window->findChild<LogModel *>();
+        const auto *rowOrderProxy = mWindow->findChild<RowOrderProxyModel *>();
+        const auto *tableView = mWindow->findChild<LogTableView *>();
+        auto *model = mWindow->findChild<LogModel *>();
         QVERIFY(rowOrderProxy != nullptr);
         QVERIFY(tableView != nullptr);
         QVERIFY(model != nullptr);
@@ -2479,30 +2477,30 @@ private slots:
         auto restore = qScopeGuard([this, originalStream, originalStatic]() {
             StreamingControl::SetNewestFirst(originalStream);
             StreamingControl::SetStaticNewestFirst(originalStatic);
-            window->SetSessionModeForTest(MainWindow::TestSessionMode::Idle);
+            mWindow->SetSessionModeForTest(MainWindow::TestSessionMode::Idle);
         });
 
         BeginSyntheticStaticSession(*model);
-        window->SetSessionModeForTest(MainWindow::TestSessionMode::Static);
+        mWindow->SetSessionModeForTest(MainWindow::TestSessionMode::Static);
 
         // Stream-mode flag has no effect on a static session: with the
         // stream flag ON and the static flag OFF, the proxy must stay
         // in the identity orientation.
         StreamingControl::SetNewestFirst(true);
         StreamingControl::SetStaticNewestFirst(false);
-        window->ApplyDisplayOrder();
+        mWindow->ApplyDisplayOrder();
         QVERIFY2(!rowOrderProxy->IsReversed(), "static session must ignore the stream-mode newest-first flag");
         QVERIFY(tableView->alternatingRowColors());
 
         // Flipping the static-mode flag drives the same proxy reversal
         // as the stream-mode flag does for live-tail sessions.
         StreamingControl::SetStaticNewestFirst(true);
-        window->ApplyDisplayOrder();
+        mWindow->ApplyDisplayOrder();
         QVERIFY(rowOrderProxy->IsReversed());
         QVERIFY(!tableView->alternatingRowColors());
 
         StreamingControl::SetStaticNewestFirst(false);
-        window->ApplyDisplayOrder();
+        mWindow->ApplyDisplayOrder();
         QVERIFY(!rowOrderProxy->IsReversed());
         QVERIFY(tableView->alternatingRowColors());
 
@@ -2528,16 +2526,16 @@ private slots:
     // The test simulates a static-mode batch arrival after the user
     // has scrolled away from the bottom and asserts the scrollbar
     // value does not change.
-    void testStaticSessionDoesNotFollowNewestRows()
+    void TestStaticSessionDoesNotFollowNewestRows()
     {
-        LogTableView *tableView = window->findChild<LogTableView *>();
-        LogModel *model = window->findChild<LogModel *>();
-        QAction *followAction = FindActionByObjectName(window, QStringLiteral("actionFollowTail"));
+        auto *tableView = mWindow->findChild<LogTableView *>();
+        auto *model = mWindow->findChild<LogModel *>();
+        const QAction *followAction = FindActionByObjectName(mWindow, QStringLiteral("actionFollowTail"));
         QVERIFY(tableView != nullptr);
         QVERIFY(model != nullptr);
         QVERIFY(followAction != nullptr);
 
-        auto restore = qScopeGuard([this]() { window->SetSessionModeForTest(MainWindow::TestSessionMode::Idle); });
+        auto restore = qScopeGuard([this]() { mWindow->SetSessionModeForTest(MainWindow::TestSessionMode::Idle); });
 
         // Static session, with `actionFollowTail` left in its startup
         // baseline (checked). Production users never see this toggle
@@ -2545,7 +2543,7 @@ private slots:
         // disabled), but the *value* persists across sessions and is
         // what the buggy auto-scroll path was reading.
         loglib::StreamLineSource &streamSource = BeginSyntheticStaticSession(*model);
-        window->SetSessionModeForTest(MainWindow::TestSessionMode::Static);
+        mWindow->SetSessionModeForTest(MainWindow::TestSessionMode::Static);
         QVERIFY(followAction->isChecked());
 
         QtStreamingLogSink *sink = model->Sink();
@@ -2620,26 +2618,26 @@ private slots:
     // sessions too -- so a user who scrolled to the bottom of a
     // partially-parsed static file would have the next incoming
     // batch yank the viewport away.
-    void testStaticSessionDoesNotReArmFollowOnScrollToTail()
+    void TestStaticSessionDoesNotReArmFollowOnScrollToTail()
     {
-        LogTableView *tableView = window->findChild<LogTableView *>();
-        LogModel *model = window->findChild<LogModel *>();
-        QAction *followAction = FindActionByObjectName(window, QStringLiteral("actionFollowTail"));
+        auto *tableView = mWindow->findChild<LogTableView *>();
+        auto *model = mWindow->findChild<LogModel *>();
+        QAction *followAction = FindActionByObjectName(mWindow, QStringLiteral("actionFollowTail"));
         QVERIFY(tableView != nullptr);
         QVERIFY(model != nullptr);
         QVERIFY(followAction != nullptr);
 
-        auto restore = qScopeGuard([this]() { window->SetSessionModeForTest(MainWindow::TestSessionMode::Idle); });
+        auto restore = qScopeGuard([this]() { mWindow->SetSessionModeForTest(MainWindow::TestSessionMode::Idle); });
 
         BeginSyntheticStaticSession(*model);
-        window->SetSessionModeForTest(MainWindow::TestSessionMode::Static);
+        mWindow->SetSessionModeForTest(MainWindow::TestSessionMode::Static);
 
         // Force the action *unchecked* so the re-arm path has a
         // visible state transition to attempt.
         followAction->setChecked(false);
         QVERIFY(!followAction->isChecked());
 
-        QSignalSpy toSpy(tableView, &LogTableView::userScrolledToTail);
+        const QSignalSpy toSpy(tableView, &LogTableView::userScrolledToTail);
         QVERIFY(toSpy.isValid());
 
         // Synthesise the same `userScrolledToTail` emission the
@@ -2662,10 +2660,10 @@ private slots:
     // de-reverse on a stream session, proving the mode dispatch in
     // `ApplyDisplayOrder` actually picks per-mode (and isn't reading
     // either flag's value unconditionally).
-    void testNewestFirstFollowsSessionModeOnTransition()
+    void TestNewestFirstFollowsSessionModeOnTransition()
     {
-        RowOrderProxyModel *rowOrderProxy = window->findChild<RowOrderProxyModel *>();
-        LogModel *model = window->findChild<LogModel *>();
+        const auto *rowOrderProxy = mWindow->findChild<RowOrderProxyModel *>();
+        auto *model = mWindow->findChild<LogModel *>();
         QVERIFY(rowOrderProxy != nullptr);
         QVERIFY(model != nullptr);
 
@@ -2674,7 +2672,7 @@ private slots:
         auto restore = qScopeGuard([this, originalStream, originalStatic]() {
             StreamingControl::SetNewestFirst(originalStream);
             StreamingControl::SetStaticNewestFirst(originalStatic);
-            window->SetSessionModeForTest(MainWindow::TestSessionMode::Idle);
+            mWindow->SetSessionModeForTest(MainWindow::TestSessionMode::Idle);
         });
 
         // Both ON: every session orientation should land reversed.
@@ -2682,31 +2680,31 @@ private slots:
         StreamingControl::SetStaticNewestFirst(true);
 
         BeginSyntheticStaticSession(*model);
-        window->SetSessionModeForTest(MainWindow::TestSessionMode::Static);
-        window->ApplyDisplayOrder();
+        mWindow->SetSessionModeForTest(MainWindow::TestSessionMode::Static);
+        mWindow->ApplyDisplayOrder();
         QVERIFY(rowOrderProxy->IsReversed());
 
         // End the static session and start a stream one; the proxy
         // must stay reversed because the stream-mode flag is also ON.
         model->EndStreaming(false);
         static_cast<void>(BeginSyntheticStreamSession(*model));
-        window->SetSessionModeForTest(MainWindow::TestSessionMode::LiveTail);
-        window->ApplyDisplayOrder();
+        mWindow->SetSessionModeForTest(MainWindow::TestSessionMode::LiveTail);
+        mWindow->ApplyDisplayOrder();
         QVERIFY(rowOrderProxy->IsReversed());
 
         // Asymmetric: only the static-mode flag is ON. The proxy must
         // de-reverse for the stream session (still active) and only
         // re-reverse once we transition back to a static session.
         StreamingControl::SetNewestFirst(false);
-        window->ApplyDisplayOrder();
+        mWindow->ApplyDisplayOrder();
         QVERIFY2(
             !rowOrderProxy->IsReversed(), "stream session must follow the stream-mode flag, not the static-mode one"
         );
 
         model->EndStreaming(false);
         BeginSyntheticStaticSession(*model);
-        window->SetSessionModeForTest(MainWindow::TestSessionMode::Static);
-        window->ApplyDisplayOrder();
+        mWindow->SetSessionModeForTest(MainWindow::TestSessionMode::Static);
+        mWindow->ApplyDisplayOrder();
         QVERIFY2(
             rowOrderProxy->IsReversed(),
             "static session must follow the static-mode flag even when the stream-mode flag is OFF"
@@ -2721,7 +2719,7 @@ private slots:
     // event loop, samples that the worker is parked on the (cap+1)-th
     // call, then drains via `processEvents` and confirms every batch
     // eventually lands.
-    void testBoundedQueueBlocksWorkerWhenGuiFallsBehind()
+    static void TestBoundedQueueBlocksWorkerWhenGuiFallsBehind()
     {
         constexpr std::size_t CAPACITY = 4;
         constexpr int TOTAL_BATCHES = static_cast<int>(CAPACITY) + 5;
@@ -2783,7 +2781,7 @@ private slots:
     // wake the worker immediately (no polling). Without the explicit
     // `NotifyStop` hook the worker would deadlock against
     // `mStreamingWatcher->waitForFinished()`.
-    void testStopWhileWorkerBlockedOnBoundedQueue()
+    static void TestStopWhileWorkerBlockedOnBoundedQueue()
     {
         constexpr std::size_t CAPACITY = 1;
         LogModel model(nullptr, CAPACITY);
@@ -2840,7 +2838,7 @@ private slots:
     // queue with a small capacity and a draining GUI; every batch must
     // arrive in order. Guards against drain-side dropouts and against
     // the lazy `mDrainScheduled` flag missing a re-arm window.
-    void testNoBatchLossUnderBackPressure()
+    static void TestNoBatchLossUnderBackPressure()
     {
         constexpr std::size_t CAPACITY = 8;
         constexpr int TOTAL_BATCHES = 200;
@@ -2886,10 +2884,9 @@ private slots:
         model.EndStreaming(false);
     }
 
-private:
     // Shared helper for the ISO/timestamp fixtures. Outside `private slots:`
     // so moc doesn't expose it as a test method.
-    void AssertTimestampFixture(StreamingRun &run, qint64 expectedFirstUtcUs, int rowCount)
+    static void AssertTimestampFixture(StreamingRun &run, qint64 expectedFirstUtcUs, int rowCount)
     {
         QCOMPARE(run.finishedCount, 1);
         QCOMPARE(run.cancelled, false);
@@ -2924,7 +2921,8 @@ private:
         QCOMPARE(firstUs, expectedFirstUtcUs);
     }
 
-    MainWindow *window;
+private:
+    MainWindow *mWindow{};
 };
 
 QTEST_MAIN(MainWindowTest)

--- a/test/app/src/main_window_test.cpp
+++ b/test/app/src/main_window_test.cpp
@@ -44,6 +44,7 @@
 
 #include <atomic>
 #include <chrono>
+#include <cmath>
 #include <condition_variable>
 #include <cstddef>
 #include <cstdint>
@@ -263,7 +264,7 @@ double TestTimeScale() noexcept
 std::chrono::milliseconds ScaledDeadline(std::chrono::milliseconds base) noexcept
 {
     const double scaled = static_cast<double>(base.count()) * TestTimeScale();
-    const auto rounded = static_cast<long long>(scaled + 0.5);
+    const auto rounded = std::llround(scaled);
     return std::chrono::milliseconds(rounded < 1 ? 1 : rounded);
 }
 
@@ -1111,7 +1112,8 @@ private slots:
         const int linesPerBatch = 5;
         for (int b = 0; b < batchesWhilePaused; ++b)
         {
-            const auto firstLineId = static_cast<size_t>((b * linesPerBatch) + 1);
+            const auto firstLineId =
+                static_cast<size_t>(static_cast<size_t>(b) * static_cast<size_t>(linesPerBatch) + size_t{1});
             const bool declareNewKey = (b == 0);
             // Direct call to OnBatch from this thread mirrors the worker.
             sink->OnBatch(MakeSyntheticBatch(
@@ -1185,12 +1187,15 @@ private slots:
         for (int b = 0; b < batchesWhilePaused; ++b)
         {
             loglib::StreamedBatch batch;
-            batch.firstLineNumber = static_cast<size_t>((b * linesPerBatch) + 1);
+            batch.firstLineNumber =
+                static_cast<size_t>(static_cast<size_t>(b) * static_cast<size_t>(linesPerBatch) + size_t{1});
             batch.lines.reserve(linesPerBatch);
             batch.localLineOffsets.reserve(linesPerBatch);
             for (int i = 0; i < linesPerBatch; ++i)
             {
-                const auto lineNumber = static_cast<size_t>((b * linesPerBatch) + i + 1);
+                const auto lineNumber = static_cast<size_t>(
+                    static_cast<size_t>(b) * static_cast<size_t>(linesPerBatch) + static_cast<size_t>(i) + size_t{1}
+                );
                 std::vector<std::pair<loglib::KeyId, loglib::LogValue>> values;
                 values.emplace_back(keyId, loglib::LogValue(static_cast<int64_t>(lineNumber)));
                 batch.lines.emplace_back(std::move(values), keys, *sourcePtr, lineNumber);
@@ -2165,7 +2170,7 @@ private slots:
         // identity, which is what the constructor saw) should sit at
         // proxy row (kRows - 1 - kRows/2).
         QVERIFY(pinned.isValid());
-        QCOMPARE(pinned.row(), K_ROWS - 1 - K_ROWS / 2);
+        QCOMPARE(pinned.row(), K_ROWS - 1 - (K_ROWS / 2));
 
         rowOrderProxy->SetReversed(false);
         model->EndStreaming(false);

--- a/test/app/src/test_bounded_batch_queue.cpp
+++ b/test/app/src/test_bounded_batch_queue.cpp
@@ -42,7 +42,7 @@ private slots:
     /// Capacity 2: enqueue two items, spawn a producer that wants to
     /// enqueue a third; verify it is parked on `WaitEnqueue` until a
     /// `DrainAll` opens a slot.
-    void testEnqueueBlocksAtCapacity()
+    static void TestEnqueueBlocksAtCapacity()
     {
         logapp::BoundedBatchQueue queue(2);
         QVERIFY(queue.WaitEnqueue(MakeBatch(0)));
@@ -85,7 +85,7 @@ private slots:
     /// `NotifyStop` must wake the blocked producer immediately (no
     /// polling loop). Capacity 1 + one prefilled item parks the
     /// producer; the wake must arrive well inside the deadline.
-    void testNotifyStopWakesBlockedProducer()
+    static void TestNotifyStopWakesBlockedProducer()
     {
         logapp::BoundedBatchQueue queue(1);
         QVERIFY(queue.WaitEnqueue(MakeBatch(0)));
@@ -126,7 +126,7 @@ private slots:
     /// the drain-phase `OnBatch` contract: between `RequestStop` and
     /// the worker join the worker may emit more batches and they must
     /// reach the GUI).
-    void testStopWithSpaceStillEnqueues()
+    static void TestStopWithSpaceStillEnqueues()
     {
         logapp::BoundedBatchQueue queue(4);
         queue.NotifyStop();
@@ -140,7 +140,7 @@ private slots:
 
     /// `WaitEnqueue` against a full + stopped queue must not park the
     /// caller; it returns `false` immediately with the batch dropped.
-    void testStopWithFullQueueReturnsFalseImmediately()
+    static void TestStopWithFullQueueReturnsFalseImmediately()
     {
         logapp::BoundedBatchQueue queue(1);
         QVERIFY(queue.WaitEnqueue(MakeBatch(0)));
@@ -161,7 +161,7 @@ private slots:
     /// Producer enqueues 100 items in order; consumer issues several
     /// `DrainAll` calls. The concatenation of drained items must be
     /// the original sequence.
-    void testFifoOrderAcrossDrains()
+    static void TestFifoOrderAcrossDrains()
     {
         constexpr std::size_t COUNT = 100;
         logapp::BoundedBatchQueue queue(8);
@@ -202,7 +202,7 @@ private slots:
     /// stopped flag so the queue is usable again. After Reset the
     /// queue should also block again on full-capacity (i.e. the
     /// stopped flag is genuinely cleared, not just hidden).
-    void testResetClearsAndReArms()
+    static void TestResetClearsAndReArms()
     {
         logapp::BoundedBatchQueue queue(2);
         QVERIFY(queue.WaitEnqueue(MakeBatch(7)));
@@ -226,7 +226,7 @@ private slots:
 
     /// One producer + one consumer move 100 000 items through a
     /// capacity-8 queue; verify FIFO and a generous time bound.
-    void testStressOneProducerOneConsumer()
+    static void TestStressOneProducerOneConsumer()
     {
         constexpr std::size_t COUNT = 100'000;
         logapp::BoundedBatchQueue queue(8);

--- a/test/app/src/test_bounded_batch_queue.cpp
+++ b/test/app/src/test_bounded_batch_queue.cpp
@@ -34,6 +34,7 @@ constexpr auto STRESS_DEADLINE = std::chrono::seconds(5);
 
 } // namespace
 
+// NOLINTNEXTLINE(misc-use-internal-linkage): `Q_OBJECT` QtTest fixture.
 class BoundedBatchQueueTest : public QObject
 {
     Q_OBJECT

--- a/test/common/include/test_common/network_log_client.hpp
+++ b/test/common/include/test_common/network_log_client.hpp
@@ -53,7 +53,7 @@ public:
     /// Connect (and TLS-handshake when @p tls is non-nullopt). Throws
     /// `std::runtime_error` on connect / handshake failure.
     /// `tls` non-nullopt in a build without `LOGLIB_HAS_TLS` throws.
-    TcpLogClient(std::string host, uint16_t port, std::optional<TlsOptions> tls = std::nullopt);
+    TcpLogClient(const std::string &host, uint16_t port, std::optional<TlsOptions> tls = std::nullopt);
 
     ~TcpLogClient();
 
@@ -88,7 +88,7 @@ class UdpLogClient
 public:
     /// Resolve @p host and create an unconnected UDP socket. Throws
     /// `std::runtime_error` if @p host cannot be resolved.
-    UdpLogClient(std::string host, uint16_t port);
+    UdpLogClient(const std::string &host, uint16_t port);
 
     ~UdpLogClient();
 

--- a/test/common/src/log_generator.cpp
+++ b/test/common/src/log_generator.cpp
@@ -64,7 +64,7 @@ JsonLogLine GenerateRandomJsonLogLine(std::mt19937 &rng, std::size_t lineIndex)
     json["message"] = message;
     json["thread_id"] = static_cast<std::int64_t>(lineIndex % 16);
     json["component"] = std::string(COMPONENTS[static_cast<std::size_t>(componentDist(rng))]);
-    return JsonLogLine(std::move(json));
+    return {std::move(json)};
 }
 
 std::vector<JsonLogLine> GenerateRandomJsonLogs(std::size_t count, std::uint32_t seed)
@@ -212,15 +212,15 @@ std::vector<JsonLogLine> GenerateWideJsonLogs(std::size_t count, std::size_t col
             {
             case Family::String:
             {
-                if (keyName.rfind("timestamp", 0) == 0)
+                if (keyName.starts_with("timestamp"))
                 {
                     json[keyName] = FormatNow();
                 }
-                else if (keyName.rfind("level", 0) == 0)
+                else if (keyName.starts_with("level"))
                 {
                     json[keyName] = std::string(LEVELS[static_cast<std::size_t>(levelDist(rng))]);
                 }
-                else if (keyName.rfind("component", 0) == 0)
+                else if (keyName.starts_with("component"))
                 {
                     json[keyName] = std::string(COMPONENTS[static_cast<std::size_t>(componentDist(rng))]);
                 }
@@ -242,11 +242,11 @@ std::vector<JsonLogLine> GenerateWideJsonLogs(std::size_t count, std::size_t col
             }
             case Family::Numeric:
             {
-                if (keyName.rfind("thread_id", 0) == 0)
+                if (keyName.starts_with("thread_id"))
                 {
                     json[keyName] = static_cast<std::int64_t>(i % 16);
                 }
-                else if (keyName.rfind("cpu_usage_pct", 0) == 0)
+                else if (keyName.starts_with("cpu_usage_pct"))
                 {
                     json[keyName] = static_cast<std::int64_t>(smallIntDist(rng));
                 }
@@ -272,7 +272,7 @@ std::vector<JsonLogLine> GenerateWideJsonLogs(std::size_t count, std::size_t col
                 arr.emplace_back(static_cast<std::int64_t>(intDist(rng)));
                 arr.emplace_back(static_cast<std::int64_t>(smallIntDist(rng)));
                 arr.emplace_back(std::string(WORDS[static_cast<std::size_t>(wordDist(rng))]));
-                json[keyName] = std::move(arr);
+                json[keyName] = arr;
                 break;
             }
             case Family::Object:

--- a/test/common/src/network_log_client.cpp
+++ b/test/common/src/network_log_client.cpp
@@ -17,7 +17,7 @@ namespace test_common::internal
 class TcpLogClientImpl
 {
 public:
-    TcpLogClientImpl(std::string host, uint16_t port, std::optional<TcpLogClient::TlsOptions> tls);
+    TcpLogClientImpl(const std::string &host, uint16_t port, std::optional<TcpLogClient::TlsOptions> tls);
     ~TcpLogClientImpl();
 
     TcpLogClientImpl(const TcpLogClientImpl &) = delete;
@@ -44,7 +44,7 @@ private:
     bool mUsesTls = false;
 };
 
-TcpLogClientImpl::TcpLogClientImpl(std::string host, uint16_t port, std::optional<TcpLogClient::TlsOptions> tls)
+TcpLogClientImpl::TcpLogClientImpl(const std::string &host, uint16_t port, std::optional<TcpLogClient::TlsOptions> tls)
     : mSocket(mIoContext)
 {
     asio::error_code ec;
@@ -224,7 +224,7 @@ void TcpLogClientImpl::Close()
 class UdpLogClientImpl
 {
 public:
-    UdpLogClientImpl(std::string host, uint16_t port);
+    UdpLogClientImpl(const std::string &host, uint16_t port);
     ~UdpLogClientImpl();
 
     UdpLogClientImpl(const UdpLogClientImpl &) = delete;
@@ -241,7 +241,7 @@ private:
     asio::ip::udp::endpoint mPeer;
 };
 
-UdpLogClientImpl::UdpLogClientImpl(std::string host, uint16_t port)
+UdpLogClientImpl::UdpLogClientImpl(const std::string &host, uint16_t port)
     : mSocket(mIoContext)
 {
     asio::error_code ec;
@@ -310,8 +310,8 @@ void UdpLogClientImpl::Close()
 namespace test_common
 {
 
-TcpLogClient::TcpLogClient(std::string host, uint16_t port, std::optional<TlsOptions> tls)
-    : mImpl(std::make_unique<internal::TcpLogClientImpl>(std::move(host), port, std::move(tls)))
+TcpLogClient::TcpLogClient(const std::string &host, uint16_t port, std::optional<TlsOptions> tls)
+    : mImpl(std::make_unique<internal::TcpLogClientImpl>(host, port, std::move(tls)))
 {
 }
 
@@ -335,8 +335,8 @@ void TcpLogClient::Close()
     mImpl->Close();
 }
 
-UdpLogClient::UdpLogClient(std::string host, uint16_t port)
-    : mImpl(std::make_unique<internal::UdpLogClientImpl>(std::move(host), port))
+UdpLogClient::UdpLogClient(const std::string &host, uint16_t port)
+    : mImpl(std::make_unique<internal::UdpLogClientImpl>(host, port))
 {
 }
 

--- a/test/common/src/network_log_client.cpp
+++ b/test/common/src/network_log_client.cpp
@@ -311,6 +311,7 @@ namespace test_common
 {
 
 TcpLogClient::TcpLogClient(const std::string &host, uint16_t port, std::optional<TlsOptions> tls)
+    // NOLINTNEXTLINE(clang-analyzer-cplusplus.NewDelete): Asio `win_thread` false positive under MSVC headers.
     : mImpl(std::make_unique<internal::TcpLogClientImpl>(host, port, std::move(tls)))
 {
 }
@@ -336,6 +337,7 @@ void TcpLogClient::Close()
 }
 
 UdpLogClient::UdpLogClient(const std::string &host, uint16_t port)
+    // NOLINTNEXTLINE(clang-analyzer-cplusplus.NewDelete): Asio `win_thread` false positive under MSVC headers.
     : mImpl(std::make_unique<internal::UdpLogClientImpl>(host, port))
 {
 }

--- a/test/lib/include/common.hpp
+++ b/test/lib/include/common.hpp
@@ -7,6 +7,7 @@
 
 #include <glaze/glaze.hpp>
 
+#include <filesystem>
 #include <memory>
 #include <vector>
 
@@ -29,6 +30,7 @@ public:
 private:
     static constexpr char FILE_PATH[] = "test.json";
     std::string mFilePath;
+    std::filesystem::path mFsPath;
     std::vector<Line> mLines;
     std::vector<std::string> mStringLines;
     std::vector<glz::generic_sorted_u64> mJsonLines;
@@ -46,6 +48,7 @@ public:
 private:
     static constexpr char FILE_PATH[] = "test_config.json";
     std::string mFilePath;
+    std::filesystem::path mFsPath;
 };
 
 class TestLogFile
@@ -66,6 +69,7 @@ public:
 private:
     static constexpr char FILE_PATH[] = "test_file.json";
     std::string mFilePath;
+    std::filesystem::path mFsPath;
 };
 
 void InitializeTimezoneData();

--- a/test/lib/include/common.hpp
+++ b/test/lib/include/common.hpp
@@ -43,7 +43,7 @@ public:
     ~TestLogConfiguration();
 
     const std::string &GetFilePath() const;
-    void Write(const loglib::LogConfiguration &configuration);
+    void Write(const loglib::LogConfiguration &configuration) const;
 
 private:
     static constexpr char FILE_PATH[] = "test_config.json";

--- a/test/lib/include/common.hpp
+++ b/test/lib/include/common.hpp
@@ -7,8 +7,6 @@
 
 #include <glaze/glaze.hpp>
 
-#include <filesystem>
-#include <fstream>
 #include <memory>
 #include <vector>
 
@@ -20,7 +18,7 @@ public:
     TestJsonLogFile(std::string filePath = FILE_PATH);
     TestJsonLogFile(Line line, std::string filePath = FILE_PATH);
     TestJsonLogFile(std::vector<Line> lines, std::string filePath = FILE_PATH);
-    ~TestJsonLogFile();
+    ~TestJsonLogFile() noexcept;
 
     const std::string &GetFilePath() const;
     void WriteToFile(std::vector<Line> lines);
@@ -40,7 +38,7 @@ class TestLogConfiguration
 {
 public:
     TestLogConfiguration(std::string filePath = FILE_PATH);
-    ~TestLogConfiguration();
+    ~TestLogConfiguration() noexcept;
 
     const std::string &GetFilePath() const;
     void Write(const loglib::LogConfiguration &configuration) const;
@@ -54,7 +52,7 @@ class TestLogFile
 {
 public:
     TestLogFile(std::string filePath = FILE_PATH);
-    ~TestLogFile();
+    ~TestLogFile() noexcept;
 
     const std::string &GetFilePath() const;
     void Write(const std::string &content) const;

--- a/test/lib/src/benchmark_json.cpp
+++ b/test/lib/src/benchmark_json.cpp
@@ -8,7 +8,6 @@
 #include <loglib/file_line_source.hpp>
 #include <loglib/internal/advanced_parser_options.hpp>
 #include <loglib/key_index.hpp>
-#include <loglib/log_factory.hpp>
 #include <loglib/log_file.hpp>
 #include <loglib/log_line.hpp>
 #include <loglib/log_parser.hpp>
@@ -27,7 +26,6 @@
 #include <chrono>
 #include <cmath>
 #include <cstddef>
-#include <cstdint>
 #include <filesystem>
 #include <memory>
 #include <numeric>
@@ -35,7 +33,7 @@
 #include <utility>
 #include <vector>
 
-#if defined(_WIN32)
+#ifdef _WIN32
 #ifndef WIN32_LEAN_AND_MEAN
 #define WIN32_LEAN_AND_MEAN
 #endif
@@ -117,10 +115,10 @@ template <typename Fn> SampleStats CollectSamples(std::size_t samples, Fn &&fn)
 
     const auto sum = std::accumulate(elapsed.begin(), elapsed.end(), std::chrono::nanoseconds::zero());
     const auto mean = sum / static_cast<long long>(samples);
-    const auto low = *std::min_element(elapsed.begin(), elapsed.end());
-    const auto high = *std::max_element(elapsed.begin(), elapsed.end());
+    const auto low = *std::ranges::min_element(elapsed);
+    const auto high = *std::ranges::max_element(elapsed);
 
-    double meanNs = static_cast<double>(mean.count());
+    const auto meanNs = static_cast<double>(mean.count());
     double sqAccum = 0.0;
     for (const auto &e : elapsed)
     {
@@ -129,16 +127,16 @@ template <typename Fn> SampleStats CollectSamples(std::size_t samples, Fn &&fn)
     }
     const double stddevNs = std::sqrt(sqAccum / static_cast<double>(samples));
 
-    return SampleStats{mean, low, high, stddevNs};
+    return SampleStats{.mean = mean, .low = low, .high = high, .stddevNs = stddevNs};
 }
 
 template <typename Fn> void RunTimedSamples(const char *label, std::size_t samples, Fn &&fn)
 {
     const SampleStats stats = CollectSamples(samples, std::forward<Fn>(fn));
-    using ms = std::chrono::duration<double, std::milli>;
+    using Ms = std::chrono::duration<double, std::milli>;
     WARN(
-        label << " (samples=" << samples << "): mean=" << ms(stats.mean).count() << " ms, low=" << ms(stats.low).count()
-              << " ms, high=" << ms(stats.high).count() << " ms, stddev=" << (stats.stddevNs / 1'000'000.0) << " ms"
+        label << " (samples=" << samples << "): mean=" << Ms(stats.mean).count() << " ms, low=" << Ms(stats.low).count()
+              << " ms, high=" << Ms(stats.high).count() << " ms, stddev=" << (stats.stddevNs / 1'000'000.0) << " ms"
     );
 }
 
@@ -151,24 +149,24 @@ template <typename Fn>
 void RunTimedSamples(const char *label, std::size_t samples, ThroughputInputs throughput, Fn &&fn)
 {
     const SampleStats stats = CollectSamples(samples, std::forward<Fn>(fn));
-    using ms = std::chrono::duration<double, std::milli>;
-    using s = std::chrono::duration<double>;
+    using Ms = std::chrono::duration<double, std::milli>;
+    using S = std::chrono::duration<double>;
 
-    const double meanSec = s(stats.mean).count();
-    const double lowSec = s(stats.low).count();
-    const double highSec = s(stats.high).count();
+    const double meanSec = S(stats.mean).count();
+    const double lowSec = S(stats.low).count();
+    const double highSec = S(stats.high).count();
     const double bytesMB = static_cast<double>(throughput.bytes) / (1024.0 * 1024.0);
-    const double linesD = static_cast<double>(throughput.lines);
+    const auto linesD = static_cast<double>(throughput.lines);
     const double meanMBps = meanSec == 0.0 ? 0.0 : bytesMB / meanSec;
     const double highMBps = lowSec == 0.0 ? 0.0 : bytesMB / lowSec;
     const double lowMBps = highSec == 0.0 ? 0.0 : bytesMB / highSec;
     const double meanLinesPerSec = meanSec == 0.0 ? 0.0 : linesD / meanSec;
-    const double meanNs = static_cast<double>(stats.mean.count());
+    const auto meanNs = static_cast<double>(stats.mean.count());
     const double stddevMBps = meanNs == 0.0 ? 0.0 : meanMBps * (stats.stddevNs / meanNs);
 
     WARN(
-        label << " (samples=" << samples << "): mean=" << ms(stats.mean).count() << " ms, low=" << ms(stats.low).count()
-              << " ms, high=" << ms(stats.high).count() << " ms, stddev=" << (stats.stddevNs / 1'000'000.0) << " ms | "
+        label << " (samples=" << samples << "): mean=" << Ms(stats.mean).count() << " ms, low=" << Ms(stats.low).count()
+              << " ms, high=" << Ms(stats.high).count() << " ms, stddev=" << (stats.stddevNs / 1'000'000.0) << " ms | "
               << meanMBps << " MB/s mean (low=" << lowMBps << ", high=" << highMBps << ", stddev=" << stddevMBps
               << "), " << meanLinesPerSec << " lines/s mean"
     );
@@ -216,7 +214,7 @@ StructuralBytes ComputeStructuralBytes(const LogTable &table)
 /// number, hence "informational".
 std::size_t SamplePeakWorkingSetBytes()
 {
-#if defined(_WIN32)
+#ifdef _WIN32
     PROCESS_MEMORY_COUNTERS counters{};
     counters.cb = sizeof(counters);
     if (::GetProcessMemoryInfo(::GetCurrentProcess(), &counters, sizeof(counters)) != 0)
@@ -310,7 +308,6 @@ struct StreamingRunResult
 };
 
 StreamingRunResult RunStreamingFlow(
-    const JsonParser &parser,
     const std::filesystem::path &configPath,
     const std::filesystem::path &logPath,
     std::shared_ptr<const LogConfiguration> configuration,
@@ -318,7 +315,7 @@ StreamingRunResult RunStreamingFlow(
 )
 {
     StreamingRunResult result;
-    internal::AdvancedParserOptions advanced;
+    const internal::AdvancedParserOptions advanced;
 
     const std::size_t peakBefore = captureMemory ? SamplePeakWorkingSetBytes() : 0;
 
@@ -343,9 +340,9 @@ StreamingRunResult RunStreamingFlow(
         sink.table = &table;
 
         ParserOptions opts;
-        opts.configuration = configuration;
+        opts.configuration = std::move(configuration);
 
-        parser.ParseStreaming(*parseSource, sink, opts, advanced);
+        loglib::JsonParser::ParseStreaming(*parseSource, sink, opts, advanced);
 
         result.appendTotal = sink.appendTotal;
         result.appendBatches = sink.appendBatches;
@@ -374,7 +371,6 @@ StreamingRunResult RunStreamingFlow(
 /// `RunTimedSamples`'s throughput overload.
 void RunStreamingBenchmark(
     const char *label,
-    const JsonParser &parser,
     const std::filesystem::path &configPath,
     const std::filesystem::path &logPath,
     std::shared_ptr<const LogConfiguration> configuration,
@@ -388,8 +384,7 @@ void RunStreamingBenchmark(
         // signal is deterministic across runs, so a single sample suffices,
         // and we avoid paying for the introspection walk on every timed
         // sample.
-        StreamingRunResult warmup =
-            RunStreamingFlow(parser, configPath, logPath, configuration, /*captureMemory=*/true);
+        const StreamingRunResult warmup = RunStreamingFlow(configPath, logPath, configuration, /*captureMemory=*/true);
         REQUIRE(warmup.rowCount == expectedRows);
         ReportThroughput((std::string(label) + " warm-up").c_str(), warmup.elapsed, bytes, expectedRows);
 
@@ -404,7 +399,7 @@ void RunStreamingBenchmark(
         if (warmup.memoryCaptured)
         {
             constexpr double MIB = 1024.0 * 1024.0;
-            const double linesD = static_cast<double>(expectedRows == 0 ? 1 : expectedRows);
+            const auto linesD = static_cast<double>(expectedRows == 0 ? 1 : expectedRows);
             const double bytesPerLine =
                 expectedRows == 0 ? 0.0 : static_cast<double>(warmup.structuralBytes.Total()) / linesD;
             const double fileBytesMiB = static_cast<double>(bytes) / MIB;
@@ -424,8 +419,8 @@ void RunStreamingBenchmark(
         }
     }
 
-    RunTimedSamples(label, samples, {bytes, expectedRows}, [&]() {
-        StreamingRunResult run = RunStreamingFlow(parser, configPath, logPath, configuration);
+    RunTimedSamples(label, samples, {.bytes = bytes, .lines = expectedRows}, [&]() {
+        const StreamingRunResult run = RunStreamingFlow(configPath, logPath, configuration);
         REQUIRE(run.rowCount == expectedRows);
     });
 }
@@ -457,7 +452,7 @@ TEST_CASE("Parse and load JSON log (sync)", "[.][benchmark][json_parser][parse_s
         ReportThroughput("Parse 10'000 (sync) warm-up", elapsed, bytes, logs.size());
     }
 
-    RunTimedSamples("Parse 10'000 JSON log entries (sync)", 5, {bytes, logs.size()}, [&]() {
+    RunTimedSamples("Parse 10'000 JSON log entries (sync)", 5, {.bytes = bytes, .lines = logs.size()}, [&]() {
         LogTable table;
         ParseResult result = ParseFile(parser, testFile.GetFilePath());
         REQUIRE(result.data.Lines().size() == testFile.Lines().size());
@@ -476,18 +471,16 @@ TEST_CASE("Stream JSON log to LogTable (1'000'000 lines)", "[.][benchmark][json_
 
     auto logs = GenerateRandomJsonLogs(1'000'000);
     const TestJsonLogFile testFile(logs);
-    const JsonParser parser;
     const size_t bytes = std::filesystem::file_size(testFile.GetFilePath());
 
     InitializeTimezoneData();
 
     auto configuration = MakeTimestampConfiguration();
-    TestLogConfiguration configFile;
+    const TestLogConfiguration configFile;
     configFile.Write(*configuration);
 
     RunStreamingBenchmark(
         "Stream 1'000'000 JSON log entries to LogTable",
-        parser,
         configFile.GetFilePath(),
         testFile.GetFilePath(),
         configuration,
@@ -508,18 +501,16 @@ TEST_CASE("Stream JSON log to LogTable (wide, 200'000 lines)", "[.][benchmark][j
 
     auto logs = GenerateWideJsonLogs(200'000);
     const TestJsonLogFile testFile(logs);
-    const JsonParser parser;
     const size_t bytes = std::filesystem::file_size(testFile.GetFilePath());
 
     InitializeTimezoneData();
 
     auto configuration = MakeTimestampConfiguration();
-    TestLogConfiguration configFile;
+    const TestLogConfiguration configFile;
     configFile.Write(*configuration);
 
     RunStreamingBenchmark(
         "Stream 200'000 wide JSON log entries to LogTable",
-        parser,
         configFile.GetFilePath(),
         testFile.GetFilePath(),
         configuration,
@@ -540,7 +531,7 @@ TEST_CASE("LogLine::GetValue micro-benchmark", "[.][benchmark][log_line][get_val
     const TestJsonLogFile testFile(logs);
     const JsonParser parser;
 
-    ParseResult result = ParseFile(parser, testFile.GetFilePath());
+    const ParseResult result = ParseFile(parser, testFile.GetFilePath());
     REQUIRE(result.errors.empty());
     const LogData &data = result.data;
     const std::vector<LogLine> &lines = data.Lines();
@@ -618,7 +609,7 @@ TEST_CASE("Allocation footprint and string_view fast-path fraction", "[.][benchm
     // (which would always allocate a `std::string` for the slow path),
     // so the per-value cost of this benchmark stays representative of
     // the parse hot path.
-    size_t lineCount = result.data.Lines().size();
+    const size_t lineCount = result.data.Lines().size();
     size_t totalValues = 0;
     size_t mmapSliceValues = 0;
     size_t ownedStringValues = 0;
@@ -626,7 +617,7 @@ TEST_CASE("Allocation footprint and string_view fast-path fraction", "[.][benchm
     {
         for (size_t i = 0; i < result.data.Keys().Size(); ++i)
         {
-            const KeyId id = static_cast<KeyId>(i);
+            const auto id = static_cast<KeyId>(i);
             const bool mmap = line.IsMmapSlice(id);
             const bool owned = line.IsOwnedString(id);
             if (mmap)
@@ -682,8 +673,8 @@ TEST_CASE("Cancellation latency", "[.][benchmark][json_parser][cancellation]")
     {
         KeyIndex keys;
         loglib::StopSource stop;
-        std::chrono::steady_clock::time_point requestedAt{};
-        std::chrono::steady_clock::time_point finishedAt{};
+        std::chrono::steady_clock::time_point requestedAt;
+        std::chrono::steady_clock::time_point finishedAt;
         bool cancelled = false;
         size_t batches = 0;
 
@@ -727,7 +718,7 @@ TEST_CASE("Cancellation latency", "[.][benchmark][json_parser][cancellation]")
         latenciesUs.push_back(latency);
     }
 
-    std::sort(latenciesUs.begin(), latenciesUs.end());
+    std::ranges::sort(latenciesUs);
     const double median = latenciesUs[latenciesUs.size() / 2];
     const double p95 = latenciesUs[(latenciesUs.size() * 95) / 100];
     const double maxLatency = latenciesUs.back();

--- a/test/lib/src/benchmark_json.cpp
+++ b/test/lib/src/benchmark_json.cpp
@@ -101,7 +101,7 @@ struct SampleStats
 /// clock. Avoids the Catch2 iteration-estimation pass and 100-resample
 /// bootstrap, which together added 3-5x wall-time on multi-second-per-
 /// sample fixtures and timed the 1M-line streaming case out at 30 min.
-template <typename Fn> SampleStats CollectSamples(std::size_t samples, Fn &&fn)
+template <typename Fn> SampleStats CollectSamples(std::size_t samples, Fn fn)
 {
     REQUIRE(samples > 0);
     std::vector<std::chrono::nanoseconds> elapsed;

--- a/test/lib/src/benchmark_stream.cpp
+++ b/test/lib/src/benchmark_stream.cpp
@@ -113,7 +113,7 @@ struct LatencyMeasuringSink final : LogParseSink
     void OnBatch(StreamedBatch batch) override
     {
         const auto now = std::chrono::steady_clock::now();
-        std::lock_guard<std::mutex> lock(mu);
+        const std::scoped_lock lock(mu);
         arrivals.reserve(arrivals.size() + batch.lines.size());
         for (const auto &line : batch.lines)
         {
@@ -150,7 +150,7 @@ void RunProducer(
     writes.reserve(static_cast<size_t>(lineCount));
     for (int i = 0; i < lineCount; ++i)
     {
-        const size_t lineId = static_cast<size_t>(i + 1);
+        const auto lineId = static_cast<size_t>(i + 1);
         // Stamp the line with its own id so the consumer can match
         // `LineId` -> arrival timestamp without per-line bookkeeping in the
         // sink. Padding keeps the line size representative of real log data.
@@ -162,7 +162,7 @@ void RunProducer(
         std::fwrite(buf, 1, static_cast<size_t>(n), fp);
         std::fflush(fp);
         const auto committedAt = std::chrono::steady_clock::now();
-        writes.push_back({lineId, committedAt});
+        writes.push_back({.lineId = lineId, .committedAt = committedAt});
 
         if (interLineDelay.count() > 0)
         {
@@ -178,8 +178,8 @@ double Percentile(std::vector<double> sorted, double pct)
     {
         return 0.0;
     }
-    std::sort(sorted.begin(), sorted.end());
-    const size_t idx = static_cast<size_t>((pct / 100.0) * static_cast<double>(sorted.size() - 1) + 0.5);
+    std::ranges::sort(sorted);
+    const auto idx = static_cast<size_t>(((pct / 100.0) * static_cast<double>(sorted.size() - 1)) + 0.5);
     return sorted[std::min(idx, sorted.size() - 1)];
 }
 
@@ -196,10 +196,10 @@ TEST_CASE("Stream Mode write-to-row latency", "[.][benchmark][stream_latency]")
 {
     BENCHMARK_REQUIRES_RELEASE_BUILD();
 
-    TempDir dir;
+    const TempDir dir;
     const auto path = dir.File("latency.log");
     {
-        std::ofstream out(path, std::ios::binary | std::ios::trunc);
+        const std::ofstream out(path, std::ios::binary | std::ios::trunc);
         REQUIRE(out.is_open());
     }
 
@@ -237,12 +237,12 @@ TEST_CASE("Stream Mode write-to-row latency", "[.][benchmark][stream_latency]")
     // `_write` syscall directly. MSVC prefers `fopen_s`; the safer API
     // adds nothing here (the path is test-controlled) so suppress C4996
     // locally rather than fork the call site by platform.
-#if defined(_MSC_VER)
+#ifdef _MSC_VER
 #pragma warning(push)
 #pragma warning(disable : 4996)
 #endif
     FILE *fp = std::fopen(path.string().c_str(), "ab");
-#if defined(_MSC_VER)
+#ifdef _MSC_VER
 #pragma warning(pop)
 #endif
     REQUIRE(fp != nullptr);
@@ -272,7 +272,7 @@ TEST_CASE("Stream Mode write-to-row latency", "[.][benchmark][stream_latency]")
     const auto deadline = std::chrono::steady_clock::now() + 1500ms;
     while (std::chrono::steady_clock::now() < deadline)
     {
-        std::lock_guard<std::mutex> lock(sink.mu);
+        const std::scoped_lock lock(sink.mu);
         if (static_cast<int>(sink.arrivals.size()) >= LINE_COUNT)
         {
             break;
@@ -290,13 +290,11 @@ TEST_CASE("Stream Mode write-to-row latency", "[.][benchmark][stream_latency]")
     std::vector<double> latenciesMs;
     latenciesMs.reserve(static_cast<size_t>(LINE_COUNT));
     {
-        std::lock_guard<std::mutex> lock(sink.mu);
+        const std::scoped_lock lock(sink.mu);
         // Convert arrivals into a sorted-by-lineId snapshot so the lookup is
         // O(1). The parser emits in source order, so this is normally
         // already sorted, but we don't rely on it.
-        std::sort(sink.arrivals.begin(), sink.arrivals.end(), [](const auto &a, const auto &b) {
-            return a.first < b.first;
-        });
+        std::ranges::sort(sink.arrivals, [](const auto &a, const auto &b) { return a.first < b.first; });
         size_t arrIdx = 0;
         for (const auto &write : writes)
         {
@@ -316,7 +314,7 @@ TEST_CASE("Stream Mode write-to-row latency", "[.][benchmark][stream_latency]")
 
     REQUIRE(!latenciesMs.empty());
 
-    std::sort(latenciesMs.begin(), latenciesMs.end());
+    std::ranges::sort(latenciesMs);
     const double median = Percentile(latenciesMs, 50.0);
     const double p95 = Percentile(latenciesMs, 95.0);
     const double maxLatency = latenciesMs.back();

--- a/test/lib/src/benchmark_stream.cpp
+++ b/test/lib/src/benchmark_stream.cpp
@@ -22,6 +22,8 @@
 
 #include <catch2/catch_all.hpp>
 
+#include <cmath>
+
 #include <algorithm>
 #include <atomic>
 #include <chrono>
@@ -71,6 +73,8 @@ public:
         mPath = base / ("loglib_stream_latency_" + std::to_string(suffix));
         std::filesystem::create_directories(mPath);
     }
+    // NOLINTNEXTLINE(bugprone-exception-escape): MSVC may model throwing paths through STL `remove_all`; teardown
+    // ignores errors via `error_code`.
     ~TempDir() noexcept
     {
         std::error_code ec;
@@ -150,17 +154,18 @@ void RunProducer(
     writes.reserve(static_cast<size_t>(lineCount));
     for (int i = 0; i < lineCount; ++i)
     {
-        const auto lineId = static_cast<size_t>(i + 1);
+        const auto lineId = static_cast<size_t>(static_cast<size_t>(i) + 1u);
         // Stamp the line with its own id so the consumer can match
         // `LineId` -> arrival timestamp without per-line bookkeeping in the
         // sink. Padding keeps the line size representative of real log data.
         char buf[160];
+        // NOLINTNEXTLINE(cppcoreguidelines-pro-type-vararg): benchmark I/O; fixed buffer + bounded format.
         const int n = std::snprintf(
             buf, sizeof(buf), "{\"i\":%zu,\"msg\":\"latency benchmark line %zu padding padding\"}\n", lineId, lineId
         );
         REQUIRE(n > 0);
-        std::fwrite(buf, 1, static_cast<size_t>(n), fp);
-        std::fflush(fp);
+        static_cast<void>(std::fwrite(buf, 1, static_cast<size_t>(n), fp));
+        static_cast<void>(std::fflush(fp));
         const auto committedAt = std::chrono::steady_clock::now();
         writes.push_back({.lineId = lineId, .committedAt = committedAt});
 
@@ -179,7 +184,7 @@ double Percentile(std::vector<double> sorted, double pct)
         return 0.0;
     }
     std::ranges::sort(sorted);
-    const auto idx = static_cast<size_t>(((pct / 100.0) * static_cast<double>(sorted.size() - 1)) + 0.5);
+    const auto idx = static_cast<size_t>(std::lround((pct / 100.0) * static_cast<double>(sorted.size() - 1)));
     return sorted[std::min(idx, sorted.size() - 1)];
 }
 
@@ -260,7 +265,7 @@ TEST_CASE("Stream Mode write-to-row latency", "[.][benchmark][stream_latency]")
     });
 
     producer.join();
-    std::fclose(fp);
+    static_cast<void>(std::fclose(fp));
 
     // Wait for the consumer to drain. We poll the sink's arrivals vector
     // under its mutex; the parser will keep parking on `WaitForBytes`

--- a/test/lib/src/benchmark_stream.cpp
+++ b/test/lib/src/benchmark_stream.cpp
@@ -71,7 +71,7 @@ public:
         mPath = base / ("loglib_stream_latency_" + std::to_string(suffix));
         std::filesystem::create_directories(mPath);
     }
-    ~TempDir()
+    ~TempDir() noexcept
     {
         std::error_code ec;
         std::filesystem::remove_all(mPath, ec);

--- a/test/lib/src/common.cpp
+++ b/test/lib/src/common.cpp
@@ -13,9 +13,9 @@
 using namespace loglib;
 
 TestJsonLogFile::TestJsonLogFile(std::string filePath)
-    : mFilePath(std::move(filePath))
+    : mFilePath(std::move(filePath)), mFsPath(mFilePath)
 {
-    const std::ofstream file(mFilePath);
+    const std::ofstream file(mFsPath);
     REQUIRE(file.is_open());
 }
 
@@ -34,7 +34,7 @@ TestJsonLogFile::TestJsonLogFile(std::vector<Line> lines, std::string filePath)
 TestJsonLogFile::~TestJsonLogFile() noexcept
 {
     std::error_code ec;
-    std::filesystem::remove(GetFilePath(), ec);
+    std::filesystem::remove(mFsPath, ec);
 }
 
 const std::string &TestJsonLogFile::GetFilePath() const
@@ -48,7 +48,7 @@ void TestJsonLogFile::WriteToFile(std::vector<Line> lines)
     mStringLines.clear();
     mJsonLines.clear();
 
-    std::ofstream file(GetFilePath(), std::ios::app);
+    std::ofstream file(mFsPath, std::ios::app);
     if (file.is_open())
     {
         for (const auto &line : lines)
@@ -80,16 +80,16 @@ const std::vector<glz::generic_sorted_u64> &TestJsonLogFile::JsonLines() const
 }
 
 TestLogConfiguration::TestLogConfiguration(std::string filePath)
-    : mFilePath(std::move(filePath))
+    : mFilePath(std::move(filePath)), mFsPath(mFilePath)
 {
-    const std::ofstream file(GetFilePath());
+    const std::ofstream file(mFsPath);
     REQUIRE(file.is_open());
 }
 
 TestLogConfiguration::~TestLogConfiguration() noexcept
 {
     std::error_code ec;
-    std::filesystem::remove(GetFilePath(), ec);
+    std::filesystem::remove(mFsPath, ec);
 }
 
 const std::string &TestLogConfiguration::GetFilePath() const
@@ -99,7 +99,7 @@ const std::string &TestLogConfiguration::GetFilePath() const
 
 void TestLogConfiguration::Write(const LogConfiguration &configuration) const
 {
-    std::ofstream file(GetFilePath());
+    std::ofstream file(mFsPath);
     REQUIRE(file.is_open());
     std::string json;
     const auto error = glz::write_json(configuration, json);
@@ -116,15 +116,15 @@ const std::string &TestLogFile::GetFilePath() const
 }
 
 TestLogFile::TestLogFile(std::string filePath)
-    : mFilePath(std::move(filePath))
+    : mFilePath(std::move(filePath)), mFsPath(mFilePath)
 {
-    const std::ofstream file(GetFilePath(), std::ios::binary);
+    const std::ofstream file(mFsPath, std::ios::binary);
     REQUIRE(file.is_open());
 }
 
 void TestLogFile::Write(const std::string &content) const
 {
-    std::ofstream file(GetFilePath(), std::ios::binary);
+    std::ofstream file(mFsPath, std::ios::binary);
     REQUIRE(file.is_open());
     file << content;
 }
@@ -132,15 +132,15 @@ void TestLogFile::Write(const std::string &content) const
 TestLogFile::~TestLogFile() noexcept
 {
     std::error_code ec;
-    std::filesystem::remove(GetFilePath(), ec);
+    std::filesystem::remove(mFsPath, ec);
 }
 
 std::unique_ptr<loglib::LogFile> TestLogFile::CreateLogFile() const
 {
     // Binary stream so streampos matches LogFile's byte offsets on every
     // platform (no CRLF translation).
-    std::ifstream file(GetFilePath(), std::ios::binary);
-    auto logFile = std::make_unique<LogFile>(GetFilePath());
+    std::ifstream file(mFsPath, std::ios::binary);
+    auto logFile = std::make_unique<LogFile>(mFsPath);
 
     // Push one offset per '\n'; for an unterminated last line, push
     // `fileSize + 1` as the virtual terminator (see LogFile::GetLine).

--- a/test/lib/src/common.cpp
+++ b/test/lib/src/common.cpp
@@ -6,6 +6,8 @@
 #include <catch2/catch_all.hpp>
 #include <date/tz.h>
 
+#include <filesystem>
+#include <fstream>
 #include <utility>
 
 using namespace loglib;
@@ -29,9 +31,10 @@ TestJsonLogFile::TestJsonLogFile(std::vector<Line> lines, std::string filePath)
     WriteToFile(std::move(lines));
 }
 
-TestJsonLogFile::~TestJsonLogFile()
+TestJsonLogFile::~TestJsonLogFile() noexcept
 {
-    std::filesystem::remove(GetFilePath());
+    std::error_code ec;
+    std::filesystem::remove(GetFilePath(), ec);
 }
 
 const std::string &TestJsonLogFile::GetFilePath() const
@@ -83,9 +86,10 @@ TestLogConfiguration::TestLogConfiguration(std::string filePath)
     REQUIRE(file.is_open());
 }
 
-TestLogConfiguration::~TestLogConfiguration()
+TestLogConfiguration::~TestLogConfiguration() noexcept
 {
-    std::filesystem::remove(GetFilePath());
+    std::error_code ec;
+    std::filesystem::remove(GetFilePath(), ec);
 }
 
 const std::string &TestLogConfiguration::GetFilePath() const
@@ -125,9 +129,10 @@ void TestLogFile::Write(const std::string &content) const
     file << content;
 }
 
-TestLogFile::~TestLogFile()
+TestLogFile::~TestLogFile() noexcept
 {
-    std::filesystem::remove(GetFilePath());
+    std::error_code ec;
+    std::filesystem::remove(GetFilePath(), ec);
 }
 
 std::unique_ptr<loglib::LogFile> TestLogFile::CreateLogFile() const

--- a/test/lib/src/common.cpp
+++ b/test/lib/src/common.cpp
@@ -6,8 +6,6 @@
 #include <catch2/catch_all.hpp>
 #include <date/tz.h>
 
-#include <algorithm>
-#include <random>
 #include <utility>
 
 using namespace loglib;
@@ -15,7 +13,7 @@ using namespace loglib;
 TestJsonLogFile::TestJsonLogFile(std::string filePath)
     : mFilePath(std::move(filePath))
 {
-    std::ofstream file(mFilePath);
+    const std::ofstream file(mFilePath);
     REQUIRE(file.is_open());
 }
 
@@ -81,7 +79,7 @@ const std::vector<glz::generic_sorted_u64> &TestJsonLogFile::JsonLines() const
 TestLogConfiguration::TestLogConfiguration(std::string filePath)
     : mFilePath(std::move(filePath))
 {
-    std::ofstream file(GetFilePath());
+    const std::ofstream file(GetFilePath());
     REQUIRE(file.is_open());
 }
 
@@ -95,7 +93,7 @@ const std::string &TestLogConfiguration::GetFilePath() const
     return mFilePath;
 }
 
-void TestLogConfiguration::Write(const LogConfiguration &configuration)
+void TestLogConfiguration::Write(const LogConfiguration &configuration) const
 {
     std::ofstream file(GetFilePath());
     REQUIRE(file.is_open());
@@ -116,7 +114,7 @@ const std::string &TestLogFile::GetFilePath() const
 TestLogFile::TestLogFile(std::string filePath)
     : mFilePath(std::move(filePath))
 {
-    std::ofstream file(GetFilePath(), std::ios::binary);
+    const std::ofstream file(GetFilePath(), std::ios::binary);
     REQUIRE(file.is_open());
 }
 

--- a/test/lib/src/test_file_line_source.cpp
+++ b/test/lib/src/test_file_line_source.cpp
@@ -15,7 +15,7 @@ using loglib::LogFile;
 
 TEST_CASE("FileLineSource: forwards Path() to the wrapped LogFile", "[FileLineSource]")
 {
-    TestLogFile testLogFile;
+    const TestLogFile testLogFile;
     testLogFile.Write("hello\n");
     auto logFile = testLogFile.CreateLogFile();
 
@@ -30,7 +30,7 @@ TEST_CASE("FileLineSource: rejects null files", "[FileLineSource]")
 
 TEST_CASE("FileLineSource: RawLine returns CR-stripped per-line text", "[FileLineSource]")
 {
-    TestLogFile testLogFile;
+    const TestLogFile testLogFile;
     testLogFile.Write("Line 1\nLine 2\nLine 3\n");
     auto logFile = testLogFile.CreateLogFile();
 
@@ -46,7 +46,7 @@ TEST_CASE("FileLineSource: RawLine returns CR-stripped per-line text", "[FileLin
 
 TEST_CASE("FileLineSource: ResolveMmapBytes indexes into the mmap data", "[FileLineSource]")
 {
-    TestLogFile testLogFile;
+    const TestLogFile testLogFile;
     const std::string content = "abcdef\nghijkl\n";
     testLogFile.Write(content);
     auto logFile = testLogFile.CreateLogFile();
@@ -71,7 +71,7 @@ TEST_CASE("FileLineSource: ResolveMmapBytes indexes into the mmap data", "[FileL
 
 TEST_CASE("FileLineSource: ResolveOwnedBytes indexes into the LogFile owned-string arena", "[FileLineSource]")
 {
-    TestLogFile testLogFile;
+    const TestLogFile testLogFile;
     testLogFile.Write("x\n");
     auto logFile = testLogFile.CreateLogFile();
 
@@ -92,7 +92,7 @@ TEST_CASE("FileLineSource: ResolveOwnedBytes indexes into the LogFile owned-stri
 
 TEST_CASE("FileLineSource: eviction is a no-op for finite mmap sources", "[FileLineSource]")
 {
-    TestLogFile testLogFile;
+    const TestLogFile testLogFile;
     testLogFile.Write("a\nb\nc\n");
     auto logFile = testLogFile.CreateLogFile();
 
@@ -107,7 +107,7 @@ TEST_CASE("FileLineSource: eviction is a no-op for finite mmap sources", "[FileL
 
 TEST_CASE("FileLineSource: File() returns the underlying LogFile", "[FileLineSource]")
 {
-    TestLogFile testLogFile;
+    const TestLogFile testLogFile;
     testLogFile.Write("hello\n");
     auto logFile = testLogFile.CreateLogFile();
     LogFile *raw = logFile.get();
@@ -122,7 +122,7 @@ TEST_CASE("FileLineSource: File() returns the underlying LogFile", "[FileLineSou
 
 TEST_CASE("FileLineSource: ReleaseFile transfers ownership but keeps the source resolvable", "[FileLineSource]")
 {
-    TestLogFile testLogFile;
+    const TestLogFile testLogFile;
     testLogFile.Write("hello\n");
     auto logFile = testLogFile.CreateLogFile();
     LogFile *raw = logFile.get();

--- a/test/lib/src/test_json_parser.cpp
+++ b/test/lib/src/test_json_parser.cpp
@@ -245,8 +245,8 @@ TEST_CASE("Parse file with invalid lines spanning multiple pipeline batches", "[
     REQUIRE(result.errors.size() == 2);
     const std::string expectedA = "Error on line " + std::to_string(INVALID_LINE_NUMBER_A);
     const std::string expectedB = "Error on line " + std::to_string(INVALID_LINE_NUMBER_B);
-    CHECK(result.errors[0].find(expectedA) != std::string::npos);
-    CHECK(result.errors[1].find(expectedB) != std::string::npos);
+    CHECK(result.errors[0].contains(expectedA));
+    CHECK(result.errors[1].contains(expectedB));
 }
 
 TEST_CASE("Parse file with empty JSON object", "[json_parser]")
@@ -842,9 +842,9 @@ TEST_CASE("Per-worker key cache survives move construction", "[json_parser][key_
     TestPerWorkerKeyCache moved(std::move(source));
 
     REQUIRE(moved.size() == 3);
-    REQUIRE(moved.find(std::string_view{"alpha"}) != moved.end());
-    REQUIRE(moved.find(std::string_view{"beta"}) != moved.end());
-    REQUIRE(moved.find(std::string_view{"gamma"}) != moved.end());
+    REQUIRE(moved.count(std::string_view{"alpha"}) == 1);
+    REQUIRE(moved.count(std::string_view{"beta"}) == 1);
+    REQUIRE(moved.count(std::string_view{"gamma"}) == 1);
     CHECK(moved.find(std::string_view{"alpha"})->second == static_cast<KeyId>(7));
     CHECK(moved.find(std::string_view{"beta"})->second == static_cast<KeyId>(11));
     CHECK(moved.find(std::string_view{"gamma"})->second == static_cast<KeyId>(13));
@@ -1401,5 +1401,5 @@ TEST_CASE(
     INFO(errors.front());
     // Absolute line number 2 is the bad line; the surrounding "Error on
     // line N:" wrapper is composed by the streaming pipeline.
-    CHECK(errors.front().find("Error on line 2:") != std::string::npos);
+    CHECK(errors.front().contains("Error on line 2:"));
 }

--- a/test/lib/src/test_json_parser.cpp
+++ b/test/lib/src/test_json_parser.cpp
@@ -11,7 +11,6 @@
 #include <loglib/log_line.hpp>
 #include <loglib/log_parse_sink.hpp>
 #include <loglib/log_parser.hpp>
-#include <loglib/log_processing.hpp>
 #include <loglib/parse_file.hpp>
 #include <loglib/parser_options.hpp>
 #include <loglib/parsers/json_parser.hpp>
@@ -26,7 +25,6 @@
 #include <chrono>
 #include <cstdint>
 #include <filesystem>
-#include <fstream>
 #include <functional>
 #include <memory>
 #include <random>
@@ -43,7 +41,6 @@ constexpr uint64_t LARGE_UINT = 10000000000000000000ULL;
 // Drives a synchronous parse against the streaming pipeline for tests that
 // need to dial advanced tuning knobs but still consume a `ParseResult`.
 loglib::ParseResult ParseWithSink(
-    const loglib::JsonParser &parser,
     const std::filesystem::path &path,
     const loglib::ParserOptions &options = {},
     const loglib::internal::AdvancedParserOptions &advanced = {}
@@ -53,10 +50,10 @@ loglib::ParseResult ParseWithSink(
     auto source = std::make_unique<loglib::FileLineSource>(std::move(logFile));
     loglib::FileLineSource *sourcePtr = source.get();
     loglib::internal::BufferingSink sink(std::move(source));
-    parser.ParseStreaming(*sourcePtr, sink, options, advanced);
+    loglib::JsonParser::ParseStreaming(*sourcePtr, sink, options, advanced);
     loglib::LogData data = sink.TakeData();
     std::vector<std::string> errors = sink.TakeErrors();
-    return loglib::ParseResult{std::move(data), std::move(errors)};
+    return loglib::ParseResult{.data = std::move(data), .errors = std::move(errors)};
 }
 } // namespace
 
@@ -80,63 +77,63 @@ TEST_CASE(
 
 TEST_CASE("Validate non-existent file", "[json_parser]")
 {
-    loglib::JsonParser parser;
+    const loglib::JsonParser parser;
     CHECK_FALSE(parser.IsValid("non_existent_file.json"));
 }
 
 TEST_CASE("Validate empty file", "[json_parser]")
 {
-    loglib::JsonParser parser;
-    TestJsonLogFile testFile;
+    const loglib::JsonParser parser;
+    const TestJsonLogFile testFile;
     CHECK_FALSE(parser.IsValid(testFile.GetFilePath()));
 }
 
 TEST_CASE("Validate file with empty lines", "[json_parser]")
 {
-    loglib::JsonParser parser;
-    TestJsonLogFile testFile(TestJsonLogFile::Line("\n\n\n"));
+    const loglib::JsonParser parser;
+    const TestJsonLogFile testFile(TestJsonLogFile::Line("\n\n\n"));
     CHECK_FALSE(parser.IsValid(testFile.GetFilePath()));
 }
 
 TEST_CASE("Validate file with leading blank line", "[json_parser]")
 {
     // Leading blank lines are tolerated: the first non-empty line is what determines validity.
-    loglib::JsonParser parser;
-    TestJsonLogFile testFile(std::vector<TestJsonLogFile::Line>{"\n", R"({"key": "value"})"});
+    const loglib::JsonParser parser;
+    const TestJsonLogFile testFile(std::vector<TestJsonLogFile::Line>{"\n", R"({"key": "value"})"});
     CHECK(parser.IsValid(testFile.GetFilePath()));
 }
 
 TEST_CASE("Validate file with invalid line", "[json_parser]")
 {
-    loglib::JsonParser parser;
-    TestJsonLogFile testFile(TestJsonLogFile::Line("invalid json"));
+    const loglib::JsonParser parser;
+    const TestJsonLogFile testFile(TestJsonLogFile::Line("invalid json"));
     CHECK_FALSE(parser.IsValid(testFile.GetFilePath()));
 }
 
 TEST_CASE("Validate file with empty JSON object", "[json_parser]")
 {
-    loglib::JsonParser parser;
-    TestJsonLogFile testFile(TestJsonLogFile::Line(R"({})"));
+    const loglib::JsonParser parser;
+    const TestJsonLogFile testFile(TestJsonLogFile::Line(R"({})"));
     CHECK(parser.IsValid(testFile.GetFilePath()));
 }
 
 TEST_CASE("Validate file with JSON line", "[json_parser]")
 {
-    loglib::JsonParser parser;
-    TestJsonLogFile testFile(TestJsonLogFile::Line(R"({"key": "value"})"));
+    const loglib::JsonParser parser;
+    const TestJsonLogFile testFile(TestJsonLogFile::Line(R"({"key": "value"})"));
     CHECK(parser.IsValid(testFile.GetFilePath()));
 }
 
 TEST_CASE("Parse non-existent file", "[json_parser]")
 {
-    loglib::JsonParser parser;
+    const loglib::JsonParser parser;
     CHECK_THROWS_AS(ParseFile(parser, "non_existent_file.json"), std::runtime_error);
 }
 
 TEST_CASE("Parse empty file", "[json_parser]")
 {
-    loglib::JsonParser parser;
-    TestJsonLogFile testFile;
+    const loglib::JsonParser parser;
+    const TestJsonLogFile testFile;
     CHECK_THROWS_AS(ParseFile(parser, testFile.GetFilePath()), std::runtime_error);
 }
 
@@ -144,8 +141,8 @@ TEST_CASE("Parse file with empty lines", "[json_parser]")
 {
     // Blank lines are not errors, just content-free input. Parse should succeed with no data
     // and no errors so callers can distinguish this from parse failures.
-    loglib::JsonParser parser;
-    TestJsonLogFile testFile(TestJsonLogFile::Line("\n\n\n"));
+    const loglib::JsonParser parser;
+    const TestJsonLogFile testFile(TestJsonLogFile::Line("\n\n\n"));
     auto result = ParseFile(parser, testFile.GetFilePath());
     CHECK(result.data.Lines().empty());
     CHECK(result.errors.empty());
@@ -155,8 +152,8 @@ TEST_CASE("Parse file with invalid line", "[json_parser]")
 {
     // A file containing only invalid lines produces an empty LogData but reports each failure
     // through `errors` so the caller can surface them.
-    loglib::JsonParser parser;
-    TestJsonLogFile testFile(TestJsonLogFile::Line("invalid json"));
+    const loglib::JsonParser parser;
+    const TestJsonLogFile testFile(TestJsonLogFile::Line("invalid json"));
     auto result = ParseFile(parser, testFile.GetFilePath());
     CHECK(result.data.Lines().empty());
     CHECK(result.errors.size() == 1);
@@ -164,8 +161,8 @@ TEST_CASE("Parse file with invalid line", "[json_parser]")
 
 TEST_CASE("Parse file with invalid and valid line", "[json_parser]")
 {
-    loglib::JsonParser parser;
-    TestJsonLogFile testFile(std::vector<TestJsonLogFile::Line>({"invalid json", R"({"key": "value"})"}));
+    const loglib::JsonParser parser;
+    const TestJsonLogFile testFile(std::vector<TestJsonLogFile::Line>({"invalid json", R"({"key": "value"})"}));
     auto result = ParseFile(parser, testFile.GetFilePath());
     CHECK(result.errors.size() == 1);
     CHECK(result.data.Lines().size() == 1);
@@ -173,8 +170,8 @@ TEST_CASE("Parse file with invalid and valid line", "[json_parser]")
 
 TEST_CASE("Parse file with multiple invalid lines", "[json_parser]")
 {
-    loglib::JsonParser parser;
-    TestJsonLogFile testFile(std::vector<TestJsonLogFile::Line>{"invalid json 1", "invalid json 2"});
+    const loglib::JsonParser parser;
+    const TestJsonLogFile testFile(std::vector<TestJsonLogFile::Line>{"invalid json 1", "invalid json 2"});
     auto result = ParseFile(parser, testFile.GetFilePath());
     CHECK(result.data.Lines().empty());
     CHECK(result.errors.size() == 2);
@@ -189,7 +186,7 @@ TEST_CASE("Parse file with multiple invalid lines", "[json_parser]")
 // running absolute line cursor and composes "Error on line N: <body>" itself.
 TEST_CASE("Parse file with invalid lines spanning multiple pipeline batches", "[json_parser][error_line_numbers]")
 {
-    loglib::JsonParser parser;
+    const loglib::JsonParser parser;
 
     constexpr size_t VALID_LINES = 1000;
     constexpr size_t INVALID_LINE_NUMBER_A = 1500;
@@ -234,16 +231,16 @@ TEST_CASE("Parse file with invalid lines spanning multiple pipeline batches", "[
         lines.emplace_back(text.c_str());
     }
     static_cast<void>(VALID_LINES);
-    TestJsonLogFile testFile(std::move(lines));
+    const TestJsonLogFile testFile(std::move(lines));
 
     // Force several Stage A batches by capping `batchSizeBytes` well below
     // the file size; the INVALID_LINE_NUMBER_A line therefore lands in batch 2+.
-    loglib::ParserOptions options;
+    const loglib::ParserOptions options;
     loglib::internal::AdvancedParserOptions advanced;
     advanced.batchSizeBytes = 8 * 1024;
     advanced.threads = 1;
 
-    auto result = ParseWithSink(parser, testFile.GetFilePath(), options, advanced);
+    auto result = ParseWithSink(testFile.GetFilePath(), options, advanced);
 
     REQUIRE(result.errors.size() == 2);
     const std::string expectedA = "Error on line " + std::to_string(INVALID_LINE_NUMBER_A);
@@ -254,8 +251,8 @@ TEST_CASE("Parse file with invalid lines spanning multiple pipeline batches", "[
 
 TEST_CASE("Parse file with empty JSON object", "[json_parser]")
 {
-    loglib::JsonParser parser;
-    TestJsonLogFile testFile(TestJsonLogFile::Line(R"({})"));
+    const loglib::JsonParser parser;
+    const TestJsonLogFile testFile(TestJsonLogFile::Line(R"({})"));
 
     auto result = ParseFile(parser, testFile.GetFilePath());
     CHECK(result.errors.empty());
@@ -269,8 +266,8 @@ TEST_CASE("Parse file with empty JSON object", "[json_parser]")
 
 TEST_CASE("Parse file with multiple empty JSON objects", "[json_parser]")
 {
-    loglib::JsonParser parser;
-    TestJsonLogFile testFile(std::vector<TestJsonLogFile::Line>{R"({})", R"({})"});
+    const loglib::JsonParser parser;
+    const TestJsonLogFile testFile(std::vector<TestJsonLogFile::Line>{R"({})", R"({})"});
 
     auto result = ParseFile(parser, testFile.GetFilePath());
     CHECK(result.errors.empty());
@@ -287,11 +284,11 @@ TEST_CASE("Parse file with multiple empty JSON objects", "[json_parser]")
 
 TEST_CASE("Parse file with single JSON object containing single JSON element", "[json_parser]")
 {
-    loglib::JsonParser parser;
+    const loglib::JsonParser parser;
 
     SECTION("Null")
     {
-        TestJsonLogFile testFile(TestJsonLogFile::Line(R"({"key": null})"));
+        const TestJsonLogFile testFile(TestJsonLogFile::Line(R"({"key": null})"));
         auto result = ParseFile(parser, testFile.GetFilePath());
         CHECK(result.errors.empty());
         REQUIRE(result.data.Lines().size() == testFile.JsonLines().size());
@@ -308,7 +305,7 @@ TEST_CASE("Parse file with single JSON object containing single JSON element", "
         // Unescaped string values are emitted as `std::string_view` into the mmap;
         // use `AsStringView` so the test is agnostic to which alternative the parser
         // picks per the fast/slow path heuristic.
-        TestJsonLogFile testFile(TestJsonLogFile::Line(R"({"key": "value"})"));
+        const TestJsonLogFile testFile(TestJsonLogFile::Line(R"({"key": "value"})"));
         auto result = ParseFile(parser, testFile.GetFilePath());
         CHECK(result.errors.empty());
         REQUIRE(result.data.Lines().size() == testFile.JsonLines().size());
@@ -322,7 +319,7 @@ TEST_CASE("Parse file with single JSON object containing single JSON element", "
 
     SECTION("Unsigned integer")
     {
-        TestJsonLogFile testFile(TestJsonLogFile::Line(R"({"key": 10000000000000000000})"));
+        const TestJsonLogFile testFile(TestJsonLogFile::Line(R"({"key": 10000000000000000000})"));
         auto result = ParseFile(parser, testFile.GetFilePath());
         CHECK(result.errors.empty());
         REQUIRE(result.data.Lines().size() == testFile.JsonLines().size());
@@ -336,7 +333,7 @@ TEST_CASE("Parse file with single JSON object containing single JSON element", "
 
     SECTION("Integer")
     {
-        TestJsonLogFile testFile(TestJsonLogFile::Line(R"({"key": -12})"));
+        const TestJsonLogFile testFile(TestJsonLogFile::Line(R"({"key": -12})"));
         auto result = ParseFile(parser, testFile.GetFilePath());
         CHECK(result.errors.empty());
         REQUIRE(result.data.Lines().size() == testFile.JsonLines().size());
@@ -350,7 +347,7 @@ TEST_CASE("Parse file with single JSON object containing single JSON element", "
 
     SECTION("Double")
     {
-        TestJsonLogFile testFile(TestJsonLogFile::Line(R"({"key": 3.14})"));
+        const TestJsonLogFile testFile(TestJsonLogFile::Line(R"({"key": 3.14})"));
         auto result = ParseFile(parser, testFile.GetFilePath());
         CHECK(result.errors.empty());
         REQUIRE(result.data.Lines().size() == testFile.JsonLines().size());
@@ -364,7 +361,7 @@ TEST_CASE("Parse file with single JSON object containing single JSON element", "
 
     SECTION("Boolean")
     {
-        TestJsonLogFile testFile(TestJsonLogFile::Line(R"({"key": true})"));
+        const TestJsonLogFile testFile(TestJsonLogFile::Line(R"({"key": true})"));
         auto result = ParseFile(parser, testFile.GetFilePath());
         REQUIRE(result.errors.empty());
         CHECK(result.data.Lines().size() == testFile.JsonLines().size());
@@ -379,8 +376,8 @@ TEST_CASE("Parse file with single JSON object containing single JSON element", "
 
 TEST_CASE("Parse file with single JSON object containing all possible JSON elements", "[json_parser]")
 {
-    loglib::JsonParser parser;
-    TestJsonLogFile testFile(glz::generic_sorted_u64{
+    const loglib::JsonParser parser;
+    const TestJsonLogFile testFile(glz::generic_sorted_u64{
         {"null", nullptr},
         {"string", "value"},
         {"uinteger", LARGE_UINT},
@@ -419,8 +416,8 @@ TEST_CASE("Parse file with single JSON object containing all possible JSON eleme
 TEST_CASE("Parse different key types on different lines", "[json_parser]")
 {
     // This test should validate caching
-    loglib::JsonParser parser;
-    TestJsonLogFile testFile(
+    const loglib::JsonParser parser;
+    const TestJsonLogFile testFile(
         {glz::generic_sorted_u64{
              {"1", nullptr}, {"2", "value"}, {"3", LARGE_UINT}, {"4", -12}, {"5", 3.14}, {"6", true}
          },
@@ -475,8 +472,9 @@ TEST_CASE("Parse different key types on different lines", "[json_parser]")
 
 TEST_CASE("Parse file with multiple JSON objects", "[json_parser]")
 {
-    loglib::JsonParser parser;
-    TestJsonLogFile testFile({glz::generic_sorted_u64{{"key1", "value1"}}, glz::generic_sorted_u64{{"key2", "value2"}}}
+    const loglib::JsonParser parser;
+    const TestJsonLogFile testFile(
+        {glz::generic_sorted_u64{{"key1", "value1"}}, glz::generic_sorted_u64{{"key2", "value2"}}}
     );
 
     auto result = ParseFile(parser, testFile.GetFilePath());
@@ -502,10 +500,10 @@ TEST_CASE("Parse file whose last line lacks a trailing newline", "[json_parser]"
     // trailing '\n'). Without the compensating `+ 1` the last character of
     // the final line was silently lopped off when round-tripping through
     // `GetLine` -- here the final `}` would have gone missing.
-    TestLogFile testFile;
+    const TestLogFile testFile;
     testFile.Write("{\"key1\":\"value1\"}\n{\"key2\":\"value2\"}");
 
-    loglib::JsonParser parser;
+    const loglib::JsonParser parser;
     auto result = ParseFile(parser, testFile.GetFilePath());
 
     CHECK(result.errors.empty());
@@ -523,8 +521,8 @@ TEST_CASE("Parse file whose last line lacks a trailing newline", "[json_parser]"
 TEST_CASE("Parse file with multiple JSON objects and one invalid line", "[json_parser]")
 {
     // Invalid lines are reported as errors but do not abort the parse.
-    loglib::JsonParser parser;
-    TestJsonLogFile testFile(
+    const loglib::JsonParser parser;
+    const TestJsonLogFile testFile(
         {glz::generic_sorted_u64{{"key1", "value1"}}, "invalid json", glz::generic_sorted_u64{{"key2", "value2"}}}
     );
 
@@ -548,8 +546,8 @@ TEST_CASE("Parse file with multiple JSON objects and one invalid line", "[json_p
 TEST_CASE("Parse file with multiple JSON objects and multiple invalid lines", "[json_parser]")
 {
     // Invalid lines accumulate as errors; valid ones still land in the result.
-    loglib::JsonParser parser;
-    TestJsonLogFile testFile(
+    const loglib::JsonParser parser;
+    const TestJsonLogFile testFile(
         {glz::generic_sorted_u64{{"key1", "value1"}},
          "invalid json 1",
          glz::generic_sorted_u64{{"key2", "value2"}},
@@ -573,60 +571,60 @@ TEST_CASE("Parse file with multiple JSON objects and multiple invalid lines", "[
 
 TEST_CASE("Convert empty values to string", "[json_parser]")
 {
-    loglib::JsonParser parser;
-    loglib::LogMap values;
+    const loglib::JsonParser parser;
+    const loglib::LogMap values;
     CHECK(parser.ToString(values) == "{}");
 }
 
 TEST_CASE("Convert one value to string", "[json_parser]")
 {
-    loglib::JsonParser parser;
+    const loglib::JsonParser parser;
 
     SECTION("Null")
     {
-        loglib::LogMap values{{"key", std::monostate()}};
+        const loglib::LogMap values{{"key", std::monostate()}};
         CHECK(parser.ToString(values) == R"({"key":null})");
     }
 
     SECTION("String")
     {
-        loglib::LogMap values{{"key", std::string("value")}};
+        const loglib::LogMap values{{"key", std::string("value")}};
         CHECK(parser.ToString(values) == R"({"key":"value"})");
     }
 
     SECTION("Unsigned integer")
     {
-        loglib::LogMap values{{"key", uint64_t(42)}};
+        const loglib::LogMap values{{"key", static_cast<uint64_t>(42)}};
         CHECK(parser.ToString(values) == R"({"key":42})");
     }
 
     SECTION("Integer")
     {
-        loglib::LogMap values{{"key", int64_t(-12)}};
+        const loglib::LogMap values{{"key", static_cast<int64_t>(-12)}};
         CHECK(parser.ToString(values) == R"({"key":-12})");
     }
 
     SECTION("Double")
     {
-        loglib::LogMap values{{"key", 3.14}};
+        const loglib::LogMap values{{"key", 3.14}};
         CHECK(parser.ToString(values) == R"({"key":3.14})");
     }
 
     SECTION("Boolean")
     {
-        loglib::LogMap values{{"key", true}};
+        const loglib::LogMap values{{"key", true}};
         CHECK(parser.ToString(values) == R"({"key":true})");
     }
 }
 
 TEST_CASE("Convert all possible values to string", "[json_parser]")
 {
-    loglib::JsonParser parser;
-    loglib::LogMap values{
+    const loglib::JsonParser parser;
+    const loglib::LogMap values{
         {"null", std::monostate()},
         {"string", std::string("value")},
-        {"uinteger", uint64_t(42)},
-        {"integer", int64_t(-12)},
+        {"uinteger", static_cast<uint64_t>(42)},
+        {"integer", static_cast<int64_t>(-12)},
         {"double", 3.14},
         {"boolean", true}
     };
@@ -646,7 +644,7 @@ TEST_CASE("Parallel parse parity vs. single-thread", "[json_parser][parity]")
     // `string` / `string_view` distinctions into one bytes comparison).
     using namespace loglib;
 
-    JsonParser parser;
+    const JsonParser parser;
 
     // Generate a fixture sized to span multiple Stage A batches (1 MiB default) so the
     // multi-threaded run actually exercises more than one worker. ~5'000 lines × ~200 bytes
@@ -669,15 +667,15 @@ TEST_CASE("Parallel parse parity vs. single-thread", "[json_parser][parity]")
     }
     const TestJsonLogFile testFile(logs);
 
-    ParserOptions opts;
+    const ParserOptions opts;
     internal::AdvancedParserOptions singleThread;
     singleThread.threads = 1;
 
     internal::AdvancedParserOptions multiThread;
     multiThread.threads = std::max(2u, std::thread::hardware_concurrency());
 
-    auto singleResult = ParseWithSink(parser, testFile.GetFilePath(), opts, singleThread);
-    auto multiResult = ParseWithSink(parser, testFile.GetFilePath(), opts, multiThread);
+    auto singleResult = ParseWithSink(testFile.GetFilePath(), opts, singleThread);
+    auto multiResult = ParseWithSink(testFile.GetFilePath(), opts, multiThread);
 
     REQUIRE(singleResult.errors.empty());
     REQUIRE(multiResult.errors.empty());
@@ -737,13 +735,13 @@ TEST_CASE(
     }
     const TestJsonLogFile testFile(lines);
 
-    JsonParser parser;
-    ParserOptions opts;
+    const JsonParser parser;
+    const ParserOptions opts;
     internal::AdvancedParserOptions advanced;
     advanced.threads = THREADS;
 
     KeyIndex::ResetInstrumentationCounters();
-    const auto cachedResult = ParseWithSink(parser, testFile.GetFilePath(), opts, advanced);
+    const auto cachedResult = ParseWithSink(testFile.GetFilePath(), opts, advanced);
     const std::size_t cachedCalls = KeyIndex::LoadGetOrInsertCount();
 
     REQUIRE(cachedResult.errors.empty());
@@ -773,6 +771,8 @@ namespace
 // exercise here.
 struct TestTransparentStringHash
 {
+    // Named requirement; spelling is fixed.
+    // NOLINTNEXTLINE(readability-identifier-naming)
     using is_transparent = void;
 
     size_t operator()(std::string_view sv) const noexcept
@@ -791,6 +791,8 @@ struct TestTransparentStringHash
 
 struct TestTransparentStringEqual
 {
+    // Named requirement; spelling is fixed.
+    // NOLINTNEXTLINE(readability-identifier-naming)
     using is_transparent = void;
 
     bool operator()(std::string_view lhs, std::string_view rhs) const noexcept
@@ -932,8 +934,8 @@ TEST_CASE(
     ParserOptions opts;
     opts.configuration = configuration;
 
-    JsonParser parser;
-    const ParseResult result = ParseWithSink(parser, testFile.GetFilePath(), opts);
+    const JsonParser parser;
+    const ParseResult result = ParseWithSink(testFile.GetFilePath(), opts);
 
     REQUIRE(result.errors.empty());
     REQUIRE(result.data.Lines().size() == LINE_COUNT);
@@ -991,8 +993,8 @@ TEST_CASE(
     ParserOptions opts;
     opts.configuration = configuration;
 
-    JsonParser parser;
-    const ParseResult result = ParseWithSink(parser, testFile.GetFilePath(), opts);
+    const JsonParser parser;
+    const ParseResult result = ParseWithSink(testFile.GetFilePath(), opts);
 
     // Promotion failures are silent; only genuine JSON-parse errors land in `errors`.
     CHECK(result.errors.empty());
@@ -1053,7 +1055,7 @@ TEST_CASE(
     }
     const TestJsonLogFile testFile(fixtureLines);
 
-    JsonParser parser;
+    const JsonParser parser;
     const ParseResult result = ParseFile(parser, testFile.GetFilePath());
 
     REQUIRE(result.errors.empty());
@@ -1110,7 +1112,7 @@ TEST_CASE("ExtractFieldKey round-trips quoted, escaped, and Unicode-escape keys"
     lines.emplace_back(R"({"\u0041BC": "v-unicode"})");      // (d) slow path: Unicode escape
     const TestJsonLogFile testFile(lines);
 
-    JsonParser parser;
+    const JsonParser parser;
     const ParseResult result = ParseFile(parser, testFile.GetFilePath());
     REQUIRE(result.errors.empty());
     REQUIRE(result.data.Lines().size() == lines.size());
@@ -1147,7 +1149,7 @@ TEST_CASE("Padded-tail slow path parses lines within SIMDJSON_PADDING bytes of E
     lines.emplace_back(R"({"k":"abcdefghijklmnopqrstuvwxyz0123456789"})"); // longest
     const TestJsonLogFile testFile(lines);
 
-    JsonParser parser;
+    const JsonParser parser;
     const ParseResult result = ParseFile(parser, testFile.GetFilePath());
     REQUIRE(result.errors.empty());
     REQUIRE(result.data.Lines().size() == lines.size());
@@ -1194,7 +1196,7 @@ TEST_CASE(
 
     const TestJsonLogFile testFile(lines);
 
-    JsonParser parser;
+    const JsonParser parser;
     const ParseResult result = ParseFile(parser, testFile.GetFilePath());
     REQUIRE(result.errors.empty());
     REQUIRE(result.data.Lines().size() == lines.size());
@@ -1323,7 +1325,7 @@ TEST_CASE(
     StreamLineSource source(std::filesystem::path("memory.log"), std::make_unique<InMemoryProducer>(payload));
 
     CollectingStreamSink sink;
-    JsonParser parser;
+    const JsonParser parser;
     parser.ParseStreaming(source, sink, ParserOptions{});
 
     REQUIRE(sink.finished);
@@ -1382,7 +1384,7 @@ TEST_CASE(
     StreamLineSource source(std::filesystem::path("memory.log"), std::make_unique<InMemoryProducer>(payload));
 
     CollectingStreamSink sink;
-    JsonParser parser;
+    const JsonParser parser;
     parser.ParseStreaming(source, sink, ParserOptions{});
 
     REQUIRE(sink.finished);

--- a/test/lib/src/test_json_parser.cpp
+++ b/test/lib/src/test_json_parser.cpp
@@ -661,7 +661,7 @@ TEST_CASE("Parallel parse parity vs. single-thread", "[json_parser][parity]")
     {
         glz::generic_sorted_u64 json;
         json["index"] = static_cast<int64_t>(i);
-        json["level"] = std::string(LEVELS[levelDist(rng)]);
+        json["level"] = std::string(LEVELS[static_cast<size_t>(levelDist(rng))]);
         json["component"] = std::string("component_") + std::to_string(i % 7);
         json["message"] = std::string("event ") + std::to_string(i) + " — value " + std::to_string(intDist(rng));
         json["counter"] = static_cast<int64_t>(intDist(rng));

--- a/test/lib/src/test_json_parser.cpp
+++ b/test/lib/src/test_json_parser.cpp
@@ -651,6 +651,8 @@ TEST_CASE("Parallel parse parity vs. single-thread", "[json_parser][parity]")
     // each ≈ 1 MB, large enough to split.
     std::vector<TestJsonLogFile::Line> logs;
     logs.reserve(5'000);
+    // NOLINTNEXTLINE(bugprone-random-generator-seed,cert-msc32-c,cert-msc51-cpp): deterministic fixture for stable
+    // assertions.
     std::mt19937 rng(0xC0FFEE);
     std::uniform_int_distribution<int> levelDist(0, 4);
     std::uniform_int_distribution<int> intDist(-1'000, 1'000);

--- a/test/lib/src/test_key_index.cpp
+++ b/test/lib/src/test_key_index.cpp
@@ -261,6 +261,13 @@ TEST_CASE("KeyIndex KeyOf is safe to call while GetOrInsert grows the dictionary
     std::atomic<KeyId> highWater{0};
     std::atomic<bool> writerDone{false};
 
+    // Catch2's REQUIRE/CHECK macros are not thread-safe (they touch
+    // process-global state in RunContext), so reader threads only record
+    // mismatches into atomics and the actual assertions happen post-join.
+    std::atomic<uint64_t> mismatchCount{0};
+    std::atomic<KeyId> firstMismatchId{INVALID_KEY_ID};
+    std::atomic<KeyId> firstMismatchFound{INVALID_KEY_ID};
+
     std::thread writer([&] {
         for (const auto &k : keys)
         {
@@ -281,7 +288,15 @@ TEST_CASE("KeyIndex KeyOf is safe to call while GetOrInsert grows the dictionary
             }
             const KeyId id = static_cast<KeyId>(i) % limit;
             const std::string_view view = index.KeyOf(id);
-            REQUIRE(index.Find(view) == id);
+            const KeyId found = index.Find(view);
+            if (found != id)
+            {
+                if (mismatchCount.fetch_add(1, std::memory_order_relaxed) == 0)
+                {
+                    firstMismatchId.store(id, std::memory_order_relaxed);
+                    firstMismatchFound.store(found, std::memory_order_relaxed);
+                }
+            }
             if (writerDone.load(std::memory_order_acquire) && i > 1024)
             {
                 break;
@@ -300,6 +315,13 @@ TEST_CASE("KeyIndex KeyOf is safe to call while GetOrInsert grows the dictionary
     {
         th.join();
     }
+
+    INFO(
+        "mismatches=" << mismatchCount.load(std::memory_order_relaxed)
+                      << " firstMismatchId=" << firstMismatchId.load(std::memory_order_relaxed)
+                      << " firstMismatchFound=" << firstMismatchFound.load(std::memory_order_relaxed)
+    );
+    REQUIRE(mismatchCount.load(std::memory_order_relaxed) == 0);
 
     REQUIRE(index.Size() == static_cast<size_t>(KEY_COUNT));
     for (KeyId id = 0; id < static_cast<KeyId>(KEY_COUNT); ++id)

--- a/test/lib/src/test_key_index.cpp
+++ b/test/lib/src/test_key_index.cpp
@@ -3,14 +3,12 @@
 #include <catch2/catch_all.hpp>
 #include <oneapi/tbb/parallel_for.h>
 
-#include <algorithm>
 #include <atomic>
 #include <random>
 #include <set>
 #include <string>
 #include <string_view>
 #include <thread>
-#include <unordered_set>
 #include <vector>
 
 using namespace loglib;
@@ -181,7 +179,7 @@ TEST_CASE("KeyIndex move construction preserves the dictionary", "[key_index]")
     const KeyId a = source.GetOrInsert("alpha");
     const KeyId b = source.GetOrInsert("beta");
 
-    KeyIndex moved(std::move(source));
+    const KeyIndex moved(std::move(source));
     CHECK(moved.Size() == 2);
     CHECK(moved.Find("alpha") == a);
     CHECK(moved.Find("beta") == b);
@@ -210,7 +208,7 @@ TEST_CASE("KeyIndex heterogeneous fast path is safe under concurrent insert+find
 
     oneapi::tbb::parallel_for(0, THREAD_COUNT, [&](int thread) {
         // Per-thread RNG so the iteration order interleaves but is reproducible.
-        std::mt19937 rng(static_cast<unsigned>(thread) * 37u + 1u);
+        std::mt19937 rng((static_cast<unsigned>(thread) * 37u) + 1u);
         std::uniform_int_distribution<int> pickKey(0, KEY_COUNT - 1);
         for (int i = 0; i < ITERATIONS_PER_THREAD; ++i)
         {
@@ -330,12 +328,12 @@ TEST_CASE(
     // Build the query as a string_view over a stack-allocated char buffer so
     // there is no chance of an implicit std::string ever being constructed
     // along the call path.
-    constexpr char alphaBuf[] = "alpha";
-    constexpr char betaBuf[] = "beta";
-    constexpr char absentBuf[] = "missing";
-    const std::string_view alphaView(alphaBuf, sizeof(alphaBuf) - 1);
-    const std::string_view betaView(betaBuf, sizeof(betaBuf) - 1);
-    const std::string_view absentView(absentBuf, sizeof(absentBuf) - 1);
+    constexpr char ALPHA_BUF[] = "alpha";
+    constexpr char BETA_BUF[] = "beta";
+    constexpr char ABSENT_BUF[] = "missing";
+    const std::string_view alphaView(ALPHA_BUF, sizeof(ALPHA_BUF) - 1);
+    const std::string_view betaView(BETA_BUF, sizeof(BETA_BUF) - 1);
+    const std::string_view absentView(ABSENT_BUF, sizeof(ABSENT_BUF) - 1);
 
     CHECK(index.Find(alphaView) == alphaId);
     CHECK(index.Find(betaView) == betaId);

--- a/test/lib/src/test_log_configuration.cpp
+++ b/test/lib/src/test_log_configuration.cpp
@@ -3,23 +3,21 @@
 #include <loglib/key_index.hpp>
 #include <loglib/log_configuration.hpp>
 #include <loglib/log_data.hpp>
-#include <loglib/log_file.hpp>
 #include <loglib/log_line.hpp>
 
 #include <catch2/catch_all.hpp>
 #include <glaze/glaze.hpp>
 
 #include <filesystem>
-#include <fstream>
 
 using namespace loglib;
 
 TEST_CASE("Save and load empty configuration", "[LogConfigurationManager]")
 {
-    TestLogConfiguration testConfiguration;
+    const TestLogConfiguration testConfiguration;
 
     {
-        LogConfigurationManager manager;
+        const LogConfigurationManager manager;
         manager.Save(testConfiguration.GetFilePath());
     }
 
@@ -29,8 +27,8 @@ TEST_CASE("Save and load empty configuration", "[LogConfigurationManager]")
         manager.Load(testConfiguration.GetFilePath());
 
         // Verify loaded configuration is empty
-        CHECK(manager.Configuration().columns.size() == 0);
-        CHECK(manager.Configuration().filters.size() == 0);
+        CHECK(manager.Configuration().columns.empty());
+        CHECK(manager.Configuration().filters.empty());
     }
 }
 
@@ -44,7 +42,7 @@ TEST_CASE("Handle missing file", "[LogConfigurationManager]")
 
 TEST_CASE("Handle empty file", "[LogConfigurationManager]")
 {
-    TestLogConfiguration testConfiguration;
+    const TestLogConfiguration testConfiguration;
     LogConfigurationManager manager;
 
     CHECK_THROWS_AS(manager.Load(testConfiguration.GetFilePath()), std::runtime_error);
@@ -52,10 +50,12 @@ TEST_CASE("Handle empty file", "[LogConfigurationManager]")
 
 TEST_CASE("Update with empty LogData should not modify configuration", "[LogConfigurationManager]")
 {
-    TestLogConfiguration testLogConfiguration;
+    const TestLogConfiguration testLogConfiguration;
 
     LogConfiguration logConfiguration;
-    const LogConfiguration::Column defaultColumn = {"test", {"test"}, "{}", LogConfiguration::Type::any, {}};
+    const LogConfiguration::Column defaultColumn = {
+        .header = "test", .keys = {"test"}, .printFormat = "{}", .type = LogConfiguration::Type::any, .parseFormats = {}
+    };
     logConfiguration.columns.push_back(defaultColumn);
     testLogConfiguration.Write(logConfiguration);
 
@@ -64,7 +64,7 @@ TEST_CASE("Update with empty LogData should not modify configuration", "[LogConf
 
     const size_t initialColumnCount = manager.Configuration().columns.size();
 
-    LogData emptyLogData;
+    const LogData emptyLogData;
     manager.Update(emptyLogData);
 
     CHECK(manager.Configuration().columns.size() == initialColumnCount);
@@ -77,16 +77,22 @@ TEST_CASE("Update with empty LogData should not modify configuration", "[LogConf
 
 TEST_CASE("Update with mixed keys organizes timestamp first", "[LogConfigurationManager]")
 {
-    TestLogConfiguration testLogConfiguration;
+    const TestLogConfiguration testLogConfiguration;
 
     LogConfiguration logConfiguration;
-    logConfiguration.columns.push_back({"regular", {"regular"}, "{}", LogConfiguration::Type::any, {}});
+    logConfiguration.columns.push_back(
+        {.header = "regular",
+         .keys = {"regular"},
+         .printFormat = "{}",
+         .type = LogConfiguration::Type::any,
+         .parseFormats = {}}
+    );
     testLogConfiguration.Write(logConfiguration);
 
     LogConfigurationManager manager;
     manager.Load(testLogConfiguration.GetFilePath());
 
-    TestLogFile testLogFile;
+    const TestLogFile testLogFile;
     auto source = testLogFile.CreateFileLineSource();
     KeyIndex testKeys;
     std::vector<LogLine> testLines;
@@ -94,7 +100,7 @@ TEST_CASE("Update with mixed keys organizes timestamp first", "[LogConfiguration
     testLines.emplace_back(LogMap{{"newKey", std::string("test")}}, testKeys, *source, 0);
     testLines.emplace_back(LogMap{{"timestamp", std::string("2023-01-01T12:00:00Z")}}, testKeys, *source, 0);
 
-    LogData logData(std::move(source), std::move(testLines), std::move(testKeys));
+    const LogData logData(std::move(source), std::move(testLines), std::move(testKeys));
 
     manager.Update(logData);
 
@@ -148,13 +154,13 @@ TEST_CASE(
 
     // Update must skip "regular", add "timestamp" as Type::time, and place
     // it at position 0.
-    TestLogFile testLogFile;
+    const TestLogFile testLogFile;
     auto source = testLogFile.CreateFileLineSource();
     KeyIndex testKeys;
     std::vector<LogLine> testLines;
     testLines.emplace_back(LogMap{{"regular", std::string("value")}}, testKeys, *source, 0);
     testLines.emplace_back(LogMap{{"timestamp", std::string("2023-01-01T12:00:00Z")}}, testKeys, *source, 0);
-    LogData logData(std::move(source), std::move(testLines), std::move(testKeys));
+    const LogData logData(std::move(source), std::move(testLines), std::move(testKeys));
 
     manager.Update(logData);
 
@@ -169,16 +175,28 @@ TEST_CASE(
     "[LogConfigurationManager][cache_invalidation]"
 )
 {
-    TestLogConfiguration firstConfigOnDisk("test_config_first.json");
+    const TestLogConfiguration firstConfigOnDisk("test_config_first.json");
     {
         LogConfiguration logConfiguration;
-        logConfiguration.columns.push_back({"loaded_key", {"loaded_key"}, "{}", LogConfiguration::Type::any, {}});
+        logConfiguration.columns.push_back(
+            {.header = "loaded_key",
+             .keys = {"loaded_key"},
+             .printFormat = "{}",
+             .type = LogConfiguration::Type::any,
+             .parseFormats = {}}
+        );
         firstConfigOnDisk.Write(logConfiguration);
     }
-    TestLogConfiguration secondConfigOnDisk("test_config_second.json");
+    const TestLogConfiguration secondConfigOnDisk("test_config_second.json");
     {
         LogConfiguration logConfiguration;
-        logConfiguration.columns.push_back({"other_key", {"other_key"}, "{}", LogConfiguration::Type::any, {}});
+        logConfiguration.columns.push_back(
+            {.header = "other_key",
+             .keys = {"other_key"},
+             .printFormat = "{}",
+             .type = LogConfiguration::Type::any,
+             .parseFormats = {}}
+        );
         secondConfigOnDisk.Write(logConfiguration);
     }
 
@@ -219,22 +237,28 @@ TEST_CASE(
 {
     // Re-run the "mixed keys organizes timestamp first" shape with the
     // cached path; regression boundary against the old free-function walk.
-    TestLogConfiguration testLogConfiguration;
+    const TestLogConfiguration testLogConfiguration;
     LogConfiguration logConfiguration;
-    logConfiguration.columns.push_back({"regular", {"regular"}, "{}", LogConfiguration::Type::any, {}});
+    logConfiguration.columns.push_back(
+        {.header = "regular",
+         .keys = {"regular"},
+         .printFormat = "{}",
+         .type = LogConfiguration::Type::any,
+         .parseFormats = {}}
+    );
     testLogConfiguration.Write(logConfiguration);
 
     LogConfigurationManager manager;
     manager.Load(testLogConfiguration.GetFilePath());
 
-    TestLogFile testLogFile;
+    const TestLogFile testLogFile;
     auto source = testLogFile.CreateFileLineSource();
     KeyIndex testKeys;
     std::vector<LogLine> testLines;
     testLines.emplace_back(LogMap{{"regular", std::string("value")}}, testKeys, *source, 0);
     testLines.emplace_back(LogMap{{"newKey", std::string("test")}}, testKeys, *source, 0);
     testLines.emplace_back(LogMap{{"timestamp", std::string("2023-01-01T12:00:00Z")}}, testKeys, *source, 0);
-    LogData logData(std::move(source), std::move(testLines), std::move(testKeys));
+    const LogData logData(std::move(source), std::move(testLines), std::move(testKeys));
 
     manager.Update(logData);
 
@@ -252,9 +276,15 @@ TEST_CASE(
     // The cache mirrors `column.keys`, not `column.header`. With diverging
     // header/keys, AppendKeys must skip keys already listed under any
     // column's `keys`.
-    TestLogConfiguration testLogConfiguration;
+    const TestLogConfiguration testLogConfiguration;
     LogConfiguration logConfiguration;
-    logConfiguration.columns.push_back({"display", {"raw_key", "alias"}, "{}", LogConfiguration::Type::any, {}});
+    logConfiguration.columns.push_back(
+        {.header = "display",
+         .keys = {"raw_key", "alias"},
+         .printFormat = "{}",
+         .type = LogConfiguration::Type::any,
+         .parseFormats = {}}
+    );
     testLogConfiguration.Write(logConfiguration);
 
     LogConfigurationManager manager;

--- a/test/lib/src/test_log_data.cpp
+++ b/test/lib/src/test_log_data.cpp
@@ -18,7 +18,7 @@ TEST_CASE(
     "Constructor should correctly initialize LogData with a single source and provided lines and keys", "[LogData]"
 )
 {
-    TestLogFile testLogFile;
+    const TestLogFile testLogFile;
     auto source = testLogFile.CreateFileLineSource();
     FileLineSource *sourcePtr = source.get();
 
@@ -46,8 +46,8 @@ TEST_CASE(
 
 TEST_CASE("Merge() should correctly combine sources, lines and keys from two LogData objects", "[LogData]")
 {
-    TestLogFile testLogFile1("test_file_1.json");
-    TestLogFile testLogFile2("test_file_2.json");
+    const TestLogFile testLogFile1("test_file_1.json");
+    const TestLogFile testLogFile2("test_file_2.json");
 
     auto source1 = testLogFile1.CreateFileLineSource();
     FileLineSource *source1Ptr = source1.get();

--- a/test/lib/src/test_log_factory.cpp
+++ b/test/lib/src/test_log_factory.cpp
@@ -22,7 +22,7 @@ TEST_CASE("Create non-existent parser", "[log_factory]")
 
 TEST_CASE("Parse JSON log file via ParseFile auto-detect", "[log_factory]")
 {
-    TestJsonLogFile testFile(glz::generic_sorted_u64{{"key", "value"}});
+    const TestJsonLogFile testFile(glz::generic_sorted_u64{{"key", "value"}});
 
     ParseResult result = ParseFile(testFile.GetFilePath());
     CHECK(result.errors.empty());
@@ -33,6 +33,6 @@ TEST_CASE("ParseFile auto-detect rejects nonexistent or invalid file", "[log_fac
 {
     CHECK_THROWS_AS(ParseFile("nonexistent.json"), std::runtime_error);
 
-    TestJsonLogFile testFile(TestJsonLogFile::Line("Invalid log line."));
+    const TestJsonLogFile testFile(TestJsonLogFile::Line("Invalid log line."));
     CHECK_THROWS_AS(ParseFile(testFile.GetFilePath()), std::runtime_error);
 }

--- a/test/lib/src/test_log_file.cpp
+++ b/test/lib/src/test_log_file.cpp
@@ -3,18 +3,17 @@
 #include <loglib/log_file.hpp>
 
 #include <catch2/catch_all.hpp>
-#include <fstream>
 
 using namespace loglib;
 
 TEST_CASE("Successfully open a valid log file", "[LogFile]")
 {
     // Create a temporary test file
-    TestLogFile testLogFile;
+    const TestLogFile testLogFile;
     testLogFile.Write("Line 1\nLine 2\nLine 3\n");
 
     // Verify successful file opening
-    std::unique_ptr<LogFile> logFile = testLogFile.CreateLogFile();
+    const std::unique_ptr<LogFile> logFile = testLogFile.CreateLogFile();
     CHECK(logFile->GetPath() == testLogFile.GetFilePath());
 
     // Verify we can read the lines
@@ -30,10 +29,10 @@ TEST_CASE("Read last line without trailing newline", "[LogFile]")
 {
     // The last line of a file may not end with '\n'; JsonParser handles that by pushing a
     // virtual terminator one byte past EOF. Verify GetLine still returns the full content.
-    TestLogFile testLogFile;
+    const TestLogFile testLogFile;
     testLogFile.Write("Line 1\nLine 2");
 
-    std::unique_ptr<LogFile> logFile = testLogFile.CreateLogFile();
+    const std::unique_ptr<LogFile> logFile = testLogFile.CreateLogFile();
 
     CHECK(logFile->GetLineCount() == 2);
     CHECK(logFile->GetLine(0) == "Line 1");
@@ -44,10 +43,10 @@ TEST_CASE("Read lines from file with CRLF line endings", "[LogFile]")
 {
     // Ensure byte offsets and CRLF stripping work regardless of the host's line-ending
     // conventions.
-    TestLogFile testLogFile;
+    const TestLogFile testLogFile;
     testLogFile.Write("Line 1\r\nLine 2\r\nLine 3\r\n");
 
-    std::unique_ptr<LogFile> logFile = testLogFile.CreateLogFile();
+    const std::unique_ptr<LogFile> logFile = testLogFile.CreateLogFile();
 
     CHECK(logFile->GetLine(0) == "Line 1");
     CHECK(logFile->GetLine(1) == "Line 2");
@@ -67,7 +66,7 @@ TEST_CASE("Throw runtime error when opening a non-existent file", "[LogFile]")
 // changes that contract would fail this test loudly.
 TEST_CASE("LogFile move preserves mmap pointer and content", "[LogFile][mmap-stability]")
 {
-    TestLogFile testLogFile;
+    const TestLogFile testLogFile;
     testLogFile.Write("Line 1\nLine 2\nLine 3\n");
 
     auto original = testLogFile.CreateLogFile();
@@ -82,7 +81,7 @@ TEST_CASE("LogFile move preserves mmap pointer and content", "[LogFile][mmap-sta
     // the post-move comparison uses this as ground truth.
     const std::string snapshot(originalData, originalSize);
 
-    LogFile moved = std::move(*original);
+    const LogFile moved = std::move(*original);
 
     // Pointer-stability under move. `mio::mmap_source` is documented to
     // transfer the underlying handle on move; we pin that fact here so an

--- a/test/lib/src/test_log_line.cpp
+++ b/test/lib/src/test_log_line.cpp
@@ -1,8 +1,6 @@
 #include "common.hpp"
 
-#include <loglib/file_line_source.hpp>
 #include <loglib/key_index.hpp>
-#include <loglib/log_file.hpp>
 #include <loglib/log_line.hpp>
 
 #include <catch2/catch_all.hpp>
@@ -11,21 +9,21 @@ using namespace loglib;
 
 TEST_CASE("Construct LogLine with valid values and file reference", "[log_line]")
 {
-    LogMap map{
+    const LogMap map{
         {"key1", std::string("value1")},
-        {"key2", uint64_t(42)},
-        {"key3", int64_t(-12)},
+        {"key2", static_cast<uint64_t>(42)},
+        {"key3", static_cast<int64_t>(-12)},
         {"key4", 3.14},
         {"key5", true},
         {"key6", std::monostate()}
     };
 
-    TestLogFile testLogFile;
+    const TestLogFile testLogFile;
     testLogFile.Write("abcd\nefgh\n");
     auto source = testLogFile.CreateFileLineSource();
 
     KeyIndex keys;
-    LogLine line(map, keys, *source, 1);
+    const LogLine line(map, keys, *source, 1);
 
     REQUIRE(line.Values().size() == map.size());
     CHECK(std::get<std::string>(line.GetValue("key1")) == "value1");
@@ -42,12 +40,12 @@ TEST_CASE("Construct LogLine with valid values and file reference", "[log_line]"
 
     auto resultKeys = line.GetKeys();
     REQUIRE(resultKeys.size() == map.size());
-    CHECK(std::find(resultKeys.begin(), resultKeys.end(), "key1") != resultKeys.end());
-    CHECK(std::find(resultKeys.begin(), resultKeys.end(), "key2") != resultKeys.end());
-    CHECK(std::find(resultKeys.begin(), resultKeys.end(), "key3") != resultKeys.end());
-    CHECK(std::find(resultKeys.begin(), resultKeys.end(), "key4") != resultKeys.end());
-    CHECK(std::find(resultKeys.begin(), resultKeys.end(), "key5") != resultKeys.end());
-    CHECK(std::find(resultKeys.begin(), resultKeys.end(), "key6") != resultKeys.end());
+    CHECK(std::ranges::find(resultKeys, "key1") != resultKeys.end());
+    CHECK(std::ranges::find(resultKeys, "key2") != resultKeys.end());
+    CHECK(std::ranges::find(resultKeys, "key3") != resultKeys.end());
+    CHECK(std::ranges::find(resultKeys, "key4") != resultKeys.end());
+    CHECK(std::ranges::find(resultKeys, "key5") != resultKeys.end());
+    CHECK(std::ranges::find(resultKeys, "key6") != resultKeys.end());
 
     const LogMap resultMap = line.Values();
 
@@ -78,13 +76,13 @@ TEST_CASE("Construct LogLine with valid values and file reference", "[log_line]"
 
 TEST_CASE("LogLine GetKeys returns empty vector for empty LogLine", "[log_line]")
 {
-    LogMap emptyMap;
+    const LogMap emptyMap;
 
-    TestLogFile testLogFile;
+    const TestLogFile testLogFile;
     auto source = testLogFile.CreateFileLineSource();
 
     KeyIndex keys;
-    LogLine emptyLine(emptyMap, keys, *source, 0);
+    const LogLine emptyLine(emptyMap, keys, *source, 0);
 
     auto resultKeys = emptyLine.GetKeys();
     CHECK(resultKeys.empty());
@@ -93,13 +91,13 @@ TEST_CASE("LogLine GetKeys returns empty vector for empty LogLine", "[log_line]"
 
 TEST_CASE("LogLine returns monostate for empty and non-existent key", "[log_line]")
 {
-    LogMap map{{"key1", std::string("value1")}, {"key2", uint64_t(42)}};
+    const LogMap map{{"key1", std::string("value1")}, {"key2", static_cast<uint64_t>(42)}};
 
-    TestLogFile testLogFile;
+    const TestLogFile testLogFile;
     auto source = testLogFile.CreateFileLineSource();
 
     KeyIndex keys;
-    LogLine line(map, keys, *source, 0);
+    const LogLine line(map, keys, *source, 0);
 
     CHECK(std::holds_alternative<std::monostate>(line.GetValue("")));
     CHECK(std::holds_alternative<std::monostate>(line.GetValue("non_existent_key")));
@@ -110,9 +108,9 @@ TEST_CASE("LogLine returns monostate for empty and non-existent key", "[log_line
 
 TEST_CASE("Set and update values", "[log_line]")
 {
-    LogMap map{{"existingKey", std::string("initialValue")}};
+    const LogMap map{{"existingKey", std::string("initialValue")}};
 
-    TestLogFile testLogFile;
+    const TestLogFile testLogFile;
     auto source = testLogFile.CreateFileLineSource();
 
     KeyIndex keys;
@@ -143,7 +141,7 @@ TEST_CASE("Set and update values", "[log_line]")
 
     resultKeys = line.GetKeys();
     REQUIRE(resultKeys.size() == 2);
-    CHECK(std::find(resultKeys.begin(), resultKeys.end(), newKey) != resultKeys.end());
+    CHECK(std::ranges::find(resultKeys, newKey) != resultKeys.end());
 }
 
 // `AsStringView` / `HoldsString` / `ToOwnedLogValue` / `LogValueEquivalent`
@@ -191,7 +189,7 @@ TEST_CASE("ToOwnedLogValue copies string_view bytes and detaches from source sto
     // Allocate the source bytes on the heap so we can free them and prove
     // the owned LogValue does not retain a dangling view.
     auto source = std::make_unique<std::string>("ephemeral");
-    LogValue viewValue{std::string_view{*source}};
+    const LogValue viewValue{std::string_view{*source}};
 
     LogValue owned = ToOwnedLogValue(viewValue);
     REQUIRE(std::holds_alternative<std::string>(owned));
@@ -203,12 +201,12 @@ TEST_CASE("ToOwnedLogValue copies string_view bytes and detaches from source sto
     CHECK(std::get<std::string>(owned) == "ephemeral");
 
     // Non-string values pass through unchanged.
-    LogValue intValue{int64_t{-7}};
+    const LogValue intValue{int64_t{-7}};
     LogValue intCopy = ToOwnedLogValue(intValue);
     REQUIRE(std::holds_alternative<int64_t>(intCopy));
     CHECK(std::get<int64_t>(intCopy) == -7);
 
-    LogValue monoCopy = ToOwnedLogValue(LogValue{std::monostate{}});
+    const LogValue monoCopy = ToOwnedLogValue(LogValue{std::monostate{}});
     CHECK(std::holds_alternative<std::monostate>(monoCopy));
 }
 
@@ -240,7 +238,7 @@ TEST_CASE("LogValueEquivalent treats string and string_view byte-equal as equiva
 // the same value regardless of which alternative the parser chose.
 TEST_CASE("LogLine fast and slow GetValue accessors agree under both string alternatives", "[log_line][helpers]")
 {
-    TestLogFile testLogFile;
+    const TestLogFile testLogFile;
     auto source = testLogFile.CreateFileLineSource();
 
     KeyIndex keys;
@@ -256,7 +254,7 @@ TEST_CASE("LogLine fast and slow GetValue accessors agree under both string alte
     sorted.emplace_back(ownedKey, LogValue{std::string{"owned-bytes"}});
     sorted.emplace_back(intKey, LogValue{int64_t{99}});
 
-    LogLine line(std::move(sorted), keys, *source, 0);
+    const LogLine line(std::move(sorted), keys, *source, 0);
 
     // Fast vs. slow path must round-trip the same alternative.
     const LogValue fastView = line.GetValue(viewKey);

--- a/test/lib/src/test_log_processing.cpp
+++ b/test/lib/src/test_log_processing.cpp
@@ -432,4 +432,5 @@ TEST_CASE("TimeStampToDateTimeString", "[log_processing]")
 
     const date::zoned_time futureLocalTime{tz, std::chrono::round<std::chrono::milliseconds>(futureDate)};
     const std::string expectedFutureDate = date::format("%F %T", futureLocalTime);
+    CHECK(futureFormatted == expectedFutureDate);
 }

--- a/test/lib/src/test_log_processing.cpp
+++ b/test/lib/src/test_log_processing.cpp
@@ -25,7 +25,7 @@ TEST_CASE("Initialize function should correctly set up timezone database with a 
 
 TEST_CASE("ParseTimestamps errors", "[log_processing]")
 {
-    TestLogFile testLogFile;
+    const TestLogFile testLogFile;
     auto source = testLogFile.CreateFileLineSource();
     FileLineSource *sourcePtr = source.get();
     KeyIndex testKeys;
@@ -57,7 +57,7 @@ TEST_CASE("ParseTimestamps errors", "[log_processing]")
 
 TEST_CASE("ParseTimestamps success for different formats", "[log_processing]")
 {
-    TestLogFile testLogFile;
+    const TestLogFile testLogFile;
     auto source = testLogFile.CreateFileLineSource();
     FileLineSource *sourcePtr = source.get();
     KeyIndex testKeys;
@@ -176,7 +176,7 @@ TEST_CASE("TryParseIsoTimestamp accepts valid inputs", "[log_processing][iso8601
     {
         TimeStamp out{};
         REQUIRE(TryParseIsoTimestamp("1969-12-31T23:00:00", 'T', out));
-        CHECK(out == TimeStamp{std::chrono::microseconds{-3600000000ll}});
+        CHECK(out == TimeStamp{std::chrono::microseconds{-3600000000LL}});
     }
 }
 
@@ -313,18 +313,18 @@ TEST_CASE("TimeStampToLocalMillisecondsSinceEpoch", "[log_processing]")
 
     // 2023-01-01 00:00:00 UTC.
     auto utcMicroseconds = date::sys_days{date::year{2023} / 1 / 1}.time_since_epoch();
-    TimeStamp timestamp = std::chrono::time_point<std::chrono::system_clock, std::chrono::microseconds>{
+    const TimeStamp timestamp = std::chrono::time_point<std::chrono::system_clock, std::chrono::microseconds>{
         std::chrono::duration_cast<std::chrono::microseconds>(utcMicroseconds)
     };
 
-    int64_t localMilliseconds = TimeStampToLocalMillisecondsSinceEpoch(timestamp);
+    const int64_t localMilliseconds = TimeStampToLocalMillisecondsSinceEpoch(timestamp);
 
-    static auto tz = date::current_zone();
+    static const auto *tz = date::current_zone();
     auto info = tz->get_info(timestamp);
-    int64_t expectedOffset = std::chrono::duration_cast<std::chrono::milliseconds>(info.offset).count();
+    const int64_t expectedOffset = std::chrono::duration_cast<std::chrono::milliseconds>(info.offset).count();
 
-    int64_t utcMilliseconds = std::chrono::duration_cast<std::chrono::milliseconds>(utcMicroseconds).count();
-    int64_t expectedMilliseconds = utcMilliseconds + expectedOffset;
+    const int64_t utcMilliseconds = std::chrono::duration_cast<std::chrono::milliseconds>(utcMicroseconds).count();
+    const int64_t expectedMilliseconds = utcMilliseconds + expectedOffset;
 
     CHECK(localMilliseconds == expectedMilliseconds);
 }
@@ -333,25 +333,25 @@ TEST_CASE("UtcMicrosecondsToLocalMilliseconds", "[log_processing]")
 {
     InitializeTimezoneData();
 
-    static auto tz = date::current_zone();
+    static const auto *tz = date::current_zone();
 
-    std::vector<int64_t> testMicroseconds = {
+    const std::vector<int64_t> testMicroseconds = {
         0,                   // Epoch start time
-        -3600ll * 1000000ll, // 1969-12-31 23:00:00 UTC
-        1672574400000000ll   // 2023-01-01 12:00:00 UTC
+        -3600LL * 1000000LL, // 1969-12-31 23:00:00 UTC
+        1672574400000000LL   // 2023-01-01 12:00:00 UTC
     };
 
     for (const auto &microseconds : testMicroseconds)
     {
-        std::chrono::time_point<std::chrono::system_clock, std::chrono::microseconds> testTime{
+        const std::chrono::time_point<std::chrono::system_clock, std::chrono::microseconds> testTime{
             std::chrono::microseconds{microseconds}
         };
         auto info = tz->get_info(testTime);
-        int64_t expectedOffset = std::chrono::duration_cast<std::chrono::milliseconds>(info.offset).count();
-        int64_t utcMilliseconds = microseconds / 1000;
-        int64_t expectedMilliseconds = utcMilliseconds + expectedOffset;
+        const int64_t expectedOffset = std::chrono::duration_cast<std::chrono::milliseconds>(info.offset).count();
+        const int64_t utcMilliseconds = microseconds / 1000;
+        const int64_t expectedMilliseconds = utcMilliseconds + expectedOffset;
 
-        int64_t result = UtcMicrosecondsToLocalMilliseconds(microseconds);
+        const int64_t result = UtcMicrosecondsToLocalMilliseconds(microseconds);
         CHECK(result == expectedMilliseconds);
     }
 }
@@ -360,7 +360,7 @@ TEST_CASE("LocalMillisecondsSinceEpochToTimeStamp", "[log_processing]")
 {
     InitializeTimezoneData();
 
-    std::vector<TimeStamp> testTimestamps = {
+    const std::vector<TimeStamp> testTimestamps = {
         std::chrono::time_point<std::chrono::system_clock, std::chrono::microseconds>{
             std::chrono::microseconds{1672574400000000} // 2023-01-01 12:00:00 UTC
         },
@@ -372,12 +372,12 @@ TEST_CASE("LocalMillisecondsSinceEpochToTimeStamp", "[log_processing]")
 
     for (const auto &originalTimestamp : testTimestamps)
     {
-        int64_t localMilliseconds = TimeStampToLocalMillisecondsSinceEpoch(originalTimestamp);
-        TimeStamp convertedTimestamp = LocalMillisecondsSinceEpochToTimeStamp(localMilliseconds);
+        const int64_t localMilliseconds = TimeStampToLocalMillisecondsSinceEpoch(originalTimestamp);
+        const TimeStamp convertedTimestamp = LocalMillisecondsSinceEpochToTimeStamp(localMilliseconds);
 
-        int64_t originalMs =
+        const int64_t originalMs =
             std::chrono::duration_cast<std::chrono::milliseconds>(originalTimestamp.time_since_epoch()).count();
-        int64_t convertedMs =
+        const int64_t convertedMs =
             std::chrono::duration_cast<std::chrono::milliseconds>(convertedTimestamp.time_since_epoch()).count();
 
         // Round-trip is millisecond-precision (the int64_t carrier).
@@ -390,15 +390,15 @@ TEST_CASE("UtcMicrosecondsToDateTimeString", "[log_processing]")
     InitializeTimezoneData();
 
     // 2023-05-15 10:30:45 UTC.
-    int64_t testMicroseconds = 1684146645000000;
+    const int64_t testMicroseconds = 1684146645000000;
 
     std::string formattedDate = UtcMicrosecondsToDateTimeString(testMicroseconds);
 
-    std::regex dateTimePattern(R"(\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}.000)");
+    const std::regex dateTimePattern(R"(\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}.000)");
     CHECK(std::regex_match(formattedDate, dateTimePattern));
 
-    static auto tz = date::current_zone();
-    std::chrono::time_point<std::chrono::system_clock, std::chrono::microseconds> utcTime{
+    static const auto *tz = date::current_zone();
+    const std::chrono::time_point<std::chrono::system_clock, std::chrono::microseconds> utcTime{
         std::chrono::microseconds{testMicroseconds}
     };
     const date::zoned_time localTime{tz, std::chrono::round<std::chrono::milliseconds>(utcTime)};
@@ -412,24 +412,24 @@ TEST_CASE("TimeStampToDateTimeString", "[log_processing]")
     InitializeTimezoneData();
 
     // 1900-01-01 00:00:00 UTC (~70y before Unix epoch).
-    TimeStamp pastDate{std::chrono::microseconds{-2208988800000000}};
+    const TimeStamp pastDate{std::chrono::microseconds{-2208988800000000}};
     std::string pastFormatted = TimeStampToDateTimeString(pastDate);
 
-    std::regex dateTimePattern(R"(\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}.000)");
+    const std::regex dateTimePattern(R"(\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}.000)");
     CHECK(std::regex_match(pastFormatted, dateTimePattern));
 
     // 2100-01-01 00:00:00 UTC (~130y after Unix epoch).
-    TimeStamp futureDate{std::chrono::microseconds{4102444800000000}};
-    std::string futureFormatted = TimeStampToDateTimeString(futureDate);
+    const TimeStamp futureDate{std::chrono::microseconds{4102444800000000}};
+    const std::string futureFormatted = TimeStampToDateTimeString(futureDate);
 
     CHECK(std::regex_match(futureFormatted, dateTimePattern));
 
-    static auto tz = date::current_zone();
+    static const auto *tz = date::current_zone();
 
     const date::zoned_time pastLocalTime{tz, std::chrono::round<std::chrono::milliseconds>(pastDate)};
     std::string expectedPastDate = date::format("%F %T", pastLocalTime);
     CHECK(pastFormatted == expectedPastDate);
 
     const date::zoned_time futureLocalTime{tz, std::chrono::round<std::chrono::milliseconds>(futureDate)};
-    std::string expectedFutureDate = date::format("%F %T", futureLocalTime);
+    const std::string expectedFutureDate = date::format("%F %T", futureLocalTime);
 }

--- a/test/lib/src/test_log_table.cpp
+++ b/test/lib/src/test_log_table.cpp
@@ -228,7 +228,7 @@ LogLine MakeLine(KeyIndex &keys, LineSource &source, const std::vector<std::pair
         sorted.emplace_back(keys.GetOrInsert(key), value);
     }
     std::ranges::sort(sorted, [](const auto &a, const auto &b) { return a.first < b.first; });
-    return LogLine(std::move(sorted), keys, source, 0);
+    return {std::move(sorted), keys, source, 0};
 }
 
 // Helper that snapshots a column → KeyId range from a given KeyIndex into a StreamedBatch::newKeys.
@@ -585,9 +585,13 @@ TEST_CASE(
     CHECK(table.GetHeader(1) == "timestamp");
 
     // The back-fill range covers exactly the new time column (index 1, inclusive on both ends).
-    REQUIRE(table.LastBackfillRange().has_value());
-    CHECK(table.LastBackfillRange()->first == 1);
-    CHECK(table.LastBackfillRange()->second == 1);
+    const auto backfill = table.LastBackfillRange();
+    REQUIRE(backfill.has_value());
+    if (backfill.has_value())
+    {
+        CHECK(backfill->first == 1);
+        CHECK(backfill->second == 1);
+    }
 
     // The third row's timestamp is now a parsed TimeStamp (the back-fill ran over all rows
     // including the just-appended one). Rows 0 and 1 stay monostate because they never
@@ -787,7 +791,7 @@ TEST_CASE(
     for (int batchIdx = 0; batchIdx < BATCHES; ++batchIdx)
     {
         StreamedBatch batch;
-        batch.firstLineNumber = static_cast<size_t>(batchIdx + 1);
+        batch.firstLineNumber = static_cast<size_t>(static_cast<size_t>(batchIdx) + 1u);
         batch.lines.push_back(MakeLine(keys, *sourcePtr, {{"k0", std::string("steady")}}));
         REQUIRE(batch.newKeys.empty());
         table.AppendBatch(std::move(batch));

--- a/test/lib/src/test_log_table.cpp
+++ b/test/lib/src/test_log_table.cpp
@@ -14,6 +14,7 @@
 
 #include <catch2/catch_all.hpp>
 
+#include <algorithm>
 #include <chrono>
 #include <utility>
 #include <vector>
@@ -23,7 +24,7 @@ using namespace loglib;
 TEST_CASE("Initialize a LogTable with given LogData and LogConfigurationManager", "[log_table]")
 {
     // Setup test data
-    TestLogFile testFile;
+    const TestLogFile testFile;
     testFile.Write("line1\nline2");
     auto source = testFile.CreateFileLineSource();
     FileLineSource *sourcePtr = source.get();
@@ -38,9 +39,21 @@ TEST_CASE("Initialize a LogTable with given LogData and LogConfigurationManager"
 
     // Create test configuration
     LogConfiguration logConfiguration;
-    logConfiguration.columns.push_back({"Header1", {"key1"}, "{}", LogConfiguration::Type::any, {}});
-    logConfiguration.columns.push_back({"Header2", {"key2"}, "{}", LogConfiguration::Type::any, {}});
-    TestLogConfiguration testLogConfiguration;
+    logConfiguration.columns.push_back(
+        {.header = "Header1",
+         .keys = {"key1"},
+         .printFormat = "{}",
+         .type = LogConfiguration::Type::any,
+         .parseFormats = {}}
+    );
+    logConfiguration.columns.push_back(
+        {.header = "Header2",
+         .keys = {"key2"},
+         .printFormat = "{}",
+         .type = LogConfiguration::Type::any,
+         .parseFormats = {}}
+    );
+    const TestLogConfiguration testLogConfiguration;
     testLogConfiguration.Write(logConfiguration);
     LogConfigurationManager manager;
     manager.Load(testLogConfiguration.GetFilePath());
@@ -71,8 +84,8 @@ TEST_CASE("Initialize a LogTable with given LogData and LogConfigurationManager"
 
 TEST_CASE("Update LogTable with new LogData", "[log_table]")
 {
-    TestLogFile testFile("log_file.json");
-    TestLogFile newTestFile("new_log_file.json");
+    const TestLogFile testFile("log_file.json");
+    const TestLogFile newTestFile("new_log_file.json");
 
     // Setup initial test data
     testFile.Write("file1\nfile2");
@@ -88,8 +101,14 @@ TEST_CASE("Update LogTable with new LogData", "[log_table]")
 
     // Create initial configuration
     LogConfiguration logConfiguration;
-    logConfiguration.columns.push_back({"Header1", {"key1"}, "{}", LogConfiguration::Type::any, {}});
-    TestLogConfiguration testLogConfiguration;
+    logConfiguration.columns.push_back(
+        {.header = "Header1",
+         .keys = {"key1"},
+         .printFormat = "{}",
+         .type = LogConfiguration::Type::any,
+         .parseFormats = {}}
+    );
+    const TestLogConfiguration testLogConfiguration;
     testLogConfiguration.Write(logConfiguration);
     LogConfigurationManager manager;
     manager.Load(testLogConfiguration.GetFilePath());
@@ -143,7 +162,7 @@ TEST_CASE("LogTable::Reset preserves the loaded LogConfiguration", "[log_table]"
 {
     // Regression: `Reset()` clears data but must keep the configuration
     // (otherwise `LoadConfiguration → File → Open` would lose column layout).
-    TestLogFile testFile;
+    const TestLogFile testFile;
     testFile.Write("line1\nline2");
     auto source = testFile.CreateFileLineSource();
     FileLineSource *sourcePtr = source.get();
@@ -155,8 +174,20 @@ TEST_CASE("LogTable::Reset preserves the loaded LogConfiguration", "[log_table]"
     LogData logData(std::move(source), std::move(testLines), std::move(testKeys));
 
     LogConfiguration logConfiguration;
-    logConfiguration.columns.push_back({"CustomA", {"key1"}, "{}", LogConfiguration::Type::any, {}});
-    logConfiguration.columns.push_back({"CustomB", {"key2"}, "{}", LogConfiguration::Type::any, {}});
+    logConfiguration.columns.push_back(
+        {.header = "CustomA",
+         .keys = {"key1"},
+         .printFormat = "{}",
+         .type = LogConfiguration::Type::any,
+         .parseFormats = {}}
+    );
+    logConfiguration.columns.push_back(
+        {.header = "CustomB",
+         .keys = {"key2"},
+         .printFormat = "{}",
+         .type = LogConfiguration::Type::any,
+         .parseFormats = {}}
+    );
     LogConfiguration::LogFilter filter;
     filter.type = LogConfiguration::LogFilter::Type::string;
     filter.row = 0;
@@ -164,7 +195,7 @@ TEST_CASE("LogTable::Reset preserves the loaded LogConfiguration", "[log_table]"
     filter.matchType = LogConfiguration::LogFilter::Match::contains;
     logConfiguration.filters.push_back(filter);
 
-    TestLogConfiguration testLogConfiguration;
+    const TestLogConfiguration testLogConfiguration;
     testLogConfiguration.Write(logConfiguration);
     LogConfigurationManager manager;
     manager.Load(testLogConfiguration.GetFilePath());
@@ -196,7 +227,7 @@ LogLine MakeLine(KeyIndex &keys, LineSource &source, const std::vector<std::pair
     {
         sorted.emplace_back(keys.GetOrInsert(key), value);
     }
-    std::sort(sorted.begin(), sorted.end(), [](const auto &a, const auto &b) { return a.first < b.first; });
+    std::ranges::sort(sorted, [](const auto &a, const auto &b) { return a.first < b.first; });
     return LogLine(std::move(sorted), keys, source, 0);
 }
 
@@ -222,7 +253,7 @@ StreamedBatch BuildStreamedBatch(
         batch.newKeys.reserve(currentKeyCount - prevKeyCount);
         for (size_t i = prevKeyCount; i < currentKeyCount; ++i)
         {
-            batch.newKeys.emplace_back(std::string(keys.KeyOf(static_cast<KeyId>(i))));
+            batch.newKeys.emplace_back(keys.KeyOf(static_cast<KeyId>(i)));
         }
     }
     return batch;
@@ -234,7 +265,7 @@ TEST_CASE(
     "LogTable::AppendBatch -- steady-state batches with no new keys do not extend columns", "[log_table][append_batch]"
 )
 {
-    TestLogFile testFile("steady.json");
+    const TestLogFile testFile("steady.json");
     testFile.Write("");
     auto source = std::make_unique<FileLineSource>(std::make_unique<LogFile>(testFile.GetFilePath()));
     FileLineSource *sourcePtr = source.get();
@@ -267,7 +298,7 @@ TEST_CASE(
 
 TEST_CASE("LogTable::AppendBatch -- new-key batches append columns at the end", "[log_table][append_batch]")
 {
-    TestLogFile testFile("append_columns.json");
+    const TestLogFile testFile("append_columns.json");
     testFile.Write("");
     auto source = std::make_unique<FileLineSource>(std::make_unique<LogFile>(testFile.GetFilePath()));
     FileLineSource *sourcePtr = source.get();
@@ -296,7 +327,7 @@ TEST_CASE("LogTable::AppendBatch -- new-key batches append columns at the end", 
 
 TEST_CASE("LogTable::AppendBatch -- empty-rows-only batches do not crash", "[log_table][append_batch]")
 {
-    TestLogFile testFile("empty_rows.json");
+    const TestLogFile testFile("empty_rows.json");
     testFile.Write("");
     auto source = std::make_unique<FileLineSource>(std::make_unique<LogFile>(testFile.GetFilePath()));
 
@@ -333,7 +364,7 @@ TEST_CASE("LogTable::AppendBatch -- empty-rows-only batches do not crash", "[log
 // invalidating any persistent `QModelIndex` held by the view.
 TEST_CASE("LogTable column to KeyId cache is append-only across Update and AppendBatch", "[log_table][append_only]")
 {
-    TestLogFile testFile("append_only.json");
+    const TestLogFile testFile("append_only.json");
     testFile.Write("");
     auto source = std::make_unique<FileLineSource>(std::make_unique<LogFile>(testFile.GetFilePath()));
     FileLineSource *sourcePtr = source.get();
@@ -425,9 +456,9 @@ TEST_CASE("LogTable column to KeyId cache is append-only across Update and Appen
 // Avoids timestamp keys so the auto-promotion reorder stays out of scope.
 TEST_CASE("LogTable::Update is append-only for non-timestamp keys", "[log_table][append_only]")
 {
-    TestLogFile fileA("log_file_initial.json");
-    TestLogFile fileB("log_file_second.json");
-    TestLogFile fileC("log_file_third.json");
+    const TestLogFile fileA("log_file_initial.json");
+    const TestLogFile fileB("log_file_second.json");
+    const TestLogFile fileC("log_file_third.json");
 
     fileA.Write("a1\n");
     auto sourceA = fileA.CreateFileLineSource();
@@ -440,9 +471,21 @@ TEST_CASE("LogTable::Update is append-only for non-timestamp keys", "[log_table]
     LogData dataA(std::move(sourceA), std::move(linesA), std::move(keysA));
 
     LogConfiguration cfg;
-    cfg.columns.push_back({"alpha", {"alpha"}, "{}", LogConfiguration::Type::any, {}});
-    cfg.columns.push_back({"beta", {"beta"}, "{}", LogConfiguration::Type::any, {}});
-    TestLogConfiguration cfgFile;
+    cfg.columns.push_back(
+        {.header = "alpha",
+         .keys = {"alpha"},
+         .printFormat = "{}",
+         .type = LogConfiguration::Type::any,
+         .parseFormats = {}}
+    );
+    cfg.columns.push_back(
+        {.header = "beta",
+         .keys = {"beta"},
+         .printFormat = "{}",
+         .type = LogConfiguration::Type::any,
+         .parseFormats = {}}
+    );
+    const TestLogConfiguration cfgFile;
     cfgFile.Write(cfg);
     LogConfigurationManager mgr;
     mgr.Load(cfgFile.GetFilePath());
@@ -497,7 +540,7 @@ TEST_CASE(
 {
     InitializeTimezoneData();
 
-    TestLogFile testFile("backfill.json");
+    const TestLogFile testFile("backfill.json");
     testFile.Write("");
     auto source = std::make_unique<FileLineSource>(std::make_unique<LogFile>(testFile.GetFilePath()));
     FileLineSource *sourcePtr = source.get();
@@ -600,16 +643,23 @@ TEST_CASE(
 {
     InitializeTimezoneData();
 
-    TestLogFile testFile("snapshot_time_keys.json");
+    const TestLogFile testFile("snapshot_time_keys.json");
     testFile.Write("");
     auto source = std::make_unique<FileLineSource>(std::make_unique<LogFile>(testFile.GetFilePath()));
     FileLineSource *sourcePtr = source.get();
 
     LogConfiguration cfg;
-    cfg.columns.push_back({"timestamp", {"timestamp"}, "%F %H:%M:%S", LogConfiguration::Type::time, {"%FT%T", "%F %T"}}
+    cfg.columns.push_back(
+        {.header = "timestamp",
+         .keys = {"timestamp"},
+         .printFormat = "%F %H:%M:%S",
+         .type = LogConfiguration::Type::time,
+         .parseFormats = {"%FT%T", "%F %T"}}
     );
-    cfg.columns.push_back({"msg", {"msg"}, "{}", LogConfiguration::Type::any, {}});
-    TestLogConfiguration cfgFile;
+    cfg.columns.push_back(
+        {.header = "msg", .keys = {"msg"}, .printFormat = "{}", .type = LogConfiguration::Type::any, .parseFormats = {}}
+    );
+    const TestLogConfiguration cfgFile;
     cfgFile.Write(cfg);
     LogConfigurationManager mgr;
     mgr.Load(cfgFile.GetFilePath());
@@ -692,7 +742,7 @@ TEST_CASE(
     constexpr int KEY_COUNT = 100;
     constexpr int BATCHES = 1'000;
 
-    TestLogFile testFile("refresh_no_alloc.json");
+    const TestLogFile testFile("refresh_no_alloc.json");
     testFile.Write("");
     auto source = std::make_unique<FileLineSource>(std::make_unique<LogFile>(testFile.GetFilePath()));
     FileLineSource *sourcePtr = source.get();
@@ -711,7 +761,7 @@ TEST_CASE(
     }
     cfg.columns.push_back(std::move(wide));
 
-    TestLogConfiguration cfgFile;
+    const TestLogConfiguration cfgFile;
     cfgFile.Write(cfg);
     LogConfigurationManager mgr;
     mgr.Load(cfgFile.GetFilePath());
@@ -776,7 +826,7 @@ TEST_CASE(
 {
     constexpr int UNTOUCHED_KEY_COUNT = 50;
 
-    TestLogFile testFile("refresh_no_alloc_incremental.json");
+    const TestLogFile testFile("refresh_no_alloc_incremental.json");
     testFile.Write("");
     auto source = std::make_unique<FileLineSource>(std::make_unique<LogFile>(testFile.GetFilePath()));
     FileLineSource *sourcePtr = source.get();
@@ -801,7 +851,7 @@ TEST_CASE(
     }
     cfg.columns.push_back(std::move(untouched));
 
-    TestLogConfiguration cfgFile;
+    const TestLogConfiguration cfgFile;
     cfgFile.Write(cfg);
     LogConfigurationManager mgr;
     mgr.Load(cfgFile.GetFilePath());
@@ -866,7 +916,7 @@ StreamedBatch MakeStreamBatch(
     batch.firstLineNumber = firstLineId;
     if (declareNewKey)
     {
-        batch.newKeys.emplace_back(std::string("value"));
+        batch.newKeys.emplace_back("value");
     }
     batch.lines.reserve(count);
     for (size_t i = 0; i < count; ++i)
@@ -936,8 +986,8 @@ TEST_CASE("LogTable::EvictPrefixRows trims oldest stream rows in source order", 
     // the last is `TOTAL_LINES = 5000`.
     const auto firstValue = std::get<int64_t>(table.GetValue(0, 0));
     const auto lastValue = std::get<int64_t>(table.GetValue(CAP - 1, 0));
-    CHECK(firstValue == static_cast<int64_t>(TOTAL_LINES - CAP + 1));
-    CHECK(lastValue == static_cast<int64_t>(TOTAL_LINES));
+    CHECK(std::cmp_equal(firstValue, TOTAL_LINES - CAP + 1));
+    CHECK(std::cmp_equal(lastValue, TOTAL_LINES));
 }
 
 TEST_CASE("LogTable::EvictPrefixRows handles a giant single-batch overflow", "[log_table][retention]")
@@ -968,8 +1018,8 @@ TEST_CASE("LogTable::EvictPrefixRows handles a giant single-batch overflow", "[l
     table.AppendBatch(MakeStreamBatch(streamSourceRef, keys, valueKey, headDrop + 1, CAP, /*declareNewKey=*/true));
 
     REQUIRE(table.RowCount() == CAP);
-    CHECK(std::get<int64_t>(table.GetValue(0, 0)) == static_cast<int64_t>(headDrop + 1));
-    CHECK(std::get<int64_t>(table.GetValue(CAP - 1, 0)) == static_cast<int64_t>(GIANT_BATCH));
+    CHECK(std::cmp_equal(std::get<int64_t>(table.GetValue(0, 0)), headDrop + 1));
+    CHECK(std::cmp_equal(std::get<int64_t>(table.GetValue(CAP - 1, 0)), GIANT_BATCH));
 }
 
 TEST_CASE(
@@ -1020,9 +1070,9 @@ TEST_CASE(
     // `std::filesystem::remove` (throwing variant); on Windows you cannot
     // delete an mmap'd file, so they must outlive the table that holds
     // the mmap.
-    TestLogFile fileA("multifile_a.json");
+    const TestLogFile fileA("multifile_a.json");
     fileA.Write("alpha\nbeta\n");
-    TestLogFile fileB("multifile_b.json");
+    const TestLogFile fileB("multifile_b.json");
     fileB.Write("gamma\ndelta\n");
 
     auto sourceA = std::make_unique<FileLineSource>(std::make_unique<LogFile>(fileA.GetFilePath()));

--- a/test/lib/src/test_log_table.cpp
+++ b/test/lib/src/test_log_table.cpp
@@ -384,14 +384,14 @@ TEST_CASE("LogTable column to KeyId cache is append-only across Update and Appen
         for (size_t i = 0; i < pinnedHeaders.size(); ++i)
         {
             REQUIRE(t.ColumnCount() > i);
-            CHECK(t.GetHeader(static_cast<int>(i)) == pinnedHeaders[i]);
+            CHECK(t.GetHeader(i) == pinnedHeaders[i]);
         }
         pinnedHeaders.clear();
         const size_t total = t.ColumnCount();
         pinnedHeaders.reserve(total);
         for (size_t i = 0; i < total; ++i)
         {
-            pinnedHeaders.emplace_back(t.GetHeader(static_cast<int>(i)));
+            pinnedHeaders.emplace_back(t.GetHeader(i));
         }
     };
 

--- a/test/lib/src/test_parser_pipeline.cpp
+++ b/test/lib/src/test_parser_pipeline.cpp
@@ -18,6 +18,7 @@
 #include <algorithm>
 #include <chrono>
 #include <cstring>
+#include <filesystem>
 #include <fstream>
 #include <memory>
 #include <string>
@@ -223,18 +224,25 @@ class TempTextFile
 {
 public:
     explicit TempTextFile(const std::string &content, std::string filePath = "test_kv.log")
-        : mFilePath(std::move(filePath))
+        : mFilePath(std::move(filePath)), mFsPath(mFilePath)
     {
-        std::ofstream file(mFilePath, std::ios::binary);
+        std::ofstream file(mFsPath, std::ios::binary);
         REQUIRE(file.is_open());
         file.write(content.data(), static_cast<std::streamsize>(content.size()));
     }
 
+    // NOLINTNEXTLINE(bugprone-exception-escape): MSVC may model throwing paths through STL; teardown ignores errors via
+    // `error_code`.
     ~TempTextFile() noexcept
     {
         std::error_code ec;
-        std::filesystem::remove(mFilePath, ec);
+        std::filesystem::remove(mFsPath, ec);
     }
+
+    TempTextFile(const TempTextFile &) = delete;
+    TempTextFile &operator=(const TempTextFile &) = delete;
+    TempTextFile(TempTextFile &&) = delete;
+    TempTextFile &operator=(TempTextFile &&) = delete;
 
     const std::string &Path() const
     {
@@ -243,6 +251,7 @@ public:
 
 private:
     std::string mFilePath;
+    std::filesystem::path mFsPath;
 };
 
 /// Test sink: gathers every batch the harness emits so cases can assert on the
@@ -474,8 +483,8 @@ TEST_CASE("Mock parser: per-line errors propagate through StreamedBatch::errors"
     }
     REQUIRE(totalLines == 2);
     REQUIRE(allErrors.size() == 2);
-    REQUIRE(allErrors[0].find("Error on line 2") != std::string::npos);
-    REQUIRE(allErrors[1].find("Error on line 4") != std::string::npos);
+    REQUIRE(allErrors[0].contains("Error on line 2"));
+    REQUIRE(allErrors[1].contains("Error on line 4"));
 }
 
 // Regression: when errors land past the first Stage A batch, Stage C must
@@ -531,7 +540,7 @@ TEST_CASE(
     {
         const std::string expected = "Error on line " + std::to_string(expectedErrorLines[i]);
         INFO("error #" << i << " text: " << allErrors[i] << ", expected to start with: " << expected);
-        CHECK(allErrors[i].find(expected) != std::string::npos);
+        CHECK(allErrors[i].contains(expected));
     }
 }
 

--- a/test/lib/src/test_parser_pipeline.cpp
+++ b/test/lib/src/test_parser_pipeline.cpp
@@ -16,7 +16,6 @@
 #include <catch2/catch_all.hpp>
 
 #include <algorithm>
-#include <atomic>
 #include <chrono>
 #include <cstring>
 #include <fstream>
@@ -56,12 +55,12 @@ public:
     {
     };
 
-    void ParseStreaming(
+    static void ParseStreaming(
         FileLineSource &source,
         LogParseSink &sink,
         const loglib::ParserOptions &options,
         const loglib::internal::AdvancedParserOptions &advanced
-    ) const
+    )
     {
         FileLineSource *sourcePtr = &source;
         LogFile &file = source.File();
@@ -81,7 +80,7 @@ public:
             // Size-bounded advance: `cursor + batchBytes` is UB if it lands
             // more than one past `fileEnd`, which the default batch size
             // hits on every sub-batchSize file's final batch.
-            const size_t remaining = static_cast<size_t>(fileEnd - cursor);
+            const auto remaining = static_cast<size_t>(fileEnd - cursor);
             const size_t advance = std::min(batchBytes, remaining);
             const char *target = cursor + advance;
             if (advance < remaining)
@@ -137,9 +136,9 @@ public:
 
                 if (line.front() == '!')
                 {
-                    parsed.errors.push_back(
-                        loglib::internal::ParsedLineError{relativeLineNumber, "injected parser failure"}
-                    );
+                    parsed.errors.push_back(loglib::internal::ParsedLineError{
+                        .relativeLine = relativeLineNumber, .body = "injected parser failure"
+                    });
                     ++relativeLineNumber;
                     continue;
                 }
@@ -162,14 +161,14 @@ public:
                     {
                         ++pos;
                     }
-                    std::string_view field = line.substr(fieldStart, pos - fieldStart);
+                    const std::string_view field = line.substr(fieldStart, pos - fieldStart);
                     const size_t eq = field.find('=');
                     if (eq == std::string_view::npos)
                     {
                         continue;
                     }
-                    std::string_view keyView = field.substr(0, eq);
-                    std::string_view valueView = field.substr(eq + 1);
+                    const std::string_view keyView = field.substr(0, eq);
+                    const std::string_view valueView = field.substr(eq + 1);
 
                     const loglib::KeyId keyId = loglib::internal::InternKeyVia(keyView, keys, &worker.keyCache);
 
@@ -296,16 +295,15 @@ std::string GenerateRecords(size_t count)
 // goes through the `advance == remaining` branch.
 TEST_CASE("Mock parser: single sub-batchSize file does not overshoot fileEnd", "[mock_parser]")
 {
-    TempTextFile fixture("level=info msg=tiny\n", "test_kv_tiny.log");
-    loglib::ParserOptions options;
+    const TempTextFile fixture("level=info msg=tiny\n", "test_kv_tiny.log");
+    const loglib::ParserOptions options;
     loglib::internal::AdvancedParserOptions advanced;
     advanced.threads = 1;
     advanced.batchSizeBytes = 4 * 1024 * 1024; // larger than the file
 
     CollectingSink sink;
-    KeyValueLineParser parser;
     FileLineSource source(std::make_unique<LogFile>(fixture.Path()));
-    parser.ParseStreaming(source, sink, options, advanced);
+    KeyValueLineParser::ParseStreaming(source, sink, options, advanced);
 
     REQUIRE(sink.startedCount == 1);
     REQUIRE(sink.finishedCount == 1);
@@ -322,15 +320,14 @@ TEST_CASE("Mock parser: empty and early-stopped parses still emit one OnBatch", 
 {
     SECTION("Empty file")
     {
-        TempTextFile fixture(std::string{}, "test_kv_empty.log");
-        loglib::ParserOptions options;
+        const TempTextFile fixture(std::string{}, "test_kv_empty.log");
+        const loglib::ParserOptions options;
         loglib::internal::AdvancedParserOptions advanced;
         advanced.threads = 1;
 
         CollectingSink sink;
-        KeyValueLineParser parser;
         FileLineSource source(std::make_unique<LogFile>(fixture.Path()));
-        parser.ParseStreaming(source, sink, options, advanced);
+        KeyValueLineParser::ParseStreaming(source, sink, options, advanced);
 
         CHECK(sink.startedCount == 1);
         CHECK(sink.finishedCount == 1);
@@ -342,7 +339,7 @@ TEST_CASE("Mock parser: empty and early-stopped parses still emit one OnBatch", 
 
     SECTION("Stop requested before parse starts")
     {
-        TempTextFile fixture("level=info msg=hi\n", "test_kv_stop_before.log");
+        const TempTextFile fixture("level=info msg=hi\n", "test_kv_stop_before.log");
         loglib::StopSource stopSource;
         stopSource.request_stop();
         loglib::ParserOptions options;
@@ -351,9 +348,8 @@ TEST_CASE("Mock parser: empty and early-stopped parses still emit one OnBatch", 
         advanced.threads = 1;
 
         CollectingSink sink;
-        KeyValueLineParser parser;
         FileLineSource source(std::make_unique<LogFile>(fixture.Path()));
-        parser.ParseStreaming(source, sink, options, advanced);
+        KeyValueLineParser::ParseStreaming(source, sink, options, advanced);
 
         CHECK(sink.startedCount == 1);
         CHECK(sink.finishedCount == 1);
@@ -382,19 +378,18 @@ TEST_CASE("Mock parser: firstLineNumber matches the first line in the batch", "[
         content += "level=info index=" + std::to_string(i) + "\n";
     }
 
-    TempTextFile fixture(content, "test_kv_empty_primed.log");
-    loglib::ParserOptions options;
+    const TempTextFile fixture(content, "test_kv_empty_primed.log");
+    const loglib::ParserOptions options;
     loglib::internal::AdvancedParserOptions advanced;
     advanced.threads = 1;
     advanced.batchSizeBytes = errorBlockBytes - 1;
 
     CollectingSink sink;
-    KeyValueLineParser parser;
     FileLineSource source(std::make_unique<LogFile>(fixture.Path()));
-    parser.ParseStreaming(source, sink, options, advanced);
+    KeyValueLineParser::ParseStreaming(source, sink, options, advanced);
 
     REQUIRE_FALSE(sink.cancelled);
-    REQUIRE(sink.batches.size() >= 1);
+    REQUIRE(!sink.batches.empty());
     for (const auto &b : sink.batches)
     {
         if (!b.lines.empty())
@@ -412,21 +407,20 @@ TEST_CASE("Mock parser: firstLineNumber matches the first line in the batch", "[
 TEST_CASE("Mock parser: multi-batch parse emits LogLines and newKeys", "[mock_parser]")
 {
     constexpr size_t RECORD_COUNT = 5'000;
-    TempTextFile fixture(GenerateRecords(RECORD_COUNT));
-    loglib::ParserOptions options;
+    const TempTextFile fixture(GenerateRecords(RECORD_COUNT));
+    const loglib::ParserOptions options;
     loglib::internal::AdvancedParserOptions advanced;
     advanced.batchSizeBytes = 8 * 1024;
     advanced.threads = 2;
 
     CollectingSink sink;
-    KeyValueLineParser parser;
     FileLineSource source(std::make_unique<LogFile>(fixture.Path()));
-    parser.ParseStreaming(source, sink, options, advanced);
+    KeyValueLineParser::ParseStreaming(source, sink, options, advanced);
 
     REQUIRE(sink.startedCount == 1);
     REQUIRE(sink.finishedCount == 1);
     REQUIRE_FALSE(sink.cancelled);
-    REQUIRE(sink.batches.size() >= 1);
+    REQUIRE(!sink.batches.empty());
 
     size_t totalLines = 0;
     std::vector<std::string> allNewKeys;
@@ -440,7 +434,7 @@ TEST_CASE("Mock parser: multi-batch parse emits LogLines and newKeys", "[mock_pa
     }
     REQUIRE(totalLines == RECORD_COUNT);
 
-    std::sort(allNewKeys.begin(), allNewKeys.end());
+    std::ranges::sort(allNewKeys);
     REQUIRE(allNewKeys == std::vector<std::string>{"index", "level", "msg"});
 
     LogValue lastIndex = sink.batches.back().lines.back().GetValue("index");
@@ -455,16 +449,15 @@ TEST_CASE("Mock parser: per-line errors propagate through StreamedBatch::errors"
     content += "level=warn msg=ok2\n";
     content += "!second_error\n";
 
-    TempTextFile fixture(content);
-    loglib::ParserOptions options;
+    const TempTextFile fixture(content);
+    const loglib::ParserOptions options;
     loglib::internal::AdvancedParserOptions advanced;
     advanced.threads = 1;
     advanced.batchSizeBytes = 1024 * 1024;
 
     CollectingSink sink;
-    KeyValueLineParser parser;
     FileLineSource source(std::make_unique<LogFile>(fixture.Path()));
-    parser.ParseStreaming(source, sink, options, advanced);
+    KeyValueLineParser::ParseStreaming(source, sink, options, advanced);
 
     REQUIRE_FALSE(sink.cancelled);
 
@@ -511,19 +504,18 @@ TEST_CASE(
         }
     }
 
-    TempTextFile fixture(content, "test_kv_multi_batch_errors.log");
-    loglib::ParserOptions options;
+    const TempTextFile fixture(content, "test_kv_multi_batch_errors.log");
+    const loglib::ParserOptions options;
     loglib::internal::AdvancedParserOptions advanced;
     advanced.threads = 1;
     advanced.batchSizeBytes = 4 * 1024;
 
     CollectingSink sink;
-    KeyValueLineParser parser;
     FileLineSource source(std::make_unique<LogFile>(fixture.Path()));
-    parser.ParseStreaming(source, sink, options, advanced);
+    KeyValueLineParser::ParseStreaming(source, sink, options, advanced);
 
     REQUIRE_FALSE(sink.cancelled);
-    REQUIRE(sink.batches.size() >= 1);
+    REQUIRE(!sink.batches.empty());
 
     std::vector<std::string> allErrors;
     for (const auto &b : sink.batches)
@@ -545,7 +537,7 @@ TEST_CASE(
 TEST_CASE("Mock parser: cancellation latency bounded by ntokens x batch size", "[mock_parser][cancellation]")
 {
     constexpr size_t RECORD_COUNT = 200'000;
-    TempTextFile fixture(GenerateRecords(RECORD_COUNT));
+    const TempTextFile fixture(GenerateRecords(RECORD_COUNT));
     constexpr size_t BATCH_BYTES = 64 * 1024;
     constexpr unsigned int THREADS = 4;
 
@@ -557,8 +549,8 @@ TEST_CASE("Mock parser: cancellation latency bounded by ntokens x batch size", "
     struct CancellingSink : CollectingSink
     {
         loglib::StopSource stop;
-        std::chrono::steady_clock::time_point requestedAt{};
-        std::chrono::steady_clock::time_point finishedAt{};
+        std::chrono::steady_clock::time_point requestedAt;
+        std::chrono::steady_clock::time_point finishedAt;
         size_t batchCount = 0;
 
         void OnBatch(StreamedBatch batch) override
@@ -581,9 +573,8 @@ TEST_CASE("Mock parser: cancellation latency bounded by ntokens x batch size", "
     CancellingSink sink;
     options.stopToken = sink.stop.get_token();
 
-    KeyValueLineParser parser;
     FileLineSource source(std::make_unique<LogFile>(fixture.Path()));
-    parser.ParseStreaming(source, sink, options, advanced);
+    KeyValueLineParser::ParseStreaming(source, sink, options, advanced);
 
     REQUIRE(sink.cancelled);
     const auto latency = sink.finishedAt - sink.requestedAt;
@@ -608,7 +599,7 @@ TEST_CASE("Mock parser: timestamp promotion via shared post-decoding hook", "[mo
     content += "ts=2024-01-15T10:00:00Z level=info msg=first\n";
     content += "ts=2024-01-15T10:00:01Z level=info msg=second\n";
     content += "ts=2024-01-15T10:00:02Z level=warn msg=third\n";
-    TempTextFile fixture(content);
+    const TempTextFile fixture(content);
     auto configuration = std::make_shared<LogConfiguration>();
     LogConfiguration::Column timeColumn;
     timeColumn.header = "Timestamp";
@@ -623,9 +614,8 @@ TEST_CASE("Mock parser: timestamp promotion via shared post-decoding hook", "[mo
     advanced.threads = 1;
 
     CollectingSink sink;
-    KeyValueLineParser parser;
     FileLineSource source(std::make_unique<LogFile>(fixture.Path()));
-    parser.ParseStreaming(source, sink, options, advanced);
+    KeyValueLineParser::ParseStreaming(source, sink, options, advanced);
 
     size_t promoted = 0;
     size_t totalLines = 0;

--- a/test/lib/src/test_parser_pipeline.cpp
+++ b/test/lib/src/test_parser_pipeline.cpp
@@ -230,9 +230,10 @@ public:
         file.write(content.data(), static_cast<std::streamsize>(content.size()));
     }
 
-    ~TempTextFile()
+    ~TempTextFile() noexcept
     {
-        std::filesystem::remove(mFilePath);
+        std::error_code ec;
+        std::filesystem::remove(mFilePath, ec);
     }
 
     const std::string &Path() const

--- a/test/lib/src/test_stream_line_source.cpp
+++ b/test/lib/src/test_stream_line_source.cpp
@@ -213,7 +213,7 @@ TEST_CASE("StreamLineSource: Producer() returns the underlying BytesProducer", "
 
     // Round-trip a couple of producer methods through the source to
     // confirm the wiring is live (real parser code would use this seam).
-    std::span<char> buffer;
+    const std::span<char> buffer;
     CHECK(source.Producer()->Read(buffer) == 0);
     CHECK(raw->mReadCalls == 1);
 }

--- a/test/lib/src/test_stream_stop_teardown.cpp
+++ b/test/lib/src/test_stream_stop_teardown.cpp
@@ -130,7 +130,7 @@ TailingBytesProducer::Options TestOptions()
 // covers Stop() -> request_stop() -> thread join -> OnFinished.
 TEST_CASE("Stream Stop teardown unblocks a worker parked in WaitForBytes within 500 ms", "[stream_stop_teardown]")
 {
-    TempDir dir;
+    const TempDir dir;
     const auto path = dir.File("idle.log");
     // Start with one line so the parser drains pre-fill, then parks.
     Append(path, "{\"a\":1}\n");
@@ -172,7 +172,7 @@ TEST_CASE("Stream Stop teardown unblocks a worker parked in WaitForBytes within 
 // boundary, so worst case is one line decode plus Stop-then-join.
 TEST_CASE("Stream Stop teardown stops a mid-decode worker within 500 ms", "[stream_stop_teardown]")
 {
-    TempDir dir;
+    const TempDir dir;
     const auto path = dir.File("buffered.log");
 
     // ~100 KiB buffered batch: 1500 lines x ~70 bytes each.
@@ -182,7 +182,7 @@ TEST_CASE("Stream Stop teardown stops a mid-decode worker within 500 ms", "[stre
         blob.reserve(100 * 1024);
         for (int i = 0; i < LINE_COUNT; ++i)
         {
-            blob += "{\"i\":" + std::to_string(i) + ",\"msg\":\"line ";
+            blob += "{\"i\":" + std::to_string(i) + R"(,"msg":"line )";
             blob += std::to_string(i);
             blob += " padding padding padding\"}\n";
         }

--- a/test/lib/src/test_stream_stop_teardown.cpp
+++ b/test/lib/src/test_stream_stop_teardown.cpp
@@ -57,7 +57,7 @@ public:
         std::filesystem::create_directories(mPath);
     }
 
-    ~TempDir()
+    ~TempDir() noexcept
     {
         std::error_code ec;
         std::filesystem::remove_all(mPath, ec);

--- a/test/lib/src/test_stream_stop_teardown.cpp
+++ b/test/lib/src/test_stream_stop_teardown.cpp
@@ -57,6 +57,8 @@ public:
         std::filesystem::create_directories(mPath);
     }
 
+    // NOLINTNEXTLINE(bugprone-exception-escape): MSVC may model throwing paths through STL `remove_all`; teardown
+    // ignores errors via `error_code`.
     ~TempDir() noexcept
     {
         std::error_code ec;

--- a/test/lib/src/test_tailing_bytes_producer.cpp
+++ b/test/lib/src/test_tailing_bytes_producer.cpp
@@ -358,7 +358,7 @@ TEST_CASE("TailingBytesProducer detects growth across many small writes", "[Tail
 
     const auto lines = SplitLines(drained);
     REQUIRE(lines.size() >= static_cast<size_t>(COUNT));
-    for (int i = 0; i < COUNT; ++i)
+    for (size_t i = 0; i < static_cast<size_t>(COUNT); ++i)
     {
         CHECK(lines[i] == "g" + std::to_string(i));
     }

--- a/test/lib/src/test_tailing_bytes_producer.cpp
+++ b/test/lib/src/test_tailing_bytes_producer.cpp
@@ -40,6 +40,8 @@ public:
         std::filesystem::create_directories(mPath);
     }
 
+    // NOLINTNEXTLINE(bugprone-exception-escape): MSVC may model throwing paths through STL `remove_all`; teardown
+    // ignores errors via `error_code`.
     ~TempDir() noexcept
     {
         std::error_code ec;

--- a/test/lib/src/test_tailing_bytes_producer.cpp
+++ b/test/lib/src/test_tailing_bytes_producer.cpp
@@ -327,9 +327,9 @@ TEST_CASE(
     Append(path, "\nafter\n");
     const auto post =
         DrainUntil(source, ScaledMs(2000ms), [](const std::string &acc) { return acc.contains("after\n"); });
-    CHECK(post.find("after\n") != std::string::npos);
+    CHECK(post.contains("after\n"));
     // The 2 MiB "xxx…" prefix must NOT have been synthesized into a line.
-    CHECK(post.find("xxxxx") == std::string::npos);
+    CHECK(!post.contains("xxxxx"));
 }
 
 TEST_CASE("TailingBytesProducer detects growth across many small writes", "[TailingBytesProducer]")
@@ -518,7 +518,7 @@ TEST_CASE("TailingBytesProducer discards partial line on rotation", "[TailingByt
     REQUIRE(!postLines.empty());
     CHECK(postLines.back() == "after");
     // The partial "incomplete" must NEVER appear.
-    CHECK(post.find("incomplete") == std::string::npos);
+    CHECK(!post.contains("incomplete"));
 }
 
 TEST_CASE("TailingBytesProducer flushes the partial line on Stop", "[TailingBytesProducer]")

--- a/test/lib/src/test_tailing_bytes_producer.cpp
+++ b/test/lib/src/test_tailing_bytes_producer.cpp
@@ -191,7 +191,7 @@ TailingBytesProducer::Options FastPollOptions()
 
 TEST_CASE("TailingBytesProducer pre-fill of last N complete lines on a small file", "[TailingBytesProducer]")
 {
-    TempDir dir;
+    const TempDir dir;
     const auto path = dir.File("preset_lines.log");
 
     std::string content;
@@ -227,7 +227,7 @@ TEST_CASE("TailingBytesProducer pre-fill of last N complete lines on a small fil
 
 TEST_CASE("TailingBytesProducer pre-fill on a file shorter than N", "[TailingBytesProducer]")
 {
-    TempDir dir;
+    const TempDir dir;
     const auto path = dir.File("short.log");
     Overwrite(path, "a\nb\nc\n");
 
@@ -251,7 +251,7 @@ TEST_CASE("TailingBytesProducer pre-fill on a file shorter than N", "[TailingByt
 // pre-fill bytes land — exposing a missing notify.
 TEST_CASE("TailingBytesProducer Prefill notifies WaitForBytes immediately", "[TailingBytesProducer]")
 {
-    TempDir dir;
+    const TempDir dir;
     const auto path = dir.File("notify_prefill.log");
 
     // ~500 KiB across 5 000 ~100-byte lines. With 512-byte backwards
@@ -298,7 +298,7 @@ TEST_CASE(
     // 2 MiB file with no newlines and a 128 KiB scan budget must not
     // wedge the ctor: pre-fill aborts, yields zero lines, seeks to
     // EOF, and future appends still appear in the tail.
-    TempDir dir;
+    const TempDir dir;
     const auto path = dir.File("huge_line.log");
     {
         std::ofstream out(path, std::ios::binary);
@@ -325,9 +325,8 @@ TEST_CASE(
 
     // Tailing still works: appending a complete line produces it.
     Append(path, "\nafter\n");
-    const auto post = DrainUntil(source, ScaledMs(2000ms), [](const std::string &acc) {
-        return acc.find("after\n") != std::string::npos;
-    });
+    const auto post =
+        DrainUntil(source, ScaledMs(2000ms), [](const std::string &acc) { return acc.contains("after\n"); });
     CHECK(post.find("after\n") != std::string::npos);
     // The 2 MiB "xxx…" prefix must NOT have been synthesized into a line.
     CHECK(post.find("xxxxx") == std::string::npos);
@@ -335,7 +334,7 @@ TEST_CASE(
 
 TEST_CASE("TailingBytesProducer detects growth across many small writes", "[TailingBytesProducer]")
 {
-    TempDir dir;
+    const TempDir dir;
     const auto path = dir.File("growth.log");
     Overwrite(path, ""); // start empty
 
@@ -365,7 +364,7 @@ TEST_CASE("TailingBytesProducer detects growth across many small writes", "[Tail
 
 TEST_CASE("TailingBytesProducer recovers from rename-and-create rotation", "[TailingBytesProducer][rotation]")
 {
-    TempDir dir;
+    const TempDir dir;
     const auto path = dir.File("rotate.log");
     const auto rotatedPath = dir.File("rotate.log.1");
     Overwrite(path, "pre1\npre2\n");
@@ -400,7 +399,7 @@ TEST_CASE("TailingBytesProducer recovers from rename-and-create rotation", "[Tai
 
 TEST_CASE("TailingBytesProducer recovers from copytruncate rotation", "[TailingBytesProducer][rotation]")
 {
-    TempDir dir;
+    const TempDir dir;
     const auto path = dir.File("copytrunc.log");
     Overwrite(path, "old1\nold2\nold3\n");
 
@@ -431,7 +430,7 @@ TEST_CASE("TailingBytesProducer recovers from copytruncate rotation", "[TailingB
 
 TEST_CASE("TailingBytesProducer recovers from in-place truncate", "[TailingBytesProducer][rotation]")
 {
-    TempDir dir;
+    const TempDir dir;
     const auto path = dir.File("inplace_trunc.log");
     Overwrite(path, "x1\nx2\nx3\n");
 
@@ -450,7 +449,7 @@ TEST_CASE("TailingBytesProducer recovers from in-place truncate", "[TailingBytes
         return std::count(acc.begin(), acc.end(), '\n') >= 1;
     });
     const auto postLines = SplitLines(post);
-    REQUIRE(postLines.size() >= 1);
+    REQUIRE(!postLines.empty());
     CHECK(postLines[0] == "y1");
     CHECK(source.RotationCount() >= 1);
 }
@@ -460,7 +459,7 @@ TEST_CASE(
     "[TailingBytesProducer][rotation]"
 )
 {
-    TempDir dir;
+    const TempDir dir;
     const auto path = dir.File("paused.log");
     Overwrite(path, "p1\np2\n");
 
@@ -492,7 +491,7 @@ TEST_CASE(
 
 TEST_CASE("TailingBytesProducer discards partial line on rotation", "[TailingBytesProducer][rotation]")
 {
-    TempDir dir;
+    const TempDir dir;
     const auto path = dir.File("partial_rot.log");
     // Note: no trailing newline → "incomplete" stays in the partial-line buffer.
     Overwrite(path, "complete\nincomplete");
@@ -504,7 +503,7 @@ TEST_CASE("TailingBytesProducer discards partial line on rotation", "[TailingByt
         return std::count(acc.begin(), acc.end(), '\n') >= 1;
     });
     auto firstLines = SplitLines(first);
-    REQUIRE(firstLines.size() >= 1);
+    REQUIRE(!firstLines.empty());
     CHECK(firstLines[0] == "complete");
 
     // Rotate via in-place truncate. The partial "incomplete" must be
@@ -513,11 +512,10 @@ TEST_CASE("TailingBytesProducer discards partial line on rotation", "[TailingByt
     std::this_thread::sleep_for(ScaledMs(50ms));
     Append(path, "after\n");
 
-    const auto post = DrainUntil(source, ScaledMs(1000ms), [](const std::string &acc) {
-        return acc.find("after\n") != std::string::npos;
-    });
+    const auto post =
+        DrainUntil(source, ScaledMs(1000ms), [](const std::string &acc) { return acc.contains("after\n"); });
     const auto postLines = SplitLines(post);
-    REQUIRE(postLines.size() >= 1);
+    REQUIRE(!postLines.empty());
     CHECK(postLines.back() == "after");
     // The partial "incomplete" must NEVER appear.
     CHECK(post.find("incomplete") == std::string::npos);
@@ -525,7 +523,7 @@ TEST_CASE("TailingBytesProducer discards partial line on rotation", "[TailingByt
 
 TEST_CASE("TailingBytesProducer flushes the partial line on Stop", "[TailingBytesProducer]")
 {
-    TempDir dir;
+    const TempDir dir;
     const auto path = dir.File("partial_stop.log");
     Overwrite(path, "first\ntrailing-no-newline");
 
@@ -535,7 +533,7 @@ TEST_CASE("TailingBytesProducer flushes the partial line on Stop", "[TailingByte
         return std::count(acc.begin(), acc.end(), '\n') >= 1;
     });
     auto preLines = SplitLines(pre);
-    REQUIRE(preLines.size() >= 1);
+    REQUIRE(!preLines.empty());
     CHECK(preLines[0] == "first");
 
     // Now Stop. The partial-line buffer must be flushed as a synthetic
@@ -544,14 +542,14 @@ TEST_CASE("TailingBytesProducer flushes the partial line on Stop", "[TailingByte
 
     auto post = DrainUntil(source, ScaledMs(1000ms), [&](const std::string & /*acc*/) { return source.IsClosed(); });
     const auto postLines = SplitLines(post);
-    REQUIRE(postLines.size() >= 1);
+    REQUIRE(!postLines.empty());
     CHECK(postLines.back() == "trailing-no-newline");
     CHECK(source.IsClosed());
 }
 
 TEST_CASE("TailingBytesProducer Stop unblocks WaitForBytes parked on an idle file", "[TailingBytesProducer]")
 {
-    TempDir dir;
+    const TempDir dir;
     const auto path = dir.File("idle.log");
     Overwrite(path, ""); // empty; worker will park waiting for growth
 
@@ -577,7 +575,7 @@ TEST_CASE("TailingBytesProducer Stop unblocks WaitForBytes parked on an idle fil
 
 TEST_CASE("TailingBytesProducer debounces rapid rotations within 1 s", "[TailingBytesProducer][rotation]")
 {
-    TempDir dir;
+    const TempDir dir;
     const auto path = dir.File("debounce.log");
     Overwrite(path, "seed\n");
 
@@ -593,7 +591,7 @@ TEST_CASE("TailingBytesProducer debounces rapid rotations within 1 s", "[Tailing
 
     // Wait for pre-fill to consume the seed and for the worker to settle
     // on a steady mReadOffset.
-    DrainUntil(source, ScaledMs(500ms), [](const std::string &acc) { return acc.find("seed\n") != std::string::npos; });
+    DrainUntil(source, ScaledMs(500ms), [](const std::string &acc) { return acc.contains("seed\n"); });
 
     // Rename-and-create rotations flip the path's inode; identity
     // detection (branch i) is state-based, so the worker reliably
@@ -617,9 +615,7 @@ TEST_CASE("TailingBytesProducer debounces rapid rotations within 1 s", "[Tailing
     }
 
     // Drain so we know the worker has processed at least the last rotation.
-    DrainUntil(source, ScaledMs(1000ms), [](const std::string &acc) {
-        return acc.find("rot2\n") != std::string::npos;
-    });
+    DrainUntil(source, ScaledMs(1000ms), [](const std::string &acc) { return acc.contains("rot2\n"); });
 
     // RotationCount counts every detected rotation; the callback
     // collapses them into one per debounce window.
@@ -629,7 +625,7 @@ TEST_CASE("TailingBytesProducer debounces rapid rotations within 1 s", "[Tailing
 
 TEST_CASE("TailingBytesProducer throws on initial open failure", "[TailingBytesProducer]")
 {
-    TempDir dir;
+    const TempDir dir;
     const auto path = dir.File("does_not_exist.log");
 
     CHECK_THROWS_AS(TailingBytesProducer(path, 100, FastPollOptions()), std::system_error);
@@ -637,7 +633,7 @@ TEST_CASE("TailingBytesProducer throws on initial open failure", "[TailingBytesP
 
 TEST_CASE("TailingBytesProducer Stop after natural drain leaves IsClosed true", "[TailingBytesProducer]")
 {
-    TempDir dir;
+    const TempDir dir;
     const auto path = dir.File("simple.log");
     Overwrite(path, "only\n");
 
@@ -670,7 +666,7 @@ TEST_CASE(
     // `Waiting`; a subsequent re-create lifts it back to `Running`.
     // Edge-triggered: one delete/create pair => one `Waiting` and
     // one `Running` observation.
-    TempDir dir;
+    const TempDir dir;
     const auto path = dir.File("status.log");
     Overwrite(path, "seed\n");
 
@@ -679,7 +675,7 @@ TEST_CASE(
 
     TailingBytesProducer source(path, /*retentionLines=*/100, FastPollOptions());
     source.SetStatusCallback([&](loglib::SourceStatus s) {
-        std::lock_guard<std::mutex> lock(statusMu);
+        const std::scoped_lock lock(statusMu);
         observed.push_back(s);
     });
 
@@ -690,7 +686,7 @@ TEST_CASE(
     // before exercising the delete/recreate transitions so the test
     // assertions read naturally about user-visible state changes only.
     {
-        std::lock_guard<std::mutex> lock(statusMu);
+        const std::scoped_lock lock(statusMu);
         REQUIRE_FALSE(observed.empty());
         CHECK(observed.front() == loglib::SourceStatus::Running);
         observed.clear();
@@ -698,7 +694,7 @@ TEST_CASE(
 
     // Drain the pre-fill so the worker is in its steady-state tail loop
     // before we perturb the file.
-    DrainUntil(source, ScaledMs(500ms), [](const std::string &acc) { return acc.find("seed\n") != std::string::npos; });
+    DrainUntil(source, ScaledMs(500ms), [](const std::string &acc) { return acc.contains("seed\n"); });
 
     // Delete the file → branch (ii) → Waiting.
     std::filesystem::remove(path);
@@ -707,7 +703,7 @@ TEST_CASE(
     while (std::chrono::steady_clock::now() < waitingDeadline)
     {
         {
-            std::lock_guard<std::mutex> lock(statusMu);
+            const std::scoped_lock lock(statusMu);
             if (!observed.empty() && observed.back() == loglib::SourceStatus::Waiting)
             {
                 break;
@@ -719,7 +715,7 @@ TEST_CASE(
     }
 
     {
-        std::lock_guard<std::mutex> lock(statusMu);
+        const std::scoped_lock lock(statusMu);
         REQUIRE_FALSE(observed.empty());
         CHECK(observed.front() == loglib::SourceStatus::Waiting);
     }
@@ -731,7 +727,7 @@ TEST_CASE(
     while (std::chrono::steady_clock::now() < runningDeadline)
     {
         {
-            std::lock_guard<std::mutex> lock(statusMu);
+            const std::scoped_lock lock(statusMu);
             if (!observed.empty() && observed.back() == loglib::SourceStatus::Running)
             {
                 break;
@@ -742,7 +738,7 @@ TEST_CASE(
         std::this_thread::sleep_for(ScaledMs(25ms));
     }
 
-    std::lock_guard<std::mutex> lock(statusMu);
+    const std::scoped_lock lock(statusMu);
     REQUIRE(observed.size() >= 2);
     CHECK(observed.back() == loglib::SourceStatus::Running);
 

--- a/test/lib/src/test_tailing_bytes_producer.cpp
+++ b/test/lib/src/test_tailing_bytes_producer.cpp
@@ -40,7 +40,7 @@ public:
         std::filesystem::create_directories(mPath);
     }
 
-    ~TempDir()
+    ~TempDir() noexcept
     {
         std::error_code ec;
         std::filesystem::remove_all(mPath, ec);

--- a/test/lib/src/test_tcp_server_producer.cpp
+++ b/test/lib/src/test_tcp_server_producer.cpp
@@ -11,7 +11,6 @@
 #include <span>
 #include <string>
 #include <thread>
-#include <vector>
 
 using loglib::TcpServerProducer;
 using loglib_test::ScaledMs;
@@ -124,8 +123,8 @@ TEST_CASE("TcpServerProducer: accept cap rejects extra connections", "[tcp_produ
     opts.maxConcurrentClients = 2;
     TcpServerProducer producer(opts);
 
-    test_common::TcpLogClient a("127.0.0.1", producer.BoundPort());
-    test_common::TcpLogClient b("127.0.0.1", producer.BoundPort());
+    const test_common::TcpLogClient a("127.0.0.1", producer.BoundPort());
+    const test_common::TcpLogClient b("127.0.0.1", producer.BoundPort());
     REQUIRE(WaitFor([&] { return producer.ActiveClientCount() == 2; }, ScaledMs(2000ms)));
 
     // Third connection: the producer accepts and immediately closes

--- a/test/lib/src/test_tcp_server_producer.cpp
+++ b/test/lib/src/test_tcp_server_producer.cpp
@@ -140,12 +140,14 @@ TEST_CASE("TcpServerProducer: accept cap rejects extra connections", "[tcp_produ
         {
             c.Send("rejected\n");
         }
-        catch (const std::exception &)
+        catch (const std::exception &ex)
         {
+            static_cast<void>(ex);
         }
     }
-    catch (const std::exception &)
+    catch (const std::exception &ex)
     {
+        static_cast<void>(ex);
     }
 
     REQUIRE(WaitFor([&] { return producer.TotalClientsRejected() >= 1; }, ScaledMs(2000ms)));

--- a/test/lib/src/test_tcp_server_producer_tls.cpp
+++ b/test/lib/src/test_tcp_server_producer_tls.cpp
@@ -164,7 +164,7 @@ std::string DrainUntil(TcpServerProducer &producer, size_t target, std::chrono::
 
 TEST_CASE("TcpServerProducer (TLS): plaintext client cannot exchange data", "[tcp_producer][tls]")
 {
-    TempDir tmp;
+    const TempDir tmp;
     const auto certPath = tmp.File("cert.pem");
     const auto keyPath = tmp.File("key.pem");
     GenerateSelfSignedCert(certPath, keyPath);
@@ -195,7 +195,7 @@ TEST_CASE("TcpServerProducer (TLS): plaintext client cannot exchange data", "[tc
 
 TEST_CASE("TcpServerProducer (TLS): TLS client send-receive with self-signed cert", "[tcp_producer][tls]")
 {
-    TempDir tmp;
+    const TempDir tmp;
     const auto certPath = tmp.File("cert.pem");
     const auto keyPath = tmp.File("key.pem");
     GenerateSelfSignedCert(certPath, keyPath);

--- a/test/lib/src/test_tcp_server_producer_tls.cpp
+++ b/test/lib/src/test_tcp_server_producer_tls.cpp
@@ -37,6 +37,8 @@ public:
         mPath = std::filesystem::temp_directory_path() / ("loglib_tcp_tls_" + std::to_string(gen()));
         std::filesystem::create_directories(mPath);
     }
+    // NOLINTNEXTLINE(bugprone-exception-escape): MSVC may model throwing paths through STL `remove_all`; teardown
+    // ignores errors via `error_code`.
     ~TempDir() noexcept
     {
         std::error_code ec;

--- a/test/lib/src/test_tcp_server_producer_tls.cpp
+++ b/test/lib/src/test_tcp_server_producer_tls.cpp
@@ -37,7 +37,7 @@ public:
         mPath = std::filesystem::temp_directory_path() / ("loglib_tcp_tls_" + std::to_string(gen()));
         std::filesystem::create_directories(mPath);
     }
-    ~TempDir()
+    ~TempDir() noexcept
     {
         std::error_code ec;
         std::filesystem::remove_all(mPath, ec);
@@ -186,8 +186,9 @@ TEST_CASE("TcpServerProducer (TLS): plaintext client cannot exchange data", "[tc
     {
         plain.Send("plaintext-into-tls\n");
     }
-    catch (const std::exception &)
+    catch (const std::exception &ex)
     {
+        static_cast<void>(ex); // send may fail if the server side closes first
     }
     const std::string drained = DrainUntil(producer, /*target*/ 1, ScaledMs(500ms));
     REQUIRE(drained.empty());

--- a/test/lib/src/test_udp_server_producer.cpp
+++ b/test/lib/src/test_udp_server_producer.cpp
@@ -11,7 +11,6 @@
 #include <span>
 #include <string>
 #include <thread>
-#include <vector>
 
 using loglib::UdpServerProducer;
 using loglib_test::ScaledMs;

--- a/test/log_generator/src/main.cpp
+++ b/test/log_generator/src/main.cpp
@@ -30,6 +30,7 @@
 #include <test_common/network_log_client.hpp>
 
 #include <argparse/argparse.hpp>
+
 #include <glaze/glaze.hpp>
 
 #include <cctype>
@@ -55,7 +56,7 @@ namespace
 // the common suffixes `B`, `KB`, `MB`, `GB` (case-insensitive, base 1024).
 // We deliberately keep this in one TU rather than pulling in fmt/std::regex
 // because the `log_generator` binary should stay tiny.
-std::uint64_t ParseSize(std::string text)
+std::uint64_t ParseSize(const std::string &text)
 {
     if (text.empty())
     {
@@ -102,7 +103,7 @@ std::uint64_t ParseSize(std::string text)
     {
         throw std::invalid_argument("size must contain a numeric value");
     }
-    for (char c : upper)
+    for (const char c : upper)
     {
         if (std::isdigit(static_cast<unsigned char>(c)) == 0)
         {
@@ -117,7 +118,7 @@ std::uint64_t ParseSize(std::string text)
 // Parse a line-count literal: plain integer or with `K` / `M` / `G` suffix
 // (base 1000, case-insensitive). Distinct from `ParseSize` because line
 // counts conventionally use SI multipliers (`100K` = 100'000, not 102'400).
-std::uint64_t ParseCount(std::string text)
+std::uint64_t ParseCount(const std::string &text)
 {
     if (text.empty())
     {
@@ -160,7 +161,7 @@ std::uint64_t ParseCount(std::string text)
     {
         throw std::invalid_argument("count must contain a numeric value");
     }
-    for (char c : upper)
+    for (const char c : upper)
     {
         if (std::isdigit(static_cast<unsigned char>(c)) == 0)
         {
@@ -581,7 +582,7 @@ int main(int argc, char *argv[])
         std::cerr << "Invalid --keep-rolled: must be >= 0\n" << program;
         return 1;
     }
-    const std::size_t keepRolled = static_cast<std::size_t>(keepRolledInt);
+    const auto keepRolled = static_cast<std::size_t>(keepRolledInt);
 
     const bool rollingEnabled = rollBytes != 0 || rollLines != 0;
     const bool isNetworkTarget =

--- a/test/log_generator/src/main.cpp
+++ b/test/log_generator/src/main.cpp
@@ -445,6 +445,8 @@ void Rotate(std::ofstream &out, const std::filesystem::path &basePath, RollStrat
 
 } // namespace
 
+// NOLINTNEXTLINE(bugprone-exception-escape): CLI tool; `ParseSize` and argparse surface errors via exceptions by
+// design.
 int main(int argc, char *argv[])
 {
     argparse::ArgumentParser program("log_generator", "0.2.0");


### PR DESCRIPTION
## Summary

Stand up Clang-based static and dynamic analysis as a hard CI gate, then apply the broad cleanup it surfaced.

Three new CI legs run on every PR alongside the existing release packaging:

- **`clang-asan-ubsan`** — Clang 22 RelWithDebInfo + AddressSanitizer + UndefinedBehaviorSanitizer, `-fno-sanitize-recover=all` so the first hit fails CTest.
- **`clang-tsan`** — ThreadSanitizer over the loglib threading code (TBB pipeline, `StreamLineSource`, `TailingBytesProducer`, `LogModel::Reset` teardown, `BoundedBatchQueue`). The Qt `apptest` is excluded by name regex because Qt's private mutexes drown the signal; the pure-C++ `apptest_queue` still runs.
- **`clang-coverage`** — `-fprofile-instr-generate -fcoverage-mapping`; merges the per-binary `.profraw`s with `llvm-profdata-22`, exports lcov, uploads to Codecov (`fail_ci_if_error`), and **also runs `cpp-linter-action` against this build's `compile_commands.json`** so clang-tidy is gated on the same job that produces the database. Tidy hits short-circuit before the test/codecov tail.

All three are surfaced as `CMakePresets.json` configure / build / test / workflow presets and run end-to-end with `cmake --workflow --preset clang-<mode>` locally. IPO/LTO is forced off in the shared `_clang_ci_base` because LTO breaks sanitizer stack traces and skews coverage line mapping.

## Clang-tidy configuration

- Project-wide [`.clang-tidy`](.clang-tidy) enables `bugprone`/`cert`/`clang-analyzer`/`concurrency`/`cppcoreguidelines`/`misc`/`modernize`/`performance`/`portability`/`readability`, with a documented short list of disables (each with a one-line justification) and the project naming conventions encoded as `readability-identifier-naming.*`.
- Per-directory overrides only relax what Qt forces:
  - [`app/.clang-tidy`](app/.clang-tidy) accepts Qt-mandated camelBack public methods (signals, slots, `QAbstractTableModel` overrides) and disables checks that fight Qt's parent-owned `new Widget(this)` idiom and moc's `private:` after `private slots:` boundary.
  - [`test/.clang-tidy`](test/.clang-tidy) accepts magic numbers and public test fixture members.
  - [`test/app/.clang-tidy`](test/app/.clang-tidy) keeps `initTestCase` / `cleanupTestCase` / `init` / `cleanup` in camelBack so `QTest` actually invokes them.
- Diff-only checks via `cpp-linter-action` (SHA-pinned to v2.18.0) post inline review comments on PRs and a rolling thread comment; the leg fails if `checks-failed > 0`. Local equivalent (`clang-tidy-diff-22.py` against the same `compile_commands.json`) is documented in `CONTRIBUTING.md`.

## Sanitizer environment

The test presets bake in the same env vars CI uses, so `ctest --preset clang-<mode>` reproduces CI exactly:

- `ASAN_OPTIONS=detect_leaks=1:halt_on_error=1:abort_on_error=1:strict_string_checks=1:detect_stack_use_after_return=1`
- `UBSAN_OPTIONS=halt_on_error=1:print_stacktrace=1:abort_on_error=1`
- `LSAN_OPTIONS=suppressions=${sourceDir}/.ci/lsan.supp:print_suppressions=0` — [`.ci/lsan.supp`](.ci/lsan.supp) suppresses Qt / fontconfig / glibc dlopen / oneTBB process-global one-shot allocations only, each with a comment.
- `TSAN_OPTIONS=halt_on_error=1:second_deadlock_stack=1:history_size=7:suppressions=${sourceDir}/.ci/tsan.supp` — [`.ci/tsan.supp`](.ci/tsan.supp) is empty by default; entries must carry a rationale.
- `LLVM_PROFILE_FILE=${sourceDir}/build/clang-coverage/profiles/%p-%m.profraw` so `llvm-profdata-22 merge` is unambiguous.

## Real fixes uncovered by the new gates

The bulk of the diff is mechanical (`auto fixes with clang-tidy`, naming, `constexpr`, `QLatin1String`, etc.), but a few non-obvious bugs / hardenings are worth calling out:

- **TSan-clean `KeyIndex` parallel test** (`6b5e3e1`): the multi-threaded test was using Catch2's `REQUIRE` from worker threads (not thread-safe). Switched mismatch tracking to `std::atomic` and asserted only after the join, with detailed mismatch logging when something does diverge.
- **Portable `ReadAtOffset`** (`88ffe26`, `8dab1e0`): explicit `off_t` handling and `std::cmp_less` for the loop guard so the offset arithmetic round-trips cleanly under UBSan on 32-bit `off_t` builds.
- **MSVC runtime DLLs bundled app-locally** (`95a246b`): added a `POST_BUILD` step driven by `InstallRequiredSystemLibraries` (with `_LIBS_SKIP=TRUE` so we control the install layout), so the Windows zip is portable without the user installing the VC++ redist.
- **CI concurrency + cache hygiene** (`573679d`): cancel-in-progress on PRs but never on push/tags (so a release publish can't be aborted mid-flight); pre-commit cache key includes the resolved Python version so a runner-image 3.12→3.13 bump invalidates stale venvs.
- **Sink/producer signature audit** (`9027abe`): callbacks now take `const&` consistently; test-class destructors marked `noexcept` to silence the ASan teardown warnings.

## Documentation

- [`CONTRIBUTING.md`](CONTRIBUTING.md) gains a **Sanitizers and coverage** section (section anchor referenced from the new presets) covering: per-preset one-liner repro, the env knobs above, the `llvm-profdata-22` / `llvm-cov-22` post-processing recipe, the `clang-tidy-diff-22.py` local PR-diff equivalent, and the rationale for the suppression files.
- The build-presets table in `## Building` lists `clang-asan-ubsan` / `clang-tsan` / `clang-coverage` alongside the existing `release` / `debug` / `relwithdebinfo`.