### PR TITLE
Column Filter Menu

### DIFF
--- a/app/include/filter_editor.hpp
+++ b/app/include/filter_editor.hpp
@@ -43,6 +43,12 @@ public:
     /// Restore a boolean filter.
     void Load(int row, bool includeTrue, bool includeFalse);
 
+    /// Preselect the column without loading a payload. Used by the
+    /// header right-click "Add filter on <column>" entry to open a
+    /// fresh editor pointing at the clicked column. No-op when
+    /// @p row is out of range.
+    void SetInitialColumn(int row);
+
     int GetRowToFilter() const;
     QString GetStringToFilter() const;
     int GetMatchType() const;

--- a/app/include/filter_editor.hpp
+++ b/app/include/filter_editor.hpp
@@ -43,10 +43,9 @@ public:
     /// Restore a boolean filter.
     void Load(int row, bool includeTrue, bool includeFalse);
 
-    /// Preselect the column without loading a payload. Used by the
-    /// header right-click "Add filter on <column>" entry to open a
-    /// fresh editor pointing at the clicked column. No-op when
-    /// @p row is out of range or refers to a hidden column.
+    /// Preselect a column on a fresh editor (no filter payload).
+    /// Used by the header right-click "Add filter on ..." entry.
+    /// No-op when @p row is out of range or hidden.
     void SetInitialColumn(int row);
 
     int GetRowToFilter() const;

--- a/app/include/filter_editor.hpp
+++ b/app/include/filter_editor.hpp
@@ -46,7 +46,7 @@ public:
     /// Preselect the column without loading a payload. Used by the
     /// header right-click "Add filter on <column>" entry to open a
     /// fresh editor pointing at the clicked column. No-op when
-    /// @p row is out of range.
+    /// @p row is out of range or refers to a hidden column.
     void SetInitialColumn(int row);
 
     int GetRowToFilter() const;

--- a/app/include/main_window.hpp
+++ b/app/include/main_window.hpp
@@ -92,25 +92,27 @@ public:
     /// so. Idempotent.
     void ResetHeaderToIdentity();
 
+    /// Bundle returned by `BuildHeaderContextMenu`. `menu` is the
+    /// root context menu (caller-owned); `showSubMenu` and
+    /// `filterSubMenus` are non-owning pointers into it that exist
+    /// purely for tests -- on the Linux Release offscreen-QPA
+    /// toolchain, `QAction::menu()` and
+    /// `QObject::children()`/`qobject_cast` both fail to recover
+    /// submenu pointers (the QtWidgets metaobject hooks for
+    /// `QMenu` are stripped at link time there). Production
+    /// callers only need `menu`.
+    struct HeaderContextMenu
+    {
+        QMenu *menu = nullptr;
+        QMenu *showSubMenu = nullptr;
+        std::unordered_map<std::string, QMenu *> filterSubMenus;
+    };
+
     /// Build the right-click header menu for @p logicalColumn.
-    /// Caller owns the returned menu. Public so tests can drive the
-    /// menu without an offscreen-QPA `findChild<QMenu*>` (see
-    /// `FiltersMenu()`). When @p outShowSubMenu is non-null and the
-    /// build produced a `Show column` submenu, the pointer is stored
-    /// there for tests -- the Linux Release offscreen build's
-    /// `QAction::menu()` and `QObject::children()`/`qobject_cast`
-    /// traversals both fail to recover this otherwise (the submenu's
-    /// QtWidgets metaobject hooks are stripped at link time).
-    /// When @p outFilterSubMenus is non-null, the per-filter
-    /// Edit/Remove submenus built for filters targeting the clicked
-    /// column are recorded there keyed by filter id, for the same
-    /// offscreen-QPA reason.
-    [[nodiscard]] QMenu *BuildHeaderContextMenu(
-        int logicalColumn,
-        QWidget *parent = nullptr,
-        QMenu **outShowSubMenu = nullptr,
-        std::unordered_map<std::string, QMenu *> *outFilterSubMenus = nullptr
-    );
+    /// Caller owns `result.menu`. Returns a default-constructed
+    /// struct (with `menu == nullptr`) when @p logicalColumn is out
+    /// of range.
+    [[nodiscard]] HeaderContextMenu BuildHeaderContextMenu(int logicalColumn, QWidget *parent = nullptr);
 
     /// Live filter map; tests inspect it after a reorder.
     [[nodiscard]] const std::unordered_map<std::string, loglib::LogConfiguration::LogFilter> &Filters() const

--- a/app/include/main_window.hpp
+++ b/app/include/main_window.hpp
@@ -101,8 +101,15 @@ public:
     /// `QAction::menu()` and `QObject::children()`/`qobject_cast`
     /// traversals both fail to recover this otherwise (the submenu's
     /// QtWidgets metaobject hooks are stripped at link time).
+    /// When @p outFilterSubMenus is non-null, the per-filter
+    /// Edit/Remove submenus built for filters targeting the clicked
+    /// column are recorded there keyed by filter id, for the same
+    /// offscreen-QPA reason.
     [[nodiscard]] QMenu *BuildHeaderContextMenu(
-        int logicalColumn, QWidget *parent = nullptr, QMenu **outShowSubMenu = nullptr
+        int logicalColumn,
+        QWidget *parent = nullptr,
+        QMenu **outShowSubMenu = nullptr,
+        std::unordered_map<std::string, QMenu *> *outFilterSubMenus = nullptr
     );
 
     /// Live filter map; tests inspect it after a reorder.
@@ -180,10 +187,16 @@ private slots:
     /// Add a filter rule, optionally opening the editor. Pass
     /// `openEditor = false` from the configuration-load path so a
     /// dropped saved filter does not pop the editor.
+    /// When @p filter is `std::nullopt` and @p initialColumn is
+    /// non-negative, the freshly-opened editor preselects that
+    /// column. Used by the column-header right-click "Add filter on
+    /// <column>" entry. Ignored when @p filter has a value (the
+    /// loaded filter already pins the row).
     void AddFilter(
         const QString &filterId,
         const std::optional<loglib::LogConfiguration::LogFilter> &filter = std::nullopt,
-        bool openEditor = true
+        bool openEditor = true,
+        int initialColumn = -1
     );
     void ClearAllFilters();
     /// Remove a single filter rule. Pass `deferSync = true` when the
@@ -286,6 +299,12 @@ private:
     /// (`RebuildFiltersFromConfiguration`) and run a single
     /// trailing mirror + `UpdateFilters` after the loop.
     void AddLogFilter(const QString &id, const loglib::LogConfiguration::LogFilter &filter, bool deferSync = false);
+
+    /// Display title for @p filter, matching the format used in the
+    /// `Filters` menu entries (e.g. `info, warn` for an enum filter,
+    /// `[1.5, 2.0]` for a numeric range). Shared between the Filters
+    /// menu builder and the column-header right-click menu.
+    [[nodiscard]] QString BuildFilterTitle(const loglib::LogConfiguration::LogFilter &filter) const;
     void UpdateFilters();
 
     /// Snapshot `mFilters` into the wire-format vector on the

--- a/app/include/main_window.hpp
+++ b/app/include/main_window.hpp
@@ -92,15 +92,12 @@ public:
     /// so. Idempotent.
     void ResetHeaderToIdentity();
 
-    /// Bundle returned by `BuildHeaderContextMenu`. `menu` is the
-    /// root context menu (caller-owned); `showSubMenu` and
-    /// `filterSubMenus` are non-owning pointers into it that exist
-    /// purely for tests -- on the Linux Release offscreen-QPA
-    /// toolchain, `QAction::menu()` and
-    /// `QObject::children()`/`qobject_cast` both fail to recover
-    /// submenu pointers (the QtWidgets metaobject hooks for
-    /// `QMenu` are stripped at link time there). Production
-    /// callers only need `menu`.
+    /// Result of `BuildHeaderContextMenu`. `menu` is the caller-
+    /// owned root menu; `showSubMenu` and `filterSubMenus` are
+    /// non-owning test seams (the Linux Release offscreen-QPA
+    /// toolchain strips `QMenu` metaobject hooks, so tests can't
+    /// recover submenus by walking the tree). Production callers
+    /// only need `menu`.
     struct HeaderContextMenu
     {
         QMenu *menu = nullptr;
@@ -109,9 +106,8 @@ public:
     };
 
     /// Build the right-click header menu for @p logicalColumn.
-    /// Caller owns `result.menu`. Returns a default-constructed
-    /// struct (with `menu == nullptr`) when @p logicalColumn is out
-    /// of range.
+    /// Caller owns `result.menu`. `result.menu` is null when
+    /// @p logicalColumn is out of range.
     [[nodiscard]] HeaderContextMenu BuildHeaderContextMenu(int logicalColumn, QWidget *parent = nullptr);
 
     /// Live filter map; tests inspect it after a reorder.
@@ -187,13 +183,11 @@ private slots:
     void FindRecords(const QString &text, bool next, bool wildcards, bool regularExpressions);
 
     /// Add a filter rule, optionally opening the editor. Pass
-    /// `openEditor = false` from the configuration-load path so a
-    /// dropped saved filter does not pop the editor.
-    /// When @p filter is `std::nullopt` and @p initialColumn is
-    /// non-negative, the freshly-opened editor preselects that
-    /// column. Used by the column-header right-click "Add filter on
-    /// <column>" entry. Ignored when @p filter has a value (the
-    /// loaded filter already pins the row).
+    /// `openEditor = false` on the config-load path so a restored
+    /// filter does not pop the editor. When @p filter is empty and
+    /// @p initialColumn >= 0, the editor preselects that column
+    /// (used by the header "Add filter on ..." entry). Ignored
+    /// when @p filter has a value (it already pins the row).
     void AddFilter(
         const QString &filterId,
         const std::optional<loglib::LogConfiguration::LogFilter> &filter = std::nullopt,
@@ -302,10 +296,9 @@ private:
     /// trailing mirror + `UpdateFilters` after the loop.
     void AddLogFilter(const QString &id, const loglib::LogConfiguration::LogFilter &filter, bool deferSync = false);
 
-    /// Display title for @p filter, matching the format used in the
-    /// `Filters` menu entries (e.g. `info, warn` for an enum filter,
-    /// `[1.5, 2.0]` for a numeric range). Shared between the Filters
-    /// menu builder and the column-header right-click menu.
+    /// Display title for @p filter (e.g. `info, warn` for an enum
+    /// filter, `[1.5, 2.0]` for a numeric range). Shared between
+    /// the Filters menu and the column-header right-click menu.
     [[nodiscard]] QString BuildFilterTitle(const loglib::LogConfiguration::LogFilter &filter) const;
     void UpdateFilters();
 

--- a/app/include/main_window.hpp
+++ b/app/include/main_window.hpp
@@ -93,15 +93,13 @@ public:
     void ResetHeaderToIdentity();
 
     /// Result of `BuildHeaderContextMenu`. `menu` is the caller-
-    /// owned root menu; `showSubMenu` and `filterSubMenus` are
-    /// non-owning test seams (the Linux Release offscreen-QPA
-    /// toolchain strips `QMenu` metaobject hooks, so tests can't
-    /// recover submenus by walking the tree). Production callers
-    /// only need `menu`.
+    /// owned root menu; `filterSubMenus` is a non-owning test seam
+    /// (the Linux Release offscreen-QPA toolchain strips `QMenu`
+    /// metaobject hooks, so tests can't recover submenus by walking
+    /// the tree). Production callers only need `menu`.
     struct HeaderContextMenu
     {
         QMenu *menu = nullptr;
-        QMenu *showSubMenu = nullptr;
         std::unordered_map<std::string, QMenu *> filterSubMenus;
     };
 

--- a/app/src/filter_editor.cpp
+++ b/app/src/filter_editor.cpp
@@ -250,22 +250,16 @@ void FilterEditor::SetInitialColumn(int row)
     {
         return;
     }
-    // Production callers (the column-header right-click menu) only
-    // ever pass visible columns. Reject hidden columns defensively:
-    // the editor would still pop, but binding a filter to a hidden
-    // column is a confusing UX that no real entry point should hit.
+    // Defensive: production only passes visible columns, but
+    // binding a filter to a hidden column is confusing UX.
     if (!columns[static_cast<size_t>(row)].visible)
     {
         return;
     }
-    // The combobox's `currentIndexChanged` is wired to
-    // `UpdateSelectedColumn`, which swaps the stacked widget to the
-    // matching page (string / time / enum / numeric / boolean).
-    // `setCurrentIndex` emits the signal only when the index
-    // actually changes, so callers passing the same index the
-    // constructor already initialised to (0) get the right
-    // stacked page from the constructor's explicit
-    // `UpdateSelectedColumn(0)` call instead.
+    // setCurrentIndex fires `currentIndexChanged` -> `UpdateSelectedColumn`,
+    // which swaps the stacked page (string / time / enum / numeric / bool).
+    // No emit when the index is unchanged, but the constructor already
+    // calls `UpdateSelectedColumn(0)` for that case.
     mRowComboBox->setCurrentIndex(row);
 }
 

--- a/app/src/filter_editor.cpp
+++ b/app/src/filter_editor.cpp
@@ -243,6 +243,19 @@ void FilterEditor::Load(int row, bool includeTrue, bool includeFalse)
     mBoolIncludeFalse->setChecked(includeFalse);
 }
 
+void FilterEditor::SetInitialColumn(int row)
+{
+    if (row < 0 || static_cast<size_t>(row) >= mModel.Configuration().columns.size())
+    {
+        return;
+    }
+    // The combobox's `currentIndexChanged` is wired to
+    // `UpdateSelectedColumn`, which swaps the stacked widget to the
+    // matching page (string / time / enum / numeric / boolean), so
+    // setting the index here is the only call needed.
+    mRowComboBox->setCurrentIndex(row);
+}
+
 int FilterEditor::GetRowToFilter() const
 {
     return mRowComboBox->currentIndex();

--- a/app/src/filter_editor.cpp
+++ b/app/src/filter_editor.cpp
@@ -245,14 +245,27 @@ void FilterEditor::Load(int row, bool includeTrue, bool includeFalse)
 
 void FilterEditor::SetInitialColumn(int row)
 {
-    if (row < 0 || static_cast<size_t>(row) >= mModel.Configuration().columns.size())
+    const auto &columns = mModel.Configuration().columns;
+    if (row < 0 || static_cast<size_t>(row) >= columns.size())
+    {
+        return;
+    }
+    // Production callers (the column-header right-click menu) only
+    // ever pass visible columns. Reject hidden columns defensively:
+    // the editor would still pop, but binding a filter to a hidden
+    // column is a confusing UX that no real entry point should hit.
+    if (!columns[static_cast<size_t>(row)].visible)
     {
         return;
     }
     // The combobox's `currentIndexChanged` is wired to
     // `UpdateSelectedColumn`, which swaps the stacked widget to the
-    // matching page (string / time / enum / numeric / boolean), so
-    // setting the index here is the only call needed.
+    // matching page (string / time / enum / numeric / boolean).
+    // `setCurrentIndex` emits the signal only when the index
+    // actually changes, so callers passing the same index the
+    // constructor already initialised to (0) get the right
+    // stacked page from the constructor's explicit
+    // `UpdateSelectedColumn(0)` call instead.
     mRowComboBox->setCurrentIndex(row);
 }
 

--- a/app/src/main_window.cpp
+++ b/app/src/main_window.cpp
@@ -2029,6 +2029,7 @@ QString MainWindow::BuildFilterTitle(const loglib::LogConfiguration::LogFilter &
     }
     case loglib::LogConfiguration::LogFilter::Type::String:
         Q_ASSERT(filter.filterString.has_value());
+        // NOLINTNEXTLINE(bugprone-unchecked-optional-access)
         return QString::fromStdString(*filter.filterString);
     }
     Q_ASSERT_X(false, "MainWindow::BuildFilterTitle", "unhandled LogFilter::Type");

