### PR TITLE
Bump Version to 0.8.0

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.28)
 
-project(structured_log_viewer VERSION 0.7.0 LANGUAGES CXX)
+project(structured_log_viewer VERSION 0.8.0 LANGUAGES CXX)
 
 # IPO/LTO on for Release / RelWithDebInfo, off for Debug. `NOT DEFINED` gates
 # let sanitizer presets override via the cache; a plain `set(... ON)` would


### PR DESCRIPTION
## Summary

Bumps the project version from `0.7.0` to `0.8.0` in the top-level `CMakeLists.txt` to cut a new release. Once this PR merges to `main`, tagging the merge commit `v0.8.0` will trigger the `Build` workflow to package and publish AppImage / zip / dmg artifacts to the GitHub Release.

### Changes since v0.7.0

- Improve Security (#24)
- Enum Column Auto Detection (#26)
- Synchronous Filter and Sort Speedup (#27)
- Filter and Sort GUI Speedup (#28)
- Finalize Log Types (#30)
- Bump the actions group with 8 updates (#25)
- Bump the actions group with 2 updates (#29)

## Test plan

- [x] CI green (pre-commit, clang-ci sanitizers + coverage, build-linux, build-windows, build-macos)
- [x] After merge, tag `v0.8.0` on the merge commit and push; verify the `Build` workflow attaches the four platform artifacts plus checksums to the GitHub Release