--- a/app/src/main_window.cpp
+++ b/app/src/main_window.cpp
@@ -1678,10 +1678,9 @@ void MainWindow::AddFilter(
     connect(filterEditor, &FilterEditor::FilterEnumSubmitted, this, &MainWindow::FilterEnumSubmitted);
     connect(filterEditor, &FilterEditor::FilterNumericRangeSubmitted, this, &MainWindow::FilterNumericRangeSubmitted);
     connect(filterEditor, &FilterEditor::FilterBooleanSubmitted, this, &MainWindow::FilterBooleanSubmitted);
-    // Preselect the clicked column for the header right-click "Add
-    // filter on <column>" entry. The `Load(...)` overloads below
-    // also set the row, so this is only meaningful when no payload
-    // is being restored.
+    // Preselect the clicked column for the header "Add filter on
+    // ..." entry. The `Load(...)` calls below also set the row, so
+    // only meaningful when no payload is being restored.
     if (!resolvedFilter.has_value() && initialColumn >= 0)
     {
         filterEditor->SetInitialColumn(initialColumn);
@@ -1968,16 +1967,11 @@ void MainWindow::FilterBooleanSubmitted(const QString &filterID, int row, bool i
 
 QString MainWindow::BuildFilterTitle(const loglib::LogConfiguration::LogFilter &filter) const
 {
-    // No `default:`: a new `LogFilter::Type` member must trip the
-    // compiler's `-Wswitch` warning rather than silently fall into
-    // the String branch, which would dereference a `nullopt`
-    // `filter.filterString` and crash. Every payload read below
-    // assumes the matching submit slot already validated it.
-    // Debug tripwires for `ValidateFilterAgainstColumns`: every
-    // filter that lands in `mFilters` is supposed to have a fully-
-    // populated payload for its declared type. Asserting here turns
-    // a stray un-validated insert into an immediate debug failure
-    // rather than a release-only `optional` deref crash later.
+    // No `default:`: a new `LogFilter::Type` must trip `-Wswitch`
+    // rather than silently fall through and deref a `nullopt`.
+    // The Q_ASSERTs below catch un-validated inserts in debug;
+    // every filter in `mFilters` is supposed to have a fully-
+    // populated payload (enforced by `ValidateFilterAgainstColumns`).
     switch (filter.type)
     {
     case loglib::LogConfiguration::LogFilter::Type::Time:
@@ -2060,20 +2054,16 @@ void MainWindow::AddLogFilter(const QString &id, const loglib::LogConfiguration:
     mFilterSubMenus[id.toStdString()] = menuItem;
 
     const QAction *editAction = menuItem->addAction(tr("Edit"));
-    // Capture only the filter id and resolve the live filter at
-    // trigger time. Capturing the filter by value would freeze its
-    // `row` at the column it had at menu-build time, so a column
-    // reorder between build and click would mis-target Edit and the
-    // type-match guard would silently drop the filter. Regression:
+    // Capture only the id and re-resolve the live filter at trigger
+    // time, so a column reorder between menu build and click still
+    // targets the right row. Regression:
     // `TestEditFilterAfterColumnReorderUsesCurrentRow`.
     //
-    // `bugprone-exception-escape` fires because `mFilters.find` and
-    // copying a `LogFilter` can technically allocate; throwing out
-    // of a Qt slot is undefined behaviour. The body has no source
-    // of recoverable exceptions (no user input, no I/O), so the
-    // alternative -- a `try`/`catch` around two map lookups -- is
-    // pure noise. Same justification applies to the matching Edit
-    // lambda in `BuildHeaderContextMenu`.
+    // The lint suppression below covers `mFilters.find` / `LogFilter`
+    // copy, which can technically throw. The body has no real source
+    // of exceptions (no user input, no I/O), so wrapping it in
+    // try/catch would be pure noise. Same applies to the matching
+    // Edit lambda in `BuildHeaderContextMenu`.
     // NOLINTNEXTLINE(bugprone-exception-escape)
     connect(editAction, &QAction::triggered, this, [this, id]() {
         const auto it = mFilters.find(id.toStdString());
@@ -2631,29 +2621,21 @@ MainWindow::HeaderContextMenu MainWindow::BuildHeaderContextMenu(int logicalColu
         });
     }
 
-    // Filter block: an `Add filter on "<col>"` action plus a per-
-    // filter submenu for every existing filter targeting this
-    // column. The Add path re-resolves the column from `thisKeys`
-    // at trigger time so a column move between menu build and
-    // click still hits the right index. The filter submenus
-    // capture only the filter id; `mFilters[id]` is looked up
-    // live, mirroring the Filters-menu Edit/Remove actions wired
-    // in `AddLogFilter`. A leading separator keeps Hide visually
-    // distinct from the filter group when both are present.
+    // Filter block: `Add filter on "<col>"` plus a submenu per
+    // existing filter on this column. Lambdas capture stable keys /
+    // ids and re-resolve at trigger time, so a column reorder
+    // between build and click still hits the right index.
     //
-    // Both Add and Edit are gated on the model having at least one
-    // row -- `AddFilter` itself bails out with a status-bar hint in
-    // that case, so leaving the actions enabled would advertise a
-    // no-op. Remove stays enabled because dropping a filter does
-    // not need the model to be populated.
+    // Add and Edit are gated on row count > 0 -- `AddFilter` bails
+    // out with a status-bar hint otherwise, so leaving them enabled
+    // would advertise a no-op. Remove stays enabled (dropping a
+    // filter doesn't need rows).
     const bool modelHasRows = mModel->rowCount() > 0;
 
-    // Skip the Add-filter action for hidden columns: in production
-    // they cannot be right-clicked (the header is invisible), but
-    // the public test seam can pass a hidden index, and
-    // `FilterEditor::SetInitialColumn` refuses to preselect a
-    // hidden column -- leaving the action title advertising a
-    // column the editor would not actually preselect.
+    // Hidden columns: skip Add-filter. Production can't right-click
+    // them, but the test seam can, and `SetInitialColumn` refuses to
+    // preselect a hidden column -- so the action would advertise a
+    // column the editor wouldn't actually preselect.
     if (thisColumn.visible)
     {
         if (!menu->isEmpty())
@@ -2672,10 +2654,9 @@ MainWindow::HeaderContextMenu MainWindow::BuildHeaderContextMenu(int logicalColu
         });
     }
 
-    // Existing filters on this column. Sort by display title so
-    // the menu reads like a sorted list to the user; `mFilters` is
-    // an `unordered_map` keyed by UUID, which would otherwise
-    // present filters in essentially random order.
+    // Existing filters on this column, sorted by display title.
+    // `mFilters` is an unordered_map keyed by UUID, so without
+    // sorting the menu order would be effectively random.
     struct FilterEntry
     {
         std::string id;
@@ -2697,11 +2678,8 @@ MainWindow::HeaderContextMenu MainWindow::BuildHeaderContextMenu(int logicalColu
         {
             return compare < 0;
         }
-        // Tie-break by filter type first so two filters that render
-        // to the same title (e.g. a String filter spelt `true, false`
-        // and a Boolean filter) sit next to each other in type-stable
-        // order. Final tie-break on the UUID makes the order fully
-        // deterministic across rebuilds.
+        // Tie-break: type first (so a String `true, false` and a
+        // Boolean filter group together), then UUID for determinism.
         if (a.type != b.type)
         {
             return a.type < b.type;
@@ -2715,10 +2693,8 @@ MainWindow::HeaderContextMenu MainWindow::BuildHeaderContextMenu(int logicalColu
         result.filterSubMenus[entry.id] = filterSubMenu;
         QAction *editAction = filterSubMenu->addAction(tr("Edit"));
         editAction->setEnabled(modelHasRows);
-        // Same look-up-by-id pattern as the Filters-menu Edit
-        // action (capturing the filter by value would freeze its
-        // `row` at menu-build time); see `AddLogFilter` for the
-        // `bugprone-exception-escape` justification.
+        // Same id-resolve-on-trigger pattern as the Filters-menu
+        // Edit action; see `AddLogFilter` for the lint suppression.
         // NOLINTNEXTLINE(bugprone-exception-escape)
         connect(editAction, &QAction::triggered, this, [this, filterId]() {
             const auto it = mFilters.find(filterId.toStdString());

--- a/app/src/main_window.cpp
+++ b/app/src/main_window.cpp
@@ -1973,15 +1973,22 @@ QString MainWindow::BuildFilterTitle(const loglib::LogConfiguration::LogFilter &
     // the String branch, which would dereference a `nullopt`
     // `filter.filterString` and crash. Every payload read below
     // assumes the matching submit slot already validated it.
+    // Debug tripwires for `ValidateFilterAgainstColumns`: every
+    // filter that lands in `mFilters` is supposed to have a fully-
+    // populated payload for its declared type. Asserting here turns
+    // a stray un-validated insert into an immediate debug failure
+    // rather than a release-only `optional` deref crash later.
     switch (filter.type)
     {
     case loglib::LogConfiguration::LogFilter::Type::Time:
+        Q_ASSERT(filter.filterBegin.has_value() && filter.filterEnd.has_value());
         return QString::fromStdString(
             loglib::UtcMicrosecondsToDateTimeString(*filter.filterBegin) + " - " +
             loglib::UtcMicrosecondsToDateTimeString(*filter.filterEnd)
         );
     case loglib::LogConfiguration::LogFilter::Type::Enumeration:
     {
+        Q_ASSERT(!filter.filterValues.empty());
         QStringList values;
         values.reserve(static_cast<qsizetype>(filter.filterValues.size()));
         for (const std::string &v : filter.filterValues)
@@ -1992,6 +1999,7 @@ QString MainWindow::BuildFilterTitle(const loglib::LogConfiguration::LogFilter &
     }
     case loglib::LogConfiguration::LogFilter::Type::Number:
     {
+        Q_ASSERT(filter.filterMinValue.has_value() || filter.filterMaxValue.has_value());
         // Same C-locale, max-digits10 formatting as
         // `FilterEditor::Load` so the menu title and reopened editor
         // bounds match byte-for-byte. Default precision-6 would
@@ -2013,6 +2021,7 @@ QString MainWindow::BuildFilterTitle(const loglib::LogConfiguration::LogFilter &
         // `filter.filterValues` is laid out (the submit slot always
         // writes "true" first, but a hand-edited config might not).
         const BooleanFilterSides sides = DecodeBooleanFilterSides(filter.filterValues);
+        Q_ASSERT(sides.includeTrue || sides.includeFalse);
         QStringList values;
         if (sides.includeTrue)
         {
@@ -2025,6 +2034,7 @@ QString MainWindow::BuildFilterTitle(const loglib::LogConfiguration::LogFilter &
         return values.join(QStringLiteral(", "));
     }
     case loglib::LogConfiguration::LogFilter::Type::String:
+        Q_ASSERT(filter.filterString.has_value());
         return QString::fromStdString(*filter.filterString);
     }
     Q_ASSERT_X(false, "MainWindow::BuildFilterTitle", "unhandled LogFilter::Type");
@@ -2630,19 +2640,37 @@ MainWindow::HeaderContextMenu MainWindow::BuildHeaderContextMenu(int logicalColu
     // live, mirroring the Filters-menu Edit/Remove actions wired
     // in `AddLogFilter`. A leading separator keeps Hide visually
     // distinct from the filter group when both are present.
-    if (!menu->isEmpty())
+    //
+    // Both Add and Edit are gated on the model having at least one
+    // row -- `AddFilter` itself bails out with a status-bar hint in
+    // that case, so leaving the actions enabled would advertise a
+    // no-op. Remove stays enabled because dropping a filter does
+    // not need the model to be populated.
+    const bool modelHasRows = mModel->rowCount() > 0;
+
+    // Skip the Add-filter action for hidden columns: in production
+    // they cannot be right-clicked (the header is invisible), but
+    // the public test seam can pass a hidden index, and
+    // `FilterEditor::SetInitialColumn` refuses to preselect a
+    // hidden column -- leaving the action title advertising a
+    // column the editor would not actually preselect.
+    if (thisColumn.visible)
     {
-        menu->addSeparator();
-    }
-    const QAction *addFilterAction = menu->addAction(tr("Add filter on \"%1\"...").arg(thisLabel));
-    connect(addFilterAction, &QAction::triggered, this, [this, keys = thisKeys]() {
-        const int idx = FindColumnIndexByKeys(keys);
-        if (idx < 0)
+        if (!menu->isEmpty())
         {
-            return;
+            menu->addSeparator();
         }
-        AddFilter(QUuid::createUuid().toString(), std::nullopt, /*openEditor=*/true, /*initialColumn=*/idx);
-    });
+        QAction *addFilterAction = menu->addAction(tr("Add filter on \"%1\"…").arg(thisLabel));
+        addFilterAction->setEnabled(modelHasRows);
+        connect(addFilterAction, &QAction::triggered, this, [this, keys = thisKeys]() {
+            const int idx = FindColumnIndexByKeys(keys);
+            if (idx < 0)
+            {
+                return;
+            }
+            AddFilter(QUuid::createUuid().toString(), std::nullopt, /*openEditor=*/true, /*initialColumn=*/idx);
+        });
+    }
 
     // Existing filters on this column. Sort by display title so
     // the menu reads like a sorted list to the user; `mFilters` is
@@ -2652,6 +2680,7 @@ MainWindow::HeaderContextMenu MainWindow::BuildHeaderContextMenu(int logicalColu
     {
         std::string id;
         QString title;
+        loglib::LogConfiguration::LogFilter::Type type;
     };
     std::vector<FilterEntry> filtersForColumn;
     filtersForColumn.reserve(mFilters.size());
@@ -2659,22 +2688,33 @@ MainWindow::HeaderContextMenu MainWindow::BuildHeaderContextMenu(int logicalColu
     {
         if (entry.second.row == logicalColumn)
         {
-            filtersForColumn.push_back({entry.first, BuildFilterTitle(entry.second)});
+            filtersForColumn.push_back({entry.first, BuildFilterTitle(entry.second), entry.second.type});
         }
     }
     std::sort(filtersForColumn.begin(), filtersForColumn.end(), [](const FilterEntry &a, const FilterEntry &b) {
         const int compare = a.title.localeAwareCompare(b.title);
-        // Tie-break on the UUID so the order is fully deterministic
-        // (two filters with identical titles, e.g. both `info`, would
-        // otherwise still flicker across rebuilds).
-        return compare != 0 ? compare < 0 : a.id < b.id;
+        if (compare != 0)
+        {
+            return compare < 0;
+        }
+        // Tie-break by filter type first so two filters that render
+        // to the same title (e.g. a String filter spelt `true, false`
+        // and a Boolean filter) sit next to each other in type-stable
+        // order. Final tie-break on the UUID makes the order fully
+        // deterministic across rebuilds.
+        if (a.type != b.type)
+        {
+            return a.type < b.type;
+        }
+        return a.id < b.id;
     });
     for (const FilterEntry &entry : filtersForColumn)
     {
         const QString filterId = QString::fromStdString(entry.id);
         QMenu *filterSubMenu = menu->addMenu(entry.title);
         result.filterSubMenus[entry.id] = filterSubMenu;
-        const QAction *editAction = filterSubMenu->addAction(tr("Edit"));
+        QAction *editAction = filterSubMenu->addAction(tr("Edit"));
+        editAction->setEnabled(modelHasRows);
         // Same look-up-by-id pattern as the Filters-menu Edit
         // action (capturing the filter by value would freeze its
         // `row` at menu-build time); see `AddLogFilter` for the

--- a/app/src/main_window.cpp
+++ b/app/src/main_window.cpp
@@ -2668,7 +2668,9 @@ MainWindow::HeaderContextMenu MainWindow::BuildHeaderContextMenu(int logicalColu
     {
         if (entry.second.row == logicalColumn)
         {
-            filtersForColumn.push_back({entry.first, BuildFilterTitle(entry.second), entry.second.type});
+            filtersForColumn.push_back(
+                {.id = entry.first, .title = BuildFilterTitle(entry.second), .type = entry.second.type}
+            );
         }
     }
     std::sort(filtersForColumn.begin(), filtersForColumn.end(), [](const FilterEntry &a, const FilterEntry &b) {

--- a/app/src/main_window.cpp
+++ b/app/src/main_window.cpp
@@ -1968,6 +1968,11 @@ void MainWindow::FilterBooleanSubmitted(const QString &filterID, int row, bool i
 
 QString MainWindow::BuildFilterTitle(const loglib::LogConfiguration::LogFilter &filter) const
 {
+    // No `default:`: a new `LogFilter::Type` member must trip the
+    // compiler's `-Wswitch` warning rather than silently fall into
+    // the String branch, which would dereference a `nullopt`
+    // `filter.filterString` and crash. Every payload read below
+    // assumes the matching submit slot already validated it.
     switch (filter.type)
     {
     case loglib::LogConfiguration::LogFilter::Type::Time:
@@ -2020,9 +2025,10 @@ QString MainWindow::BuildFilterTitle(const loglib::LogConfiguration::LogFilter &
         return values.join(QStringLiteral(", "));
     }
     case loglib::LogConfiguration::LogFilter::Type::String:
-    default:
         return QString::fromStdString(*filter.filterString);
     }
+    Q_ASSERT_X(false, "MainWindow::BuildFilterTitle", "unhandled LogFilter::Type");
+    return {};
 }
 
 void MainWindow::AddLogFilter(const QString &id, const loglib::LogConfiguration::LogFilter &filter, bool deferSync)
@@ -2043,13 +2049,21 @@ void MainWindow::AddLogFilter(const QString &id, const loglib::LogConfiguration:
     // both fail under the Linux Release offscreen-QPA toolchain.
     mFilterSubMenus[id.toStdString()] = menuItem;
 
-    const QAction *editAction = menuItem->addAction("Edit");
+    const QAction *editAction = menuItem->addAction(tr("Edit"));
     // Capture only the filter id and resolve the live filter at
     // trigger time. Capturing the filter by value would freeze its
     // `row` at the column it had at menu-build time, so a column
     // reorder between build and click would mis-target Edit and the
     // type-match guard would silently drop the filter. Regression:
     // `TestEditFilterAfterColumnReorderUsesCurrentRow`.
+    //
+    // `bugprone-exception-escape` fires because `mFilters.find` and
+    // copying a `LogFilter` can technically allocate; throwing out
+    // of a Qt slot is undefined behaviour. The body has no source
+    // of recoverable exceptions (no user input, no I/O), so the
+    // alternative -- a `try`/`catch` around two map lookups -- is
+    // pure noise. Same justification applies to the matching Edit
+    // lambda in `BuildHeaderContextMenu`.
     // NOLINTNEXTLINE(bugprone-exception-escape)
     connect(editAction, &QAction::triggered, this, [this, id]() {
         const auto it = mFilters.find(id.toStdString());
@@ -2061,8 +2075,8 @@ void MainWindow::AddLogFilter(const QString &id, const loglib::LogConfiguration:
         AddFilter(id, it->second);
     });
 
-    const QAction *clearAction = menuItem->addAction("Clear");
-    connect(clearAction, &QAction::triggered, this, [this, id]() { ClearFilter(id); });
+    const QAction *removeAction = menuItem->addAction(tr("Remove"));
+    connect(removeAction, &QAction::triggered, this, [this, id]() { ClearFilter(id); });
     ui->actionClearAllFilters->setDisabled(false);
 }
 
@@ -2560,36 +2574,25 @@ void MainWindow::ShowHeaderContextMenu(const QPoint &pos)
     {
         return;
     }
-    QMenu *menu = BuildHeaderContextMenu(logical, header);
-    if (menu == nullptr)
+    HeaderContextMenu built = BuildHeaderContextMenu(logical, header);
+    if (built.menu == nullptr)
     {
         return;
     }
-    menu->setAttribute(Qt::WA_DeleteOnClose);
-    menu->popup(header->mapToGlobal(pos));
+    built.menu->setAttribute(Qt::WA_DeleteOnClose);
+    built.menu->popup(header->mapToGlobal(pos));
 }
 
-QMenu *MainWindow::BuildHeaderContextMenu(
-    int logicalColumn,
-    QWidget *parent,
-    QMenu **outShowSubMenu,
-    std::unordered_map<std::string, QMenu *> *outFilterSubMenus
-)
+MainWindow::HeaderContextMenu MainWindow::BuildHeaderContextMenu(int logicalColumn, QWidget *parent)
 {
-    if (outShowSubMenu != nullptr)
-    {
-        *outShowSubMenu = nullptr;
-    }
-    if (outFilterSubMenus != nullptr)
-    {
-        outFilterSubMenus->clear();
-    }
+    HeaderContextMenu result;
     const auto &columns = mModel->Configuration().columns;
     if (logicalColumn < 0 || static_cast<size_t>(logicalColumn) >= columns.size())
     {
-        return nullptr;
+        return result;
     }
     auto *menu = new QMenu(parent != nullptr ? parent : mTableView);
+    result.menu = menu;
 
     // Capture stable `keys` rather than the logical index: a column
     // move while the menu is open would otherwise leave the action
@@ -2620,11 +2623,13 @@ QMenu *MainWindow::BuildHeaderContextMenu(
 
     // Filter block: an `Add filter on "<col>"` action plus a per-
     // filter submenu for every existing filter targeting this
-    // column. Both paths re-resolve the column from `thisKeys` at
-    // trigger time so a column move between menu build and click
-    // still hits the right index. The filter submenus capture only
-    // the filter id; `mFilters[id]` is looked up live, mirroring
-    // the Filters-menu Edit/Clear actions wired in `AddLogFilter`.
+    // column. The Add path re-resolves the column from `thisKeys`
+    // at trigger time so a column move between menu build and
+    // click still hits the right index. The filter submenus
+    // capture only the filter id; `mFilters[id]` is looked up
+    // live, mirroring the Filters-menu Edit/Remove actions wired
+    // in `AddLogFilter`. A leading separator keeps Hide visually
+    // distinct from the filter group when both are present.
     if (!menu->isEmpty())
     {
         menu->addSeparator();
@@ -2639,31 +2644,41 @@ QMenu *MainWindow::BuildHeaderContextMenu(
         AddFilter(QUuid::createUuid().toString(), std::nullopt, /*openEditor=*/true, /*initialColumn=*/idx);
     });
 
-    // Existing filters on this column. Sort by id for a stable
-    // menu order across rebuilds (`mFilters` is an unordered_map).
-    std::vector<std::string> filterIdsForColumn;
-    filterIdsForColumn.reserve(mFilters.size());
+    // Existing filters on this column. Sort by display title so
+    // the menu reads like a sorted list to the user; `mFilters` is
+    // an `unordered_map` keyed by UUID, which would otherwise
+    // present filters in essentially random order.
+    struct FilterEntry
+    {
+        std::string id;
+        QString title;
+    };
+    std::vector<FilterEntry> filtersForColumn;
+    filtersForColumn.reserve(mFilters.size());
     for (const auto &entry : mFilters)
     {
         if (entry.second.row == logicalColumn)
         {
-            filterIdsForColumn.push_back(entry.first);
+            filtersForColumn.push_back({entry.first, BuildFilterTitle(entry.second)});
         }
     }
-    std::sort(filterIdsForColumn.begin(), filterIdsForColumn.end());
-    for (const std::string &filterIdStd : filterIdsForColumn)
+    std::sort(filtersForColumn.begin(), filtersForColumn.end(), [](const FilterEntry &a, const FilterEntry &b) {
+        const int compare = a.title.localeAwareCompare(b.title);
+        // Tie-break on the UUID so the order is fully deterministic
+        // (two filters with identical titles, e.g. both `info`, would
+        // otherwise still flicker across rebuilds).
+        return compare != 0 ? compare < 0 : a.id < b.id;
+    });
+    for (const FilterEntry &entry : filtersForColumn)
     {
-        const QString filterId = QString::fromStdString(filterIdStd);
-        const QString filterTitle = BuildFilterTitle(mFilters.at(filterIdStd));
-        QMenu *filterSubMenu = menu->addMenu(filterTitle);
-        if (outFilterSubMenus != nullptr)
-        {
-            (*outFilterSubMenus)[filterIdStd] = filterSubMenu;
-        }
+        const QString filterId = QString::fromStdString(entry.id);
+        QMenu *filterSubMenu = menu->addMenu(entry.title);
+        result.filterSubMenus[entry.id] = filterSubMenu;
         const QAction *editAction = filterSubMenu->addAction(tr("Edit"));
         // Same look-up-by-id pattern as the Filters-menu Edit
-        // action: capturing the filter by value would freeze its
-        // `row` at menu-build time.
+        // action (capturing the filter by value would freeze its
+        // `row` at menu-build time); see `AddLogFilter` for the
+        // `bugprone-exception-escape` justification.
         // NOLINTNEXTLINE(bugprone-exception-escape)
         connect(editAction, &QAction::triggered, this, [this, filterId]() {
             const auto it = mFilters.find(filterId.toStdString());
@@ -2696,10 +2711,7 @@ QMenu *MainWindow::BuildHeaderContextMenu(
             menu->addSeparator();
         }
         QMenu *showMenu = menu->addMenu(tr("Show column"));
-        if (outShowSubMenu != nullptr)
-        {
-            *outShowSubMenu = showMenu;
-        }
+        result.showSubMenu = showMenu;
         for (const int hiddenLogical : hiddenColumns)
         {
             const std::vector<std::string> &hiddenKeys = columns[static_cast<size_t>(hiddenLogical)].keys;
@@ -2714,7 +2726,7 @@ QMenu *MainWindow::BuildHeaderContextMenu(
             });
         }
     }
-    return menu;
+    return result;
 }
 
 void MainWindow::SetColumnVisible(int logicalIndex, bool visible)

--- a/app/src/main_window.cpp
+++ b/app/src/main_window.cpp
@@ -2601,10 +2601,9 @@ MainWindow::HeaderContextMenu MainWindow::BuildHeaderContextMenu(int logicalColu
     const std::vector<std::string> &thisKeys = columns[static_cast<size_t>(logicalColumn)].keys;
     const auto &thisColumn = columns[static_cast<size_t>(logicalColumn)];
 
-    // O(N) bulk build; `ColumnMenuLabel` per column would be
-    // O(N^2) on the `Show column` submenu.
-    const std::vector<QString> labels = BuildAllColumnMenuLabels();
-    const QString &thisLabel = labels[static_cast<size_t>(logicalColumn)];
+    // Only the clicked column's label is needed -- re-showing hidden
+    // columns is handled by the `View` menu, not this context menu.
+    const QString thisLabel = ColumnMenuLabel(static_cast<size_t>(logicalColumn));
 
     // Only offer Hide for visible columns. Production right-clicks
     // always hit a visible section; the test seam may pass a hidden
@@ -2709,39 +2708,10 @@ MainWindow::HeaderContextMenu MainWindow::BuildHeaderContextMenu(int logicalColu
         connect(removeAction, &QAction::triggered, this, [this, filterId]() { ClearFilter(filterId); });
     }
 
-    // Hidden columns populate the `Show column` submenu. The clicked
-    // column is normally visible, so it would not appear here in
-    // production -- tests can call this with a hidden index.
-    std::vector<int> hiddenColumns;
-    for (size_t i = 0; i < columns.size(); ++i)
-    {
-        if (!columns[i].visible)
-        {
-            hiddenColumns.push_back(static_cast<int>(i));
-        }
-    }
-    if (!hiddenColumns.empty())
-    {
-        if (!menu->isEmpty())
-        {
-            menu->addSeparator();
-        }
-        QMenu *showMenu = menu->addMenu(tr("Show column"));
-        result.showSubMenu = showMenu;
-        for (const int hiddenLogical : hiddenColumns)
-        {
-            const std::vector<std::string> &hiddenKeys = columns[static_cast<size_t>(hiddenLogical)].keys;
-            const QString &hiddenLabel = labels[static_cast<size_t>(hiddenLogical)];
-            const QAction *showAction = showMenu->addAction(hiddenLabel);
-            connect(showAction, &QAction::triggered, this, [this, keys = hiddenKeys]() {
-                const int idx = FindColumnIndexByKeys(keys);
-                if (idx >= 0)
-                {
-                    SetColumnVisible(idx, true);
-                }
-            });
-        }
-    }
+    // Re-showing hidden columns is intentionally not offered here:
+    // the `View` menu already covers it (and is the only escape
+    // hatch when *every* column is hidden, since no header section
+    // is left to right-click).
     return result;
 }
 

--- a/app/src/main_window.cpp
+++ b/app/src/main_window.cpp
@@ -1568,7 +1568,10 @@ void MainWindow::FindRecords(const QString &text, bool next, bool wildcards, boo
 }
 
 void MainWindow::AddFilter(
-    const QString &filterId, const std::optional<loglib::LogConfiguration::LogFilter> &filter, bool openEditor
+    const QString &filterId,
+    const std::optional<loglib::LogConfiguration::LogFilter> &filter,
+    bool openEditor,
+    int initialColumn
 )
 {
     if (mModel->rowCount() == 0)
@@ -1675,6 +1678,14 @@ void MainWindow::AddFilter(
     connect(filterEditor, &FilterEditor::FilterEnumSubmitted, this, &MainWindow::FilterEnumSubmitted);
     connect(filterEditor, &FilterEditor::FilterNumericRangeSubmitted, this, &MainWindow::FilterNumericRangeSubmitted);
     connect(filterEditor, &FilterEditor::FilterBooleanSubmitted, this, &MainWindow::FilterBooleanSubmitted);
+    // Preselect the clicked column for the header right-click "Add
+    // filter on <column>" entry. The `Load(...)` overloads below
+    // also set the row, so this is only meaningful when no payload
+    // is being restored.
+    if (!resolvedFilter.has_value() && initialColumn >= 0)
+    {
+        filterEditor->SetInitialColumn(initialColumn);
+    }
     if (resolvedFilter.has_value())
     {
         if (resolvedFilter->type == loglib::LogConfiguration::LogFilter::Type::Time)
@@ -1955,24 +1966,15 @@ void MainWindow::FilterBooleanSubmitted(const QString &filterID, int row, bool i
     AddLogFilter(filterID, filter);
 }
 
-void MainWindow::AddLogFilter(const QString &id, const loglib::LogConfiguration::LogFilter &filter, bool deferSync)
+QString MainWindow::BuildFilterTitle(const loglib::LogConfiguration::LogFilter &filter) const
 {
-    mFilters[id.toStdString()] = filter;
-    if (!deferSync)
-    {
-        MirrorFiltersToConfiguration();
-        UpdateFilters();
-    }
-
-    QString title;
     switch (filter.type)
     {
     case loglib::LogConfiguration::LogFilter::Type::Time:
-        title = QString::fromStdString(
+        return QString::fromStdString(
             loglib::UtcMicrosecondsToDateTimeString(*filter.filterBegin) + " - " +
             loglib::UtcMicrosecondsToDateTimeString(*filter.filterEnd)
         );
-        break;
     case loglib::LogConfiguration::LogFilter::Type::Enumeration:
     {
         QStringList values;
@@ -1981,8 +1983,7 @@ void MainWindow::AddLogFilter(const QString &id, const loglib::LogConfiguration:
         {
             values.append(QString::fromStdString(v));
         }
-        title = values.join(QStringLiteral(", "));
-        break;
+        return values.join(QStringLiteral(", "));
     }
     case loglib::LogConfiguration::LogFilter::Type::Number:
     {
@@ -1999,8 +2000,7 @@ void MainWindow::AddLogFilter(const QString &id, const loglib::LogConfiguration:
             filter.filterMaxValue.has_value()
                 ? cLocale.toString(*filter.filterMaxValue, 'g', std::numeric_limits<double>::max_digits10)
                 : QStringLiteral("+inf");
-        title = QStringLiteral("[%1, %2]").arg(minStr, maxStr);
-        break;
+        return QStringLiteral("[%1, %2]").arg(minStr, maxStr);
     }
     case loglib::LogConfiguration::LogFilter::Type::Boolean:
     {
@@ -2017,14 +2017,24 @@ void MainWindow::AddLogFilter(const QString &id, const loglib::LogConfiguration:
         {
             values.append(QStringLiteral("false"));
         }
-        title = values.join(QStringLiteral(", "));
-        break;
+        return values.join(QStringLiteral(", "));
     }
     case loglib::LogConfiguration::LogFilter::Type::String:
     default:
-        title = QString::fromStdString(*filter.filterString);
-        break;
+        return QString::fromStdString(*filter.filterString);
     }
+}
+
+void MainWindow::AddLogFilter(const QString &id, const loglib::LogConfiguration::LogFilter &filter, bool deferSync)
+{
+    mFilters[id.toStdString()] = filter;
+    if (!deferSync)
+    {
+        MirrorFiltersToConfiguration();
+        UpdateFilters();
+    }
+
+    const QString title = BuildFilterTitle(filter);
 
     QMenu *menuItem = ui->menuFilters->addMenu(title);
     menuItem->menuAction()->setData(QVariant(id));
@@ -2559,11 +2569,20 @@ void MainWindow::ShowHeaderContextMenu(const QPoint &pos)
     menu->popup(header->mapToGlobal(pos));
 }
 
-QMenu *MainWindow::BuildHeaderContextMenu(int logicalColumn, QWidget *parent, QMenu **outShowSubMenu)
+QMenu *MainWindow::BuildHeaderContextMenu(
+    int logicalColumn,
+    QWidget *parent,
+    QMenu **outShowSubMenu,
+    std::unordered_map<std::string, QMenu *> *outFilterSubMenus
+)
 {
     if (outShowSubMenu != nullptr)
     {
         *outShowSubMenu = nullptr;
+    }
+    if (outFilterSubMenus != nullptr)
+    {
+        outFilterSubMenus->clear();
     }
     const auto &columns = mModel->Configuration().columns;
     if (logicalColumn < 0 || static_cast<size_t>(logicalColumn) >= columns.size())
@@ -2582,14 +2601,14 @@ QMenu *MainWindow::BuildHeaderContextMenu(int logicalColumn, QWidget *parent, QM
     // O(N) bulk build; `ColumnMenuLabel` per column would be
     // O(N^2) on the `Show column` submenu.
     const std::vector<QString> labels = BuildAllColumnMenuLabels();
+    const QString &thisLabel = labels[static_cast<size_t>(logicalColumn)];
 
     // Only offer Hide for visible columns. Production right-clicks
     // always hit a visible section; the test seam may pass a hidden
     // index, where Hide would be a confusing no-op.
     if (thisColumn.visible)
     {
-        const QString &hideLabel = labels[static_cast<size_t>(logicalColumn)];
-        const QAction *hideAction = menu->addAction(tr("Hide \"%1\"").arg(hideLabel));
+        const QAction *hideAction = menu->addAction(tr("Hide \"%1\"").arg(thisLabel));
         connect(hideAction, &QAction::triggered, this, [this, keys = thisKeys]() {
             const int idx = FindColumnIndexByKeys(keys);
             if (idx >= 0)
@@ -2597,6 +2616,66 @@ QMenu *MainWindow::BuildHeaderContextMenu(int logicalColumn, QWidget *parent, QM
                 SetColumnVisible(idx, false);
             }
         });
+    }
+
+    // Filter block: an `Add filter on "<col>"` action plus a per-
+    // filter submenu for every existing filter targeting this
+    // column. Both paths re-resolve the column from `thisKeys` at
+    // trigger time so a column move between menu build and click
+    // still hits the right index. The filter submenus capture only
+    // the filter id; `mFilters[id]` is looked up live, mirroring
+    // the Filters-menu Edit/Clear actions wired in `AddLogFilter`.
+    if (!menu->isEmpty())
+    {
+        menu->addSeparator();
+    }
+    const QAction *addFilterAction = menu->addAction(tr("Add filter on \"%1\"...").arg(thisLabel));
+    connect(addFilterAction, &QAction::triggered, this, [this, keys = thisKeys]() {
+        const int idx = FindColumnIndexByKeys(keys);
+        if (idx < 0)
+        {
+            return;
+        }
+        AddFilter(QUuid::createUuid().toString(), std::nullopt, /*openEditor=*/true, /*initialColumn=*/idx);
+    });
+
+    // Existing filters on this column. Sort by id for a stable
+    // menu order across rebuilds (`mFilters` is an unordered_map).
+    std::vector<std::string> filterIdsForColumn;
+    filterIdsForColumn.reserve(mFilters.size());
+    for (const auto &entry : mFilters)
+    {
+        if (entry.second.row == logicalColumn)
+        {
+            filterIdsForColumn.push_back(entry.first);
+        }
+    }
+    std::sort(filterIdsForColumn.begin(), filterIdsForColumn.end());
+    for (const std::string &filterIdStd : filterIdsForColumn)
+    {
+        const QString filterId = QString::fromStdString(filterIdStd);
+        const QString filterTitle = BuildFilterTitle(mFilters.at(filterIdStd));
+        QMenu *filterSubMenu = menu->addMenu(filterTitle);
+        if (outFilterSubMenus != nullptr)
+        {
+            (*outFilterSubMenus)[filterIdStd] = filterSubMenu;
+        }
+        const QAction *editAction = filterSubMenu->addAction(tr("Edit"));
+        // Same look-up-by-id pattern as the Filters-menu Edit
+        // action: capturing the filter by value would freeze its
+        // `row` at menu-build time.
+        // NOLINTNEXTLINE(bugprone-exception-escape)
+        connect(editAction, &QAction::triggered, this, [this, filterId]() {
+            const auto it = mFilters.find(filterId.toStdString());
+            if (it == mFilters.end())
+            {
+                AddFilter(filterId);
+                return;
+            }
+            AddFilter(filterId, it->second);
+        });
+        const QAction *removeAction = filterSubMenu->addAction(tr("Remove"));
+        connect(removeAction, &QAction::triggered, this, [this, filterId]() { ClearFilter(filterId); });
     }
 
     // Hidden columns populate the `Show column` submenu. The clicked

--- a/doc/README.md
+++ b/doc/README.md
@@ -186,7 +186,7 @@ You can rearrange and hide columns to fit your view:
 
 - **Reorder**: drag a column header sideways to a new position. Filters and the sort indicator track the column to its new index, and the new order is preserved by [configurations](#configurations).
 - **Hide a column**: right-click the header and choose **Hide "\<col>"**, or uncheck the column in the **View** menu. Hidden columns stay in the model — data, sort, search, and filters keep working — only the header section is hidden.
-- **Show a hidden column**: right-click any visible header and pick the column from the **Show column** submenu, or re-check it in the **View** menu. The **View** menu is also the way back when *every* column is hidden (no header section is left to right-click).
+- **Show a hidden column**: re-check the column in the **View** menu. The **View** menu is the only way back, and stays reachable even when *every* column is hidden (no header section is left to right-click).
 
 Duplicate header names are disambiguated as `header [key]` in both menus so columns sharing a header are still individually addressable.
 

--- a/doc/README.md
+++ b/doc/README.md
@@ -180,6 +180,18 @@ You can persist a customized column layout and filter set via [configurations](#
 - **Smooth scrolling** is enabled by default (per-pixel) both vertically and horizontally.
 - **Alternating row colors** improve readability on dense logs. The table respects the application's light/dark palette.
 
+### Column Management
+
+You can rearrange and hide columns to fit your view:
+
+- **Reorder**: drag a column header sideways to a new position. Filters and the sort indicator track the column to its new index, and the new order is preserved by [configurations](#configurations).
+- **Hide a column**: right-click the header and choose **Hide "\<col>"**, or uncheck the column in the **View** menu. Hidden columns stay in the model — data, sort, search, and filters keep working — only the header section is hidden.
+- **Show a hidden column**: right-click any visible header and pick the column from the **Show column** submenu, or re-check it in the **View** menu. The **View** menu is also the way back when *every* column is hidden (no header section is left to right-click).
+
+Duplicate header names are disambiguated as `header [key]` in both menus so columns sharing a header are still individually addressable.
+
+> Hiding the column the table is currently sorted by clears the sort, since the sort glyph would otherwise live on a hidden section with no way to undo it.
+
 ### Selecting and Copying Rows
 
 - Click a row to select it. Hold `Ctrl`/`Shift` to extend the selection.
@@ -232,20 +244,20 @@ Each filter entry in the Filters menu has **Edit** and **Remove** sub-actions:
 - **Remove** drops just that filter.
 - **Filters → Clear All** removes every filter at once.
 
-You can also right-click a column header for the same actions scoped to that column: **Add filter on "&lt;col&gt;"…** opens the Filter Editor preselected to the clicked column, and every existing filter targeting the column appears with its own **Edit** / **Remove** sub-menu.
+You can also right-click a column header for the same actions scoped to that column: **Add filter on "\<col>"…** opens the Filter Editor preselected to the clicked column, and every existing filter targeting the column appears with its own **Edit** / **Remove** sub-menu.
 
 Filters are live: the table updates immediately when a filter is added, edited, or removed.
 
 ## Configurations
 
-A *configuration* captures the current column layout (headers, keys, print format, timestamp parse formats). Configurations are saved as JSON files, and can be loaded into future sessions to skip auto-detection and to enforce a consistent layout across teammates.
+A *configuration* captures the current column layout — headers, keys, print format, timestamp parse formats, column type (`time` / `enumeration` / …), **column order**, **per-column visibility** — and the **active filter set**. Configurations are saved as JSON files and can be loaded into future sessions to skip auto-detection and to enforce a consistent layout across teammates.
 
-- **File → Save Configuration…** (`Ctrl+S`) — writes the current layout to a `.json` file.
+- **File → Save Configuration…** (`Ctrl+S`) — writes the current layout and filters to a `.json` file.
 - **File → Load Configuration…** — loads a configuration file and clears any open logs. Open logs again afterwards to apply the layout.
 
 Because `Open…` auto-detects configurations, double-clicking a saved configuration file also works (it loads the layout without opening any logs).
 
-> Filters are not currently persisted in configurations.
+> Saved filters are validated against the loaded column set on every Load. Filters that no longer match a column (e.g. the key was renamed, or the column type changed in an incompatible way) are dropped and reported in a summary dialog so you can re-create them; the rest are restored as live entries in the **Filters** menu.
 
 ## Preferences
 

--- a/doc/README.md
+++ b/doc/README.md
@@ -224,15 +224,17 @@ When the **Row to filter** dropdown points at an [enumeration column](#automatic
 
 If a column is demoted back to text mid-session, saved enum filters fall back to comparing the row's text value against the saved selection. A saved text filter on a column that later auto-promotes to enum continues to match by text; re-edit it to switch to the value picker.
 
-### Editing or Clearing a Filter
+### Editing or Removing a Filter
 
-Each filter entry in the Filters menu has **Edit** and **Clear** sub-actions:
+Each filter entry in the Filters menu has **Edit** and **Remove** sub-actions:
 
 - **Edit** re-opens the Filter Editor pre-populated with the current values.
-- **Clear** removes just that filter.
+- **Remove** drops just that filter.
 - **Filters → Clear All** removes every filter at once.
 
-Filters are live: the table updates immediately when a filter is added, edited, or cleared.
+You can also right-click a column header for the same actions scoped to that column: **Add filter on "&lt;col&gt;"…** opens the Filter Editor preselected to the clicked column, and every existing filter targeting the column appears with its own **Edit** / **Remove** sub-menu.
+
+Filters are live: the table updates immediately when a filter is added, edited, or removed.
 
 ## Configurations
 

--- a/test/app/src/main_window_test.cpp
+++ b/test/app/src/main_window_test.cpp
@@ -3957,11 +3957,15 @@ private slots:
         QCOMPARE(showActionLabels, expected);
     }
 
-    // The header menu must omit `Hide` when the clicked column is
-    // already hidden (the action would be a confusing no-op). The
-    // Show submenu is still present so the user can re-show.
-    // Hidden-column right-clicks are reachable only via the test
-    // seam; production right-clicks only fire on visible sections.
+    // The header menu must omit both `Hide` and `Add filter on ...`
+    // when the clicked column is already hidden -- both actions
+    // would be confusing no-ops (Hide is already hidden;
+    // `FilterEditor::SetInitialColumn` silently refuses to preselect
+    // a hidden column, so the Add-filter action would advertise a
+    // column the editor would not actually point at). The Show
+    // submenu is still present so the user can re-show. Hidden-
+    // column right-clicks are reachable only via the test seam;
+    // production right-clicks only fire on visible sections.
     void TestHeaderContextMenuOmitsHideForHiddenColumn()
     {
         const int levelCol = StreamFixtureForColumnTests();
@@ -3977,6 +3981,10 @@ private slots:
         {
             QVERIFY2(
                 !act->text().startsWith("Hide"), "menu rooted at a hidden column must not advertise a Hide action"
+            );
+            QVERIFY2(
+                !act->text().startsWith("Add filter on"),
+                "menu rooted at a hidden column must not advertise an Add-filter action"
             );
         }
     }
@@ -4185,10 +4193,7 @@ private slots:
         removeAction->trigger();
         QCoreApplication::processEvents();
 
-        QVERIFY2(
-            !mWindow->Filters().contains(filterId.toStdString()),
-            "Remove must drop the filter from mFilters"
-        );
+        QVERIFY2(!mWindow->Filters().contains(filterId.toStdString()), "Remove must drop the filter from mFilters");
     }
 
     // Triggering `Edit` on a header-menu filter sub-menu opens a
@@ -4327,6 +4332,142 @@ private slots:
         editor->close();
         editor->deleteLater();
         QCoreApplication::processEvents();
+    }
+
+    // The header menu actions must appear in a stable, polished
+    // order: Hide → separator → Add filter on "..." → filter
+    // submenus → separator → Show column. The order is only encoded
+    // in `BuildHeaderContextMenu`'s control flow today, so a future
+    // reorder could silently flip the menu's polish without tripping
+    // any other test.
+    void TestHeaderContextMenuActionOrdering()
+    {
+        const int levelCol = StreamFixtureForColumnTests();
+        QVERIFY2(levelCol >= 0, "level column must exist after streaming");
+        auto *model = mWindow->Model();
+        const int msgCol = ColumnByHeader(*model, QStringLiteral("msg"));
+        QVERIFY2(msgCol >= 0, "msg column must exist after streaming");
+
+        // Hide `msg` so the Show-column submenu appears, and add a
+        // filter on `level` so the filter-submenu group is present.
+        // The menu is rooted at `level` (still visible) so every
+        // group is reachable.
+        mWindow->SetColumnVisible(msgCol, false);
+        const QString filterId = QStringLiteral("order-test");
+        QVERIFY2(
+            QMetaObject::invokeMethod(
+                mWindow,
+                "FilterEnumSubmitted",
+                Qt::DirectConnection,
+                Q_ARG(QString, filterId),
+                Q_ARG(int, levelCol),
+                Q_ARG(QStringList, QStringList{QStringLiteral("info")})
+            ),
+            "FilterEnumSubmitted slot must be invocable via meta-object"
+        );
+        QCoreApplication::processEvents();
+
+        auto built = mWindow->BuildHeaderContextMenu(levelCol, nullptr);
+        QVERIFY2(built.menu != nullptr, "BuildHeaderContextMenu must return a menu");
+        const QScopeGuard menuDeleter([&built]() { built.menu->deleteLater(); });
+
+        const QList<QAction *> topActions = built.menu->actions();
+        QVERIFY2(topActions.size() >= 6, "menu must contain Hide + sep + Add + filter + sep + Show submenu");
+
+        // Hide → separator → Add filter on ... → filter submenu →
+        // separator → Show column.
+        QVERIFY2(topActions[0]->text().startsWith("Hide"), "first action must be Hide");
+        QVERIFY2(topActions[1]->isSeparator(), "second action must be a separator");
+        QVERIFY2(topActions[2]->text().startsWith("Add filter on"), "third action must be Add filter on ...");
+        // The filter submenu is the next non-separator action; its
+        // title is the filter's display value, not a fixed string.
+        QVERIFY2(!topActions[3]->isSeparator(), "fourth action must be the filter submenu");
+        QVERIFY2(topActions[4]->isSeparator(), "fifth action must be a separator before Show column");
+        QVERIFY2(
+            topActions[5]->text() == QStringLiteral("Show column"), "sixth action must be the Show column submenu"
+        );
+    }
+
+    // The Add-filter and per-filter Edit actions must be disabled
+    // when the model has zero rows: `AddFilter` already short-
+    // circuits with a status-bar message in that case, so leaving
+    // the menu entries enabled would advertise a no-op. Remove
+    // stays enabled because dropping a filter does not need any
+    // rows. Exercised via the save / reset / load detour because
+    // that is the only seam that yields a columns-without-rows
+    // state (production hits it only transiently during a fresh
+    // stream open).
+    void TestHeaderContextMenuDisablesFilterActionsWhenModelEmpty()
+    {
+        const int levelCol = StreamFixtureForColumnTests();
+        QVERIFY2(levelCol >= 0, "level column must exist after streaming");
+        auto *model = mWindow->Model();
+
+        // Round-trip the configuration so the model ends up with the
+        // streamed columns but no rows. Same shape as
+        // `TestColumnVisibilityRoundTripsThroughSaveLoad`.
+        QTemporaryDir tempDir;
+        QVERIFY(tempDir.isValid());
+        const QString savedPath = tempDir.filePath(QStringLiteral("rowless.json"));
+        model->ConfigurationManager().Save(savedPath.toStdString());
+        model->Reset();
+        model->ConfigurationManager().Load(savedPath.toStdString());
+        mWindow->ApplyColumnVisibility();
+        QCoreApplication::processEvents();
+
+        QCOMPARE(model->rowCount(), 0);
+        const int reloadedLevelCol = ColumnByHeader(*model, QStringLiteral("level"));
+        QVERIFY2(reloadedLevelCol >= 0, "level column must survive the config round-trip");
+
+        // Inject a filter post-reload so the Edit/Remove sub-menus
+        // are populated. `FilterEnumSubmitted` does not need rows.
+        const QString filterId = QStringLiteral("empty-model-filter");
+        QVERIFY2(
+            QMetaObject::invokeMethod(
+                mWindow,
+                "FilterEnumSubmitted",
+                Qt::DirectConnection,
+                Q_ARG(QString, filterId),
+                Q_ARG(int, reloadedLevelCol),
+                Q_ARG(QStringList, QStringList{QStringLiteral("info")})
+            ),
+            "FilterEnumSubmitted slot must be invocable via meta-object"
+        );
+        QCoreApplication::processEvents();
+
+        auto built = mWindow->BuildHeaderContextMenu(reloadedLevelCol, nullptr);
+        QVERIFY2(built.menu != nullptr, "BuildHeaderContextMenu must return a menu");
+        const QScopeGuard menuDeleter([&built]() { built.menu->deleteLater(); });
+
+        const QAction *addFilterAction = nullptr;
+        for (QAction *act : built.menu->actions())
+        {
+            if (act->text().startsWith(QStringLiteral("Add filter on")))
+            {
+                addFilterAction = act;
+                break;
+            }
+        }
+        QVERIFY2(addFilterAction != nullptr, "menu must contain an Add-filter action");
+        // NOLINTNEXTLINE(clang-analyzer-core.CallAndMessage): false positive; prior `QVERIFY2` aborts on null.
+        QVERIFY2(!addFilterAction->isEnabled(), "Add filter must be disabled when the model has no rows");
+
+        QMenu *subMenu = built.filterSubMenus.at(filterId.toStdString());
+        QVERIFY2(subMenu != nullptr, "filter sub-menu must be exposed");
+        const QString editLabel = MainWindow::tr("Edit");
+        const QString removeLabel = MainWindow::tr("Remove");
+        // NOLINTNEXTLINE(clang-analyzer-core.CallAndMessage): false positive; prior `QVERIFY2` aborts on null.
+        for (const QAction *act : subMenu->actions())
+        {
+            if (act->text() == editLabel)
+            {
+                QVERIFY2(!act->isEnabled(), "Edit must be disabled when the model has no rows");
+            }
+            else if (act->text() == removeLabel)
+            {
+                QVERIFY2(act->isEnabled(), "Remove must stay enabled even when the model has no rows");
+            }
+        }
     }
 
     // `Column::visible` survives the Save / Reset / Load round-trip

--- a/test/app/src/main_window_test.cpp
+++ b/test/app/src/main_window_test.cpp
@@ -3929,26 +3929,25 @@ private slots:
         mWindow->SetColumnVisible(msgCol, false);
 
         // `BuildHeaderContextMenu` reports the freshly-built `Show
-        // column` submenu via the optional out-parameter; `QAction::
-        // menu()` and `qobject_cast<QMenu*>(child)` both return null
-        // on the Linux Release offscreen-QPA toolchain (the QtWidgets
+        // column` submenu via the returned struct; `QAction::menu()`
+        // and `qobject_cast<QMenu*>(child)` both return null on the
+        // Linux Release offscreen-QPA toolchain (the QtWidgets
         // metaobject hooks for `QMenu` are stripped at link time
         // there), so the test cannot recover the pointer by walking
-        // the tree. The out-parameter is the contract.
-        QMenu *showMenu = nullptr;
-        QMenu *menu = mWindow->BuildHeaderContextMenu(levelCol, nullptr, &showMenu);
-        QVERIFY2(menu != nullptr, "BuildHeaderContextMenu must return a menu");
-        const QScopeGuard menuDeleter([menu]() { menu->deleteLater(); });
+        // the tree. The struct is the contract.
+        auto built = mWindow->BuildHeaderContextMenu(levelCol, nullptr);
+        QVERIFY2(built.menu != nullptr, "BuildHeaderContextMenu must return a menu");
+        const QScopeGuard menuDeleter([&built]() { built.menu->deleteLater(); });
 
-        const QList<QAction *> topActions = menu->actions();
+        const QList<QAction *> topActions = built.menu->actions();
         QVERIFY2(topActions.size() >= 3, "visible-column menu must contain Hide + separator + Show submenu");
         QVERIFY2(topActions.front()->text().startsWith("Hide"), "first action must be the Hide entry");
 
-        QVERIFY2(showMenu != nullptr, "menu must contain a Show column submenu");
+        QVERIFY2(built.showSubMenu != nullptr, "menu must contain a Show column submenu");
 
         QStringList showActionLabels;
         // NOLINTNEXTLINE(clang-analyzer-core.CallAndMessage): false positive; prior `QVERIFY2` aborts on null.
-        for (const QAction *act : showMenu->actions())
+        for (const QAction *act : built.showSubMenu->actions())
         {
             showActionLabels.append(act->text());
         }
@@ -3970,11 +3969,11 @@ private slots:
 
         mWindow->SetColumnVisible(levelCol, false);
 
-        QMenu *menu = mWindow->BuildHeaderContextMenu(levelCol, nullptr);
-        QVERIFY2(menu != nullptr, "BuildHeaderContextMenu must return a menu");
-        const QScopeGuard menuDeleter([menu]() { menu->deleteLater(); });
+        auto built = mWindow->BuildHeaderContextMenu(levelCol, nullptr);
+        QVERIFY2(built.menu != nullptr, "BuildHeaderContextMenu must return a menu");
+        const QScopeGuard menuDeleter([&built]() { built.menu->deleteLater(); });
 
-        for (const QAction *act : menu->actions())
+        for (const QAction *act : built.menu->actions())
         {
             QVERIFY2(
                 !act->text().startsWith("Hide"), "menu rooted at a hidden column must not advertise a Hide action"
@@ -3990,12 +3989,12 @@ private slots:
         const int levelCol = StreamFixtureForColumnTests();
         QVERIFY2(levelCol >= 0, "level column must exist after streaming");
 
-        QMenu *menu = mWindow->BuildHeaderContextMenu(levelCol, nullptr);
-        QVERIFY2(menu != nullptr, "BuildHeaderContextMenu must return a menu");
-        const QScopeGuard menuDeleter([menu]() { menu->deleteLater(); });
+        auto built = mWindow->BuildHeaderContextMenu(levelCol, nullptr);
+        QVERIFY2(built.menu != nullptr, "BuildHeaderContextMenu must return a menu");
+        const QScopeGuard menuDeleter([&built]() { built.menu->deleteLater(); });
 
         const QAction *addFilterAction = nullptr;
-        for (const QAction *act : menu->actions())
+        for (const QAction *act : built.menu->actions())
         {
             if (act->text().startsWith(QStringLiteral("Add filter on")))
             {
@@ -4018,12 +4017,12 @@ private slots:
         const int levelCol = StreamFixtureForColumnTests();
         QVERIFY2(levelCol >= 0, "level column must exist after streaming");
 
-        QMenu *menu = mWindow->BuildHeaderContextMenu(levelCol, nullptr);
-        QVERIFY2(menu != nullptr, "BuildHeaderContextMenu must return a menu");
-        const QScopeGuard menuDeleter([menu]() { menu->deleteLater(); });
+        auto built = mWindow->BuildHeaderContextMenu(levelCol, nullptr);
+        QVERIFY2(built.menu != nullptr, "BuildHeaderContextMenu must return a menu");
+        const QScopeGuard menuDeleter([&built]() { built.menu->deleteLater(); });
 
         QAction *addFilterAction = nullptr;
-        for (QAction *act : menu->actions())
+        for (QAction *act : built.menu->actions())
         {
             if (act->text().startsWith(QStringLiteral("Add filter on")))
             {
@@ -4109,20 +4108,24 @@ private slots:
         QCoreApplication::processEvents();
         QCOMPARE(mWindow->Filters().size(), static_cast<size_t>(3));
 
-        std::unordered_map<std::string, QMenu *> filterSubMenus;
-        QMenu *menu = mWindow->BuildHeaderContextMenu(levelCol, nullptr, nullptr, &filterSubMenus);
-        QVERIFY2(menu != nullptr, "BuildHeaderContextMenu must return a menu");
-        const QScopeGuard menuDeleter([menu]() { menu->deleteLater(); });
+        auto built = mWindow->BuildHeaderContextMenu(levelCol, nullptr);
+        QVERIFY2(built.menu != nullptr, "BuildHeaderContextMenu must return a menu");
+        const QScopeGuard menuDeleter([&built]() { built.menu->deleteLater(); });
 
-        QCOMPARE(filterSubMenus.size(), static_cast<size_t>(2));
-        QVERIFY2(filterSubMenus.contains(levelFilter1.toStdString()), "level-filter-1 submenu must be exposed");
-        QVERIFY2(filterSubMenus.contains(levelFilter2.toStdString()), "level-filter-2 submenu must be exposed");
+        QCOMPARE(built.filterSubMenus.size(), static_cast<size_t>(2));
+        QVERIFY2(built.filterSubMenus.contains(levelFilter1.toStdString()), "level-filter-1 submenu must be exposed");
+        QVERIFY2(built.filterSubMenus.contains(levelFilter2.toStdString()), "level-filter-2 submenu must be exposed");
         QVERIFY2(
-            !filterSubMenus.contains(msgFilter.toStdString()),
+            !built.filterSubMenus.contains(msgFilter.toStdString()),
             "filters on a different column must not appear in this header menu"
         );
 
-        for (const auto &[id, subMenu] : filterSubMenus)
+        // Compare against the same translation context the production
+        // code uses, so a future translation of "Edit" / "Remove" in
+        // `MainWindow`'s context can't quietly break the assertion.
+        const QString editLabel = MainWindow::tr("Edit");
+        const QString removeLabel = MainWindow::tr("Remove");
+        for (const auto &[id, subMenu] : built.filterSubMenus)
         {
             QVERIFY2(subMenu != nullptr, "filter sub-menu pointer must be non-null");
             const QList<QAction *> actions = subMenu->actions();
@@ -4132,8 +4135,8 @@ private slots:
             {
                 labels.append(act->text());
             }
-            QVERIFY2(labels.contains(QStringLiteral("Edit")), "filter sub-menu must contain an Edit action");
-            QVERIFY2(labels.contains(QStringLiteral("Remove")), "filter sub-menu must contain a Remove action");
+            QVERIFY2(labels.contains(editLabel), "filter sub-menu must contain an Edit action");
+            QVERIFY2(labels.contains(removeLabel), "filter sub-menu must contain a Remove action");
         }
     }
 
@@ -4159,18 +4162,18 @@ private slots:
         QCoreApplication::processEvents();
         QVERIFY2(mWindow->Filters().contains(filterId.toStdString()), "filter must land in mFilters before remove");
 
-        std::unordered_map<std::string, QMenu *> filterSubMenus;
-        QMenu *menu = mWindow->BuildHeaderContextMenu(levelCol, nullptr, nullptr, &filterSubMenus);
-        QVERIFY2(menu != nullptr, "BuildHeaderContextMenu must return a menu");
-        const QScopeGuard menuDeleter([menu]() { menu->deleteLater(); });
+        auto built = mWindow->BuildHeaderContextMenu(levelCol, nullptr);
+        QVERIFY2(built.menu != nullptr, "BuildHeaderContextMenu must return a menu");
+        const QScopeGuard menuDeleter([&built]() { built.menu->deleteLater(); });
 
-        QMenu *subMenu = filterSubMenus.at(filterId.toStdString());
-        QVERIFY2(subMenu != nullptr, "filter sub-menu must be exposed via the out-parameter");
+        QMenu *subMenu = built.filterSubMenus.at(filterId.toStdString());
+        QVERIFY2(subMenu != nullptr, "filter sub-menu must be exposed via the struct");
         QAction *removeAction = nullptr;
+        const QString removeLabel = MainWindow::tr("Remove");
         // NOLINTNEXTLINE(clang-analyzer-core.CallAndMessage): false positive; prior `QVERIFY2` aborts on null.
         for (QAction *act : subMenu->actions())
         {
-            if (act->text() == QStringLiteral("Remove"))
+            if (act->text() == removeLabel)
             {
                 removeAction = act;
                 break;
@@ -4209,18 +4212,18 @@ private slots:
         );
         QCoreApplication::processEvents();
 
-        std::unordered_map<std::string, QMenu *> filterSubMenus;
-        QMenu *menu = mWindow->BuildHeaderContextMenu(levelCol, nullptr, nullptr, &filterSubMenus);
-        QVERIFY2(menu != nullptr, "BuildHeaderContextMenu must return a menu");
-        const QScopeGuard menuDeleter([menu]() { menu->deleteLater(); });
+        auto built = mWindow->BuildHeaderContextMenu(levelCol, nullptr);
+        QVERIFY2(built.menu != nullptr, "BuildHeaderContextMenu must return a menu");
+        const QScopeGuard menuDeleter([&built]() { built.menu->deleteLater(); });
 
-        QMenu *subMenu = filterSubMenus.at(filterId.toStdString());
+        QMenu *subMenu = built.filterSubMenus.at(filterId.toStdString());
         QVERIFY2(subMenu != nullptr, "filter sub-menu must be exposed");
         QAction *editAction = nullptr;
+        const QString editLabel = MainWindow::tr("Edit");
         // NOLINTNEXTLINE(clang-analyzer-core.CallAndMessage): false positive; prior `QVERIFY2` aborts on null.
         for (QAction *act : subMenu->actions())
         {
-            if (act->text() == QStringLiteral("Edit"))
+            if (act->text() == editLabel)
             {
                 editAction = act;
                 break;
@@ -4266,12 +4269,12 @@ private slots:
         const int columnCount = model->columnCount();
         QVERIFY2(columnCount >= 2, "fixture must yield at least two columns");
 
-        QMenu *menu = mWindow->BuildHeaderContextMenu(levelCol, nullptr);
-        QVERIFY2(menu != nullptr, "BuildHeaderContextMenu must return a menu");
-        const QScopeGuard menuDeleter([menu]() { menu->deleteLater(); });
+        auto built = mWindow->BuildHeaderContextMenu(levelCol, nullptr);
+        QVERIFY2(built.menu != nullptr, "BuildHeaderContextMenu must return a menu");
+        const QScopeGuard menuDeleter([&built]() { built.menu->deleteLater(); });
 
         QAction *addFilterAction = nullptr;
-        for (QAction *act : menu->actions())
+        for (QAction *act : built.menu->actions())
         {
             if (act->text().startsWith(QStringLiteral("Add filter on")))
             {
@@ -4830,7 +4833,7 @@ private slots:
         QVERIFY2(filterMenuAction != nullptr, "active filter must have a Filters-menu entry");
 
         const QMenu *filterSubMenu = mWindow->FilterSubMenu(filterId);
-        QVERIFY2(filterSubMenu != nullptr, "filter menu entry must own an Edit/Clear sub-menu");
+        QVERIFY2(filterSubMenu != nullptr, "filter menu entry must own an Edit/Remove sub-menu");
         QAction *editAction = nullptr;
         // NOLINTNEXTLINE(clang-analyzer-core.CallAndMessage): false positive; prior `QVERIFY2` aborts on null.
         for (QAction *action : filterSubMenu->actions())

--- a/test/app/src/main_window_test.cpp
+++ b/test/app/src/main_window_test.cpp
@@ -3912,11 +3912,15 @@ private slots:
         QVERIFY2(!header->isSectionHidden(levelCol), "header section must no longer be hidden");
     }
 
-    // The header menu's `Show column` submenu lists every hidden
-    // column. Built against a visible clicked column so the `Hide`
-    // entry is present too. The hidden-column branch is covered by
-    // `TestHeaderContextMenuOmitsHideForHiddenColumn`.
-    void TestHeaderContextMenuListsHiddenColumns()
+    // The header menu must never advertise a hidden column on a
+    // visible-column right-click: re-showing hidden columns is
+    // intentionally delegated to the `View` menu (the only escape
+    // hatch when *every* column is hidden, since no header section
+    // is left to right-click). Built against a visible clicked
+    // column so the `Hide` entry is present and the contrast is
+    // sharp. Pinned so a future regression that reintroduces a
+    // `Show column` submenu trips here.
+    void TestHeaderContextMenuOmitsShowColumnSubmenu()
     {
         const int levelCol = StreamFixtureForColumnTests();
         QVERIFY2(levelCol >= 0, "level column must exist after streaming");
@@ -3924,43 +3928,35 @@ private slots:
         const int msgCol = ColumnByHeader(*model, QStringLiteral("msg"));
         QVERIFY2(msgCol >= 0, "msg column must exist after streaming");
 
-        // Hide only `msg` so the menu on `level` shows both Hide
-        // (for `level`) and Show column (listing `msg`).
         mWindow->SetColumnVisible(msgCol, false);
 
-        // `BuildHeaderContextMenu` exposes the Show-column submenu
-        // via the returned struct. On Linux Release offscreen-QPA,
-        // QMenu metaobject hooks are stripped, so `QAction::menu()`
-        // and `qobject_cast<QMenu*>(child)` both return null --
-        // tests can't recover the submenu by walking the tree, so
-        // the struct is the contract.
         auto built = mWindow->BuildHeaderContextMenu(levelCol, nullptr);
         QVERIFY2(built.menu != nullptr, "BuildHeaderContextMenu must return a menu");
         const QScopeGuard menuDeleter([&built]() { built.menu->deleteLater(); });
 
         const QList<QAction *> topActions = built.menu->actions();
-        QVERIFY2(topActions.size() >= 3, "visible-column menu must contain Hide + separator + Show submenu");
+        QVERIFY2(!topActions.isEmpty(), "visible-column menu must contain at least the Hide entry");
         QVERIFY2(topActions.front()->text().startsWith("Hide"), "first action must be the Hide entry");
 
-        QVERIFY2(built.showSubMenu != nullptr, "menu must contain a Show column submenu");
-
-        QStringList showActionLabels;
-        // NOLINTNEXTLINE(clang-analyzer-core.CallAndMessage): false positive; prior `QVERIFY2` aborts on null.
-        for (const QAction *act : built.showSubMenu->actions())
+        for (const QAction *act : topActions)
         {
-            showActionLabels.append(act->text());
+            QVERIFY2(
+                act->text() != QStringLiteral("Show column"),
+                "header context menu must not offer a Show column submenu (use the View menu)"
+            );
+            QVERIFY2(
+                act->text() != QStringLiteral("msg"),
+                "header context menu must not list the hidden `msg` column as an action"
+            );
         }
-        QStringList expected{QStringLiteral("msg")};
-        expected.sort();
-        showActionLabels.sort();
-        QCOMPARE(showActionLabels, expected);
     }
 
     // For a hidden column the menu must omit both `Hide` and
-    // `Add filter on ...` (both would be confusing no-ops); the
-    // Show submenu is still present so the user can re-show.
-    // Hidden-column right-clicks are only reachable via the test
-    // seam -- production right-clicks fire on visible sections.
+    // `Add filter on ...` (both would be confusing no-ops). The
+    // hidden-column right-click is only reachable via the test
+    // seam -- production right-clicks fire on visible sections --
+    // and re-showing hidden columns is delegated to the `View`
+    // menu, so the resulting menu is empty in this branch.
     void TestHeaderContextMenuOmitsHideForHiddenColumn()
     {
         const int levelCol = StreamFixtureForColumnTests();
@@ -4328,10 +4324,10 @@ private slots:
     }
 
     // The header menu must keep a stable, polished order: Hide →
-    // separator → Add filter → filter submenus → separator → Show
-    // column. The order is only encoded in `BuildHeaderContextMenu`'s
-    // control flow, so a future reorder could quietly break the
-    // menu's polish without tripping any other test.
+    // separator → Add filter → filter submenus. The order is only
+    // encoded in `BuildHeaderContextMenu`'s control flow, so a
+    // future reorder could quietly break the menu's polish without
+    // tripping any other test.
     void TestHeaderContextMenuActionOrdering()
     {
         const int levelCol = StreamFixtureForColumnTests();
@@ -4340,10 +4336,10 @@ private slots:
         const int msgCol = ColumnByHeader(*model, QStringLiteral("msg"));
         QVERIFY2(msgCol >= 0, "msg column must exist after streaming");
 
-        // Hide `msg` so the Show-column submenu appears, add a
-        // filter on `level` so the filter group is present, and
-        // root the menu at `level` (still visible) so every group
-        // is reachable.
+        // Hide `msg` to assert it does *not* leak into the menu
+        // (re-showing is owned by the `View` menu), add a filter on
+        // `level` so the filter group is present, and root the menu
+        // at `level` (still visible) so every group is reachable.
         mWindow->SetColumnVisible(msgCol, false);
         const QString filterId = QStringLiteral("order-test");
         QVERIFY2(
@@ -4364,20 +4360,15 @@ private slots:
         const QScopeGuard menuDeleter([&built]() { built.menu->deleteLater(); });
 
         const QList<QAction *> topActions = built.menu->actions();
-        QVERIFY2(topActions.size() >= 6, "menu must contain Hide + sep + Add + filter + sep + Show submenu");
+        QCOMPARE(topActions.size(), 4);
 
-        // Hide → separator → Add filter on ... → filter submenu →
-        // separator → Show column.
+        // Hide → separator → Add filter on ... → filter submenu.
         QVERIFY2(topActions[0]->text().startsWith("Hide"), "first action must be Hide");
         QVERIFY2(topActions[1]->isSeparator(), "second action must be a separator");
         QVERIFY2(topActions[2]->text().startsWith("Add filter on"), "third action must be Add filter on ...");
-        // Next non-separator is the filter submenu; its title is the
+        // Last non-separator is the filter submenu; its title is the
         // filter's display value, not a fixed string.
         QVERIFY2(!topActions[3]->isSeparator(), "fourth action must be the filter submenu");
-        QVERIFY2(topActions[4]->isSeparator(), "fifth action must be a separator before Show column");
-        QVERIFY2(
-            topActions[5]->text() == QStringLiteral("Show column"), "sixth action must be the Show column submenu"
-        );
     }
 
     // With zero rows, Add-filter and per-filter Edit must be

--- a/test/app/src/main_window_test.cpp
+++ b/test/app/src/main_window_test.cpp
@@ -4003,6 +4003,7 @@ private slots:
         }
         QVERIFY2(addFilterAction != nullptr, "menu must contain an `Add filter on ...` action");
         QVERIFY2(
+            // NOLINTNEXTLINE(clang-analyzer-core.CallAndMessage): false positive; prior `QVERIFY2` aborts on null.
             addFilterAction->text().contains(QStringLiteral("level")),
             "Add filter action title must reference the clicked column"
         );
@@ -4163,7 +4164,7 @@ private slots:
         QVERIFY2(built.menu != nullptr, "BuildHeaderContextMenu must return a menu");
         const QScopeGuard menuDeleter([&built]() { built.menu->deleteLater(); });
 
-        QMenu *subMenu = built.filterSubMenus.at(filterId.toStdString());
+        const QMenu *subMenu = built.filterSubMenus.at(filterId.toStdString());
         QVERIFY2(subMenu != nullptr, "filter sub-menu must be exposed via the struct");
         QAction *removeAction = nullptr;
         const QString removeLabel = MainWindow::tr("Remove");
@@ -4210,7 +4211,7 @@ private slots:
         QVERIFY2(built.menu != nullptr, "BuildHeaderContextMenu must return a menu");
         const QScopeGuard menuDeleter([&built]() { built.menu->deleteLater(); });
 
-        QMenu *subMenu = built.filterSubMenus.at(filterId.toStdString());
+        const QMenu *subMenu = built.filterSubMenus.at(filterId.toStdString());
         QVERIFY2(subMenu != nullptr, "filter sub-menu must be exposed");
         QAction *editAction = nullptr;
         const QString editLabel = MainWindow::tr("Edit");
@@ -4386,7 +4387,7 @@ private slots:
         // Round-trip the configuration so the model keeps its
         // streamed columns but loses all rows. Same shape as
         // `TestColumnVisibilityRoundTripsThroughSaveLoad`.
-        QTemporaryDir tempDir;
+        const QTemporaryDir tempDir;
         QVERIFY(tempDir.isValid());
         const QString savedPath = tempDir.filePath(QStringLiteral("rowless.json"));
         model->ConfigurationManager().Save(savedPath.toStdString());
@@ -4420,7 +4421,7 @@ private slots:
         const QScopeGuard menuDeleter([&built]() { built.menu->deleteLater(); });
 
         const QAction *addFilterAction = nullptr;
-        for (QAction *act : built.menu->actions())
+        for (const QAction *act : built.menu->actions())
         {
             if (act->text().startsWith(QStringLiteral("Add filter on")))
             {
@@ -4432,7 +4433,7 @@ private slots:
         // NOLINTNEXTLINE(clang-analyzer-core.CallAndMessage): false positive; prior `QVERIFY2` aborts on null.
         QVERIFY2(!addFilterAction->isEnabled(), "Add filter must be disabled when the model has no rows");
 
-        QMenu *subMenu = built.filterSubMenus.at(filterId.toStdString());
+        const QMenu *subMenu = built.filterSubMenus.at(filterId.toStdString());
         QVERIFY2(subMenu != nullptr, "filter sub-menu must be exposed");
         const QString editLabel = MainWindow::tr("Edit");
         const QString removeLabel = MainWindow::tr("Remove");

--- a/test/app/src/main_window_test.cpp
+++ b/test/app/src/main_window_test.cpp
@@ -3982,6 +3982,350 @@ private slots:
         }
     }
 
+    // The header menu must always offer an `Add filter on "<col>"...`
+    // action so the user can scope a filter to the clicked column
+    // without leaving the right-click menu.
+    void TestHeaderContextMenuOffersAddFilter()
+    {
+        const int levelCol = StreamFixtureForColumnTests();
+        QVERIFY2(levelCol >= 0, "level column must exist after streaming");
+
+        QMenu *menu = mWindow->BuildHeaderContextMenu(levelCol, nullptr);
+        QVERIFY2(menu != nullptr, "BuildHeaderContextMenu must return a menu");
+        const QScopeGuard menuDeleter([menu]() { menu->deleteLater(); });
+
+        const QAction *addFilterAction = nullptr;
+        for (const QAction *act : menu->actions())
+        {
+            if (act->text().startsWith(QStringLiteral("Add filter on")))
+            {
+                addFilterAction = act;
+                break;
+            }
+        }
+        QVERIFY2(addFilterAction != nullptr, "menu must contain an `Add filter on ...` action");
+        QVERIFY2(
+            addFilterAction->text().contains(QStringLiteral("level")),
+            "Add filter action title must reference the clicked column"
+        );
+    }
+
+    // Triggering the header menu's Add filter entry opens a
+    // `FilterEditor` with the row combobox already pointed at the
+    // clicked column, so the user does not have to re-pick it.
+    void TestHeaderContextMenuAddFilterOpensEditorWithColumnPreselected()
+    {
+        const int levelCol = StreamFixtureForColumnTests();
+        QVERIFY2(levelCol >= 0, "level column must exist after streaming");
+
+        QMenu *menu = mWindow->BuildHeaderContextMenu(levelCol, nullptr);
+        QVERIFY2(menu != nullptr, "BuildHeaderContextMenu must return a menu");
+        const QScopeGuard menuDeleter([menu]() { menu->deleteLater(); });
+
+        QAction *addFilterAction = nullptr;
+        for (QAction *act : menu->actions())
+        {
+            if (act->text().startsWith(QStringLiteral("Add filter on")))
+            {
+                addFilterAction = act;
+                break;
+            }
+        }
+        QVERIFY2(addFilterAction != nullptr, "menu must contain an `Add filter on ...` action");
+
+        // NOLINTNEXTLINE(clang-analyzer-core.CallAndMessage): false positive; prior `QVERIFY2` aborts on null.
+        addFilterAction->trigger();
+        QCoreApplication::processEvents();
+
+        FilterEditor *editor = nullptr;
+        for (QWidget *widget : QApplication::topLevelWidgets())
+        {
+            if (auto *e = qobject_cast<FilterEditor *>(widget))
+            {
+                editor = e;
+                break;
+            }
+        }
+        QVERIFY2(editor != nullptr, "Add filter must spawn a FilterEditor");
+        // NOLINTNEXTLINE(clang-analyzer-core.CallAndMessage): false positive; prior `QVERIFY2` aborts on null.
+        QCOMPARE(editor->GetRowToFilter(), levelCol);
+
+        editor->close();
+        editor->deleteLater();
+        QCoreApplication::processEvents();
+    }
+
+    // The header menu lists every existing filter targeting the
+    // clicked column as a per-filter submenu (titled with the
+    // filter's display value, mirroring the Filters menu). Each
+    // submenu carries an `Edit` and a `Remove` action.
+    void TestHeaderContextMenuListsExistingFiltersForColumn()
+    {
+        const int levelCol = StreamFixtureForColumnTests();
+        QVERIFY2(levelCol >= 0, "level column must exist after streaming");
+        auto *model = mWindow->Model();
+        const int msgCol = ColumnByHeader(*model, QStringLiteral("msg"));
+        QVERIFY2(msgCol >= 0, "msg column must exist after streaming");
+
+        // Two filters on `level`, one filter on `msg` (which must
+        // not appear in the header menu rooted at `level`).
+        const QString levelFilter1 = QStringLiteral("level-filter-1");
+        const QString levelFilter2 = QStringLiteral("level-filter-2");
+        const QString msgFilter = QStringLiteral("msg-filter");
+        QVERIFY2(
+            QMetaObject::invokeMethod(
+                mWindow,
+                "FilterEnumSubmitted",
+                Qt::DirectConnection,
+                Q_ARG(QString, levelFilter1),
+                Q_ARG(int, levelCol),
+                Q_ARG(QStringList, QStringList{QStringLiteral("info")})
+            ),
+            "FilterEnumSubmitted slot must be invocable via meta-object"
+        );
+        QVERIFY2(
+            QMetaObject::invokeMethod(
+                mWindow,
+                "FilterEnumSubmitted",
+                Qt::DirectConnection,
+                Q_ARG(QString, levelFilter2),
+                Q_ARG(int, levelCol),
+                Q_ARG(QStringList, QStringList{QStringLiteral("warn")})
+            ),
+            "FilterEnumSubmitted slot must be invocable via meta-object"
+        );
+        QVERIFY2(
+            QMetaObject::invokeMethod(
+                mWindow,
+                "FilterSubmitted",
+                Qt::DirectConnection,
+                Q_ARG(QString, msgFilter),
+                Q_ARG(int, msgCol),
+                Q_ARG(QString, QStringLiteral("m1")),
+                Q_ARG(int, static_cast<int>(loglib::LogConfiguration::LogFilter::Match::Contains))
+            ),
+            "FilterSubmitted slot must be invocable via meta-object"
+        );
+        QCoreApplication::processEvents();
+        QCOMPARE(mWindow->Filters().size(), static_cast<size_t>(3));
+
+        std::unordered_map<std::string, QMenu *> filterSubMenus;
+        QMenu *menu = mWindow->BuildHeaderContextMenu(levelCol, nullptr, nullptr, &filterSubMenus);
+        QVERIFY2(menu != nullptr, "BuildHeaderContextMenu must return a menu");
+        const QScopeGuard menuDeleter([menu]() { menu->deleteLater(); });
+
+        QCOMPARE(filterSubMenus.size(), static_cast<size_t>(2));
+        QVERIFY2(filterSubMenus.contains(levelFilter1.toStdString()), "level-filter-1 submenu must be exposed");
+        QVERIFY2(filterSubMenus.contains(levelFilter2.toStdString()), "level-filter-2 submenu must be exposed");
+        QVERIFY2(
+            !filterSubMenus.contains(msgFilter.toStdString()),
+            "filters on a different column must not appear in this header menu"
+        );
+
+        for (const auto &[id, subMenu] : filterSubMenus)
+        {
+            QVERIFY2(subMenu != nullptr, "filter sub-menu pointer must be non-null");
+            const QList<QAction *> actions = subMenu->actions();
+            QStringList labels;
+            // NOLINTNEXTLINE(clang-analyzer-core.CallAndMessage): false positive; prior `QVERIFY2` aborts on null.
+            for (const QAction *act : actions)
+            {
+                labels.append(act->text());
+            }
+            QVERIFY2(labels.contains(QStringLiteral("Edit")), "filter sub-menu must contain an Edit action");
+            QVERIFY2(labels.contains(QStringLiteral("Remove")), "filter sub-menu must contain a Remove action");
+        }
+    }
+
+    // Triggering `Remove` on a header-menu filter sub-menu drops
+    // the filter from `mFilters` (and from the wire-format mirror).
+    void TestHeaderContextMenuRemoveClearsFilter()
+    {
+        const int levelCol = StreamFixtureForColumnTests();
+        QVERIFY2(levelCol >= 0, "level column must exist after streaming");
+
+        const QString filterId = QStringLiteral("header-remove");
+        QVERIFY2(
+            QMetaObject::invokeMethod(
+                mWindow,
+                "FilterEnumSubmitted",
+                Qt::DirectConnection,
+                Q_ARG(QString, filterId),
+                Q_ARG(int, levelCol),
+                Q_ARG(QStringList, QStringList{QStringLiteral("info")})
+            ),
+            "FilterEnumSubmitted slot must be invocable via meta-object"
+        );
+        QCoreApplication::processEvents();
+        QVERIFY2(mWindow->Filters().contains(filterId.toStdString()), "filter must land in mFilters before remove");
+
+        std::unordered_map<std::string, QMenu *> filterSubMenus;
+        QMenu *menu = mWindow->BuildHeaderContextMenu(levelCol, nullptr, nullptr, &filterSubMenus);
+        QVERIFY2(menu != nullptr, "BuildHeaderContextMenu must return a menu");
+        const QScopeGuard menuDeleter([menu]() { menu->deleteLater(); });
+
+        QMenu *subMenu = filterSubMenus.at(filterId.toStdString());
+        QVERIFY2(subMenu != nullptr, "filter sub-menu must be exposed via the out-parameter");
+        QAction *removeAction = nullptr;
+        // NOLINTNEXTLINE(clang-analyzer-core.CallAndMessage): false positive; prior `QVERIFY2` aborts on null.
+        for (QAction *act : subMenu->actions())
+        {
+            if (act->text() == QStringLiteral("Remove"))
+            {
+                removeAction = act;
+                break;
+            }
+        }
+        QVERIFY2(removeAction != nullptr, "sub-menu must contain a Remove action");
+
+        // NOLINTNEXTLINE(clang-analyzer-core.CallAndMessage): false positive; prior `QVERIFY2` aborts on null.
+        removeAction->trigger();
+        QCoreApplication::processEvents();
+
+        QVERIFY2(
+            !mWindow->Filters().contains(filterId.toStdString()),
+            "Remove must drop the filter from mFilters"
+        );
+    }
+
+    // Triggering `Edit` on a header-menu filter sub-menu opens a
+    // `FilterEditor` bound to the same column the filter targets.
+    void TestHeaderContextMenuEditOpensEditor()
+    {
+        const int levelCol = StreamFixtureForColumnTests();
+        QVERIFY2(levelCol >= 0, "level column must exist after streaming");
+
+        const QString filterId = QStringLiteral("header-edit");
+        QVERIFY2(
+            QMetaObject::invokeMethod(
+                mWindow,
+                "FilterEnumSubmitted",
+                Qt::DirectConnection,
+                Q_ARG(QString, filterId),
+                Q_ARG(int, levelCol),
+                Q_ARG(QStringList, QStringList{QStringLiteral("info")})
+            ),
+            "FilterEnumSubmitted slot must be invocable via meta-object"
+        );
+        QCoreApplication::processEvents();
+
+        std::unordered_map<std::string, QMenu *> filterSubMenus;
+        QMenu *menu = mWindow->BuildHeaderContextMenu(levelCol, nullptr, nullptr, &filterSubMenus);
+        QVERIFY2(menu != nullptr, "BuildHeaderContextMenu must return a menu");
+        const QScopeGuard menuDeleter([menu]() { menu->deleteLater(); });
+
+        QMenu *subMenu = filterSubMenus.at(filterId.toStdString());
+        QVERIFY2(subMenu != nullptr, "filter sub-menu must be exposed");
+        QAction *editAction = nullptr;
+        // NOLINTNEXTLINE(clang-analyzer-core.CallAndMessage): false positive; prior `QVERIFY2` aborts on null.
+        for (QAction *act : subMenu->actions())
+        {
+            if (act->text() == QStringLiteral("Edit"))
+            {
+                editAction = act;
+                break;
+            }
+        }
+        QVERIFY2(editAction != nullptr, "sub-menu must contain an Edit action");
+
+        // NOLINTNEXTLINE(clang-analyzer-core.CallAndMessage): false positive; prior `QVERIFY2` aborts on null.
+        editAction->trigger();
+        QCoreApplication::processEvents();
+
+        FilterEditor *editor = nullptr;
+        for (QWidget *widget : QApplication::topLevelWidgets())
+        {
+            if (auto *e = qobject_cast<FilterEditor *>(widget))
+            {
+                editor = e;
+                break;
+            }
+        }
+        QVERIFY2(editor != nullptr, "Edit must open a FilterEditor");
+        // NOLINTNEXTLINE(clang-analyzer-core.CallAndMessage): false positive; prior `QVERIFY2` aborts on null.
+        QCOMPARE(editor->GetRowToFilter(), levelCol);
+        QVERIFY2(
+            mWindow->Filters().contains(filterId.toStdString()),
+            "Edit must not drop the filter; the lambda re-resolves mFilters[id] live"
+        );
+
+        editor->close();
+        editor->deleteLater();
+        QCoreApplication::processEvents();
+    }
+
+    // Regression-guard for the keys-based re-resolution in the new
+    // `Add filter on ...` lambda: a column reorder between menu
+    // build and click must still target the column's *current*
+    // index. Same shape as `TestEditFilterAfterColumnReorderUsesCurrentRow`.
+    void TestHeaderContextMenuAddFilterAfterColumnReorderResolvesByKeys()
+    {
+        const int levelCol = StreamFixtureForColumnTests();
+        QVERIFY2(levelCol >= 0, "level column must exist after streaming");
+        auto *model = mWindow->Model();
+        const int columnCount = model->columnCount();
+        QVERIFY2(columnCount >= 2, "fixture must yield at least two columns");
+
+        QMenu *menu = mWindow->BuildHeaderContextMenu(levelCol, nullptr);
+        QVERIFY2(menu != nullptr, "BuildHeaderContextMenu must return a menu");
+        const QScopeGuard menuDeleter([menu]() { menu->deleteLater(); });
+
+        QAction *addFilterAction = nullptr;
+        for (QAction *act : menu->actions())
+        {
+            if (act->text().startsWith(QStringLiteral("Add filter on")))
+            {
+                addFilterAction = act;
+                break;
+            }
+        }
+        QVERIFY2(addFilterAction != nullptr, "menu must contain an `Add filter on ...` action");
+
+        // Reorder `level` *after* the menu is built but *before*
+        // the action is triggered. The lambda must re-resolve the
+        // index from the captured keys.
+        const int src = levelCol;
+        const int dest = (src == 0) ? columnCount - 1 : 0;
+        QVERIFY(src != dest);
+        QVERIFY2(
+            QMetaObject::invokeMethod(
+                mWindow,
+                "OnHeaderSectionMoved",
+                Qt::DirectConnection,
+                Q_ARG(int, src),
+                Q_ARG(int, src),
+                Q_ARG(int, dest)
+            ),
+            "OnHeaderSectionMoved slot must be invocable via meta-object"
+        );
+        QCoreApplication::processEvents();
+        QCOMPARE(ColumnByHeader(*model, QStringLiteral("level")), dest);
+
+        // NOLINTNEXTLINE(clang-analyzer-core.CallAndMessage): false positive; prior `QVERIFY2` aborts on null.
+        addFilterAction->trigger();
+        QCoreApplication::processEvents();
+
+        FilterEditor *editor = nullptr;
+        for (QWidget *widget : QApplication::topLevelWidgets())
+        {
+            if (auto *e = qobject_cast<FilterEditor *>(widget))
+            {
+                editor = e;
+                break;
+            }
+        }
+        QVERIFY2(editor != nullptr, "Add filter must spawn a FilterEditor");
+        // The editor's row must reflect the *post-reorder* column
+        // index, proving the lambda re-resolved by keys at trigger
+        // time rather than freezing on the build-time index.
+        // NOLINTNEXTLINE(clang-analyzer-core.CallAndMessage): false positive; prior `QVERIFY2` aborts on null.
+        QCOMPARE(editor->GetRowToFilter(), dest);
+
+        editor->close();
+        editor->deleteLater();
+        QCoreApplication::processEvents();
+    }
+
     // `Column::visible` survives the Save / Reset / Load round-trip
     // (driven through the manager directly so the file dialogs
     // don't pop).

--- a/test/app/src/main_window_test.cpp
+++ b/test/app/src/main_window_test.cpp
@@ -3928,13 +3928,12 @@ private slots:
         // (for `level`) and Show column (listing `msg`).
         mWindow->SetColumnVisible(msgCol, false);
 
-        // `BuildHeaderContextMenu` reports the freshly-built `Show
-        // column` submenu via the returned struct; `QAction::menu()`
-        // and `qobject_cast<QMenu*>(child)` both return null on the
-        // Linux Release offscreen-QPA toolchain (the QtWidgets
-        // metaobject hooks for `QMenu` are stripped at link time
-        // there), so the test cannot recover the pointer by walking
-        // the tree. The struct is the contract.
+        // `BuildHeaderContextMenu` exposes the Show-column submenu
+        // via the returned struct. On Linux Release offscreen-QPA,
+        // QMenu metaobject hooks are stripped, so `QAction::menu()`
+        // and `qobject_cast<QMenu*>(child)` both return null --
+        // tests can't recover the submenu by walking the tree, so
+        // the struct is the contract.
         auto built = mWindow->BuildHeaderContextMenu(levelCol, nullptr);
         QVERIFY2(built.menu != nullptr, "BuildHeaderContextMenu must return a menu");
         const QScopeGuard menuDeleter([&built]() { built.menu->deleteLater(); });
@@ -3957,15 +3956,11 @@ private slots:
         QCOMPARE(showActionLabels, expected);
     }
 
-    // The header menu must omit both `Hide` and `Add filter on ...`
-    // when the clicked column is already hidden -- both actions
-    // would be confusing no-ops (Hide is already hidden;
-    // `FilterEditor::SetInitialColumn` silently refuses to preselect
-    // a hidden column, so the Add-filter action would advertise a
-    // column the editor would not actually point at). The Show
-    // submenu is still present so the user can re-show. Hidden-
-    // column right-clicks are reachable only via the test seam;
-    // production right-clicks only fire on visible sections.
+    // For a hidden column the menu must omit both `Hide` and
+    // `Add filter on ...` (both would be confusing no-ops); the
+    // Show submenu is still present so the user can re-show.
+    // Hidden-column right-clicks are only reachable via the test
+    // seam -- production right-clicks fire on visible sections.
     void TestHeaderContextMenuOmitsHideForHiddenColumn()
     {
         const int levelCol = StreamFixtureForColumnTests();
@@ -3989,9 +3984,9 @@ private slots:
         }
     }
 
-    // The header menu must always offer an `Add filter on "<col>"...`
-    // action so the user can scope a filter to the clicked column
-    // without leaving the right-click menu.
+    // The header menu always offers `Add filter on "<col>"...` so
+    // the user can scope a filter to the clicked column without
+    // leaving the right-click menu.
     void TestHeaderContextMenuOffersAddFilter()
     {
         const int levelCol = StreamFixtureForColumnTests();
@@ -4017,9 +4012,8 @@ private slots:
         );
     }
 
-    // Triggering the header menu's Add filter entry opens a
-    // `FilterEditor` with the row combobox already pointed at the
-    // clicked column, so the user does not have to re-pick it.
+    // Triggering Add filter opens a `FilterEditor` with the row
+    // combobox already pointed at the clicked column.
     void TestHeaderContextMenuAddFilterOpensEditorWithColumnPreselected()
     {
         const int levelCol = StreamFixtureForColumnTests();
@@ -4062,10 +4056,9 @@ private slots:
         QCoreApplication::processEvents();
     }
 
-    // The header menu lists every existing filter targeting the
-    // clicked column as a per-filter submenu (titled with the
-    // filter's display value, mirroring the Filters menu). Each
-    // submenu carries an `Edit` and a `Remove` action.
+    // Every existing filter on the clicked column gets a per-filter
+    // submenu (titled with its display value, mirroring the Filters
+    // menu) carrying `Edit` and `Remove` actions.
     void TestHeaderContextMenuListsExistingFiltersForColumn()
     {
         const int levelCol = StreamFixtureForColumnTests();
@@ -4074,8 +4067,8 @@ private slots:
         const int msgCol = ColumnByHeader(*model, QStringLiteral("msg"));
         QVERIFY2(msgCol >= 0, "msg column must exist after streaming");
 
-        // Two filters on `level`, one filter on `msg` (which must
-        // not appear in the header menu rooted at `level`).
+        // Two filters on `level`, one on `msg` (the latter must
+        // not appear in the menu rooted at `level`).
         const QString levelFilter1 = QStringLiteral("level-filter-1");
         const QString levelFilter2 = QStringLiteral("level-filter-2");
         const QString msgFilter = QStringLiteral("msg-filter");
@@ -4128,9 +4121,9 @@ private slots:
             "filters on a different column must not appear in this header menu"
         );
 
-        // Compare against the same translation context the production
-        // code uses, so a future translation of "Edit" / "Remove" in
-        // `MainWindow`'s context can't quietly break the assertion.
+        // Use MainWindow's translation context so a future
+        // translation of "Edit" / "Remove" cannot silently break
+        // this assertion.
         const QString editLabel = MainWindow::tr("Edit");
         const QString removeLabel = MainWindow::tr("Remove");
         for (const auto &[id, subMenu] : built.filterSubMenus)
@@ -4148,8 +4141,8 @@ private slots:
         }
     }
 
-    // Triggering `Remove` on a header-menu filter sub-menu drops
-    // the filter from `mFilters` (and from the wire-format mirror).
+    // Triggering `Remove` on a header-menu filter submenu drops
+    // the filter from `mFilters` (and the wire-format mirror).
     void TestHeaderContextMenuRemoveClearsFilter()
     {
         const int levelCol = StreamFixtureForColumnTests();
@@ -4196,8 +4189,8 @@ private slots:
         QVERIFY2(!mWindow->Filters().contains(filterId.toStdString()), "Remove must drop the filter from mFilters");
     }
 
-    // Triggering `Edit` on a header-menu filter sub-menu opens a
-    // `FilterEditor` bound to the same column the filter targets.
+    // Triggering `Edit` on a header-menu filter submenu opens a
+    // `FilterEditor` bound to the filter's column.
     void TestHeaderContextMenuEditOpensEditor()
     {
         const int levelCol = StreamFixtureForColumnTests();
@@ -4262,10 +4255,10 @@ private slots:
         QCoreApplication::processEvents();
     }
 
-    // Regression-guard for the keys-based re-resolution in the new
-    // `Add filter on ...` lambda: a column reorder between menu
-    // build and click must still target the column's *current*
-    // index. Same shape as `TestEditFilterAfterColumnReorderUsesCurrentRow`.
+    // Regression: the `Add filter on ...` lambda must re-resolve by
+    // keys, so a column reorder between menu build and click still
+    // targets the column's current index. Mirrors
+    // `TestEditFilterAfterColumnReorderUsesCurrentRow`.
     void TestHeaderContextMenuAddFilterAfterColumnReorderResolvesByKeys()
     {
         const int levelCol = StreamFixtureForColumnTests();
@@ -4289,9 +4282,9 @@ private slots:
         }
         QVERIFY2(addFilterAction != nullptr, "menu must contain an `Add filter on ...` action");
 
-        // Reorder `level` *after* the menu is built but *before*
-        // the action is triggered. The lambda must re-resolve the
-        // index from the captured keys.
+        // Reorder `level` after the menu is built but before the
+        // action is triggered; the lambda must re-resolve the index
+        // from the captured keys.
         const int src = levelCol;
         const int dest = (src == 0) ? columnCount - 1 : 0;
         QVERIFY(src != dest);
@@ -4323,9 +4316,9 @@ private slots:
             }
         }
         QVERIFY2(editor != nullptr, "Add filter must spawn a FilterEditor");
-        // The editor's row must reflect the *post-reorder* column
-        // index, proving the lambda re-resolved by keys at trigger
-        // time rather than freezing on the build-time index.
+        // The editor's row must reflect the post-reorder index,
+        // proving the lambda re-resolved by keys rather than
+        // freezing on the build-time index.
         // NOLINTNEXTLINE(clang-analyzer-core.CallAndMessage): false positive; prior `QVERIFY2` aborts on null.
         QCOMPARE(editor->GetRowToFilter(), dest);
 
@@ -4334,12 +4327,11 @@ private slots:
         QCoreApplication::processEvents();
     }
 
-    // The header menu actions must appear in a stable, polished
-    // order: Hide → separator → Add filter on "..." → filter
-    // submenus → separator → Show column. The order is only encoded
-    // in `BuildHeaderContextMenu`'s control flow today, so a future
-    // reorder could silently flip the menu's polish without tripping
-    // any other test.
+    // The header menu must keep a stable, polished order: Hide →
+    // separator → Add filter → filter submenus → separator → Show
+    // column. The order is only encoded in `BuildHeaderContextMenu`'s
+    // control flow, so a future reorder could quietly break the
+    // menu's polish without tripping any other test.
     void TestHeaderContextMenuActionOrdering()
     {
         const int levelCol = StreamFixtureForColumnTests();
@@ -4348,10 +4340,10 @@ private slots:
         const int msgCol = ColumnByHeader(*model, QStringLiteral("msg"));
         QVERIFY2(msgCol >= 0, "msg column must exist after streaming");
 
-        // Hide `msg` so the Show-column submenu appears, and add a
-        // filter on `level` so the filter-submenu group is present.
-        // The menu is rooted at `level` (still visible) so every
-        // group is reachable.
+        // Hide `msg` so the Show-column submenu appears, add a
+        // filter on `level` so the filter group is present, and
+        // root the menu at `level` (still visible) so every group
+        // is reachable.
         mWindow->SetColumnVisible(msgCol, false);
         const QString filterId = QStringLiteral("order-test");
         QVERIFY2(
@@ -4379,8 +4371,8 @@ private slots:
         QVERIFY2(topActions[0]->text().startsWith("Hide"), "first action must be Hide");
         QVERIFY2(topActions[1]->isSeparator(), "second action must be a separator");
         QVERIFY2(topActions[2]->text().startsWith("Add filter on"), "third action must be Add filter on ...");
-        // The filter submenu is the next non-separator action; its
-        // title is the filter's display value, not a fixed string.
+        // Next non-separator is the filter submenu; its title is the
+        // filter's display value, not a fixed string.
         QVERIFY2(!topActions[3]->isSeparator(), "fourth action must be the filter submenu");
         QVERIFY2(topActions[4]->isSeparator(), "fifth action must be a separator before Show column");
         QVERIFY2(
@@ -4388,23 +4380,20 @@ private slots:
         );
     }
 
-    // The Add-filter and per-filter Edit actions must be disabled
-    // when the model has zero rows: `AddFilter` already short-
-    // circuits with a status-bar message in that case, so leaving
-    // the menu entries enabled would advertise a no-op. Remove
-    // stays enabled because dropping a filter does not need any
-    // rows. Exercised via the save / reset / load detour because
-    // that is the only seam that yields a columns-without-rows
-    // state (production hits it only transiently during a fresh
-    // stream open).
+    // With zero rows, Add-filter and per-filter Edit must be
+    // disabled (`AddFilter` short-circuits with a status-bar hint,
+    // so enabled entries would advertise a no-op). Remove stays
+    // enabled -- dropping a filter doesn't need rows. The save /
+    // reset / load detour is the only seam that yields a
+    // columns-without-rows state outside a fresh stream open.
     void TestHeaderContextMenuDisablesFilterActionsWhenModelEmpty()
     {
         const int levelCol = StreamFixtureForColumnTests();
         QVERIFY2(levelCol >= 0, "level column must exist after streaming");
         auto *model = mWindow->Model();
 
-        // Round-trip the configuration so the model ends up with the
-        // streamed columns but no rows. Same shape as
+        // Round-trip the configuration so the model keeps its
+        // streamed columns but loses all rows. Same shape as
         // `TestColumnVisibilityRoundTripsThroughSaveLoad`.
         QTemporaryDir tempDir;
         QVERIFY(tempDir.isValid());
@@ -4419,7 +4408,7 @@ private slots:
         const int reloadedLevelCol = ColumnByHeader(*model, QStringLiteral("level"));
         QVERIFY2(reloadedLevelCol >= 0, "level column must survive the config round-trip");
 
-        // Inject a filter post-reload so the Edit/Remove sub-menus
+        // Inject a filter post-reload so the Edit/Remove submenus
         // are populated. `FilterEnumSubmitted` does not need rows.
         const QString filterId = QStringLiteral("empty-model-filter");
         QVERIFY2(


### PR DESCRIPTION
## Why

Right-clicking a column header only let the user hide a column or show a previously hidden one. To add or remove a filter scoped to that column, the user had to leave the menu, choose **Filters → Add**, then re-pick the column inside `FilterEditor` — even though the clicked column was already an unambiguous signal of intent. Once filters landed in the header menu, the redundant `Show column` submenu fell out: the **View** menu already covers re-showing hidden columns and stays reachable when every column is hidden.

## What

### Header right-click menu

`MainWindow::BuildHeaderContextMenu` now renders, in order:

1. **Hide "\<col>"** (existing behaviour).
2. **Add filter on "\<col>"…** — opens `FilterEditor` preselected to the clicked column via a new `FilterEditor::SetInitialColumn`. The lambda captures the column's stable `keys` and re-resolves through `FindColumnIndexByKeys` at trigger time, so a reorder between menu build and click still targets the right column. Hidden columns and zero-row models disable the action (both would advertise no-ops).
3. One submenu per existing filter whose `LogFilter::row` matches the clicked column, titled with the filter's display value (`info, warn`, `[1.5, 2.0]`, …). Each carries **Edit** / **Remove** actions that re-look up `mFilters[id]` live, mirroring the Filters-menu entries. Submenus sort by `(localeAwareCompare(title), type, id)` so two filters that render to the same string still group deterministically.

The legacy `Show column` submenu on the header right-click is removed — the **View** menu is now the single entry point for unhiding columns (and the only escape hatch when every column is hidden).

### Plumbing

- New private `MainWindow::BuildFilterTitle` helper extracted from `AddLogFilter` so the Filters menu and the header menu render byte-identical titles. The switch lost its `default:` so a new `LogFilter::Type` trips `-Wswitch` instead of dereferencing a `nullopt` payload; debug `Q_ASSERT`s on every payload read catch un-validated inserts into `mFilters` in debug rather than crashing only in release.
- `MainWindow::AddFilter` grew a defaulted `int initialColumn = -1`. When the caller passes `std::nullopt` for the filter and a non-negative column, the spawned `FilterEditor` is preselected via `SetInitialColumn`. When `filter` has a value, `initialColumn` is ignored — the loaded filter already pins the row.
- `BuildHeaderContextMenu` returns a `MainWindow::HeaderContextMenu` struct (`menu`, `filterSubMenus`) by value, replacing the previous three out-parameters. Production callers ignore everything but `.menu`; the struct exists for tests because the Linux Release offscreen-QPA toolchain strips the QtWidgets metaobject hooks that make `QAction::menu()` and `qobject_cast<QMenu*>` work, so tests cannot recover submenu pointers by walking the tree.
- Renamed the Filters-menu per-filter **Clear** action to **Remove** and wrapped both it and **Edit** in `tr(...)`, so the same translation context covers all four entry points (Filters menu + header menu × Edit + Remove).

### Documentation

`doc/README.md` was revisited end-to-end:

- New **Column Management** subsection under *Navigating the Table* documenting drag-reorder, the **View** menu, and the right-click **Hide "\<col>"** entry (none of which were user-documented even before this PR).
- *Editing or Removing a Filter* renamed (was *Editing or Clearing a Filter*), `Clear` → `Remove` everywhere, and the new column-header right-click affordance documented.
- *Configurations* section corrected: the scope sentence now lists column order, per-column visibility, column type, and filters (not just headers/keys/formats). The stale "Filters are not currently persisted in configurations." blockquote is replaced with the actual validate-and-drop behaviour on load.

The root `README.md` did not need any edits.

## Tests

New `MainWindowTest` cases, all under the offscreen-QPA `apptest` target:

- `TestHeaderContextMenuOffersAddFilter` — the action is always present and references the clicked column in its title.
- `TestHeaderContextMenuAddFilterOpensEditorWithColumnPreselected` — triggering Add spawns a `FilterEditor` whose `GetRowToFilter()` matches the clicked column.
- `TestHeaderContextMenuAddFilterAfterColumnReorderResolvesByKeys` — regression-guard mirroring `TestEditFilterAfterColumnReorderUsesCurrentRow`: builds the menu, reorders via `OnHeaderSectionMoved`, then triggers Add and asserts the editor's row reflects the post-reorder index.
- `TestHeaderContextMenuListsExistingFiltersForColumn` — seeds two enum filters on `level` and one string filter on `msg`, asserts only the two `level` filters surface as submenus, each with **Edit** and **Remove**.
- `TestHeaderContextMenuEditOpensEditor` / `TestHeaderContextMenuRemoveClearsFilter` — verify the submenu actions open the editor and drop the filter respectively.
- `TestHeaderContextMenuOmitsHideForHiddenColumn` — extended to also assert the Add-filter action is absent for hidden columns.
- `TestHeaderContextMenuOmitsShowColumnSubmenu` — pins the deletion of the `Show column` submenu so a regression that re-introduces it trips here.
- `TestHeaderContextMenuActionOrdering` — pins the final four-entry order (`Hide → sep → Add filter → filter submenu`).
- `TestHeaderContextMenuDisablesFilterActionsWhenModelEmpty` — uses the save/reset/load detour to engineer a columns-without-rows state, then verifies **Add** and **Edit** are disabled while **Remove** stays enabled.

Existing header-menu tests were migrated to the struct return shape and switched to `MainWindow::tr(...)` for action-label comparisons.

## Non-changes

- `LogConfiguration`, `LogFilterModel`, the Filters menu's own Edit / Remove flow, persistence, and filter semantics are unchanged.
- No new keyboard shortcuts; no new settings.
- The **View** menu and drag-reorder behaviour shipped in an earlier PR; this branch only documents them (alongside the new feature).