### PR TITLE
Row Right-Click Time-Range Filter

### DIFF
--- a/app/include/filter_editor.hpp
+++ b/app/include/filter_editor.hpp
@@ -33,10 +33,8 @@ public:
     FilterEditor(const LogModel &model, QString filterID, QWidget *parent = nullptr);
 
     void Load(int row, const QString &filterString, int matchType);
-    /// Restore a time-range filter. `std::nullopt` on either bound
-    /// leaves that side unbounded; the matching "No begin/end limit"
-    /// checkbox is checked and the corresponding date/time edits are
-    /// disabled. `OkClicked` will emit the same shape back out.
+    /// Restore a time-range filter. `std::nullopt` on a bound leaves
+    /// that side unbounded (checkbox checked, date/time edits disabled).
     void Load(int row, std::optional<qint64> begin, std::optional<qint64> end);
     /// Preselect @p selectedValues; values absent from the current
     /// dictionary are skipped.
@@ -86,9 +84,8 @@ public:
     {
         return mOkButton;
     }
-    /// Test-only accessors for the time page widgets. Same caveat
-    /// as the enum-picker accessors: `findChildren<...>()` is empty
-    /// under offscreen QPA on the Linux runner.
+    /// Test-only accessors for the time page widgets. Same offscreen-QPA
+    /// caveat as the enum-picker accessors above.
     [[nodiscard]] QDateEdit *BeginDateEdit() const
     {
         return mBeginDateEdit;
@@ -116,9 +113,8 @@ public:
 
 signals:
     void FilterSubmitted(const QString &filterID, int row, const QString &filterString, int matchType);
-    /// Time-range filter. `std::nullopt` bounds are unbounded
-    /// (mirrors `FilterNumericRangeSubmitted`); the receiving slot
-    /// rejects the both-unbounded case (would match every row).
+    /// Time-range filter. `std::nullopt` bounds are unbounded; the slot
+    /// rejects both-unbounded (would match every row).
     void FilterTimeStampSubmitted(
         const QString &filterID, int row, std::optional<qint64> beginTimeStamp, std::optional<qint64> endTimeStamp
     );
@@ -144,11 +140,10 @@ private:
     QDateEdit *mEndDateEdit;
     QTimeEdit *mEndTimeEdit;
 
-    /// Time page: when checked, the matching `QDateEdit`+`QTimeEdit`
-    /// pair is disabled and `OkClicked` emits `std::nullopt` for that
-    /// bound. The "open bound" representation is `nullopt` rather
-    /// than `INT64_MIN`/`INT64_MAX` so the title and the editor stay
-    /// faithful through Edit -> OK round-trips.
+    /// Time page: when checked, disables the matching date/time edits
+    /// and makes `OkClicked` emit `std::nullopt` for that bound. Using
+    /// `nullopt` (rather than INT64 sentinels) preserves the open bound
+    /// across Edit -> OK round-trips.
     QCheckBox *mBeginUnboundedCheckBox;
     QCheckBox *mEndUnboundedCheckBox;
 
@@ -179,9 +174,8 @@ private:
     QPushButton *mCancelButton;
 
     void SetupLayout();
-    /// Push @p begin / @p end into the Time page; `std::nullopt`
-    /// engages the matching unbounded checkbox and disables the
-    /// matching date/time edits.
+    /// Push @p begin / @p end into the Time page; `std::nullopt` checks
+    /// the matching unbounded checkbox and disables its date/time edits.
     void SetBeginEnd(std::optional<qint64> begin, std::optional<qint64> end);
     /// Repopulate the enum picker from the column's current dictionary.
     void PopulateEnumValues(int columnIndex);

--- a/app/include/filter_editor.hpp
+++ b/app/include/filter_editor.hpp
@@ -33,7 +33,11 @@ public:
     FilterEditor(const LogModel &model, QString filterID, QWidget *parent = nullptr);
 
     void Load(int row, const QString &filterString, int matchType);
-    void Load(int row, qint64 begin, qint64 end);
+    /// Restore a time-range filter. `std::nullopt` on either bound
+    /// leaves that side unbounded; the matching "No begin/end limit"
+    /// checkbox is checked and the corresponding date/time edits are
+    /// disabled. `OkClicked` will emit the same shape back out.
+    void Load(int row, std::optional<qint64> begin, std::optional<qint64> end);
     /// Preselect @p selectedValues; values absent from the current
     /// dictionary are skipped.
     void Load(int row, const QStringList &selectedValues);
@@ -85,7 +89,12 @@ public:
 
 signals:
     void FilterSubmitted(const QString &filterID, int row, const QString &filterString, int matchType);
-    void FilterTimeStampSubmitted(const QString &filterID, int row, qint64 beginTimeStamp, qint64 endTimeStamp);
+    /// Time-range filter. `std::nullopt` bounds are unbounded
+    /// (mirrors `FilterNumericRangeSubmitted`); the receiving slot
+    /// rejects the both-unbounded case (would match every row).
+    void FilterTimeStampSubmitted(
+        const QString &filterID, int row, std::optional<qint64> beginTimeStamp, std::optional<qint64> endTimeStamp
+    );
     void FilterEnumSubmitted(const QString &filterID, int row, const QStringList &selectedValues);
     /// Numeric range filter. `std::nullopt` bounds are unbounded.
     void FilterNumericRangeSubmitted(
@@ -107,6 +116,14 @@ private:
     QTimeEdit *mBeginTimeEdit;
     QDateEdit *mEndDateEdit;
     QTimeEdit *mEndTimeEdit;
+
+    /// Time page: when checked, the matching `QDateEdit`+`QTimeEdit`
+    /// pair is disabled and `OkClicked` emits `std::nullopt` for that
+    /// bound. The "open bound" representation is `nullopt` rather
+    /// than `INT64_MIN`/`INT64_MAX` so the title and the editor stay
+    /// faithful through Edit -> OK round-trips.
+    QCheckBox *mBeginUnboundedCheckBox;
+    QCheckBox *mEndUnboundedCheckBox;
 
     /// Multi-select picker for `Type::Enumeration` columns. Items are
     /// alphabetised; Select/Clear All operate on visible rows only.
@@ -135,7 +152,10 @@ private:
     QPushButton *mCancelButton;
 
     void SetupLayout();
-    void SetBeginEnd(qint64 begin, qint64 end);
+    /// Push @p begin / @p end into the Time page; `std::nullopt`
+    /// engages the matching unbounded checkbox and disables the
+    /// matching date/time edits.
+    void SetBeginEnd(std::optional<qint64> begin, std::optional<qint64> end);
     /// Repopulate the enum picker from the column's current dictionary.
     void PopulateEnumValues(int columnIndex);
     /// Populate the enum picker with the six canonical level names

--- a/app/include/filter_editor.hpp
+++ b/app/include/filter_editor.hpp
@@ -86,6 +86,33 @@ public:
     {
         return mOkButton;
     }
+    /// Test-only accessors for the time page widgets. Same caveat
+    /// as the enum-picker accessors: `findChildren<...>()` is empty
+    /// under offscreen QPA on the Linux runner.
+    [[nodiscard]] QDateEdit *BeginDateEdit() const
+    {
+        return mBeginDateEdit;
+    }
+    [[nodiscard]] QTimeEdit *BeginTimeEdit() const
+    {
+        return mBeginTimeEdit;
+    }
+    [[nodiscard]] QDateEdit *EndDateEdit() const
+    {
+        return mEndDateEdit;
+    }
+    [[nodiscard]] QTimeEdit *EndTimeEdit() const
+    {
+        return mEndTimeEdit;
+    }
+    [[nodiscard]] QCheckBox *BeginUnboundedCheckBox() const
+    {
+        return mBeginUnboundedCheckBox;
+    }
+    [[nodiscard]] QCheckBox *EndUnboundedCheckBox() const
+    {
+        return mEndUnboundedCheckBox;
+    }
 
 signals:
     void FilterSubmitted(const QString &filterID, int row, const QString &filterString, int matchType);

--- a/app/include/main_window.hpp
+++ b/app/include/main_window.hpp
@@ -264,9 +264,10 @@ public:
     [[nodiscard]] HeaderContextMenu BuildHeaderContextMenu(int logicalColumn, QWidget *parent = nullptr);
 
     /// Build the right-click row menu for source-model row
-    /// @p sourceRow. Carries the inclusive "Show only logs at or
-    /// after this time" / "Show only logs at or before this time"
-    /// actions, both pinned to the first `Type::Time` column.
+    /// @p sourceRow. Carries the inclusive "Show only newer logs"
+    /// / "Show only older logs" actions (boundary is the clicked
+    /// row's timestamp; both bounds are inclusive `>= / <=`), both
+    /// pinned to the first `Type::Time` column.
     /// Returns null when there is nothing to show: no `Type::Time`
     /// column, the row's slot is `std::monostate` (absent
     /// timestamp), an empty model, or @p sourceRow out of range.

--- a/app/include/main_window.hpp
+++ b/app/include/main_window.hpp
@@ -263,6 +263,19 @@ public:
     /// @p logicalColumn is out of range.
     [[nodiscard]] HeaderContextMenu BuildHeaderContextMenu(int logicalColumn, QWidget *parent = nullptr);
 
+    /// Build the right-click row menu for source-model row
+    /// @p sourceRow. Carries the inclusive "Show only logs at or
+    /// after this time" / "Show only logs at or before this time"
+    /// actions, both pinned to the first `Type::Time` column.
+    /// Caller owns the returned menu. Returns null when there is
+    /// nothing to show: no `Type::Time` column, the row's slot is
+    /// `std::monostate` (absent timestamp), an empty model, or
+    /// @p sourceRow out of range. Separated from
+    /// `ShowRowContextMenu` so tests can inspect the actions
+    /// without spawning a real popup, mirroring
+    /// `BuildHeaderContextMenu`.
+    [[nodiscard]] QMenu *BuildRowContextMenu(int sourceRow, QWidget *parent = nullptr);
+
     /// Live filter map; tests inspect it after a reorder.
     [[nodiscard]] const std::unordered_map<std::string, loglib::LogConfiguration::LogFilter> &Filters() const
     {
@@ -509,6 +522,12 @@ private slots:
 
     /// Build and show the header context menu at @p pos.
     void ShowHeaderContextMenu(const QPoint &pos);
+
+    /// Build and show the row-level context menu at @p pos
+    /// (viewport coords). The menu adds an inclusive time-range
+    /// filter pinned to the first `Type::Time` column using the
+    /// clicked row's timestamp as the boundary.
+    void ShowRowContextMenu(const QPoint &pos);
 
     /// Rebuild the `View` menu on each `aboutToShow`. Each column
     /// gets a checkable action that toggles `Column::visible`.

--- a/app/include/main_window.hpp
+++ b/app/include/main_window.hpp
@@ -267,13 +267,19 @@ public:
     /// @p sourceRow. Carries the inclusive "Show only logs at or
     /// after this time" / "Show only logs at or before this time"
     /// actions, both pinned to the first `Type::Time` column.
-    /// Caller owns the returned menu. Returns null when there is
-    /// nothing to show: no `Type::Time` column, the row's slot is
-    /// `std::monostate` (absent timestamp), an empty model, or
-    /// @p sourceRow out of range. Separated from
-    /// `ShowRowContextMenu` so tests can inspect the actions
-    /// without spawning a real popup, mirroring
+    /// Returns null when there is nothing to show: no `Type::Time`
+    /// column, the row's slot is `std::monostate` (absent
+    /// timestamp), an empty model, or @p sourceRow out of range.
+    /// Separated from `ShowRowContextMenu` so tests can inspect the
+    /// actions without spawning a real popup, mirroring
     /// `BuildHeaderContextMenu`.
+    ///
+    /// Ownership: the returned `QMenu *` is parented to @p parent
+    /// (or `mTableView` when @p parent is null), so it is destroyed
+    /// alongside the parent. `ShowRowContextMenu` additionally sets
+    /// `Qt::WA_DeleteOnClose` on the popup itself; tests that take
+    /// the menu without showing it must `deleteLater()` it via a
+    /// `QScopeGuard` (every existing `TestRowContextMenu*` does).
     [[nodiscard]] QMenu *BuildRowContextMenu(int sourceRow, QWidget *parent = nullptr);
 
     /// Live filter map; tests inspect it after a reorder.

--- a/app/include/main_window.hpp
+++ b/app/include/main_window.hpp
@@ -478,7 +478,14 @@ private slots:
     /// so the mirror + rule rebuild only run once.
     void ClearFilter(const QString &filterID, bool deferSync = false);
     void FilterSubmitted(const QString &filterID, int row, const QString &filterString, int matchType);
-    void FilterTimeStampSubmitted(const QString &filterID, int row, qint64 beginTimeStamp, qint64 endTimeStamp);
+    /// Slot for `FilterEditor::FilterTimeStampSubmitted`. Either
+    /// bound may be `std::nullopt` to leave that side unbounded
+    /// (mirrors `FilterNumericRangeSubmitted`); the predicate
+    /// substitutes its own min/max sentinels at construction time.
+    /// Both-nullopt is rejected (would match every row).
+    void FilterTimeStampSubmitted(
+        const QString &filterID, int row, std::optional<qint64> beginTimeStamp, std::optional<qint64> endTimeStamp
+    );
     void FilterEnumSubmitted(const QString &filterID, int row, const QStringList &selectedValues);
     /// Slot for `FilterEditor::FilterNumericRangeSubmitted`. Either bound
     /// may be `std::nullopt` to leave that side unbounded.

--- a/app/include/main_window.hpp
+++ b/app/include/main_window.hpp
@@ -263,24 +263,18 @@ public:
     /// @p logicalColumn is out of range.
     [[nodiscard]] HeaderContextMenu BuildHeaderContextMenu(int logicalColumn, QWidget *parent = nullptr);
 
-    /// Build the right-click row menu for source-model row
-    /// @p sourceRow. Carries the inclusive "Show only newer logs"
-    /// / "Show only older logs" actions (boundary is the clicked
-    /// row's timestamp; both bounds are inclusive `>= / <=`), both
-    /// pinned to the first `Type::Time` column.
-    /// Returns null when there is nothing to show: no `Type::Time`
-    /// column, the row's slot is `std::monostate` (absent
-    /// timestamp), an empty model, or @p sourceRow out of range.
-    /// Separated from `ShowRowContextMenu` so tests can inspect the
-    /// actions without spawning a real popup, mirroring
-    /// `BuildHeaderContextMenu`.
+    /// Build the row right-click menu for source-model row @p sourceRow:
+    /// inclusive "newer than" / "older than" actions pinned to the first
+    /// `Type::Time` column, using the row's timestamp as the boundary.
+    /// Returns null when there is no time column, the row's time slot is
+    /// `std::monostate`, the model is empty, or @p sourceRow is out of
+    /// range. Split out of `ShowRowContextMenu` so tests can inspect the
+    /// actions without spawning a popup.
     ///
-    /// Ownership: the returned `QMenu *` is parented to @p parent
-    /// (or `mTableView` when @p parent is null), so it is destroyed
-    /// alongside the parent. `ShowRowContextMenu` additionally sets
-    /// `Qt::WA_DeleteOnClose` on the popup itself; tests that take
-    /// the menu without showing it must `deleteLater()` it via a
-    /// `QScopeGuard` (every existing `TestRowContextMenu*` does).
+    /// Ownership: parented to @p parent (or `mTableView` if null). Tests
+    /// that take the menu without showing it should `deleteLater()` via
+    /// a `QScopeGuard`; `ShowRowContextMenu` instead sets
+    /// `Qt::WA_DeleteOnClose` on the live popup.
     [[nodiscard]] QMenu *BuildRowContextMenu(int sourceRow, QWidget *parent = nullptr);
 
     /// Live filter map; tests inspect it after a reorder.
@@ -485,11 +479,9 @@ private slots:
     /// so the mirror + rule rebuild only run once.
     void ClearFilter(const QString &filterID, bool deferSync = false);
     void FilterSubmitted(const QString &filterID, int row, const QString &filterString, int matchType);
-    /// Slot for `FilterEditor::FilterTimeStampSubmitted`. Either
-    /// bound may be `std::nullopt` to leave that side unbounded
-    /// (mirrors `FilterNumericRangeSubmitted`); the predicate
-    /// substitutes its own min/max sentinels at construction time.
-    /// Both-nullopt is rejected (would match every row).
+    /// Slot for `FilterEditor::FilterTimeStampSubmitted`. `std::nullopt`
+    /// on a bound leaves that side unbounded (the predicate substitutes
+    /// INT64 sentinels at construction); both-nullopt is rejected.
     void FilterTimeStampSubmitted(
         const QString &filterID, int row, std::optional<qint64> beginTimeStamp, std::optional<qint64> endTimeStamp
     );
@@ -537,10 +529,9 @@ private slots:
     /// Build and show the header context menu at @p pos.
     void ShowHeaderContextMenu(const QPoint &pos);
 
-    /// Build and show the row-level context menu at @p pos
-    /// (viewport coords). The menu adds an inclusive time-range
-    /// filter pinned to the first `Type::Time` column using the
-    /// clicked row's timestamp as the boundary.
+    /// Build and show the row right-click menu at @p pos (viewport
+    /// coords). Adds an inclusive time-range filter pinned to the first
+    /// `Type::Time` column, boundary = clicked row's timestamp.
     void ShowRowContextMenu(const QPoint &pos);
 
     /// Rebuild the `View` menu on each `aboutToShow`. Each column

--- a/app/src/filter_editor.cpp
+++ b/app/src/filter_editor.cpp
@@ -137,9 +137,9 @@ FilterEditor::FilterEditor(const LogModel &model, QString filterID, QWidget *par
         mBeginTimeEdit->setMaximumTime(time);
     });
 
-    // Unbounded checkboxes disable the matching date/time edits and
-    // clear any "both unbounded" warning border. The OK handler
-    // reads the checkbox state to decide whether to emit nullopt.
+    // Unbounded checkbox disables the matching date/time edits and clears
+    // any "both unbounded" warning border. OnOkClicked reads the checkbox
+    // to decide whether to emit nullopt.
     connect(mBeginUnboundedCheckBox, &QCheckBox::toggled, this, [this](bool checked) {
         mBeginDateEdit->setEnabled(!checked);
         mBeginTimeEdit->setEnabled(!checked);
@@ -500,12 +500,10 @@ void FilterEditor::SetupLayout()
 
 void FilterEditor::SetBeginEnd(std::optional<qint64> begin, std::optional<qint64> end)
 {
-    // Compute the date/time pair to seed every edit with. When a side
-    // is unbounded we still want the date widget to show *something*
-    // sensible (the user may toggle the checkbox off and start
-    // picking), so seed the unbounded side with the bounded side's
-    // value. When both sides are unbounded, fall back to the current
-    // local time; the user picks a real date the moment they uncheck.
+    // Seed each edit with a sensible value even when its side is
+    // unbounded (the user may uncheck the checkbox and start picking):
+    // unbounded side reuses the other side's value, both-unbounded
+    // falls back to "now".
     auto pickSeed = [](std::optional<qint64> primary, std::optional<qint64> fallback) -> QDateTime {
         if (primary.has_value())
         {
@@ -520,31 +518,13 @@ void FilterEditor::SetBeginEnd(std::optional<qint64> begin, std::optional<qint64
     const QDateTime beginDateTime = pickSeed(begin, end);
     const QDateTime endDateTime = pickSeed(end, begin);
 
-    // Per-widget seed + constraint application. The seed and the
-    // min/max-or-clear MUST stay paired per widget (not batched as
-    // "all setDateTime then all setMin/Max"), because each
-    // `setDateTime` fires the `dateChanged` / `timeChanged` cross-
-    // coupling that propagates begin <-> end constraints; reordering
-    // lets the cascade clamp values to unintended times.
-    //
-    // Bounded side: re-install the seed-derived constraint, matching
-    // the historic "you can only narrow within the loaded range" UX.
-    // Unbounded side: explicitly clear any constraint left over from
-    // a previous `SetBeginEnd` (e.g. `UpdateSelectedColumn` seeds
-    // bounded min/max from the model; `Load` then overwrites with an
-    // unbounded side). Without the explicit clear, an Edit on
-    // `(nullopt, X)` would seed `mBeginDateEdit` with the fallback
-    // `X` AND keep a previous `setMinimumDateTime(X)` in force,
-    // pinning begin to `[X, X]` and making it impossible to widen.
-    //
-    // Caveat (pre-existing UX): `setDateTime` clamps to whatever
-    // constraint was installed by the prior `UpdateSelectedColumn`
-    // call. The Edit -> OK round-trip is therefore only exact when
-    // the persisted bound is inside the model's current `[min, max]`;
-    // a bound outside that range (possible after row eviction or
-    // streaming growth) silently snaps to the model boundary on
-    // load. In practice the filter behaviour is unchanged because
-    // rows outside the range no longer exist in the table.
+    // Apply seed + constraint per widget. The two MUST stay paired
+    // (don't batch all setDateTime then all setMin/Max): each
+    // setDateTime fires the cross-coupling that propagates begin <-> end
+    // constraints, and reordering lets the cascade clamp to unintended
+    // values. The unbounded side must explicitly clear any stale
+    // constraint left over from `UpdateSelectedColumn` so an Edit on
+    // e.g. `(nullopt, X)` doesn't keep begin pinned to `[X, X]`.
     enum class Side
     {
         Lower,
@@ -581,8 +561,7 @@ void FilterEditor::SetBeginEnd(std::optional<qint64> begin, std::optional<qint64
     applySeedAndBound(mEndDateEdit, endDateTime, end, Side::Upper);
     applySeedAndBound(mEndTimeEdit, endDateTime, end, Side::Upper);
 
-    // Drive the checkboxes from the optionals; the toggled handler
-    // disables the matching edits as a side effect.
+    // The toggled handler disables the matching edits as a side effect.
     mBeginUnboundedCheckBox->setChecked(!begin.has_value());
     mEndUnboundedCheckBox->setChecked(!end.has_value());
 }
@@ -611,9 +590,8 @@ void FilterEditor::OnOkClicked()
 
     if (column.type == LogConfiguration::Type::Time)
     {
-        // Mirrors the `Number` page below: at least one bound must
-        // stay engaged. Both checkboxes ticked would match every
-        // row, so paint the matching widgets red and stop.
+        // At least one bound must stay engaged; both unbounded would
+        // match every row, so paint the checkboxes red and stop.
         const bool beginUnbounded = mBeginUnboundedCheckBox->isChecked();
         const bool endUnbounded = mEndUnboundedCheckBox->isChecked();
         if (beginUnbounded && endUnbounded)

--- a/app/src/filter_editor.cpp
+++ b/app/src/filter_editor.cpp
@@ -520,60 +520,67 @@ void FilterEditor::SetBeginEnd(std::optional<qint64> begin, std::optional<qint64
     const QDateTime beginDateTime = pickSeed(begin, end);
     const QDateTime endDateTime = pickSeed(end, begin);
 
-    // Bounded side: re-install the seed-derived min/max constraint,
-    // matching the historic "you can only narrow within the loaded
-    // range" UX. Unbounded side: explicitly clear any constraint
-    // left over from a previous `SetBeginEnd` (e.g.
-    // `UpdateSelectedColumn` seeds bounded min/max from the model;
-    // `Load` then overwrites with an unbounded side). Without the
-    // explicit clear, an Edit on `(nullopt, X)` would seed
-    // `mBeginDateEdit` with the fallback `X` AND keep a previous
-    // `setMinimumDateTime(X)` in force, pinning begin to `[X, X]`
-    // and making it impossible to widen the range.
+    // Per-widget seed + constraint application. The seed and the
+    // min/max-or-clear MUST stay paired per widget (not batched as
+    // "all setDateTime then all setMin/Max"), because each
+    // `setDateTime` fires the `dateChanged` / `timeChanged` cross-
+    // coupling that propagates begin <-> end constraints; reordering
+    // lets the cascade clamp values to unintended times.
     //
-    // setDateTime / setMinimumDateTime are interleaved per widget
-    // (not batched) so the `dateChanged` / `timeChanged` cross-
-    // coupling between begin and end fires against an already-
-    // constrained widget; reordering to "all setDateTime then all
-    // setMin/Max" lets the cross-coupling cascade clamp values to
-    // unintended times.
-    mBeginDateEdit->setDateTime(beginDateTime);
-    if (begin.has_value())
+    // Bounded side: re-install the seed-derived constraint, matching
+    // the historic "you can only narrow within the loaded range" UX.
+    // Unbounded side: explicitly clear any constraint left over from
+    // a previous `SetBeginEnd` (e.g. `UpdateSelectedColumn` seeds
+    // bounded min/max from the model; `Load` then overwrites with an
+    // unbounded side). Without the explicit clear, an Edit on
+    // `(nullopt, X)` would seed `mBeginDateEdit` with the fallback
+    // `X` AND keep a previous `setMinimumDateTime(X)` in force,
+    // pinning begin to `[X, X]` and making it impossible to widen.
+    //
+    // Caveat (pre-existing UX): `setDateTime` clamps to whatever
+    // constraint was installed by the prior `UpdateSelectedColumn`
+    // call. The Edit -> OK round-trip is therefore only exact when
+    // the persisted bound is inside the model's current `[min, max]`;
+    // a bound outside that range (possible after row eviction or
+    // streaming growth) silently snaps to the model boundary on
+    // load. In practice the filter behaviour is unchanged because
+    // rows outside the range no longer exist in the table.
+    enum class Side
     {
-        mBeginDateEdit->setMinimumDateTime(beginDateTime);
-    }
-    else
-    {
-        mBeginDateEdit->clearMinimumDateTime();
-    }
-    mBeginTimeEdit->setDateTime(beginDateTime);
-    if (begin.has_value())
-    {
-        mBeginTimeEdit->setMinimumDateTime(beginDateTime);
-    }
-    else
-    {
-        mBeginTimeEdit->clearMinimumDateTime();
-    }
+        Lower,
+        Upper
+    };
+    auto applySeedAndBound =
+        [](QDateTimeEdit *edit, const QDateTime &seed, std::optional<qint64> bound, Side side) {
+            edit->setDateTime(seed);
+            if (bound.has_value())
+            {
+                if (side == Side::Lower)
+                {
+                    edit->setMinimumDateTime(seed);
+                }
+                else
+                {
+                    edit->setMaximumDateTime(seed);
+                }
+            }
+            else
+            {
+                if (side == Side::Lower)
+                {
+                    edit->clearMinimumDateTime();
+                }
+                else
+                {
+                    edit->clearMaximumDateTime();
+                }
+            }
+        };
 
-    mEndDateEdit->setDateTime(endDateTime);
-    if (end.has_value())
-    {
-        mEndDateEdit->setMaximumDateTime(endDateTime);
-    }
-    else
-    {
-        mEndDateEdit->clearMaximumDateTime();
-    }
-    mEndTimeEdit->setDateTime(endDateTime);
-    if (end.has_value())
-    {
-        mEndTimeEdit->setMaximumDateTime(endDateTime);
-    }
-    else
-    {
-        mEndTimeEdit->clearMaximumDateTime();
-    }
+    applySeedAndBound(mBeginDateEdit, beginDateTime, begin, Side::Lower);
+    applySeedAndBound(mBeginTimeEdit, beginDateTime, begin, Side::Lower);
+    applySeedAndBound(mEndDateEdit, endDateTime, end, Side::Upper);
+    applySeedAndBound(mEndTimeEdit, endDateTime, end, Side::Upper);
 
     // Drive the checkboxes from the optionals; the toggled handler
     // disables the matching edits as a side effect.

--- a/app/src/filter_editor.cpp
+++ b/app/src/filter_editor.cpp
@@ -51,6 +51,9 @@ FilterEditor::FilterEditor(const LogModel &model, QString filterID, QWidget *par
     mEndDateEdit = new QDateEdit(this);
     mEndTimeEdit = new QTimeEdit(this);
 
+    mBeginUnboundedCheckBox = new QCheckBox("No begin limit", this);
+    mEndUnboundedCheckBox = new QCheckBox("No end limit", this);
+
     mStackedWidget = new QStackedWidget(this);
 
     // Picker model + proxy. `setUniformItemSizes(true)` keeps layout
@@ -134,6 +137,20 @@ FilterEditor::FilterEditor(const LogModel &model, QString filterID, QWidget *par
         mBeginTimeEdit->setMaximumTime(time);
     });
 
+    // Unbounded checkboxes disable the matching date/time edits and
+    // clear any "both unbounded" warning border. The OK handler
+    // reads the checkbox state to decide whether to emit nullopt.
+    connect(mBeginUnboundedCheckBox, &QCheckBox::toggled, this, [this](bool checked) {
+        mBeginDateEdit->setEnabled(!checked);
+        mBeginTimeEdit->setEnabled(!checked);
+        ClearWarningStyles();
+    });
+    connect(mEndUnboundedCheckBox, &QCheckBox::toggled, this, [this](bool checked) {
+        mEndDateEdit->setEnabled(!checked);
+        mEndTimeEdit->setEnabled(!checked);
+        ClearWarningStyles();
+    });
+
     connect(mEnumSearchEdit, &QLineEdit::textChanged, this, [this](const QString &text) {
         mEnumValuesProxy->setFilterFixedString(text);
         ClearWarningStyles();
@@ -196,7 +213,7 @@ void FilterEditor::Load(int row, const QString &filterString, int matchType)
     mMatchTypeComboBox->setCurrentIndex(mMatchTypeComboBox->findData(QVariant(matchType)));
 }
 
-void FilterEditor::Load(int row, const qint64 begin, qint64 end)
+void FilterEditor::Load(int row, std::optional<qint64> begin, std::optional<qint64> end)
 {
     mRowComboBox->setCurrentIndex(row);
     SetBeginEnd(begin, end);
@@ -419,11 +436,13 @@ void FilterEditor::SetupLayout()
     beginLayout->addWidget(new QLabel("Begin Date and Time:", this));
     beginLayout->addWidget(mBeginDateEdit);
     beginLayout->addWidget(mBeginTimeEdit);
+    beginLayout->addWidget(mBeginUnboundedCheckBox);
 
     auto *endLayout = new QHBoxLayout;
     endLayout->addWidget(new QLabel("End Date and Time:", this));
     endLayout->addWidget(mEndDateEdit);
     endLayout->addWidget(mEndTimeEdit);
+    endLayout->addWidget(mEndUnboundedCheckBox);
 
     secondPageLayout->addLayout(beginLayout);
     secondPageLayout->addLayout(endLayout);
@@ -479,10 +498,27 @@ void FilterEditor::SetupLayout()
     mainLayout->addLayout(buttonLayout);
 }
 
-void FilterEditor::SetBeginEnd(qint64 begin, qint64 end)
+void FilterEditor::SetBeginEnd(std::optional<qint64> begin, std::optional<qint64> end)
 {
-    const QDateTime beginDateTime = ConvertToQDateTime(begin);
-    const QDateTime endDateTime = ConvertToQDateTime(end);
+    // Compute the date/time pair to seed every edit with. When a side
+    // is unbounded we still want the date widget to show *something*
+    // sensible (the user may toggle the checkbox off and start
+    // picking), so seed the unbounded side with the bounded side's
+    // value. When both sides are unbounded, fall back to the current
+    // local time; the user picks a real date the moment they uncheck.
+    auto pickSeed = [](std::optional<qint64> primary, std::optional<qint64> fallback) -> QDateTime {
+        if (primary.has_value())
+        {
+            return ConvertToQDateTime(*primary);
+        }
+        if (fallback.has_value())
+        {
+            return ConvertToQDateTime(*fallback);
+        }
+        return QDateTime::currentDateTime();
+    };
+    const QDateTime beginDateTime = pickSeed(begin, end);
+    const QDateTime endDateTime = pickSeed(end, begin);
 
     mBeginDateEdit->setDateTime(beginDateTime);
     mBeginDateEdit->setMinimumDateTime(beginDateTime);
@@ -493,6 +529,11 @@ void FilterEditor::SetBeginEnd(qint64 begin, qint64 end)
     mEndDateEdit->setMaximumDateTime(endDateTime);
     mEndTimeEdit->setDateTime(endDateTime);
     mEndTimeEdit->setMaximumDateTime(endDateTime);
+
+    // Drive the checkboxes from the optionals; the toggled handler
+    // disables the matching edits as a side effect.
+    mBeginUnboundedCheckBox->setChecked(!begin.has_value());
+    mEndUnboundedCheckBox->setChecked(!end.has_value());
 }
 
 QDateTime FilterEditor::ConvertToQDateTime(qint64 timestamp)
@@ -519,12 +560,24 @@ void FilterEditor::OnOkClicked()
 
     if (column.type == LogConfiguration::Type::Time)
     {
-        emit FilterTimeStampSubmitted(
-            mFilterID,
-            index,
-            ConvertToTimeStamp(mBeginDateEdit->date(), mBeginTimeEdit->time()),
-            ConvertToTimeStamp(mEndDateEdit->date(), mEndTimeEdit->time())
-        );
+        // Mirrors the `Number` page below: at least one bound must
+        // stay engaged. Both checkboxes ticked would match every
+        // row, so paint the matching widgets red and stop.
+        const bool beginUnbounded = mBeginUnboundedCheckBox->isChecked();
+        const bool endUnbounded = mEndUnboundedCheckBox->isChecked();
+        if (beginUnbounded && endUnbounded)
+        {
+            mBeginUnboundedCheckBox->setStyleSheet("QCheckBox { color: red; }");
+            mEndUnboundedCheckBox->setStyleSheet("QCheckBox { color: red; }");
+            return;
+        }
+        const std::optional<qint64> beginMicros =
+            beginUnbounded ? std::nullopt
+                           : std::optional<qint64>{ConvertToTimeStamp(mBeginDateEdit->date(), mBeginTimeEdit->time())};
+        const std::optional<qint64> endMicros =
+            endUnbounded ? std::nullopt
+                         : std::optional<qint64>{ConvertToTimeStamp(mEndDateEdit->date(), mEndTimeEdit->time())};
+        emit FilterTimeStampSubmitted(mFilterID, index, beginMicros, endMicros);
     }
     else if (column.type == LogConfiguration::Type::Enumeration || column.type == LogConfiguration::Type::Level)
     {
@@ -846,4 +899,6 @@ void FilterEditor::ClearWarningStyles()
     mNumericMaxEdit->setStyleSheet(QString());
     mBoolIncludeTrue->setStyleSheet(QString());
     mBoolIncludeFalse->setStyleSheet(QString());
+    mBeginUnboundedCheckBox->setStyleSheet(QString());
+    mEndUnboundedCheckBox->setStyleSheet(QString());
 }

--- a/app/src/filter_editor.cpp
+++ b/app/src/filter_editor.cpp
@@ -550,32 +550,31 @@ void FilterEditor::SetBeginEnd(std::optional<qint64> begin, std::optional<qint64
         Lower,
         Upper
     };
-    auto applySeedAndBound =
-        [](QDateTimeEdit *edit, const QDateTime &seed, std::optional<qint64> bound, Side side) {
-            edit->setDateTime(seed);
-            if (bound.has_value())
+    auto applySeedAndBound = [](QDateTimeEdit *edit, const QDateTime &seed, std::optional<qint64> bound, Side side) {
+        edit->setDateTime(seed);
+        if (bound.has_value())
+        {
+            if (side == Side::Lower)
             {
-                if (side == Side::Lower)
-                {
-                    edit->setMinimumDateTime(seed);
-                }
-                else
-                {
-                    edit->setMaximumDateTime(seed);
-                }
+                edit->setMinimumDateTime(seed);
             }
             else
             {
-                if (side == Side::Lower)
-                {
-                    edit->clearMinimumDateTime();
-                }
-                else
-                {
-                    edit->clearMaximumDateTime();
-                }
+                edit->setMaximumDateTime(seed);
             }
-        };
+        }
+        else
+        {
+            if (side == Side::Lower)
+            {
+                edit->clearMinimumDateTime();
+            }
+            else
+            {
+                edit->clearMaximumDateTime();
+            }
+        }
+    };
 
     applySeedAndBound(mBeginDateEdit, beginDateTime, begin, Side::Lower);
     applySeedAndBound(mBeginTimeEdit, beginDateTime, begin, Side::Lower);

--- a/app/src/filter_editor.cpp
+++ b/app/src/filter_editor.cpp
@@ -520,15 +520,60 @@ void FilterEditor::SetBeginEnd(std::optional<qint64> begin, std::optional<qint64
     const QDateTime beginDateTime = pickSeed(begin, end);
     const QDateTime endDateTime = pickSeed(end, begin);
 
+    // Bounded side: re-install the seed-derived min/max constraint,
+    // matching the historic "you can only narrow within the loaded
+    // range" UX. Unbounded side: explicitly clear any constraint
+    // left over from a previous `SetBeginEnd` (e.g.
+    // `UpdateSelectedColumn` seeds bounded min/max from the model;
+    // `Load` then overwrites with an unbounded side). Without the
+    // explicit clear, an Edit on `(nullopt, X)` would seed
+    // `mBeginDateEdit` with the fallback `X` AND keep a previous
+    // `setMinimumDateTime(X)` in force, pinning begin to `[X, X]`
+    // and making it impossible to widen the range.
+    //
+    // setDateTime / setMinimumDateTime are interleaved per widget
+    // (not batched) so the `dateChanged` / `timeChanged` cross-
+    // coupling between begin and end fires against an already-
+    // constrained widget; reordering to "all setDateTime then all
+    // setMin/Max" lets the cross-coupling cascade clamp values to
+    // unintended times.
     mBeginDateEdit->setDateTime(beginDateTime);
-    mBeginDateEdit->setMinimumDateTime(beginDateTime);
+    if (begin.has_value())
+    {
+        mBeginDateEdit->setMinimumDateTime(beginDateTime);
+    }
+    else
+    {
+        mBeginDateEdit->clearMinimumDateTime();
+    }
     mBeginTimeEdit->setDateTime(beginDateTime);
-    mBeginTimeEdit->setMinimumDateTime(beginDateTime);
+    if (begin.has_value())
+    {
+        mBeginTimeEdit->setMinimumDateTime(beginDateTime);
+    }
+    else
+    {
+        mBeginTimeEdit->clearMinimumDateTime();
+    }
 
     mEndDateEdit->setDateTime(endDateTime);
-    mEndDateEdit->setMaximumDateTime(endDateTime);
+    if (end.has_value())
+    {
+        mEndDateEdit->setMaximumDateTime(endDateTime);
+    }
+    else
+    {
+        mEndDateEdit->clearMaximumDateTime();
+    }
     mEndTimeEdit->setDateTime(endDateTime);
-    mEndTimeEdit->setMaximumDateTime(endDateTime);
+    if (end.has_value())
+    {
+        mEndTimeEdit->setMaximumDateTime(endDateTime);
+    }
+    else
+    {
+        mEndTimeEdit->clearMaximumDateTime();
+    }
 
     // Drive the checkboxes from the optionals; the toggled handler
     // disables the matching edits as a side effect.

--- a/app/src/main_window.cpp
+++ b/app/src/main_window.cpp
@@ -3230,7 +3230,10 @@ void MainWindow::AddFilter(
     {
         if (resolvedFilter->type == loglib::LogConfiguration::LogFilter::Type::Time)
         {
-            if (!resolvedFilter->filterBegin.has_value() || !resolvedFilter->filterEnd.has_value())
+            // Mirrors `FilterTimeStampSubmitted`'s validation: at least
+            // one bound must be set; the other side may be `nullopt`
+            // (rendered as "No begin/end limit" in the editor).
+            if (!resolvedFilter->filterBegin.has_value() && !resolvedFilter->filterEnd.has_value())
             {
                 statusBar()->showMessage(
                     QString("Filter '%1' was dropped because its time range is missing").arg(filterId),
@@ -3240,11 +3243,15 @@ void MainWindow::AddFilter(
                 delete filterEditor;
                 return;
             }
-            filterEditor->Load(
-                resolvedFilter->row,
-                static_cast<qint64>(*resolvedFilter->filterBegin),
-                static_cast<qint64>(*resolvedFilter->filterEnd)
-            );
+            const std::optional<qint64> begin =
+                resolvedFilter->filterBegin.has_value()
+                    ? std::optional<qint64>{static_cast<qint64>(*resolvedFilter->filterBegin)}
+                    : std::nullopt;
+            const std::optional<qint64> end =
+                resolvedFilter->filterEnd.has_value()
+                    ? std::optional<qint64>{static_cast<qint64>(*resolvedFilter->filterEnd)}
+                    : std::nullopt;
+            filterEditor->Load(resolvedFilter->row, begin, end);
         }
         else if (resolvedFilter->type == loglib::LogConfiguration::LogFilter::Type::Enumeration)
         {
@@ -3393,15 +3400,32 @@ void MainWindow::FilterSubmitted(const QString &filterID, int row, const QString
     AddLogFilter(filterID, filter);
 }
 
-void MainWindow::FilterTimeStampSubmitted(const QString &filterID, int row, qint64 beginTimeStamp, qint64 endTimeStamp)
+void MainWindow::FilterTimeStampSubmitted(
+    const QString &filterID, int row, std::optional<qint64> beginTimeStamp, std::optional<qint64> endTimeStamp
+)
 {
-    // Reject an inverted range up front; the predicate would
-    // otherwise hide every row silently. Mirrors the regex probe
-    // in `FilterSubmitted`.
-    if (beginTimeStamp > endTimeStamp)
+    // Mirrors `FilterNumericRangeSubmitted`. `nullopt` means
+    // "unbounded" on that side; both-nullopt would match every row
+    // and is rejected up front. The predicate handles the open side
+    // via `value_or(INT64_MIN/MAX)` at construction; the editor and
+    // the title both keep `nullopt` as the canonical representation.
+    if (!beginTimeStamp.has_value() && !endTimeStamp.has_value())
     {
         statusBar()->showMessage(
-            QString("Time-range filter rejected: begin (%1) is after end (%2)").arg(beginTimeStamp).arg(endTimeStamp),
+            QString("Time-range filter rejected: at least one bound (begin or end) must be set"),
+            STATUS_BAR_MESSAGE_TIMEOUT_MS
+        );
+        ClearFilter(filterID);
+        return;
+    }
+    // Inversion only matters when both sides are bounded; an open
+    // side is always compatible with whatever the other side picks.
+    if (beginTimeStamp.has_value() && endTimeStamp.has_value() && *beginTimeStamp > *endTimeStamp)
+    {
+        statusBar()->showMessage(
+            QString("Time-range filter rejected: begin (%1) is after end (%2)")
+                .arg(*beginTimeStamp)
+                .arg(*endTimeStamp),
             STATUS_BAR_MESSAGE_TIMEOUT_MS
         );
         ClearFilter(filterID);
@@ -3516,11 +3540,20 @@ QString MainWindow::BuildFilterTitle(const loglib::LogConfiguration::LogFilter &
     switch (filter.type)
     {
     case loglib::LogConfiguration::LogFilter::Type::Time:
-        Q_ASSERT(filter.filterBegin.has_value() && filter.filterEnd.has_value());
-        return QString::fromStdString(
-            loglib::UtcMicrosecondsToDateTimeString(*filter.filterBegin) + " - " +
-            loglib::UtcMicrosecondsToDateTimeString(*filter.filterEnd)
-        );
+    {
+        // `nullopt` on a side renders as the literal "any" rather
+        // than formatting the predicate's INT64_MIN/MAX sentinels
+        // (which produced absurd 294247 AD / 292277 BC dates and
+        // pushed the title past usable widths).
+        // `ValidateFilterAgainstColumns` rejects both-nullopt, so at
+        // least one side is always a real timestamp here.
+        Q_ASSERT(filter.filterBegin.has_value() || filter.filterEnd.has_value());
+        const std::string beginStr =
+            filter.filterBegin.has_value() ? loglib::UtcMicrosecondsToDateTimeString(*filter.filterBegin) : "any";
+        const std::string endStr =
+            filter.filterEnd.has_value() ? loglib::UtcMicrosecondsToDateTimeString(*filter.filterEnd) : "any";
+        return QString::fromStdString(beginStr + " - " + endStr);
+    }
     case loglib::LogConfiguration::LogFilter::Type::Enumeration:
     {
         Q_ASSERT(!filter.filterValues.empty());
@@ -4432,7 +4465,10 @@ QMenu *MainWindow::BuildRowContextMenu(int sourceRow, QWidget *parent)
         {
             return;
         }
-        FilterTimeStampSubmitted(QUuid::createUuid().toString(), col, boundary, std::numeric_limits<qint64>::max());
+        // `std::nullopt` for the upper bound: the predicate fills in
+        // INT64_MAX, but the title and the editor see "any" and
+        // round-trip the open bound faithfully.
+        FilterTimeStampSubmitted(QUuid::createUuid().toString(), col, boundary, std::nullopt);
     });
 
     QAction *beforeAction = menu->addAction(tr("Show only logs at or before this time (%1)").arg(colLabel));
@@ -4443,7 +4479,7 @@ QMenu *MainWindow::BuildRowContextMenu(int sourceRow, QWidget *parent)
         {
             return;
         }
-        FilterTimeStampSubmitted(QUuid::createUuid().toString(), col, std::numeric_limits<qint64>::min(), boundary);
+        FilterTimeStampSubmitted(QUuid::createUuid().toString(), col, std::nullopt, boundary);
     });
 
     return menu;

--- a/app/src/main_window.cpp
+++ b/app/src/main_window.cpp
@@ -359,7 +359,10 @@ std::optional<FilterValidationFailure> ValidateFilterAgainstColumns(
     switch (filter.type)
     {
     case LogFilter::Type::Time:
-        if (!filter.filterBegin.has_value() || !filter.filterEnd.has_value())
+        // Mirrors `Number` below: at least one bound must be populated;
+        // `nullopt` on the other side means "unbounded" and is fed to
+        // the predicate as INT64_MIN / INT64_MAX at construction.
+        if (!filter.filterBegin.has_value() && !filter.filterEnd.has_value())
         {
             return FilterValidationFailure{
                 .reason = FilterValidationReason::MissingTimeRange, .row = filter.row, .columnHeader = column.header
@@ -3850,14 +3853,19 @@ void MainWindow::UpdateFilters()
         switch (filter.type)
         {
         case LogFilterType::Time:
-            // `FilterTimeStampSubmitted` populates both bounds before the
-            // filter ever reaches `mFilters`, and the switch case pins
-            // `type == Time`, so the optionals are engaged here.
+            // `nullopt` on either side means "unbounded" (mirrors the
+            // `Number` filter's `filterMinValue`/`filterMaxValue`
+            // semantics). `value_or` substitutes the predicate's
+            // closed-range sentinels so the per-row visitor stays a
+            // simple `>=` / `<=` pair and the title / FilterEditor
+            // can keep `nullopt` as the canonical representation.
+            // `ValidateFilterAgainstColumns` rejects the both-null
+            // case, so at least one side is always bounded here.
             rules.emplace_back(
                 std::in_place_type<loglib::TimeRangeRowPredicate>,
                 column,
-                *filter.filterBegin, // NOLINT(bugprone-unchecked-optional-access)
-                *filter.filterEnd    // NOLINT(bugprone-unchecked-optional-access)
+                filter.filterBegin.value_or(std::numeric_limits<int64_t>::min()),
+                filter.filterEnd.value_or(std::numeric_limits<int64_t>::max())
             );
             break;
         case LogFilterType::Enumeration:

--- a/app/src/main_window.cpp
+++ b/app/src/main_window.cpp
@@ -359,9 +359,8 @@ std::optional<FilterValidationFailure> ValidateFilterAgainstColumns(
     switch (filter.type)
     {
     case LogFilter::Type::Time:
-        // Mirrors `Number` below: at least one bound must be populated;
-        // `nullopt` on the other side means "unbounded" and is fed to
-        // the predicate as INT64_MIN / INT64_MAX at construction.
+        // At least one bound must be set; `nullopt` on the other side is
+        // fed to the predicate as INT64_MIN / INT64_MAX at construction.
         if (!filter.filterBegin.has_value() && !filter.filterEnd.has_value())
         {
             return FilterValidationFailure{
@@ -491,12 +490,9 @@ MainWindow::MainWindow(SessionHistoryManager *historyManager, QWidget *parent)
         &MainWindow::ShowHeaderContextMenu
     );
 
-    // Row-level context menu: offers an inclusive time-range
-    // filter pinned to the clicked row's timestamp. The header
-    // version above lives on the header widget; this one lives on
-    // the table view, so `customContextMenuRequested` fires with
-    // `pos` in viewport coords (mapped via `viewport()->mapToGlobal`
-    // in `ShowRowContextMenu`).
+    // Row-level context menu: inclusive time-range filter pinned to the
+    // clicked row's timestamp. Installed on the table view itself, so
+    // `pos` arrives in viewport coords (see `ShowRowContextMenu`).
     mTableView->setContextMenuPolicy(Qt::CustomContextMenu);
     connect(mTableView, &QWidget::customContextMenuRequested, this, &MainWindow::ShowRowContextMenu);
     // Catch every column move (header drag and implicit moves like
@@ -2034,20 +2030,13 @@ void MainWindow::SetConfigurationUiEnabled(bool enabled)
     ui->actionSaveConfiguration->setEnabled(enabled);
     ui->actionSaveSession->setEnabled(enabled);
     ui->actionPreferences->setEnabled(enabled);
-    // Reorder + header right-click are gated mid-stream because
-    // `LogModel::MoveColumn` rotates `columns` while the streaming
-    // pipeline is busy mutating it through `AppendKeys`; a drag
-    // between batches would scramble the proxy chain's column-keyed
-    // state. The `View` menu stays reachable (only flips the
-    // `visible` flag).
+    // Header reorder + right-click are gated mid-stream because
+    // `LogModel::MoveColumn` would race with `AppendKeys` mutating
+    // `columns`. The View menu stays reachable (only flips `visible`).
     //
-    // Note: the *row* right-click menu (set up on `mTableView`
-    // itself in the constructor) is intentionally NOT gated here.
-    // Its only side effect is `AddLogFilter`, which mutates the
-    // `mFilters` map and rebuilds proxy rules -- neither of those
-    // races with the streaming pipeline's `columns` mutation. The
-    // mid-stream filter add is a useful workflow (narrow the view
-    // to "newer logs only" while live-tailing a growing file).
+    // The row right-click menu is NOT gated: its only effect is
+    // `AddLogFilter`, which doesn't race with the streaming pipeline,
+    // and "narrow to newer logs" is a useful live-tail workflow.
     if (QHeaderView *header = mTableView->horizontalHeader(); header != nullptr)
     {
         header->setSectionsMovable(enabled);
@@ -3238,9 +3227,8 @@ void MainWindow::AddFilter(
     {
         if (resolvedFilter->type == loglib::LogConfiguration::LogFilter::Type::Time)
         {
-            // Mirrors `FilterTimeStampSubmitted`'s validation: at least
-            // one bound must be set; the other side may be `nullopt`
-            // (rendered as "No begin/end limit" in the editor).
+            // At least one bound must be set; the other side may be
+            // `nullopt` (shown as "No begin/end limit" in the editor).
             if (!resolvedFilter->filterBegin.has_value() && !resolvedFilter->filterEnd.has_value())
             {
                 statusBar()->showMessage(
@@ -3412,11 +3400,9 @@ void MainWindow::FilterTimeStampSubmitted(
     const QString &filterID, int row, std::optional<qint64> beginTimeStamp, std::optional<qint64> endTimeStamp
 )
 {
-    // Mirrors `FilterNumericRangeSubmitted`. `nullopt` means
-    // "unbounded" on that side; both-nullopt would match every row
-    // and is rejected up front. The predicate handles the open side
-    // via `value_or(INT64_MIN/MAX)` at construction; the editor and
-    // the title both keep `nullopt` as the canonical representation.
+    // `nullopt` means "unbounded" on that side. Both-nullopt would
+    // match every row and is rejected up front; the predicate
+    // substitutes INT64 sentinels for the open side at construction.
     if (!beginTimeStamp.has_value() && !endTimeStamp.has_value())
     {
         statusBar()->showMessage(
@@ -3426,8 +3412,7 @@ void MainWindow::FilterTimeStampSubmitted(
         ClearFilter(filterID);
         return;
     }
-    // Inversion only matters when both sides are bounded; an open
-    // side is always compatible with whatever the other side picks.
+    // Inversion only matters when both sides are bounded.
     if (beginTimeStamp.has_value() && endTimeStamp.has_value() && *beginTimeStamp > *endTimeStamp)
     {
         statusBar()->showMessage(
@@ -3547,16 +3532,11 @@ QString MainWindow::BuildFilterTitle(const loglib::LogConfiguration::LogFilter &
     {
     case loglib::LogConfiguration::LogFilter::Type::Time:
     {
-        // `nullopt` on a side renders as the literal "any" rather
-        // than formatting the predicate's INT64_MIN/MAX sentinels
-        // (which produced absurd 294247 AD / 292277 BC dates and
-        // pushed the title past usable widths).
-        // `ValidateFilterAgainstColumns` rejects both-nullopt
-        // upstream, so well-formed flows always carry at least one
-        // bounded side. The both-`nullopt` branch renders as
-        // "any - any" so a hand-edited config or a future migration
-        // mid-flight surfaces in the UI rather than tripping a
-        // `Q_ASSERT` in Debug while Release falls through silently.
+        // `nullopt` renders as "any" rather than formatting the INT64
+        // sentinels (which produced absurd 294247 AD / 292277 BC dates).
+        // Validation rejects both-nullopt upstream, but render it as
+        // "any - any" rather than asserting so a hand-edited config
+        // surfaces visibly instead of crashing in Debug.
         const std::string beginStr =
             filter.filterBegin.has_value() ? loglib::UtcMicrosecondsToDateTimeString(*filter.filterBegin) : "any";
         const std::string endStr =
@@ -3895,14 +3875,10 @@ void MainWindow::UpdateFilters()
         switch (filter.type)
         {
         case LogFilterType::Time:
-            // `nullopt` on either side means "unbounded" (mirrors the
-            // `Number` filter's `filterMinValue`/`filterMaxValue`
-            // semantics). `value_or` substitutes the predicate's
-            // closed-range sentinels so the per-row visitor stays a
-            // simple `>=` / `<=` pair and the title / FilterEditor
-            // can keep `nullopt` as the canonical representation.
-            // `ValidateFilterAgainstColumns` rejects the both-null
-            // case, so at least one side is always bounded here.
+            // `nullopt` = unbounded; `value_or` feeds INT64 sentinels so
+            // the per-row visitor stays a simple `>=` / `<=` pair while
+            // the title and FilterEditor keep `nullopt` as canonical.
+            // Validation guarantees at least one side is bounded.
             rules.emplace_back(
                 std::in_place_type<loglib::TimeRangeRowPredicate>,
                 column,
@@ -4414,11 +4390,9 @@ void MainWindow::ShowRowContextMenu(const QPoint &pos)
         return;
     }
     menu->setAttribute(Qt::WA_DeleteOnClose);
-    // `customContextMenuRequested` on a `QAbstractItemView` delivers
-    // `pos` in viewport coords -- map via `viewport()` (not the
-    // table view) so the popup lands under the cursor. The header
-    // variant uses `header->mapToGlobal` because the header is its
-    // own widget.
+    // `customContextMenuRequested` from a `QAbstractItemView` delivers
+    // `pos` in viewport coords; map via `viewport()` so the popup lands
+    // under the cursor.
     menu->popup(mTableView->viewport()->mapToGlobal(pos));
 }
 
@@ -4430,11 +4404,8 @@ QMenu *MainWindow::BuildRowContextMenu(int sourceRow, QWidget *parent)
         return nullptr;
     }
 
-    // Use the first `Type::Time` column. Logs can carry several
-    // time columns; the row context menu is intentionally simple
-    // (a single inclusive before/after pair pinned to the canonical
-    // time column), so it shares `FirstTimeColumnIndex` with the
-    // Record Details summary in `record_detail_widget.cpp`.
+    // Pin to the first time column (shared with the Record Details
+    // summary via `FirstTimeColumnIndex`).
     const auto &config = mModel->Configuration();
     const auto &columns = config.columns;
     const int timeCol = loglib::FirstTimeColumnIndex(config);
@@ -4443,12 +4414,8 @@ QMenu *MainWindow::BuildRowContextMenu(int sourceRow, QWidget *parent)
         return nullptr;
     }
 
-    // `monostate` (no value on this row) and non-time-shaped slots
-    // (raw strings, doubles, bools) return `nullopt` so the menu
-    // never advertises a no-op entry. The shared helper mirrors the
-    // `TimeRangeRowPredicate` visitor at
-    // `library/src/log_filter.cpp` exactly, so the menu and the
-    // predicate stay in lockstep on what counts as a "time" slot.
+    // `nullopt` for `monostate` and non-time-shaped slots: skip the
+    // menu rather than advertise a no-op action.
     const std::optional<int64_t> micros = loglib::AsEpochMicroseconds(
         mModel->Table().GetValue(static_cast<size_t>(sourceRow), static_cast<size_t>(timeCol))
     );
@@ -4459,32 +4426,24 @@ QMenu *MainWindow::BuildRowContextMenu(int sourceRow, QWidget *parent)
 
     auto *menu = new QMenu(parent != nullptr ? parent : mTableView);
 
-    // Capture stable column keys (not the index) so the action
-    // still hits the right column if a streaming reorder fires
-    // between menu build and click. The timestamp itself is a
-    // value capture; survives a `Reset` of the source row.
+    // Capture the stable column keys (not the index) so the action
+    // still targets the right column if a streaming reorder fires
+    // between menu build and click.
     const std::vector<std::string> timeKeys = columns[static_cast<size_t>(timeCol)].keys;
-    // `ColumnMenuLabel` disambiguates duplicate headers by
-    // appending `[key]`, matching `BuildHeaderContextMenu`. Without
-    // this, two `Type::Time` columns sharing a header name would
-    // produce ambiguous "Show only newer logs (ts)" entries.
+    // `ColumnMenuLabel` appends `[key]` to disambiguate duplicate
+    // headers, matching `BuildHeaderContextMenu`.
     const QString colLabel = ColumnMenuLabel(static_cast<size_t>(timeCol));
     const qint64 boundary = *micros;
 
-    // Both actions share the same shape: re-resolve the column by
-    // its captured keys at trigger time (so a streaming reorder
-    // between menu build and click still hits the right column),
-    // then dispatch a fresh-uuid `FilterTimeStampSubmitted`. The
-    // only thing that varies is which side carries the bound and
-    // which side is `nullopt`. `std::nullopt` for the open side: the
-    // predicate substitutes its INT64 sentinel at construction, but
-    // the title sees "any" and the editor round-trips the open
-    // bound faithfully.
+    // Each action re-resolves the column by its captured keys at
+    // trigger time, then dispatches a fresh-uuid time filter. Only
+    // which side carries the bound varies; the open side uses
+    // `nullopt` so the title shows "any" and the editor round-trips
+    // it faithfully.
     //
-    // `timeKeys` is reference-captured here (the local outlives
-    // every synchronous `addRangeAction(...)` call below) so we
-    // copy the vector only once -- into the inner connect lambda,
-    // which IS invoked asynchronously and so must own its keys.
+    // `timeKeys` is captured by reference here (the local outlives
+    // every synchronous call below), then copied into the connect
+    // lambda which is invoked asynchronously.
     auto addRangeAction = [this, menu, &timeKeys, boundary](
                               const QString &label, std::optional<qint64> begin, std::optional<qint64> end
                           ) {

--- a/app/src/main_window.cpp
+++ b/app/src/main_window.cpp
@@ -487,6 +487,15 @@ MainWindow::MainWindow(SessionHistoryManager *historyManager, QWidget *parent)
         this,
         &MainWindow::ShowHeaderContextMenu
     );
+
+    // Row-level context menu: offers an inclusive time-range
+    // filter pinned to the clicked row's timestamp. The header
+    // version above lives on the header widget; this one lives on
+    // the table view, so `customContextMenuRequested` fires with
+    // `pos` in viewport coords (mapped via `viewport()->mapToGlobal`
+    // in `ShowRowContextMenu`).
+    mTableView->setContextMenuPolicy(Qt::CustomContextMenu);
+    connect(mTableView, &QWidget::customContextMenuRequested, this, &MainWindow::ShowRowContextMenu);
     // Catch every column move (header drag and implicit moves like
     // mid-stream timestamp bubbling) so the runtime filter map and
     // proxy rules stay aligned with the source layout.
@@ -4331,6 +4340,137 @@ MainWindow::HeaderContextMenu MainWindow::BuildHeaderContextMenu(int logicalColu
     // hatch when *every* column is hidden, since no header section
     // is left to right-click).
     return result;
+}
+
+void MainWindow::ShowRowContextMenu(const QPoint &pos)
+{
+    if (mTableView == nullptr || mSortFilterProxyModel == nullptr || mRowOrderProxyModel == nullptr)
+    {
+        return;
+    }
+    const QModelIndex proxyIndex = mTableView->indexAt(pos);
+    if (!proxyIndex.isValid())
+    {
+        return;
+    }
+    const int sourceRow = MapProxyIndexToSourceRow(proxyIndex, mSortFilterProxyModel, mRowOrderProxyModel);
+    if (sourceRow < 0)
+    {
+        return;
+    }
+    QMenu *menu = BuildRowContextMenu(sourceRow, mTableView);
+    if (menu == nullptr)
+    {
+        return;
+    }
+    menu->setAttribute(Qt::WA_DeleteOnClose);
+    // `customContextMenuRequested` on a `QAbstractItemView` delivers
+    // `pos` in viewport coords -- map via `viewport()` (not the
+    // table view) so the popup lands under the cursor. The header
+    // variant uses `header->mapToGlobal` because the header is its
+    // own widget.
+    menu->popup(mTableView->viewport()->mapToGlobal(pos));
+}
+
+QMenu *MainWindow::BuildRowContextMenu(int sourceRow, QWidget *parent)
+{
+    if (mModel == nullptr || mModel->rowCount() <= 0 || sourceRow < 0
+        || static_cast<size_t>(sourceRow) >= static_cast<size_t>(mModel->rowCount()))
+    {
+        return nullptr;
+    }
+
+    // Use the first `Type::Time` column. Logs can carry several
+    // time columns (`FindTimeColumn` in `record_detail_widget.cpp`
+    // makes the same first-match choice), but the row context
+    // menu is intentionally simple: a single inclusive
+    // before/after pair pinned to the canonical time column.
+    const auto &columns = mModel->Configuration().columns;
+    int timeCol = -1;
+    for (size_t i = 0; i < columns.size(); ++i)
+    {
+        if (columns[i].type == loglib::LogConfiguration::Type::Time)
+        {
+            timeCol = static_cast<int>(i);
+            break;
+        }
+    }
+    if (timeCol < 0)
+    {
+        return nullptr;
+    }
+
+    // Slot type follows the `TimeRangeRowPredicate` visitor at
+    // `library/src/log_filter.cpp`: `TimeStamp` is the dominant
+    // shape but the table also carries promoted-int / uint
+    // representations. `monostate` (no value on this row) returns
+    // null so the menu never advertises a no-op entry.
+    const loglib::LogValue value =
+        mModel->Table().GetValue(static_cast<size_t>(sourceRow), static_cast<size_t>(timeCol));
+    std::optional<qint64> micros;
+    std::visit(
+        [&micros](const auto &alt) {
+            using T = std::decay_t<decltype(alt)>;
+            if constexpr (std::is_same_v<T, loglib::TimeStamp>)
+            {
+                micros = alt.time_since_epoch().count();
+            }
+            else if constexpr (std::is_same_v<T, int64_t>)
+            {
+                micros = alt;
+            }
+            else if constexpr (std::is_same_v<T, uint64_t>)
+            {
+                // Clamp out-of-range uint64 microseconds rather than
+                // wrapping; matches the int64 ceiling the predicate
+                // and the persisted `LogFilter::filterBegin/End`
+                // both use.
+                if (alt <= static_cast<uint64_t>(std::numeric_limits<int64_t>::max()))
+                {
+                    micros = static_cast<int64_t>(alt);
+                }
+            }
+        },
+        value
+    );
+    if (!micros.has_value())
+    {
+        return nullptr;
+    }
+
+    auto *menu = new QMenu(parent != nullptr ? parent : mTableView);
+
+    // Capture stable column keys (not the index) so the action
+    // still hits the right column if a streaming reorder fires
+    // between menu build and click. The timestamp itself is a
+    // value capture; survives a `Reset` of the source row.
+    const std::vector<std::string> timeKeys = columns[static_cast<size_t>(timeCol)].keys;
+    const QString colLabel = QString::fromStdString(columns[static_cast<size_t>(timeCol)].header);
+    const qint64 boundary = *micros;
+
+    QAction *afterAction = menu->addAction(tr("Show only logs at or after this time (%1)").arg(colLabel));
+    // NOLINTNEXTLINE(bugprone-exception-escape)
+    connect(afterAction, &QAction::triggered, this, [this, timeKeys, boundary]() {
+        const int col = FindColumnIndexByKeys(timeKeys);
+        if (col < 0)
+        {
+            return;
+        }
+        FilterTimeStampSubmitted(QUuid::createUuid().toString(), col, boundary, std::numeric_limits<qint64>::max());
+    });
+
+    QAction *beforeAction = menu->addAction(tr("Show only logs at or before this time (%1)").arg(colLabel));
+    // NOLINTNEXTLINE(bugprone-exception-escape)
+    connect(beforeAction, &QAction::triggered, this, [this, timeKeys, boundary]() {
+        const int col = FindColumnIndexByKeys(timeKeys);
+        if (col < 0)
+        {
+            return;
+        }
+        FilterTimeStampSubmitted(QUuid::createUuid().toString(), col, std::numeric_limits<qint64>::min(), boundary);
+    });
+
+    return menu;
 }
 
 void MainWindow::SetColumnVisible(int logicalIndex, bool visible)

--- a/app/src/main_window.cpp
+++ b/app/src/main_window.cpp
@@ -2047,8 +2047,7 @@ void MainWindow::SetConfigurationUiEnabled(bool enabled)
     // `mFilters` map and rebuilds proxy rules -- neither of those
     // races with the streaming pipeline's `columns` mutation. The
     // mid-stream filter add is a useful workflow (narrow the view
-    // to "logs at or after this row's timestamp" while live-tailing
-    // a growing file).
+    // to "newer logs only" while live-tailing a growing file).
     if (QHeaderView *header = mTableView->horizontalHeader(); header != nullptr)
     {
         header->setSectionsMovable(enabled);
@@ -4470,8 +4469,7 @@ QMenu *MainWindow::BuildRowContextMenu(int sourceRow, QWidget *parent)
     // `ColumnMenuLabel` disambiguates duplicate headers by
     // appending `[key]`, matching `BuildHeaderContextMenu`. Without
     // this, two `Type::Time` columns sharing a header name would
-    // produce ambiguous "Show only logs at or after this time (ts)"
-    // entries.
+    // produce ambiguous "Show only newer logs (ts)" entries.
     const QString colLabel = ColumnMenuLabel(static_cast<size_t>(timeCol));
     const qint64 boundary = *micros;
 
@@ -4504,12 +4502,8 @@ QMenu *MainWindow::BuildRowContextMenu(int sourceRow, QWidget *parent)
         });
     };
 
-    addRangeAction(
-        tr("Show only logs at or after this time (%1)").arg(colLabel), boundary, std::nullopt
-    );
-    addRangeAction(
-        tr("Show only logs at or before this time (%1)").arg(colLabel), std::nullopt, boundary
-    );
+    addRangeAction(tr("Show only newer logs (%1)").arg(colLabel), boundary, std::nullopt);
+    addRangeAction(tr("Show only older logs (%1)").arg(colLabel), std::nullopt, boundary);
 
     return menu;
 }

--- a/app/src/main_window.cpp
+++ b/app/src/main_window.cpp
@@ -3431,9 +3431,7 @@ void MainWindow::FilterTimeStampSubmitted(
     if (beginTimeStamp.has_value() && endTimeStamp.has_value() && *beginTimeStamp > *endTimeStamp)
     {
         statusBar()->showMessage(
-            QString("Time-range filter rejected: begin (%1) is after end (%2)")
-                .arg(*beginTimeStamp)
-                .arg(*endTimeStamp),
+            QString("Time-range filter rejected: begin (%1) is after end (%2)").arg(*beginTimeStamp).arg(*endTimeStamp),
             STATUS_BAR_MESSAGE_TIMEOUT_MS
         );
         ClearFilter(filterID);
@@ -4426,8 +4424,8 @@ void MainWindow::ShowRowContextMenu(const QPoint &pos)
 
 QMenu *MainWindow::BuildRowContextMenu(int sourceRow, QWidget *parent)
 {
-    if (mModel == nullptr || mModel->rowCount() <= 0 || sourceRow < 0
-        || static_cast<size_t>(sourceRow) >= static_cast<size_t>(mModel->rowCount()))
+    if (mModel == nullptr || mModel->rowCount() <= 0 || sourceRow < 0 ||
+        static_cast<size_t>(sourceRow) >= static_cast<size_t>(mModel->rowCount()))
     {
         return nullptr;
     }

--- a/app/src/main_window.cpp
+++ b/app/src/main_window.cpp
@@ -4381,20 +4381,12 @@ QMenu *MainWindow::BuildRowContextMenu(int sourceRow, QWidget *parent)
     }
 
     // Use the first `Type::Time` column. Logs can carry several
-    // time columns (`FindTimeColumn` in `record_detail_widget.cpp`
-    // makes the same first-match choice), but the row context
-    // menu is intentionally simple: a single inclusive
-    // before/after pair pinned to the canonical time column.
+    // time columns; the row context menu is intentionally simple
+    // (a single inclusive before/after pair pinned to the canonical
+    // time column), so it shares `FirstTimeColumnIndex` with the
+    // Record Details summary in `record_detail_widget.cpp`.
     const auto &columns = mModel->Configuration().columns;
-    int timeCol = -1;
-    for (size_t i = 0; i < columns.size(); ++i)
-    {
-        if (columns[i].type == loglib::LogConfiguration::Type::Time)
-        {
-            timeCol = static_cast<int>(i);
-            break;
-        }
-    }
+    const int timeCol = loglib::FirstTimeColumnIndex(mModel->Configuration());
     if (timeCol < 0)
     {
         return nullptr;

--- a/app/src/main_window.cpp
+++ b/app/src/main_window.cpp
@@ -3545,9 +3545,12 @@ QString MainWindow::BuildFilterTitle(const loglib::LogConfiguration::LogFilter &
         // than formatting the predicate's INT64_MIN/MAX sentinels
         // (which produced absurd 294247 AD / 292277 BC dates and
         // pushed the title past usable widths).
-        // `ValidateFilterAgainstColumns` rejects both-nullopt, so at
-        // least one side is always a real timestamp here.
-        Q_ASSERT(filter.filterBegin.has_value() || filter.filterEnd.has_value());
+        // `ValidateFilterAgainstColumns` rejects both-nullopt
+        // upstream, so well-formed flows always carry at least one
+        // bounded side. The both-`nullopt` branch renders as
+        // "any - any" so a hand-edited config or a future migration
+        // mid-flight surfaces in the UI rather than tripping a
+        // `Q_ASSERT` in Debug while Release falls through silently.
         const std::string beginStr =
             filter.filterBegin.has_value() ? loglib::UtcMicrosecondsToDateTimeString(*filter.filterBegin) : "any";
         const std::string endStr =

--- a/app/src/main_window.cpp
+++ b/app/src/main_window.cpp
@@ -4457,30 +4457,36 @@ QMenu *MainWindow::BuildRowContextMenu(int sourceRow, QWidget *parent)
     const QString colLabel = QString::fromStdString(columns[static_cast<size_t>(timeCol)].header);
     const qint64 boundary = *micros;
 
-    QAction *afterAction = menu->addAction(tr("Show only logs at or after this time (%1)").arg(colLabel));
-    // NOLINTNEXTLINE(bugprone-exception-escape)
-    connect(afterAction, &QAction::triggered, this, [this, timeKeys, boundary]() {
-        const int col = FindColumnIndexByKeys(timeKeys);
-        if (col < 0)
-        {
-            return;
-        }
-        // `std::nullopt` for the upper bound: the predicate fills in
-        // INT64_MAX, but the title and the editor see "any" and
-        // round-trip the open bound faithfully.
-        FilterTimeStampSubmitted(QUuid::createUuid().toString(), col, boundary, std::nullopt);
-    });
+    // Both actions share the same shape: re-resolve the column by
+    // its captured keys at trigger time (so a streaming reorder
+    // between menu build and click still hits the right column),
+    // then dispatch a fresh-uuid `FilterTimeStampSubmitted`. The
+    // only thing that varies is which side carries the bound and
+    // which side is `nullopt`. `std::nullopt` for the open side: the
+    // predicate substitutes its INT64 sentinel at construction, but
+    // the title sees "any" and the editor round-trips the open
+    // bound faithfully.
+    auto addRangeAction = [this, menu, timeKeys, boundary](
+                              const QString &label, std::optional<qint64> begin, std::optional<qint64> end
+                          ) {
+        QAction *action = menu->addAction(label);
+        // NOLINTNEXTLINE(bugprone-exception-escape)
+        connect(action, &QAction::triggered, this, [this, timeKeys, begin, end]() {
+            const int col = FindColumnIndexByKeys(timeKeys);
+            if (col < 0)
+            {
+                return;
+            }
+            FilterTimeStampSubmitted(QUuid::createUuid().toString(), col, begin, end);
+        });
+    };
 
-    QAction *beforeAction = menu->addAction(tr("Show only logs at or before this time (%1)").arg(colLabel));
-    // NOLINTNEXTLINE(bugprone-exception-escape)
-    connect(beforeAction, &QAction::triggered, this, [this, timeKeys, boundary]() {
-        const int col = FindColumnIndexByKeys(timeKeys);
-        if (col < 0)
-        {
-            return;
-        }
-        FilterTimeStampSubmitted(QUuid::createUuid().toString(), col, std::nullopt, boundary);
-    });
+    addRangeAction(
+        tr("Show only logs at or after this time (%1)").arg(colLabel), boundary, std::nullopt
+    );
+    addRangeAction(
+        tr("Show only logs at or before this time (%1)").arg(colLabel), std::nullopt, boundary
+    );
 
     return menu;
 }

--- a/app/src/main_window.cpp
+++ b/app/src/main_window.cpp
@@ -4488,7 +4488,7 @@ QMenu *MainWindow::BuildRowContextMenu(int sourceRow, QWidget *parent)
     auto addRangeAction = [this, menu, &timeKeys, boundary](
                               const QString &label, std::optional<qint64> begin, std::optional<qint64> end
                           ) {
-        QAction *action = menu->addAction(label);
+        const QAction *action = menu->addAction(label);
         // NOLINTNEXTLINE(bugprone-exception-escape)
         connect(action, &QAction::triggered, this, [this, timeKeys, begin, end]() {
             const int col = FindColumnIndexByKeys(timeKeys);

--- a/app/src/main_window.cpp
+++ b/app/src/main_window.cpp
@@ -4429,8 +4429,9 @@ QMenu *MainWindow::BuildRowContextMenu(int sourceRow, QWidget *parent)
     // (a single inclusive before/after pair pinned to the canonical
     // time column), so it shares `FirstTimeColumnIndex` with the
     // Record Details summary in `record_detail_widget.cpp`.
-    const auto &columns = mModel->Configuration().columns;
-    const int timeCol = loglib::FirstTimeColumnIndex(mModel->Configuration());
+    const auto &config = mModel->Configuration();
+    const auto &columns = config.columns;
+    const int timeCol = loglib::FirstTimeColumnIndex(config);
     if (timeCol < 0)
     {
         return nullptr;

--- a/app/src/main_window.cpp
+++ b/app/src/main_window.cpp
@@ -4392,38 +4392,14 @@ QMenu *MainWindow::BuildRowContextMenu(int sourceRow, QWidget *parent)
         return nullptr;
     }
 
-    // Slot type follows the `TimeRangeRowPredicate` visitor at
-    // `library/src/log_filter.cpp`: `TimeStamp` is the dominant
-    // shape but the table also carries promoted-int / uint
-    // representations. `monostate` (no value on this row) returns
-    // null so the menu never advertises a no-op entry.
-    const loglib::LogValue value =
-        mModel->Table().GetValue(static_cast<size_t>(sourceRow), static_cast<size_t>(timeCol));
-    std::optional<qint64> micros;
-    std::visit(
-        [&micros](const auto &alt) {
-            using T = std::decay_t<decltype(alt)>;
-            if constexpr (std::is_same_v<T, loglib::TimeStamp>)
-            {
-                micros = alt.time_since_epoch().count();
-            }
-            else if constexpr (std::is_same_v<T, int64_t>)
-            {
-                micros = alt;
-            }
-            else if constexpr (std::is_same_v<T, uint64_t>)
-            {
-                // Clamp out-of-range uint64 microseconds rather than
-                // wrapping; matches the int64 ceiling the predicate
-                // and the persisted `LogFilter::filterBegin/End`
-                // both use.
-                if (alt <= static_cast<uint64_t>(std::numeric_limits<int64_t>::max()))
-                {
-                    micros = static_cast<int64_t>(alt);
-                }
-            }
-        },
-        value
+    // `monostate` (no value on this row) and non-time-shaped slots
+    // (raw strings, doubles, bools) return `nullopt` so the menu
+    // never advertises a no-op entry. The shared helper mirrors the
+    // `TimeRangeRowPredicate` visitor at
+    // `library/src/log_filter.cpp` exactly, so the menu and the
+    // predicate stay in lockstep on what counts as a "time" slot.
+    const std::optional<int64_t> micros = loglib::AsEpochMicroseconds(
+        mModel->Table().GetValue(static_cast<size_t>(sourceRow), static_cast<size_t>(timeCol))
     );
     if (!micros.has_value())
     {

--- a/app/src/main_window.cpp
+++ b/app/src/main_window.cpp
@@ -2034,12 +2034,21 @@ void MainWindow::SetConfigurationUiEnabled(bool enabled)
     ui->actionSaveConfiguration->setEnabled(enabled);
     ui->actionSaveSession->setEnabled(enabled);
     ui->actionPreferences->setEnabled(enabled);
-    // Reorder + right-click are gated mid-stream because
+    // Reorder + header right-click are gated mid-stream because
     // `LogModel::MoveColumn` rotates `columns` while the streaming
     // pipeline is busy mutating it through `AppendKeys`; a drag
     // between batches would scramble the proxy chain's column-keyed
     // state. The `View` menu stays reachable (only flips the
     // `visible` flag).
+    //
+    // Note: the *row* right-click menu (set up on `mTableView`
+    // itself in the constructor) is intentionally NOT gated here.
+    // Its only side effect is `AddLogFilter`, which mutates the
+    // `mFilters` map and rebuilds proxy rules -- neither of those
+    // races with the streaming pipeline's `columns` mutation. The
+    // mid-stream filter add is a useful workflow (narrow the view
+    // to "logs at or after this row's timestamp" while live-tailing
+    // a growing file).
     if (QHeaderView *header = mTableView->horizontalHeader(); header != nullptr)
     {
         header->setSectionsMovable(enabled);
@@ -4458,7 +4467,12 @@ QMenu *MainWindow::BuildRowContextMenu(int sourceRow, QWidget *parent)
     // between menu build and click. The timestamp itself is a
     // value capture; survives a `Reset` of the source row.
     const std::vector<std::string> timeKeys = columns[static_cast<size_t>(timeCol)].keys;
-    const QString colLabel = QString::fromStdString(columns[static_cast<size_t>(timeCol)].header);
+    // `ColumnMenuLabel` disambiguates duplicate headers by
+    // appending `[key]`, matching `BuildHeaderContextMenu`. Without
+    // this, two `Type::Time` columns sharing a header name would
+    // produce ambiguous "Show only logs at or after this time (ts)"
+    // entries.
+    const QString colLabel = ColumnMenuLabel(static_cast<size_t>(timeCol));
     const qint64 boundary = *micros;
 
     // Both actions share the same shape: re-resolve the column by
@@ -4470,7 +4484,12 @@ QMenu *MainWindow::BuildRowContextMenu(int sourceRow, QWidget *parent)
     // predicate substitutes its INT64 sentinel at construction, but
     // the title sees "any" and the editor round-trips the open
     // bound faithfully.
-    auto addRangeAction = [this, menu, timeKeys, boundary](
+    //
+    // `timeKeys` is reference-captured here (the local outlives
+    // every synchronous `addRangeAction(...)` call below) so we
+    // copy the vector only once -- into the inner connect lambda,
+    // which IS invoked asynchronously and so must own its keys.
+    auto addRangeAction = [this, menu, &timeKeys, boundary](
                               const QString &label, std::optional<qint64> begin, std::optional<qint64> end
                           ) {
         QAction *action = menu->addAction(label);

--- a/app/src/record_detail_widget.cpp
+++ b/app/src/record_detail_widget.cpp
@@ -91,20 +91,6 @@ QString FormatRawLineForDisplay(const std::string &raw)
     return QString::fromUtf8(bytes);
 }
 
-/// Index of the first `Type::Time` column, or -1 if none. Used to
-/// append the formatted timestamp to the summary label.
-int FindTimeColumn(const loglib::LogConfiguration &configuration)
-{
-    for (size_t i = 0; i < configuration.columns.size(); ++i)
-    {
-        if (configuration.columns[i].type == loglib::LogConfiguration::Type::Time)
-        {
-            return static_cast<int>(i);
-        }
-    }
-    return -1;
-}
-
 /// C-style escape (`\n`, `\r`, `\t`, `\\`) for the `header: value`
 /// clipboard output so each pair stays on one line. Other characters
 /// pass through unchanged.
@@ -258,7 +244,7 @@ RecordDetailContent BuildRecordDetailContent(const LogModel &model, int sourceRo
     content.formattedJson = FormatRawLineForDisplay(rawLineBytes);
 
     QString summary = RecordDetailWidget::tr("Row %1").arg(sourceRow + 1);
-    if (const int timeCol = FindTimeColumn(configuration); timeCol >= 0)
+    if (const int timeCol = loglib::FirstTimeColumnIndex(configuration); timeCol >= 0)
     {
         const QString timeText = QString::fromStdString(table.GetFormattedValue(row, static_cast<size_t>(timeCol)));
         if (!timeText.isEmpty())

--- a/library/include/loglib/log_configuration.hpp
+++ b/library/include/loglib/log_configuration.hpp
@@ -177,11 +177,9 @@ struct LogConfiguration
 /// promotion.
 [[nodiscard]] bool IsLogLevelKey(const std::string &key);
 
-/// Index of the first `Type::Time` column in @p configuration, or -1
-/// if none. Centralised so every "where is the canonical timestamp"
-/// caller (Record Details summary, the row right-click time-filter
-/// menu, ...) makes the same first-match choice without each one
-/// re-implementing the loop.
+/// Index of the first `Type::Time` column in @p configuration, or -1.
+/// Single source of truth for "which column is the canonical timestamp"
+/// (Record Details summary, row right-click time-filter menu, ...).
 [[nodiscard]] int FirstTimeColumnIndex(const LogConfiguration &configuration);
 
 /// "Source is actionable" predicate. Centralises the

--- a/library/include/loglib/log_configuration.hpp
+++ b/library/include/loglib/log_configuration.hpp
@@ -177,6 +177,13 @@ struct LogConfiguration
 /// promotion.
 [[nodiscard]] bool IsLogLevelKey(const std::string &key);
 
+/// Index of the first `Type::Time` column in @p configuration, or -1
+/// if none. Centralised so every "where is the canonical timestamp"
+/// caller (Record Details summary, the row right-click time-filter
+/// menu, ...) makes the same first-match choice without each one
+/// re-implementing the loop.
+[[nodiscard]] int FirstTimeColumnIndex(const LogConfiguration &configuration);
+
 /// "Source is actionable" predicate. Centralises the
 /// `has_value() && !locators.empty()` gate so the half-checked form
 /// can't sneak through one call site at a time.

--- a/library/include/loglib/log_value.hpp
+++ b/library/include/loglib/log_value.hpp
@@ -39,4 +39,11 @@ LogValue ToOwnedLogValue(const LogValue &value);
 /// Treats `string_view` and `string` alternatives as equal when bytes match.
 bool LogValueEquivalent(const LogValue &lhs, const LogValue &rhs);
 
+/// Returns the slot's epoch-microseconds representation if it carries a
+/// time-shaped value (`TimeStamp`, `int64_t`, or in-range `uint64_t`).
+/// `nullopt` for `monostate`, strings, doubles, bools, or out-of-range
+/// `uint64_t` (the same ceiling `TimeRangeRowPredicate` and the
+/// persisted `LogFilter::filterBegin/End` apply).
+[[nodiscard]] std::optional<int64_t> AsEpochMicroseconds(const LogValue &value);
+
 } // namespace loglib

--- a/library/include/loglib/log_value.hpp
+++ b/library/include/loglib/log_value.hpp
@@ -39,11 +39,9 @@ LogValue ToOwnedLogValue(const LogValue &value);
 /// Treats `string_view` and `string` alternatives as equal when bytes match.
 bool LogValueEquivalent(const LogValue &lhs, const LogValue &rhs);
 
-/// Returns the slot's epoch-microseconds representation if it carries a
-/// time-shaped value (`TimeStamp`, `int64_t`, or in-range `uint64_t`).
-/// `nullopt` for `monostate`, strings, doubles, bools, or out-of-range
-/// `uint64_t` (the same ceiling `TimeRangeRowPredicate` and the
-/// persisted `LogFilter::filterBegin/End` apply).
+/// Epoch microseconds for time-shaped slots (`TimeStamp`, `int64_t`, or
+/// `uint64_t` <= `int64_t::max`); `nullopt` otherwise. Matches the slot
+/// acceptance set of `TimeRangeRowPredicate`.
 [[nodiscard]] std::optional<int64_t> AsEpochMicroseconds(const LogValue &value);
 
 } // namespace loglib

--- a/library/src/log_configuration.cpp
+++ b/library/src/log_configuration.cpp
@@ -84,6 +84,18 @@ bool IsLogLevelKey(const std::string &key)
     });
 }
 
+int FirstTimeColumnIndex(const LogConfiguration &configuration)
+{
+    for (size_t i = 0; i < configuration.columns.size(); ++i)
+    {
+        if (configuration.columns[i].type == LogConfiguration::Type::Time)
+        {
+            return static_cast<int>(i);
+        }
+    }
+    return -1;
+}
+
 } // namespace loglib
 
 namespace

--- a/library/src/log_filter.cpp
+++ b/library/src/log_filter.cpp
@@ -147,12 +147,9 @@ bool TimeRangeRowPredicate::MatchesRow(const LogTable &table, size_t row) const
         return false;
     }
     const LogValue value = table.GetValue(row, mColumnIndex);
-    // Slot acceptance set mirrors `loglib::AsEpochMicroseconds` in
-    // `log_line.cpp`: `TimeStamp`, `int64_t`, in-range `uint64_t`.
-    // Keep the two visitors in lockstep so the row right-click time-
-    // filter menu (which uses the helper to decide whether to offer
-    // an action) never advertises a boundary the predicate would
-    // then reject.
+    // Slot acceptance set must stay in lockstep with
+    // `loglib::AsEpochMicroseconds`: `TimeStamp`, `int64_t`,
+    // in-range `uint64_t`.
     return std::visit(
         [this](const auto &alt) -> bool {
             using T = std::decay_t<decltype(alt)>;
@@ -167,13 +164,9 @@ bool TimeRangeRowPredicate::MatchesRow(const LogTable &table, size_t row) const
             }
             else if constexpr (std::is_same_v<T, uint64_t>)
             {
-                // `uint64_t` past `int64_t::max` is rejected (rather
-                // than wrapped) so the predicate and
-                // `AsEpochMicroseconds` agree on what counts as a
-                // "time" slot. The `mBegin <= mEnd <= int64_t::max`
-                // bound means such a slot could never match anyway,
-                // but spelling it out keeps the contract obvious
-                // and survives future bound widenings.
+                // Reject (rather than wrap) `uint64_t` past
+                // `int64_t::max` so this stays in sync with
+                // `AsEpochMicroseconds`.
                 if (alt > static_cast<uint64_t>(std::numeric_limits<int64_t>::max()))
                 {
                     return false;

--- a/library/src/log_filter.cpp
+++ b/library/src/log_filter.cpp
@@ -13,6 +13,7 @@
 #include <cmath>
 #include <cstddef>
 #include <cstdint>
+#include <limits>
 #include <numeric>
 #include <optional>
 #include <span>
@@ -146,6 +147,12 @@ bool TimeRangeRowPredicate::MatchesRow(const LogTable &table, size_t row) const
         return false;
     }
     const LogValue value = table.GetValue(row, mColumnIndex);
+    // Slot acceptance set mirrors `loglib::AsEpochMicroseconds` in
+    // `log_line.cpp`: `TimeStamp`, `int64_t`, in-range `uint64_t`.
+    // Keep the two visitors in lockstep so the row right-click time-
+    // filter menu (which uses the helper to decide whether to offer
+    // an action) never advertises a boundary the predicate would
+    // then reject.
     return std::visit(
         [this](const auto &alt) -> bool {
             using T = std::decay_t<decltype(alt)>;
@@ -160,6 +167,17 @@ bool TimeRangeRowPredicate::MatchesRow(const LogTable &table, size_t row) const
             }
             else if constexpr (std::is_same_v<T, uint64_t>)
             {
+                // `uint64_t` past `int64_t::max` is rejected (rather
+                // than wrapped) so the predicate and
+                // `AsEpochMicroseconds` agree on what counts as a
+                // "time" slot. The `mBegin <= mEnd <= int64_t::max`
+                // bound means such a slot could never match anyway,
+                // but spelling it out keeps the contract obvious
+                // and survives future bound widenings.
+                if (alt > static_cast<uint64_t>(std::numeric_limits<int64_t>::max()))
+                {
+                    return false;
+                }
                 // Clamp negative bounds to 0 so e.g. `[-1, 100]`
                 // still matches positive values.
                 const uint64_t lo = mBegin < 0 ? 0U : static_cast<uint64_t>(mBegin);

--- a/library/src/log_line.cpp
+++ b/library/src/log_line.cpp
@@ -55,12 +55,10 @@ bool LogValueEquivalent(const LogValue &lhs, const LogValue &rhs)
 
 std::optional<int64_t> AsEpochMicroseconds(const LogValue &value)
 {
-    // Mirrors `TimeRangeRowPredicate`'s slot-type acceptance set:
-    // `TimeStamp` is the dominant shape; `int64_t` / `uint64_t` ride
-    // along because promoted-int / uint micros also count as time
-    // values. `uint64_t` past `int64_t::max` is rejected (rather than
-    // wrapped) so callers see the same ceiling the predicate and the
-    // persisted `LogFilter::filterBegin/End` enforce.
+    // Slot acceptance set must stay in lockstep with
+    // `TimeRangeRowPredicate`: `TimeStamp`, `int64_t`, and `uint64_t`
+    // up to `int64_t::max`. Out-of-range `uint64_t` returns `nullopt`
+    // rather than wrapping.
     return std::visit(
         [](const auto &alt) -> std::optional<int64_t> {
             using T = std::decay_t<decltype(alt)>;

--- a/library/src/log_line.cpp
+++ b/library/src/log_line.cpp
@@ -5,6 +5,7 @@
 
 #include <algorithm>
 #include <cassert>
+#include <limits>
 #include <span>
 #include <stdexcept>
 #include <string>
@@ -50,6 +51,42 @@ bool LogValueEquivalent(const LogValue &lhs, const LogValue &rhs)
         return lhsString.has_value() && rhsString.has_value() && *lhsString == *rhsString;
     }
     return lhs == rhs;
+}
+
+std::optional<int64_t> AsEpochMicroseconds(const LogValue &value)
+{
+    // Mirrors `TimeRangeRowPredicate`'s slot-type acceptance set:
+    // `TimeStamp` is the dominant shape; `int64_t` / `uint64_t` ride
+    // along because promoted-int / uint micros also count as time
+    // values. `uint64_t` past `int64_t::max` is rejected (rather than
+    // wrapped) so callers see the same ceiling the predicate and the
+    // persisted `LogFilter::filterBegin/End` enforce.
+    return std::visit(
+        [](const auto &alt) -> std::optional<int64_t> {
+            using T = std::decay_t<decltype(alt)>;
+            if constexpr (std::is_same_v<T, TimeStamp>)
+            {
+                return alt.time_since_epoch().count();
+            }
+            else if constexpr (std::is_same_v<T, int64_t>)
+            {
+                return alt;
+            }
+            else if constexpr (std::is_same_v<T, uint64_t>)
+            {
+                if (alt <= static_cast<uint64_t>(std::numeric_limits<int64_t>::max()))
+                {
+                    return static_cast<int64_t>(alt);
+                }
+                return std::nullopt;
+            }
+            else
+            {
+                return std::nullopt;
+            }
+        },
+        value
+    );
 }
 
 namespace

--- a/test/app/src/main_window_test.cpp
+++ b/test/app/src/main_window_test.cpp
@@ -4904,7 +4904,7 @@ private slots:
 
     // Triggering the "at or after" action installs an additive
     // time filter on the time column, with the clicked row's
-    // microseconds as the lower (inclusive) bound and INT64_MAX
+    // microseconds as the lower (inclusive) bound and `nullopt`
     // as the open upper bound. The lower bound is read straight
     // off the model's `SortRole`, which already normalises every
     // `Type::Time` slot to `qint64` microseconds since epoch.
@@ -4935,15 +4935,17 @@ private slots:
         QCOMPARE(installed.type, loglib::LogConfiguration::LogFilter::Type::Time);
         QCOMPARE(installed.row, timeCol);
         QVERIFY(installed.filterBegin.has_value());
-        QVERIFY(installed.filterEnd.has_value());
-        // NOLINTBEGIN(bugprone-unchecked-optional-access)
+        // The open upper bound is encoded as `std::nullopt` so the
+        // title renders as "any" and the FilterEditor round-trips
+        // the open side faithfully.
+        QVERIFY2(!installed.filterEnd.has_value(), "open upper bound must be std::nullopt, not INT64_MAX");
+        // NOLINTNEXTLINE(bugprone-unchecked-optional-access)
         QCOMPARE(*installed.filterBegin, row1Micros);
-        QCOMPARE(*installed.filterEnd, std::numeric_limits<qint64>::max());
-        // NOLINTEND(bugprone-unchecked-optional-access)
     }
 
-    // Symmetric to the "at or after" test: the lower bound goes
-    // to INT64_MIN, the upper bound is the clicked row's micros.
+    // Symmetric to the "at or after" test: the lower bound is
+    // `std::nullopt` (open), the upper bound is the clicked row's
+    // micros.
     void TestRowContextMenuAtOrBeforeAddsTimeFilter()
     {
         const int timeCol = StreamFixtureWithTimeColumnForRowMenuTests();
@@ -4969,12 +4971,12 @@ private slots:
         const auto &installed = mWindow->Filters().begin()->second;
         QCOMPARE(installed.type, loglib::LogConfiguration::LogFilter::Type::Time);
         QCOMPARE(installed.row, timeCol);
-        QVERIFY(installed.filterBegin.has_value());
+        // The open lower bound is encoded as `std::nullopt`; the
+        // upper bound is the clicked row's micros.
+        QVERIFY2(!installed.filterBegin.has_value(), "open lower bound must be std::nullopt, not INT64_MIN");
         QVERIFY(installed.filterEnd.has_value());
-        // NOLINTBEGIN(bugprone-unchecked-optional-access)
-        QCOMPARE(*installed.filterBegin, std::numeric_limits<qint64>::min());
+        // NOLINTNEXTLINE(bugprone-unchecked-optional-access)
         QCOMPARE(*installed.filterEnd, row2Micros);
-        // NOLINTEND(bugprone-unchecked-optional-access)
     }
 
     // Regression: the action lambdas must re-resolve the time
@@ -5034,10 +5036,13 @@ private slots:
         const int timeCol = StreamFixtureWithTimeColumnForRowMenuTests();
         QVERIFY2(timeCol >= 0, "timestamp column must exist after streaming");
 
-        // Pre-seed an inert time-range filter on the same column
-        // (window-wide bounds so no rows are filtered out of the
-        // fixture).
+        // Pre-seed a permissive bounded filter on the same column.
+        // Bounds are decades around the fixture timestamps so no
+        // rows are filtered out and the filter is identifiable
+        // (real values, not the predicate's INT64 sentinels).
         const QString preSeededId = QStringLiteral("pre-seeded-time-filter");
+        const std::optional<qint64> preBegin{1'000'000'000'000'000LL};      // 2001-09-09 UTC, micros.
+        const std::optional<qint64> preEnd{4'000'000'000'000'000LL};        // 2096-10-02 UTC, micros.
         QVERIFY2(
             QMetaObject::invokeMethod(
                 mWindow,
@@ -5045,8 +5050,8 @@ private slots:
                 Qt::DirectConnection,
                 Q_ARG(QString, preSeededId),
                 Q_ARG(int, timeCol),
-                Q_ARG(qint64, std::numeric_limits<qint64>::min()),
-                Q_ARG(qint64, std::numeric_limits<qint64>::max())
+                Q_ARG(std::optional<qint64>, preBegin),
+                Q_ARG(std::optional<qint64>, preEnd)
             ),
             "FilterTimeStampSubmitted slot must be invocable via meta-object"
         );
@@ -5076,9 +5081,104 @@ private slots:
         QVERIFY(it->second.filterBegin.has_value());
         QVERIFY(it->second.filterEnd.has_value());
         // NOLINTBEGIN(bugprone-unchecked-optional-access)
-        QCOMPARE(*it->second.filterBegin, std::numeric_limits<qint64>::min());
-        QCOMPARE(*it->second.filterEnd, std::numeric_limits<qint64>::max());
+        QCOMPARE(*it->second.filterBegin, *preBegin);
+        QCOMPARE(*it->second.filterEnd, *preEnd);
         // NOLINTEND(bugprone-unchecked-optional-access)
+    }
+
+    // Regression for the "FilterEditor silently clamps unbounded
+    // bounds" bug: a time filter installed by the row context menu
+    // carries a `std::nullopt` upper bound. Editing it (Edit -> OK,
+    // no edits in between) must round-trip the open side, not
+    // silently rewrite it as `9999-12-31T23:59:59` because the
+    // `QDateTimeEdit`'s default ceiling clamped INT64_MAX.
+    void TestRowContextMenuTimeFilterRoundTripsThroughEditor()
+    {
+        const int timeCol = StreamFixtureWithTimeColumnForRowMenuTests();
+        QVERIFY2(timeCol >= 0, "timestamp column must exist after streaming");
+        auto *model = mWindow->Model();
+        const qint64 row1Micros = model->data(model->index(1, timeCol), LogModelItemDataRole::SortRole).toLongLong();
+        QVERIFY2(row1Micros > 0, "row 1 must carry a positive epoch-microseconds timestamp");
+
+        // Step 1: install an `at or after` filter via the row menu.
+        // This is the production code path that produces a
+        // `(row1Micros, nullopt)` filter.
+        QMenu *rowMenu = mWindow->BuildRowContextMenu(/*sourceRow=*/1, nullptr);
+        QVERIFY2(rowMenu != nullptr, "BuildRowContextMenu must return a menu for a row with a timestamp");
+        const QScopeGuard rowMenuDeleter([&rowMenu]() { rowMenu->deleteLater(); });
+        // NOLINTNEXTLINE(clang-analyzer-core.CallAndMessage): false positive; prior `QVERIFY2` aborts on null.
+        rowMenu->actions().at(0)->trigger();
+        QCoreApplication::processEvents();
+
+        QCOMPARE(mWindow->Filters().size(), static_cast<size_t>(1));
+        const QString filterId = QString::fromStdString(mWindow->Filters().begin()->first);
+        QVERIFY2(!mWindow->Filters().begin()->second.filterEnd.has_value(), "installed filter must carry an open upper bound (nullopt)");
+
+        // Step 2: trigger Edit from the column-header sub-menu.
+        auto built = mWindow->BuildHeaderContextMenu(timeCol, nullptr);
+        QVERIFY2(built.menu != nullptr, "BuildHeaderContextMenu must return a menu");
+        const QScopeGuard headerMenuDeleter([&built]() { built.menu->deleteLater(); });
+        const QMenu *subMenu = built.filterSubMenus.at(filterId.toStdString());
+        QVERIFY2(subMenu != nullptr, "filter sub-menu must be exposed");
+        QAction *editAction = nullptr;
+        const QString editLabel = MainWindow::tr("Edit");
+        // NOLINTNEXTLINE(clang-analyzer-core.CallAndMessage): false positive; prior `QVERIFY2` aborts on null.
+        for (QAction *act : subMenu->actions())
+        {
+            if (act->text() == editLabel)
+            {
+                editAction = act;
+                break;
+            }
+        }
+        QVERIFY2(editAction != nullptr, "sub-menu must contain an Edit action");
+        // NOLINTNEXTLINE(clang-analyzer-core.CallAndMessage): false positive; prior `QVERIFY2` aborts on null.
+        editAction->trigger();
+        QCoreApplication::processEvents();
+
+        FilterEditor *editor = nullptr;
+        for (QWidget *widget : QApplication::topLevelWidgets())
+        {
+            if (auto *e = qobject_cast<FilterEditor *>(widget))
+            {
+                editor = e;
+                break;
+            }
+        }
+        QVERIFY2(editor != nullptr, "Edit must open a FilterEditor");
+        // NOLINTNEXTLINE(clang-analyzer-core.CallAndMessage): false positive; prior `QVERIFY2` aborts on null.
+        QCOMPARE(editor->GetRowToFilter(), timeCol);
+
+        // Step 3: click OK without touching anything. The editor
+        // must read the open-bound state from its checkboxes and
+        // emit `nullopt` back, leaving the filter unchanged.
+        QPushButton *ok = editor->OkButton();
+        QVERIFY2(ok != nullptr, "FilterEditor must expose its OK button");
+        // NOLINTNEXTLINE(clang-analyzer-core.CallAndMessage): false positive; prior `QVERIFY2` aborts on null.
+        ok->click();
+        QCoreApplication::processEvents();
+
+        // Step 4: the filter is still on the same column, with the
+        // same `(row1Micros, nullopt)` shape. The pre-fix code
+        // silently rewrote `filterEnd` to whatever the
+        // `QDateTimeEdit`'s upper ceiling produced (typically
+        // `9999-12-31`'s epoch micros), losing the open upper bound.
+        QCOMPARE(mWindow->Filters().size(), static_cast<size_t>(1));
+        const auto it = mWindow->Filters().find(filterId.toStdString());
+        QVERIFY2(it != mWindow->Filters().end(), "filter id must survive Edit -> OK");
+        // NOLINTNEXTLINE(clang-analyzer-core.CallAndMessage): false positive; prior `QVERIFY2` aborts on .end().
+        QCOMPARE(it->second.type, loglib::LogConfiguration::LogFilter::Type::Time);
+        QCOMPARE(it->second.row, timeCol);
+        QVERIFY(it->second.filterBegin.has_value());
+        QVERIFY2(!it->second.filterEnd.has_value(), "open upper bound must round-trip as std::nullopt");
+        // NOLINTNEXTLINE(bugprone-unchecked-optional-access)
+        QCOMPARE(*it->second.filterBegin, row1Micros);
+
+        // The editor accepts on OK; nothing leaked. `accept()`
+        // schedules deletion via `Qt::WA_DeleteOnClose` so we don't
+        // need to delete explicitly, but spinning the loop here
+        // matches the rest of the editor-using tests.
+        QCoreApplication::processEvents();
     }
 
     // `Column::visible` survives the Save / Reset / Load round-trip

--- a/test/app/src/main_window_test.cpp
+++ b/test/app/src/main_window_test.cpp
@@ -4779,6 +4779,308 @@ private slots:
         }
     }
 
+    // Stream a small three-row fixture with a `timestamp` column
+    // (auto-detected as `Type::Time`) and a `msg` column into the
+    // window's live model. Returns the time-column index (post-
+    // bubble), or -1 on streaming failure. Mirrors
+    // `StreamFixtureForColumnTests` but tailored to the row-menu
+    // tests that need a `Type::Time` slot to read from.
+    int StreamFixtureWithTimeColumnForRowMenuTests()
+    {
+        auto *model = mWindow->Model();
+        Q_ASSERT(model != nullptr);
+
+        // Explicit `+00:00` timezone offsets rather than `Z`: the
+        // streaming parser's time-promotion picks up the explicit-
+        // offset shape reliably with as few as three rows, while the
+        // `Z` suffix lands the column at `Type::Time` but leaves the
+        // value as a raw `OwnedString` (see `mixed_tz_and_order.jsonl`
+        // for the canonical format used by `TestFixtureMixedTzAndOrder`).
+        const QStringList lines{
+            QStringLiteral(R"({"timestamp":"2024-04-28T10:00:01+00:00","msg":"first"})"),
+            QStringLiteral(R"({"timestamp":"2024-04-28T10:00:02+00:00","msg":"second"})"),
+            QStringLiteral(R"({"timestamp":"2024-04-28T10:00:03+00:00","msg":"third"})"),
+        };
+        const TempJsonFile fixture(lines);
+
+        QSignalSpy finishedSpy(model, &LogModel::streamingFinished);
+        if (!finishedSpy.isValid())
+        {
+            return -1;
+        }
+        auto file = std::make_unique<loglib::LogFile>(fixture.Path().toStdString());
+        auto fileSource = std::make_unique<loglib::FileLineSource>(std::move(file));
+        loglib::FileLineSource *fileSourcePtr = fileSource.get();
+        const loglib::StopToken stopToken = model->BeginStreamingForSyncTest(std::move(fileSource));
+
+        loglib::ParserOptions options;
+        options.stopToken = stopToken;
+        loglib::internal::AdvancedParserOptions advanced;
+        advanced.threads = 1;
+        const loglib::JsonParser parser;
+        loglib::JsonParser::ParseStreaming(*fileSourcePtr, *model->Sink(), options, advanced);
+        if (finishedSpy.count() == 0)
+        {
+            finishedSpy.wait(5000);
+        }
+        QCoreApplication::processEvents();
+
+        return ColumnByHeader(*model, QStringLiteral("timestamp"));
+    }
+
+    // `BuildRowContextMenu` must offer exactly the two inclusive
+    // "at or after" / "at or before" actions, labelled with the
+    // time column's header. Pinned so a future entry that
+    // accidentally lands on the row menu (or a label rewrite that
+    // drops the "this time" phrasing the design pinned) trips
+    // here.
+    void TestRowContextMenuOffersAtOrAfterAndAtOrBefore()
+    {
+        const int timeCol = StreamFixtureWithTimeColumnForRowMenuTests();
+        QVERIFY2(timeCol >= 0, "timestamp column must exist after streaming");
+
+        QMenu *menu = mWindow->BuildRowContextMenu(/*sourceRow=*/1, nullptr);
+        QVERIFY2(menu != nullptr, "BuildRowContextMenu must return a menu for a row with a timestamp");
+        const QScopeGuard menuDeleter([&menu]() { menu->deleteLater(); });
+
+        // NOLINTNEXTLINE(clang-analyzer-core.CallAndMessage): false positive; prior `QVERIFY2` aborts on null.
+        const QList<QAction *> actions = menu->actions();
+        QCOMPARE(actions.size(), 2);
+        QVERIFY2(actions[0]->text().startsWith(QStringLiteral("Show only logs at or after this time")), "first action must be the 'at or after' entry");
+        QVERIFY2(actions[1]->text().startsWith(QStringLiteral("Show only logs at or before this time")), "second action must be the 'at or before' entry");
+        // The column label is interpolated into both entries so
+        // users see which time column the filter will bind to.
+        QVERIFY2(actions[0]->text().contains(QStringLiteral("timestamp")), "label must reference the time column");
+        QVERIFY2(actions[1]->text().contains(QStringLiteral("timestamp")), "label must reference the time column");
+    }
+
+    // When no `Type::Time` column is present the menu must return
+    // null so the host never advertises an action with no column
+    // to bind to. The `StreamFixtureForColumnTests` fixture has
+    // only `category` and `msg`, neither of which auto-promotes
+    // to `Type::Time`.
+    void TestRowContextMenuReturnsNullWithoutTimeColumn()
+    {
+        const int levelCol = StreamFixtureForColumnTests();
+        QVERIFY2(levelCol >= 0, "level column must exist after streaming");
+
+        QMenu *menu = mWindow->BuildRowContextMenu(/*sourceRow=*/0, nullptr);
+        QVERIFY2(menu == nullptr, "BuildRowContextMenu must return null when the model has no Type::Time column");
+    }
+
+    // Empty model: nothing to bind a timestamp to, so the menu
+    // must return null. Mirrors the `model->rowCount() > 0` gate
+    // that `BuildHeaderContextMenu` applies to its Add-filter
+    // entry.
+    void TestRowContextMenuReturnsNullWhenModelEmpty()
+    {
+        // Fresh `mWindow` from `init()`; no streaming, no rows.
+        QCOMPARE(mWindow->Model()->rowCount(), 0);
+
+        QMenu *menu = mWindow->BuildRowContextMenu(/*sourceRow=*/0, nullptr);
+        QVERIFY2(menu == nullptr, "BuildRowContextMenu must return null when the model is empty");
+    }
+
+    // Out-of-range rows must not crash and must not produce a
+    // menu. Defensive cover for the unlikely race where a
+    // streaming `Reset` shrinks the model between popup build and
+    // the action's source-row capture.
+    void TestRowContextMenuReturnsNullForOutOfRangeRow()
+    {
+        const int timeCol = StreamFixtureWithTimeColumnForRowMenuTests();
+        QVERIFY2(timeCol >= 0, "timestamp column must exist after streaming");
+        const int rowCount = mWindow->Model()->rowCount();
+        QVERIFY2(rowCount > 0, "fixture must yield at least one row");
+
+        QVERIFY2(
+            mWindow->BuildRowContextMenu(/*sourceRow=*/-1, nullptr) == nullptr,
+            "BuildRowContextMenu must reject negative source rows"
+        );
+        QVERIFY2(
+            mWindow->BuildRowContextMenu(/*sourceRow=*/rowCount, nullptr) == nullptr,
+            "BuildRowContextMenu must reject source rows beyond the model"
+        );
+    }
+
+    // Triggering the "at or after" action installs an additive
+    // time filter on the time column, with the clicked row's
+    // microseconds as the lower (inclusive) bound and INT64_MAX
+    // as the open upper bound. The lower bound is read straight
+    // off the model's `SortRole`, which already normalises every
+    // `Type::Time` slot to `qint64` microseconds since epoch.
+    void TestRowContextMenuAtOrAfterAddsTimeFilter()
+    {
+        const int timeCol = StreamFixtureWithTimeColumnForRowMenuTests();
+        QVERIFY2(timeCol >= 0, "timestamp column must exist after streaming");
+        auto *model = mWindow->Model();
+        QCOMPARE(model->rowCount(), 3);
+        const qint64 row1Micros = model->data(model->index(1, timeCol), LogModelItemDataRole::SortRole).toLongLong();
+        QVERIFY2(row1Micros > 0, "row 1 must carry a positive epoch-microseconds timestamp");
+
+        QMenu *menu = mWindow->BuildRowContextMenu(/*sourceRow=*/1, nullptr);
+        QVERIFY2(menu != nullptr, "BuildRowContextMenu must return a menu for a row with a timestamp");
+        const QScopeGuard menuDeleter([&menu]() { menu->deleteLater(); });
+
+        // NOLINTNEXTLINE(clang-analyzer-core.CallAndMessage): false positive; prior `QVERIFY2` aborts on null.
+        QAction *afterAction = menu->actions().at(0);
+        QVERIFY2(afterAction != nullptr, "menu must carry an `at or after` action");
+        QCOMPARE(mWindow->Filters().size(), static_cast<size_t>(0));
+
+        // NOLINTNEXTLINE(clang-analyzer-core.CallAndMessage): false positive; prior `QVERIFY2` aborts on null.
+        afterAction->trigger();
+        QCoreApplication::processEvents();
+
+        QCOMPARE(mWindow->Filters().size(), static_cast<size_t>(1));
+        const auto &installed = mWindow->Filters().begin()->second;
+        QCOMPARE(installed.type, loglib::LogConfiguration::LogFilter::Type::Time);
+        QCOMPARE(installed.row, timeCol);
+        QVERIFY(installed.filterBegin.has_value());
+        QVERIFY(installed.filterEnd.has_value());
+        // NOLINTBEGIN(bugprone-unchecked-optional-access)
+        QCOMPARE(*installed.filterBegin, row1Micros);
+        QCOMPARE(*installed.filterEnd, std::numeric_limits<qint64>::max());
+        // NOLINTEND(bugprone-unchecked-optional-access)
+    }
+
+    // Symmetric to the "at or after" test: the lower bound goes
+    // to INT64_MIN, the upper bound is the clicked row's micros.
+    void TestRowContextMenuAtOrBeforeAddsTimeFilter()
+    {
+        const int timeCol = StreamFixtureWithTimeColumnForRowMenuTests();
+        QVERIFY2(timeCol >= 0, "timestamp column must exist after streaming");
+        auto *model = mWindow->Model();
+        QCOMPARE(model->rowCount(), 3);
+        const qint64 row2Micros = model->data(model->index(2, timeCol), LogModelItemDataRole::SortRole).toLongLong();
+        QVERIFY2(row2Micros > 0, "row 2 must carry a positive epoch-microseconds timestamp");
+
+        QMenu *menu = mWindow->BuildRowContextMenu(/*sourceRow=*/2, nullptr);
+        QVERIFY2(menu != nullptr, "BuildRowContextMenu must return a menu for a row with a timestamp");
+        const QScopeGuard menuDeleter([&menu]() { menu->deleteLater(); });
+
+        // NOLINTNEXTLINE(clang-analyzer-core.CallAndMessage): false positive; prior `QVERIFY2` aborts on null.
+        QAction *beforeAction = menu->actions().at(1);
+        QVERIFY2(beforeAction != nullptr, "menu must carry an `at or before` action");
+
+        // NOLINTNEXTLINE(clang-analyzer-core.CallAndMessage): false positive; prior `QVERIFY2` aborts on null.
+        beforeAction->trigger();
+        QCoreApplication::processEvents();
+
+        QCOMPARE(mWindow->Filters().size(), static_cast<size_t>(1));
+        const auto &installed = mWindow->Filters().begin()->second;
+        QCOMPARE(installed.type, loglib::LogConfiguration::LogFilter::Type::Time);
+        QCOMPARE(installed.row, timeCol);
+        QVERIFY(installed.filterBegin.has_value());
+        QVERIFY(installed.filterEnd.has_value());
+        // NOLINTBEGIN(bugprone-unchecked-optional-access)
+        QCOMPARE(*installed.filterBegin, std::numeric_limits<qint64>::min());
+        QCOMPARE(*installed.filterEnd, row2Micros);
+        // NOLINTEND(bugprone-unchecked-optional-access)
+    }
+
+    // Regression: the action lambdas must re-resolve the time
+    // column by its stable keys at trigger time, so a column
+    // reorder between menu build and click still targets the
+    // column's current index. Mirrors
+    // `TestHeaderContextMenuAddFilterAfterColumnReorderResolvesByKeys`.
+    void TestRowContextMenuAddTimeFilterAfterColumnReorderResolvesByKeys()
+    {
+        const int timeCol = StreamFixtureWithTimeColumnForRowMenuTests();
+        QVERIFY2(timeCol >= 0, "timestamp column must exist after streaming");
+        auto *model = mWindow->Model();
+        const int columnCount = model->columnCount();
+        QVERIFY2(columnCount >= 2, "fixture must yield at least two columns");
+
+        QMenu *menu = mWindow->BuildRowContextMenu(/*sourceRow=*/0, nullptr);
+        QVERIFY2(menu != nullptr, "BuildRowContextMenu must return a menu for a row with a timestamp");
+        const QScopeGuard menuDeleter([&menu]() { menu->deleteLater(); });
+
+        // Move the time column to a different index after the
+        // menu was built but before its action is triggered. The
+        // captured keys must re-resolve to the new index.
+        const int src = timeCol;
+        const int dest = (src == 0) ? columnCount - 1 : 0;
+        QVERIFY(src != dest);
+        QVERIFY2(
+            QMetaObject::invokeMethod(
+                mWindow, "OnHeaderSectionMoved", Qt::DirectConnection, Q_ARG(int, src), Q_ARG(int, src), Q_ARG(int, dest)
+            ),
+            "OnHeaderSectionMoved slot must be invocable via meta-object"
+        );
+        QCoreApplication::processEvents();
+        const int timeColAfter = ColumnByHeader(*model, QStringLiteral("timestamp"));
+        QCOMPARE(timeColAfter, dest);
+
+        // NOLINTNEXTLINE(clang-analyzer-core.CallAndMessage): false positive; prior `QVERIFY2` aborts on null.
+        QAction *afterAction = menu->actions().at(0);
+        QVERIFY2(afterAction != nullptr, "menu must carry an `at or after` action");
+
+        // NOLINTNEXTLINE(clang-analyzer-core.CallAndMessage): false positive; prior `QVERIFY2` aborts on null.
+        afterAction->trigger();
+        QCoreApplication::processEvents();
+
+        QCOMPARE(mWindow->Filters().size(), static_cast<size_t>(1));
+        const auto &installed = mWindow->Filters().begin()->second;
+        QCOMPARE(installed.row, timeColAfter);
+    }
+
+    // Each click adds a brand-new filter UUID rather than
+    // replacing any existing time filter on the same column. The
+    // additive behaviour is the design contract: combining
+    // "at or after X" and "at or before Y" by issuing two clicks
+    // is how the user narrows a window without ever opening the
+    // FilterEditor.
+    void TestRowContextMenuAdditiveDoesNotReplaceExisting()
+    {
+        const int timeCol = StreamFixtureWithTimeColumnForRowMenuTests();
+        QVERIFY2(timeCol >= 0, "timestamp column must exist after streaming");
+
+        // Pre-seed an inert time-range filter on the same column
+        // (window-wide bounds so no rows are filtered out of the
+        // fixture).
+        const QString preSeededId = QStringLiteral("pre-seeded-time-filter");
+        QVERIFY2(
+            QMetaObject::invokeMethod(
+                mWindow,
+                "FilterTimeStampSubmitted",
+                Qt::DirectConnection,
+                Q_ARG(QString, preSeededId),
+                Q_ARG(int, timeCol),
+                Q_ARG(qint64, std::numeric_limits<qint64>::min()),
+                Q_ARG(qint64, std::numeric_limits<qint64>::max())
+            ),
+            "FilterTimeStampSubmitted slot must be invocable via meta-object"
+        );
+        QCoreApplication::processEvents();
+        QCOMPARE(mWindow->Filters().size(), static_cast<size_t>(1));
+
+        QMenu *menu = mWindow->BuildRowContextMenu(/*sourceRow=*/1, nullptr);
+        QVERIFY2(menu != nullptr, "BuildRowContextMenu must return a menu for a row with a timestamp");
+        const QScopeGuard menuDeleter([&menu]() { menu->deleteLater(); });
+
+        // NOLINTNEXTLINE(clang-analyzer-core.CallAndMessage): false positive; prior `QVERIFY2` aborts on null.
+        QAction *afterAction = menu->actions().at(0);
+        QVERIFY2(afterAction != nullptr, "menu must carry an `at or after` action");
+
+        // NOLINTNEXTLINE(clang-analyzer-core.CallAndMessage): false positive; prior `QVERIFY2` aborts on null.
+        afterAction->trigger();
+        QCoreApplication::processEvents();
+
+        QCOMPARE(mWindow->Filters().size(), static_cast<size_t>(2));
+        // The pre-seeded filter is still present with its
+        // original bounds; the menu installed a sibling, not a
+        // replacement.
+        const auto it = mWindow->Filters().find(preSeededId.toStdString());
+        QVERIFY2(it != mWindow->Filters().end(), "pre-seeded filter must survive the menu trigger");
+        // NOLINTNEXTLINE(clang-analyzer-core.CallAndMessage): false positive; prior `QVERIFY2` aborts on .end().
+        QCOMPARE(it->second.type, loglib::LogConfiguration::LogFilter::Type::Time);
+        QVERIFY(it->second.filterBegin.has_value());
+        QVERIFY(it->second.filterEnd.has_value());
+        // NOLINTBEGIN(bugprone-unchecked-optional-access)
+        QCOMPARE(*it->second.filterBegin, std::numeric_limits<qint64>::min());
+        QCOMPARE(*it->second.filterEnd, std::numeric_limits<qint64>::max());
+        // NOLINTEND(bugprone-unchecked-optional-access)
+    }
+
     // `Column::visible` survives the Save / Reset / Load round-trip
     // (driven through the manager directly so the file dialogs
     // don't pop).

--- a/test/app/src/main_window_test.cpp
+++ b/test/app/src/main_window_test.cpp
@@ -4829,11 +4829,10 @@ private slots:
     }
 
     // `BuildRowContextMenu` must offer exactly the two inclusive
-    // "at or after" / "at or before" actions, labelled with the
-    // time column's header. Pinned so a future entry that
-    // accidentally lands on the row menu (or a label rewrite that
-    // drops the "this time" phrasing the design pinned) trips
-    // here.
+    // "newer" / "older" actions, labelled with the time column's
+    // header. Pinned so a future entry that accidentally lands on
+    // the row menu (or a label rewrite that drops the "newer/older"
+    // phrasing) trips here.
     void TestRowContextMenuOffersAtOrAfterAndAtOrBefore()
     {
         const int timeCol = StreamFixtureWithTimeColumnForRowMenuTests();
@@ -4850,14 +4849,12 @@ private slots:
         // a future `QTranslator` install: production builds the label
         // through the same `tr(...).arg(colLabel)` shape, so an exact
         // compare is both stricter and translation-safe (the prior
-        // `startsWith("Show only logs...")` would silently break under
-        // any non-empty translator).
-        const QString afterLabel =
-            MainWindow::tr("Show only logs at or after this time (%1)").arg(QStringLiteral("timestamp"));
-        const QString beforeLabel =
-            MainWindow::tr("Show only logs at or before this time (%1)").arg(QStringLiteral("timestamp"));
-        QCOMPARE(actions[0]->text(), afterLabel);
-        QCOMPARE(actions[1]->text(), beforeLabel);
+        // `startsWith("Show only newer logs")` would silently break
+        // under any non-empty translator).
+        const QString newerLabel = MainWindow::tr("Show only newer logs (%1)").arg(QStringLiteral("timestamp"));
+        const QString olderLabel = MainWindow::tr("Show only older logs (%1)").arg(QStringLiteral("timestamp"));
+        QCOMPARE(actions[0]->text(), newerLabel);
+        QCOMPARE(actions[1]->text(), olderLabel);
     }
 
     // When no `Type::Time` column is present the menu must return
@@ -4917,8 +4914,8 @@ private slots:
     // empty (the source JSON omitted the timestamp key) returns
     // `std::monostate`. `AsEpochMicroseconds` rejects monostate, so
     // the menu has no boundary to bind to and must return null.
-    // Without this gate the "at or after / before" actions would
-    // trigger with `nullopt` boundaries, installing a degenerate
+    // Without this gate the "newer/older" actions would trigger
+    // with `nullopt` boundaries, installing a degenerate
     // `(nullopt, nullopt)` filter that `ValidateFilterAgainstColumns`
     // would reject silently.
     void TestRowContextMenuReturnsNullForMonostateTimeSlot()

--- a/test/app/src/main_window_test.cpp
+++ b/test/app/src/main_window_test.cpp
@@ -4969,12 +4969,12 @@ private slots:
         QVERIFY2(middle == nullptr, "row 1's monostate time slot must suppress the menu");
     }
 
-    // Triggering the "at or after" action installs an additive
-    // time filter on the time column, with the clicked row's
-    // microseconds as the lower (inclusive) bound and `nullopt`
-    // as the open upper bound. The lower bound is read straight
-    // off the model's `SortRole`, which already normalises every
-    // `Type::Time` slot to `qint64` microseconds since epoch.
+    // Triggering the "newer" action (inclusive `>=`) installs an
+    // additive time filter on the time column, with the clicked
+    // row's microseconds as the lower (inclusive) bound and
+    // `nullopt` as the open upper bound. The lower bound is read
+    // straight off the model's `SortRole`, which already normalises
+    // every `Type::Time` slot to `qint64` microseconds since epoch.
     void TestRowContextMenuAtOrAfterAddsTimeFilter()
     {
         const int timeCol = StreamFixtureWithTimeColumnForRowMenuTests();
@@ -4989,12 +4989,12 @@ private slots:
         const QScopeGuard menuDeleter([&menu]() { menu->deleteLater(); });
 
         // NOLINTNEXTLINE(clang-analyzer-core.CallAndMessage): false positive; prior `QVERIFY2` aborts on null.
-        QAction *afterAction = menu->actions().at(0);
-        QVERIFY2(afterAction != nullptr, "menu must carry an `at or after` action");
+        QAction *newerAction = menu->actions().at(0);
+        QVERIFY2(newerAction != nullptr, "menu must carry a `newer` action at index 0");
         QCOMPARE(mWindow->Filters().size(), static_cast<size_t>(0));
 
         // NOLINTNEXTLINE(clang-analyzer-core.CallAndMessage): false positive; prior `QVERIFY2` aborts on null.
-        afterAction->trigger();
+        newerAction->trigger();
         QCoreApplication::processEvents();
 
         QCOMPARE(mWindow->Filters().size(), static_cast<size_t>(1));
@@ -5010,9 +5010,9 @@ private slots:
         QCOMPARE(*installed.filterBegin, row1Micros);
     }
 
-    // Symmetric to the "at or after" test: the lower bound is
+    // Symmetric to the "newer" test: the lower bound is
     // `std::nullopt` (open), the upper bound is the clicked row's
-    // micros.
+    // micros (inclusive `<=`).
     void TestRowContextMenuAtOrBeforeAddsTimeFilter()
     {
         const int timeCol = StreamFixtureWithTimeColumnForRowMenuTests();
@@ -5027,11 +5027,11 @@ private slots:
         const QScopeGuard menuDeleter([&menu]() { menu->deleteLater(); });
 
         // NOLINTNEXTLINE(clang-analyzer-core.CallAndMessage): false positive; prior `QVERIFY2` aborts on null.
-        QAction *beforeAction = menu->actions().at(1);
-        QVERIFY2(beforeAction != nullptr, "menu must carry an `at or before` action");
+        QAction *olderAction = menu->actions().at(1);
+        QVERIFY2(olderAction != nullptr, "menu must carry an `older` action at index 1");
 
         // NOLINTNEXTLINE(clang-analyzer-core.CallAndMessage): false positive; prior `QVERIFY2` aborts on null.
-        beforeAction->trigger();
+        olderAction->trigger();
         QCoreApplication::processEvents();
 
         QCOMPARE(mWindow->Filters().size(), static_cast<size_t>(1));
@@ -5071,7 +5071,12 @@ private slots:
         QVERIFY(src != dest);
         QVERIFY2(
             QMetaObject::invokeMethod(
-                mWindow, "OnHeaderSectionMoved", Qt::DirectConnection, Q_ARG(int, src), Q_ARG(int, src), Q_ARG(int, dest)
+                mWindow,
+                "OnHeaderSectionMoved",
+                Qt::DirectConnection,
+                Q_ARG(int, src),
+                Q_ARG(int, src),
+                Q_ARG(int, dest)
             ),
             "OnHeaderSectionMoved slot must be invocable via meta-object"
         );
@@ -5080,11 +5085,11 @@ private slots:
         QCOMPARE(timeColAfter, dest);
 
         // NOLINTNEXTLINE(clang-analyzer-core.CallAndMessage): false positive; prior `QVERIFY2` aborts on null.
-        QAction *afterAction = menu->actions().at(0);
-        QVERIFY2(afterAction != nullptr, "menu must carry an `at or after` action");
+        QAction *newerAction = menu->actions().at(0);
+        QVERIFY2(newerAction != nullptr, "menu must carry a `newer` action at index 0");
 
         // NOLINTNEXTLINE(clang-analyzer-core.CallAndMessage): false positive; prior `QVERIFY2` aborts on null.
-        afterAction->trigger();
+        newerAction->trigger();
         QCoreApplication::processEvents();
 
         QCOMPARE(mWindow->Filters().size(), static_cast<size_t>(1));
@@ -5095,8 +5100,8 @@ private slots:
     // Each click adds a brand-new filter UUID rather than
     // replacing any existing time filter on the same column. The
     // additive behaviour is the design contract: combining
-    // "at or after X" and "at or before Y" by issuing two clicks
-    // is how the user narrows a window without ever opening the
+    // "newer than X" and "older than Y" by issuing two clicks is
+    // how the user narrows a window without ever opening the
     // FilterEditor.
     void TestRowContextMenuAdditiveDoesNotReplaceExisting()
     {
@@ -5108,8 +5113,8 @@ private slots:
         // rows are filtered out and the filter is identifiable
         // (real values, not the predicate's INT64 sentinels).
         const QString preSeededId = QStringLiteral("pre-seeded-time-filter");
-        const std::optional<qint64> preBegin{1'000'000'000'000'000LL};      // 2001-09-09 UTC, micros.
-        const std::optional<qint64> preEnd{4'000'000'000'000'000LL};        // 2096-10-02 UTC, micros.
+        const std::optional<qint64> preBegin{1'000'000'000'000'000LL}; // 2001-09-09 UTC, micros.
+        const std::optional<qint64> preEnd{4'000'000'000'000'000LL};   // 2096-10-02 UTC, micros.
         QVERIFY2(
             QMetaObject::invokeMethod(
                 mWindow,
@@ -5130,11 +5135,11 @@ private slots:
         const QScopeGuard menuDeleter([&menu]() { menu->deleteLater(); });
 
         // NOLINTNEXTLINE(clang-analyzer-core.CallAndMessage): false positive; prior `QVERIFY2` aborts on null.
-        QAction *afterAction = menu->actions().at(0);
-        QVERIFY2(afterAction != nullptr, "menu must carry an `at or after` action");
+        QAction *newerAction = menu->actions().at(0);
+        QVERIFY2(newerAction != nullptr, "menu must carry a `newer` action at index 0");
 
         // NOLINTNEXTLINE(clang-analyzer-core.CallAndMessage): false positive; prior `QVERIFY2` aborts on null.
-        afterAction->trigger();
+        newerAction->trigger();
         QCoreApplication::processEvents();
 
         QCOMPARE(mWindow->Filters().size(), static_cast<size_t>(2));
@@ -5167,9 +5172,9 @@ private slots:
         const qint64 row1Micros = model->data(model->index(1, timeCol), LogModelItemDataRole::SortRole).toLongLong();
         QVERIFY2(row1Micros > 0, "row 1 must carry a positive epoch-microseconds timestamp");
 
-        // Step 1: install an `at or after` filter via the row menu.
-        // This is the production code path that produces a
-        // `(row1Micros, nullopt)` filter.
+        // Step 1: install a `newer` filter via the row menu (the
+        // production code path that produces a `(row1Micros,
+        // nullopt)` filter).
         QMenu *rowMenu = mWindow->BuildRowContextMenu(/*sourceRow=*/1, nullptr);
         QVERIFY2(rowMenu != nullptr, "BuildRowContextMenu must return a menu for a row with a timestamp");
         const QScopeGuard rowMenuDeleter([&rowMenu]() { rowMenu->deleteLater(); });
@@ -5179,7 +5184,10 @@ private slots:
 
         QCOMPARE(mWindow->Filters().size(), static_cast<size_t>(1));
         const QString filterId = QString::fromStdString(mWindow->Filters().begin()->first);
-        QVERIFY2(!mWindow->Filters().begin()->second.filterEnd.has_value(), "installed filter must carry an open upper bound (nullopt)");
+        QVERIFY2(
+            !mWindow->Filters().begin()->second.filterEnd.has_value(),
+            "installed filter must carry an open upper bound (nullopt)"
+        );
 
         // Step 2: trigger Edit from the column-header sub-menu.
         auto built = mWindow->BuildHeaderContextMenu(timeCol, nullptr);
@@ -5263,20 +5271,23 @@ private slots:
         const qint64 row2Micros = model->data(model->index(2, timeCol), LogModelItemDataRole::SortRole).toLongLong();
         QVERIFY2(row2Micros > 0, "row 2 must carry a positive epoch-microseconds timestamp");
 
-        // Step 1: install an `at or before` filter on row 2.
-        // Shape: `(nullopt, row2Micros)`. The row-menu code path
-        // is the production source of unbounded-side filters that
-        // reach the editor.
+        // Step 1: install an `older` filter on row 2. Shape:
+        // `(nullopt, row2Micros)`. The row-menu code path is the
+        // production source of unbounded-side filters that reach
+        // the editor.
         QMenu *rowMenu = mWindow->BuildRowContextMenu(/*sourceRow=*/2, nullptr);
         QVERIFY2(rowMenu != nullptr, "BuildRowContextMenu must return a menu for a row with a timestamp");
         const QScopeGuard rowMenuDeleter([&rowMenu]() { rowMenu->deleteLater(); });
         // NOLINTNEXTLINE(clang-analyzer-core.CallAndMessage): false positive; prior `QVERIFY2` aborts on null.
-        rowMenu->actions().at(1)->trigger(); // "at or before"
+        rowMenu->actions().at(1)->trigger(); // "older" (index 1)
         QCoreApplication::processEvents();
 
         QCOMPARE(mWindow->Filters().size(), static_cast<size_t>(1));
         const QString filterId = QString::fromStdString(mWindow->Filters().begin()->first);
-        QVERIFY2(!mWindow->Filters().begin()->second.filterBegin.has_value(), "installed filter must carry an open lower bound (nullopt)");
+        QVERIFY2(
+            !mWindow->Filters().begin()->second.filterBegin.has_value(),
+            "installed filter must carry an open lower bound (nullopt)"
+        );
 
         // Step 2: open the editor via the column-header sub-menu's Edit action.
         auto built = mWindow->BuildHeaderContextMenu(timeCol, nullptr);

--- a/test/app/src/main_window_test.cpp
+++ b/test/app/src/main_window_test.cpp
@@ -5240,6 +5240,140 @@ private slots:
         QCoreApplication::processEvents();
     }
 
+    // Regression for the `SetBeginEnd` constraint-leak fix: opening
+    // Edit on a `(nullopt, X)` filter must let the user uncheck the
+    // begin-unbounded checkbox and pick a begin earlier than `X`.
+    // The pre-fix code installed `setMinimumDateTime(X)` on the
+    // begin edits (using `X` as the unbounded-side seed) and never
+    // cleared it, pinning the begin edit to `[X, X]` and making the
+    // open-bound filter effectively un-widenable.
+    void TestRowContextMenuEditUncheckWidensOpenBeginBound()
+    {
+        const int timeCol = StreamFixtureWithTimeColumnForRowMenuTests();
+        QVERIFY2(timeCol >= 0, "timestamp column must exist after streaming");
+        auto *model = mWindow->Model();
+        const qint64 row2Micros = model->data(model->index(2, timeCol), LogModelItemDataRole::SortRole).toLongLong();
+        QVERIFY2(row2Micros > 0, "row 2 must carry a positive epoch-microseconds timestamp");
+
+        // Step 1: install an `at or before` filter on row 2.
+        // Shape: `(nullopt, row2Micros)`. The row-menu code path
+        // is the production source of unbounded-side filters that
+        // reach the editor.
+        QMenu *rowMenu = mWindow->BuildRowContextMenu(/*sourceRow=*/2, nullptr);
+        QVERIFY2(rowMenu != nullptr, "BuildRowContextMenu must return a menu for a row with a timestamp");
+        const QScopeGuard rowMenuDeleter([&rowMenu]() { rowMenu->deleteLater(); });
+        // NOLINTNEXTLINE(clang-analyzer-core.CallAndMessage): false positive; prior `QVERIFY2` aborts on null.
+        rowMenu->actions().at(1)->trigger(); // "at or before"
+        QCoreApplication::processEvents();
+
+        QCOMPARE(mWindow->Filters().size(), static_cast<size_t>(1));
+        const QString filterId = QString::fromStdString(mWindow->Filters().begin()->first);
+        QVERIFY2(!mWindow->Filters().begin()->second.filterBegin.has_value(), "installed filter must carry an open lower bound (nullopt)");
+
+        // Step 2: open the editor via the column-header sub-menu's Edit action.
+        auto built = mWindow->BuildHeaderContextMenu(timeCol, nullptr);
+        QVERIFY2(built.menu != nullptr, "BuildHeaderContextMenu must return a menu");
+        const QScopeGuard headerMenuDeleter([&built]() { built.menu->deleteLater(); });
+        const QMenu *subMenu = built.filterSubMenus.at(filterId.toStdString());
+        QVERIFY2(subMenu != nullptr, "filter sub-menu must be exposed");
+        QAction *editAction = nullptr;
+        const QString editLabel = MainWindow::tr("Edit");
+        // NOLINTNEXTLINE(clang-analyzer-core.CallAndMessage): false positive; prior `QVERIFY2` aborts on null.
+        for (QAction *act : subMenu->actions())
+        {
+            if (act->text() == editLabel)
+            {
+                editAction = act;
+                break;
+            }
+        }
+        QVERIFY2(editAction != nullptr, "sub-menu must contain an Edit action");
+        // NOLINTNEXTLINE(clang-analyzer-core.CallAndMessage): false positive; prior `QVERIFY2` aborts on null.
+        editAction->trigger();
+        QCoreApplication::processEvents();
+
+        FilterEditor *editor = nullptr;
+        for (QWidget *widget : QApplication::topLevelWidgets())
+        {
+            if (auto *e = qobject_cast<FilterEditor *>(widget))
+            {
+                editor = e;
+                break;
+            }
+        }
+        QVERIFY2(editor != nullptr, "Edit must open a FilterEditor");
+        // NOLINTNEXTLINE(clang-analyzer-core.CallAndMessage): false positive; prior `QVERIFY2` aborts on null.
+
+        // Step 3: the editor must reflect the loaded shape -- begin
+        // unbounded, end bounded.
+        QCheckBox *beginUnbounded = editor->BeginUnboundedCheckBox();
+        QCheckBox *endUnbounded = editor->EndUnboundedCheckBox();
+        QDateEdit *beginDate = editor->BeginDateEdit();
+        QTimeEdit *beginTime = editor->BeginTimeEdit();
+        QDateEdit *endDate = editor->EndDateEdit();
+        QTimeEdit *endTime = editor->EndTimeEdit();
+        QVERIFY(beginUnbounded != nullptr);
+        QVERIFY(endUnbounded != nullptr);
+        QVERIFY(beginDate != nullptr);
+        QVERIFY(beginTime != nullptr);
+        QVERIFY(endDate != nullptr);
+        QVERIFY(endTime != nullptr);
+        // NOLINTNEXTLINE(clang-analyzer-core.CallAndMessage): false positive; prior `QVERIFY` aborts on null.
+        QVERIFY2(beginUnbounded->isChecked(), "begin checkbox must be checked for a (nullopt, X) load");
+        QVERIFY2(!endUnbounded->isChecked(), "end checkbox must be unchecked when end is bounded");
+
+        // Step 4: assert the actual property the `SetBeginEnd` fix
+        // changes -- the begin edits' minimum constraint must NOT
+        // be pinned to the seed (which is the end's `X` value
+        // because the begin is unbounded). The pre-fix code called
+        // `setMinimumDateTime(beginDateTime)` unconditionally with
+        // `beginDateTime` falling back to `X`, leaving the begin
+        // edit clamped to `[X, X]` so a subsequent uncheck-and-pick
+        // could not pick anything earlier than `X`.
+        const QDateTime endSeed = endDate->dateTime();
+        QVERIFY2(
+            beginDate->minimumDateTime() < endSeed,
+            "begin date edit's minimum must allow picking values earlier than the bounded end seed"
+        );
+        QVERIFY2(
+            beginTime->minimumDateTime() < endSeed,
+            "begin time edit's minimum must allow picking values earlier than the bounded end seed"
+        );
+
+        // Step 5: simulate the user unchecking begin-unbounded; the
+        // edits must become enabled (no leftover disable from the
+        // initial checked state).
+        beginUnbounded->setChecked(false);
+        QCoreApplication::processEvents();
+        QVERIFY2(beginDate->isEnabled(), "begin date edit must be enabled after uncheck");
+        QVERIFY2(beginTime->isEnabled(), "begin time edit must be enabled after uncheck");
+
+        // Step 6: clicking OK with begin still effectively at the
+        // seed must still emit a real begin (not nullopt), and the
+        // original end must round-trip unchanged. The point of the
+        // test is the *ability* to widen; the actual widen path is
+        // straightforward QDateTimeEdit usage once the minimum
+        // constraint is clear.
+        QPushButton *ok = editor->OkButton();
+        QVERIFY(ok != nullptr);
+        // NOLINTNEXTLINE(clang-analyzer-core.CallAndMessage): false positive; prior `QVERIFY` aborts on null.
+        ok->click();
+        QCoreApplication::processEvents();
+
+        QCOMPARE(mWindow->Filters().size(), static_cast<size_t>(1));
+        const auto it = mWindow->Filters().find(filterId.toStdString());
+        QVERIFY2(it != mWindow->Filters().end(), "filter id must survive Edit -> OK");
+        // NOLINTNEXTLINE(clang-analyzer-core.CallAndMessage): false positive; prior `QVERIFY2` aborts on .end().
+        QCOMPARE(it->second.type, loglib::LogConfiguration::LogFilter::Type::Time);
+        QCOMPARE(it->second.row, timeCol);
+        QVERIFY2(it->second.filterBegin.has_value(), "uncheck must promote begin from nullopt to the seed value");
+        QVERIFY(it->second.filterEnd.has_value());
+        // NOLINTNEXTLINE(bugprone-unchecked-optional-access)
+        QCOMPARE(*it->second.filterEnd, row2Micros);
+
+        QCoreApplication::processEvents();
+    }
+
     // `Column::visible` survives the Save / Reset / Load round-trip
     // (driven through the manager directly so the file dialogs
     // don't pop).

--- a/test/app/src/main_window_test.cpp
+++ b/test/app/src/main_window_test.cpp
@@ -4861,8 +4861,13 @@ private slots:
     // to `Type::Time`.
     void TestRowContextMenuReturnsNullWithoutTimeColumn()
     {
-        const int levelCol = StreamFixtureForColumnTests();
-        QVERIFY2(levelCol >= 0, "level column must exist after streaming");
+        // `StreamFixtureForColumnTests` streams `category` + `msg`;
+        // the returned index is for `category`, used here only as a
+        // streaming-completed sentinel (the assertion below cares
+        // about the *absence* of a `Type::Time` column, not which
+        // non-time column landed where).
+        const int streamedColumn = StreamFixtureForColumnTests();
+        QVERIFY2(streamedColumn >= 0, "streaming must complete before the row-menu probe");
 
         QMenu *menu = mWindow->BuildRowContextMenu(/*sourceRow=*/0, nullptr);
         QVERIFY2(menu == nullptr, "BuildRowContextMenu must return null when the model has no Type::Time column");

--- a/test/app/src/main_window_test.cpp
+++ b/test/app/src/main_window_test.cpp
@@ -4902,6 +4902,65 @@ private slots:
         );
     }
 
+    // A row that *has* a `Type::Time` column but whose slot is
+    // empty (the source JSON omitted the timestamp key) returns
+    // `std::monostate`. `AsEpochMicroseconds` rejects monostate, so
+    // the menu has no boundary to bind to and must return null.
+    // Without this gate the "at or after / before" actions would
+    // trigger with `nullopt` boundaries, installing a degenerate
+    // `(nullopt, nullopt)` filter that `ValidateFilterAgainstColumns`
+    // would reject silently.
+    void TestRowContextMenuReturnsNullForMonostateTimeSlot()
+    {
+        auto *model = mWindow->Model();
+        Q_ASSERT(model != nullptr);
+
+        // Three rows so the parser auto-promotes `timestamp` to
+        // `Type::Time`; the middle row omits the timestamp key so
+        // its slot lands as `std::monostate`. The first/last rows
+        // would still produce a usable menu — the assertion below
+        // is specifically about the middle row.
+        const QStringList lines{
+            QStringLiteral(R"({"timestamp":"2024-04-28T10:00:01+00:00","msg":"first"})"),
+            QStringLiteral(R"({"msg":"middle has no timestamp"})"),
+            QStringLiteral(R"({"timestamp":"2024-04-28T10:00:03+00:00","msg":"third"})"),
+        };
+        const TempJsonFile fixture(lines);
+
+        QSignalSpy finishedSpy(model, &LogModel::streamingFinished);
+        QVERIFY(finishedSpy.isValid());
+        auto file = std::make_unique<loglib::LogFile>(fixture.Path().toStdString());
+        auto fileSource = std::make_unique<loglib::FileLineSource>(std::move(file));
+        loglib::FileLineSource *fileSourcePtr = fileSource.get();
+        const loglib::StopToken stopToken = model->BeginStreamingForSyncTest(std::move(fileSource));
+
+        loglib::ParserOptions options;
+        options.stopToken = stopToken;
+        loglib::internal::AdvancedParserOptions advanced;
+        advanced.threads = 1;
+        const loglib::JsonParser parser;
+        loglib::JsonParser::ParseStreaming(*fileSourcePtr, *model->Sink(), options, advanced);
+        if (finishedSpy.count() == 0)
+        {
+            finishedSpy.wait(5000);
+        }
+        QCoreApplication::processEvents();
+
+        const int timeCol = ColumnByHeader(*model, QStringLiteral("timestamp"));
+        QVERIFY2(timeCol >= 0, "timestamp column must exist after streaming");
+        QCOMPARE(model->rowCount(), 3);
+
+        // Rows with a real timestamp still get the menu.
+        QMenu *first = mWindow->BuildRowContextMenu(/*sourceRow=*/0, nullptr);
+        QVERIFY2(first != nullptr, "row 0 has a timestamp slot, menu must be offered");
+        first->deleteLater();
+
+        // The middle row's slot is monostate; the menu must be
+        // suppressed so the host never advertises a no-op action.
+        QMenu *middle = mWindow->BuildRowContextMenu(/*sourceRow=*/1, nullptr);
+        QVERIFY2(middle == nullptr, "row 1's monostate time slot must suppress the menu");
+    }
+
     // Triggering the "at or after" action installs an additive
     // time filter on the time column, with the clicked row's
     // microseconds as the lower (inclusive) bound and `nullopt`

--- a/test/app/src/main_window_test.cpp
+++ b/test/app/src/main_window_test.cpp
@@ -4779,23 +4779,17 @@ private slots:
         }
     }
 
-    // Stream a small three-row fixture with a `timestamp` column
-    // (auto-detected as `Type::Time`) and a `msg` column into the
-    // window's live model. Returns the time-column index (post-
-    // bubble), or -1 on streaming failure. Mirrors
-    // `StreamFixtureForColumnTests` but tailored to the row-menu
-    // tests that need a `Type::Time` slot to read from.
+    // Stream a three-row fixture with a `timestamp` column (promoted to
+    // `Type::Time`) and a `msg` column. Returns the time-column index
+    // post-bubble, or -1 on streaming failure.
     int StreamFixtureWithTimeColumnForRowMenuTests()
     {
         auto *model = mWindow->Model();
         Q_ASSERT(model != nullptr);
 
-        // Explicit `+00:00` timezone offsets rather than `Z`: the
-        // streaming parser's time-promotion picks up the explicit-
-        // offset shape reliably with as few as three rows, while the
-        // `Z` suffix lands the column at `Type::Time` but leaves the
-        // value as a raw `OwnedString` (see `mixed_tz_and_order.jsonl`
-        // for the canonical format used by `TestFixtureMixedTzAndOrder`).
+        // Use explicit `+00:00` offsets: streaming time-promotion picks
+        // them up reliably with only three rows. The `Z` suffix would
+        // type the column as Time but leave the value as a raw string.
         const QStringList lines{
             QStringLiteral(R"({"timestamp":"2024-04-28T10:00:01+00:00","msg":"first"})"),
             QStringLiteral(R"({"timestamp":"2024-04-28T10:00:02+00:00","msg":"second"})"),
@@ -4828,11 +4822,8 @@ private slots:
         return ColumnByHeader(*model, QStringLiteral("timestamp"));
     }
 
-    // `BuildRowContextMenu` must offer exactly the two inclusive
-    // "newer" / "older" actions, labelled with the time column's
-    // header. Pinned so a future entry that accidentally lands on
-    // the row menu (or a label rewrite that drops the "newer/older"
-    // phrasing) trips here.
+    // The row menu must offer exactly the two "newer"/"older" actions
+    // labelled with the time column's header.
     void TestRowContextMenuOffersAtOrAfterAndAtOrBefore()
     {
         const int timeCol = StreamFixtureWithTimeColumnForRowMenuTests();
@@ -4845,30 +4836,20 @@ private slots:
         // NOLINTNEXTLINE(clang-analyzer-core.CallAndMessage): false positive; prior `QVERIFY2` aborts on null.
         const QList<QAction *> actions = menu->actions();
         QCOMPARE(actions.size(), 2);
-        // Round-trip via `MainWindow::tr` so the assertion survives
-        // a future `QTranslator` install: production builds the label
-        // through the same `tr(...).arg(colLabel)` shape, so an exact
-        // compare is both stricter and translation-safe (the prior
-        // `startsWith("Show only newer logs")` would silently break
-        // under any non-empty translator).
+        // Build labels via `tr` so the test survives a future
+        // `QTranslator` install.
         const QString newerLabel = MainWindow::tr("Show only newer logs (%1)").arg(QStringLiteral("timestamp"));
         const QString olderLabel = MainWindow::tr("Show only older logs (%1)").arg(QStringLiteral("timestamp"));
         QCOMPARE(actions[0]->text(), newerLabel);
         QCOMPARE(actions[1]->text(), olderLabel);
     }
 
-    // When no `Type::Time` column is present the menu must return
-    // null so the host never advertises an action with no column
-    // to bind to. The `StreamFixtureForColumnTests` fixture has
-    // only `category` and `msg`, neither of which auto-promotes
-    // to `Type::Time`.
+    // Without a `Type::Time` column the menu has nothing to bind to and
+    // must return null. The `category`+`msg` fixture has no time column.
     void TestRowContextMenuReturnsNullWithoutTimeColumn()
     {
-        // `StreamFixtureForColumnTests` streams `category` + `msg`;
-        // the returned index is for `category`, used here only as a
-        // streaming-completed sentinel (the assertion below cares
-        // about the *absence* of a `Type::Time` column, not which
-        // non-time column landed where).
+        // The returned index is for `category`; used only as a
+        // streaming-completed sentinel.
         const int streamedColumn = StreamFixtureForColumnTests();
         QVERIFY2(streamedColumn >= 0, "streaming must complete before the row-menu probe");
 
@@ -4876,23 +4857,16 @@ private slots:
         QVERIFY2(menu == nullptr, "BuildRowContextMenu must return null when the model has no Type::Time column");
     }
 
-    // Empty model: nothing to bind a timestamp to, so the menu
-    // must return null. Mirrors the `model->rowCount() > 0` gate
-    // that `BuildHeaderContextMenu` applies to its Add-filter
-    // entry.
+    // Empty model: nothing to bind to, menu must be null.
     void TestRowContextMenuReturnsNullWhenModelEmpty()
     {
-        // Fresh `mWindow` from `init()`; no streaming, no rows.
         QCOMPARE(mWindow->Model()->rowCount(), 0);
 
         const QMenu *menu = mWindow->BuildRowContextMenu(/*sourceRow=*/0, nullptr);
         QVERIFY2(menu == nullptr, "BuildRowContextMenu must return null when the model is empty");
     }
 
-    // Out-of-range rows must not crash and must not produce a
-    // menu. Defensive cover for the unlikely race where a
-    // streaming `Reset` shrinks the model between popup build and
-    // the action's source-row capture.
+    // Out-of-range rows must not crash and must not produce a menu.
     void TestRowContextMenuReturnsNullForOutOfRangeRow()
     {
         const int timeCol = StreamFixtureWithTimeColumnForRowMenuTests();
@@ -4910,24 +4884,16 @@ private slots:
         );
     }
 
-    // A row that *has* a `Type::Time` column but whose slot is
-    // empty (the source JSON omitted the timestamp key) returns
-    // `std::monostate`. `AsEpochMicroseconds` rejects monostate, so
-    // the menu has no boundary to bind to and must return null.
-    // Without this gate the "newer/older" actions would trigger
-    // with `nullopt` boundaries, installing a degenerate
-    // `(nullopt, nullopt)` filter that `ValidateFilterAgainstColumns`
-    // would reject silently.
+    // A row with a `Type::Time` column but a `monostate` slot (source
+    // JSON omitted the key) must suppress the menu, otherwise the
+    // action would install a degenerate `(nullopt, nullopt)` filter.
     void TestRowContextMenuReturnsNullForMonostateTimeSlot()
     {
         auto *model = mWindow->Model();
         Q_ASSERT(model != nullptr);
 
-        // Three rows so the parser auto-promotes `timestamp` to
-        // `Type::Time`; the middle row omits the timestamp key so
-        // its slot lands as `std::monostate`. The first/last rows
-        // would still produce a usable menu — the assertion below
-        // is specifically about the middle row.
+        // Three rows so the parser promotes `timestamp` to `Type::Time`;
+        // the middle row omits the key so its slot is `monostate`.
         const QStringList lines{
             QStringLiteral(R"({"timestamp":"2024-04-28T10:00:01+00:00","msg":"first"})"),
             QStringLiteral(R"({"msg":"middle has no timestamp"})"),
@@ -4958,23 +4924,18 @@ private slots:
         QVERIFY2(timeCol >= 0, "timestamp column must exist after streaming");
         QCOMPARE(model->rowCount(), 3);
 
-        // Rows with a real timestamp still get the menu.
         QMenu *first = mWindow->BuildRowContextMenu(/*sourceRow=*/0, nullptr);
         QVERIFY2(first != nullptr, "row 0 has a timestamp slot, menu must be offered");
         first->deleteLater();
 
-        // The middle row's slot is monostate; the menu must be
-        // suppressed so the host never advertises a no-op action.
         const QMenu *middle = mWindow->BuildRowContextMenu(/*sourceRow=*/1, nullptr);
         QVERIFY2(middle == nullptr, "row 1's monostate time slot must suppress the menu");
     }
 
-    // Triggering the "newer" action (inclusive `>=`) installs an
-    // additive time filter on the time column, with the clicked
-    // row's microseconds as the lower (inclusive) bound and
-    // `nullopt` as the open upper bound. The lower bound is read
-    // straight off the model's `SortRole`, which already normalises
-    // every `Type::Time` slot to `qint64` microseconds since epoch.
+    // Triggering "newer" installs an inclusive time filter with the
+    // clicked row's micros as the lower bound and `nullopt` as the
+    // upper bound. Lower bound comes from `SortRole`, which normalises
+    // every `Type::Time` slot to epoch microseconds.
     void TestRowContextMenuAtOrAfterAddsTimeFilter()
     {
         const int timeCol = StreamFixtureWithTimeColumnForRowMenuTests();
@@ -5002,17 +4963,13 @@ private slots:
         QCOMPARE(installed.type, loglib::LogConfiguration::LogFilter::Type::Time);
         QCOMPARE(installed.row, timeCol);
         QVERIFY(installed.filterBegin.has_value());
-        // The open upper bound is encoded as `std::nullopt` so the
-        // title renders as "any" and the FilterEditor round-trips
-        // the open side faithfully.
+        // Open upper bound encoded as `std::nullopt` (not INT64_MAX).
         QVERIFY2(!installed.filterEnd.has_value(), "open upper bound must be std::nullopt, not INT64_MAX");
         // NOLINTNEXTLINE(bugprone-unchecked-optional-access)
         QCOMPARE(*installed.filterBegin, row1Micros);
     }
 
-    // Symmetric to the "newer" test: the lower bound is
-    // `std::nullopt` (open), the upper bound is the clicked row's
-    // micros (inclusive `<=`).
+    // Symmetric: "older" gives `(nullopt, micros)`.
     void TestRowContextMenuAtOrBeforeAddsTimeFilter()
     {
         const int timeCol = StreamFixtureWithTimeColumnForRowMenuTests();
@@ -5038,19 +4995,15 @@ private slots:
         const auto &installed = mWindow->Filters().begin()->second;
         QCOMPARE(installed.type, loglib::LogConfiguration::LogFilter::Type::Time);
         QCOMPARE(installed.row, timeCol);
-        // The open lower bound is encoded as `std::nullopt`; the
-        // upper bound is the clicked row's micros.
         QVERIFY2(!installed.filterBegin.has_value(), "open lower bound must be std::nullopt, not INT64_MIN");
         QVERIFY(installed.filterEnd.has_value());
         // NOLINTNEXTLINE(bugprone-unchecked-optional-access)
         QCOMPARE(*installed.filterEnd, row2Micros);
     }
 
-    // Regression: the action lambdas must re-resolve the time
-    // column by its stable keys at trigger time, so a column
-    // reorder between menu build and click still targets the
-    // column's current index. Mirrors
-    // `TestHeaderContextMenuAddFilterAfterColumnReorderResolvesByKeys`.
+    // Action lambdas must re-resolve the time column by its captured
+    // keys at trigger time so a reorder between build and click still
+    // targets the right column.
     void TestRowContextMenuAddTimeFilterAfterColumnReorderResolvesByKeys()
     {
         const int timeCol = StreamFixtureWithTimeColumnForRowMenuTests();
@@ -5063,9 +5016,9 @@ private slots:
         QVERIFY2(menu != nullptr, "BuildRowContextMenu must return a menu for a row with a timestamp");
         const QScopeGuard menuDeleter([&menu]() { menu->deleteLater(); });
 
-        // Move the time column to a different index after the
-        // menu was built but before its action is triggered. The
-        // captured keys must re-resolve to the new index.
+        // Move the time column after building the menu, before
+        // triggering. The captured keys must re-resolve to the new
+        // index.
         const int src = timeCol;
         const int dest = (src == 0) ? columnCount - 1 : 0;
         QVERIFY(src != dest);
@@ -5097,11 +5050,9 @@ private slots:
         QCOMPARE(installed.row, timeColAfter);
     }
 
-    // Each click adds a brand-new filter UUID rather than
-    // replacing any existing time filter on the same column. The
-    // additive behaviour is the design contract: combining
-    // "newer than X" and "older than Y" by issuing two clicks is
-    // how the user narrows a window without ever opening the
+    // Each click adds a fresh-UUID filter rather than replacing an
+    // existing one on the same column. The additive behaviour lets the
+    // user combine "newer than X" + "older than Y" without opening the
     // FilterEditor.
     void TestRowContextMenuAdditiveDoesNotReplaceExisting()
     {
@@ -5109,9 +5060,8 @@ private slots:
         QVERIFY2(timeCol >= 0, "timestamp column must exist after streaming");
 
         // Pre-seed a permissive bounded filter on the same column.
-        // Bounds are decades around the fixture timestamps so no
-        // rows are filtered out and the filter is identifiable
-        // (real values, not the predicate's INT64 sentinels).
+        // Bounds are decades around the fixture so it's identifiable
+        // (real values, not INT64 sentinels) and excludes no rows.
         const QString preSeededId = QStringLiteral("pre-seeded-time-filter");
         const std::optional<qint64> preBegin{1'000'000'000'000'000LL}; // 2001-09-09 UTC, micros.
         const std::optional<qint64> preEnd{4'000'000'000'000'000LL};   // 2096-10-02 UTC, micros.
@@ -5143,9 +5093,7 @@ private slots:
         QCoreApplication::processEvents();
 
         QCOMPARE(mWindow->Filters().size(), static_cast<size_t>(2));
-        // The pre-seeded filter is still present with its
-        // original bounds; the menu installed a sibling, not a
-        // replacement.
+        // Pre-seeded filter survives unchanged; the menu added a sibling.
         const auto it = mWindow->Filters().find(preSeededId.toStdString());
         QVERIFY2(it != mWindow->Filters().end(), "pre-seeded filter must survive the menu trigger");
         // NOLINTNEXTLINE(clang-analyzer-core.CallAndMessage): false positive; prior `QVERIFY2` aborts on .end().
@@ -5158,12 +5106,9 @@ private slots:
         // NOLINTEND(bugprone-unchecked-optional-access)
     }
 
-    // Regression for the "FilterEditor silently clamps unbounded
-    // bounds" bug: a time filter installed by the row context menu
-    // carries a `std::nullopt` upper bound. Editing it (Edit -> OK,
-    // no edits in between) must round-trip the open side, not
-    // silently rewrite it as `9999-12-31T23:59:59` because the
-    // `QDateTimeEdit`'s default ceiling clamped INT64_MAX.
+    // Regression: editing a `(begin, nullopt)` filter without changes
+    // must round-trip the open upper bound. The pre-fix code silently
+    // rewrote it to `9999-12-31T23:59:59` (the QDateTimeEdit ceiling).
     void TestRowContextMenuTimeFilterRoundTripsThroughEditor()
     {
         const int timeCol = StreamFixtureWithTimeColumnForRowMenuTests();
@@ -5172,9 +5117,8 @@ private slots:
         const qint64 row1Micros = model->data(model->index(1, timeCol), LogModelItemDataRole::SortRole).toLongLong();
         QVERIFY2(row1Micros > 0, "row 1 must carry a positive epoch-microseconds timestamp");
 
-        // Step 1: install a `newer` filter via the row menu (the
-        // production code path that produces a `(row1Micros,
-        // nullopt)` filter).
+        // Step 1: install a `(row1Micros, nullopt)` filter via the
+        // row menu.
         QMenu *rowMenu = mWindow->BuildRowContextMenu(/*sourceRow=*/1, nullptr);
         QVERIFY2(rowMenu != nullptr, "BuildRowContextMenu must return a menu for a row with a timestamp");
         const QScopeGuard rowMenuDeleter([&rowMenu]() { rowMenu->deleteLater(); });
@@ -5224,20 +5168,15 @@ private slots:
         // NOLINTNEXTLINE(clang-analyzer-core.CallAndMessage): false positive; prior `QVERIFY2` aborts on null.
         QCOMPARE(editor->GetRowToFilter(), timeCol);
 
-        // Step 3: click OK without touching anything. The editor
-        // must read the open-bound state from its checkboxes and
-        // emit `nullopt` back, leaving the filter unchanged.
+        // Step 3: click OK without touching anything. The editor must
+        // read the open-bound state and emit `nullopt` back.
         QPushButton *ok = editor->OkButton();
         QVERIFY2(ok != nullptr, "FilterEditor must expose its OK button");
         // NOLINTNEXTLINE(clang-analyzer-core.CallAndMessage): false positive; prior `QVERIFY2` aborts on null.
         ok->click();
         QCoreApplication::processEvents();
 
-        // Step 4: the filter is still on the same column, with the
-        // same `(row1Micros, nullopt)` shape. The pre-fix code
-        // silently rewrote `filterEnd` to whatever the
-        // `QDateTimeEdit`'s upper ceiling produced (typically
-        // `9999-12-31`'s epoch micros), losing the open upper bound.
+        // Step 4: filter must keep its `(row1Micros, nullopt)` shape.
         QCOMPARE(mWindow->Filters().size(), static_cast<size_t>(1));
         const auto it = mWindow->Filters().find(filterId.toStdString());
         QVERIFY2(it != mWindow->Filters().end(), "filter id must survive Edit -> OK");
@@ -5249,20 +5188,16 @@ private slots:
         // NOLINTNEXTLINE(bugprone-unchecked-optional-access)
         QCOMPARE(*it->second.filterBegin, row1Micros);
 
-        // The editor accepts on OK; nothing leaked. `accept()`
-        // schedules deletion via `Qt::WA_DeleteOnClose` so we don't
-        // need to delete explicitly, but spinning the loop here
-        // matches the rest of the editor-using tests.
+        // Editor deletes itself via `Qt::WA_DeleteOnClose` on accept;
+        // spin the loop to match other editor-using tests.
         QCoreApplication::processEvents();
     }
 
-    // Regression for the `SetBeginEnd` constraint-leak fix: opening
-    // Edit on a `(nullopt, X)` filter must let the user uncheck the
-    // begin-unbounded checkbox and pick a begin earlier than `X`.
-    // The pre-fix code installed `setMinimumDateTime(X)` on the
-    // begin edits (using `X` as the unbounded-side seed) and never
-    // cleared it, pinning the begin edit to `[X, X]` and making the
-    // open-bound filter effectively un-widenable.
+    // Regression: opening Edit on a `(nullopt, X)` filter must let the
+    // user uncheck the begin-unbounded checkbox and pick a begin
+    // earlier than `X`. The pre-fix code pinned begin to `[X, X]`
+    // because it set `setMinimumDateTime(X)` from the fallback seed
+    // and never cleared it.
     void TestRowContextMenuEditUncheckWidensOpenBeginBound()
     {
         const int timeCol = StreamFixtureWithTimeColumnForRowMenuTests();
@@ -5271,10 +5206,8 @@ private slots:
         const qint64 row2Micros = model->data(model->index(2, timeCol), LogModelItemDataRole::SortRole).toLongLong();
         QVERIFY2(row2Micros > 0, "row 2 must carry a positive epoch-microseconds timestamp");
 
-        // Step 1: install an `older` filter on row 2. Shape:
-        // `(nullopt, row2Micros)`. The row-menu code path is the
-        // production source of unbounded-side filters that reach
-        // the editor.
+        // Step 1: install a `(nullopt, row2Micros)` filter via the
+        // row menu's "older" action.
         QMenu *rowMenu = mWindow->BuildRowContextMenu(/*sourceRow=*/2, nullptr);
         QVERIFY2(rowMenu != nullptr, "BuildRowContextMenu must return a menu for a row with a timestamp");
         const QScopeGuard rowMenuDeleter([&rowMenu]() { rowMenu->deleteLater(); });
@@ -5323,7 +5256,7 @@ private slots:
         QVERIFY2(editor != nullptr, "Edit must open a FilterEditor");
         // NOLINTNEXTLINE(clang-analyzer-core.CallAndMessage): false positive; prior `QVERIFY2` aborts on null.
 
-        // Step 3: the editor must reflect the loaded shape -- begin
+        // Step 3: editor must reflect the loaded shape: begin
         // unbounded, end bounded.
         QCheckBox *beginUnbounded = editor->BeginUnboundedCheckBox();
         const QCheckBox *endUnbounded = editor->EndUnboundedCheckBox();
@@ -5341,14 +5274,9 @@ private slots:
         QVERIFY2(beginUnbounded->isChecked(), "begin checkbox must be checked for a (nullopt, X) load");
         QVERIFY2(!endUnbounded->isChecked(), "end checkbox must be unchecked when end is bounded");
 
-        // Step 4: assert the actual property the `SetBeginEnd` fix
-        // changes -- the begin edits' minimum constraint must NOT
-        // be pinned to the seed (which is the end's `X` value
-        // because the begin is unbounded). The pre-fix code called
-        // `setMinimumDateTime(beginDateTime)` unconditionally with
-        // `beginDateTime` falling back to `X`, leaving the begin
-        // edit clamped to `[X, X]` so a subsequent uncheck-and-pick
-        // could not pick anything earlier than `X`.
+        // Step 4: the property the `SetBeginEnd` fix changes: begin
+        // edits' minimum must NOT be pinned to the end seed, so the
+        // user can pick a value earlier than `X` after unchecking.
         const QDateTime endSeed = endDate->dateTime();
         QVERIFY2(
             beginDate->minimumDateTime() < endSeed,
@@ -5359,20 +5287,16 @@ private slots:
             "begin time edit's minimum must allow picking values earlier than the bounded end seed"
         );
 
-        // Step 5: simulate the user unchecking begin-unbounded; the
-        // edits must become enabled (no leftover disable from the
-        // initial checked state).
+        // Step 5: uncheck begin-unbounded; edits must become enabled.
         beginUnbounded->setChecked(false);
         QCoreApplication::processEvents();
         QVERIFY2(beginDate->isEnabled(), "begin date edit must be enabled after uncheck");
         QVERIFY2(beginTime->isEnabled(), "begin time edit must be enabled after uncheck");
 
-        // Step 6: clicking OK with begin still effectively at the
-        // seed must still emit a real begin (not nullopt), and the
-        // original end must round-trip unchanged. The point of the
-        // test is the *ability* to widen; the actual widen path is
-        // straightforward QDateTimeEdit usage once the minimum
-        // constraint is clear.
+        // Step 6: clicking OK now must emit a real begin (not
+        // nullopt) and round-trip the original end. The test asserts
+        // the *ability* to widen; the actual widening is straight
+        // QDateTimeEdit usage once the minimum is clear.
         QPushButton *ok = editor->OkButton();
         QVERIFY(ok != nullptr);
         // NOLINTNEXTLINE(clang-analyzer-core.CallAndMessage): false positive; prior `QVERIFY` aborts on null.

--- a/test/app/src/main_window_test.cpp
+++ b/test/app/src/main_window_test.cpp
@@ -4846,12 +4846,18 @@ private slots:
         // NOLINTNEXTLINE(clang-analyzer-core.CallAndMessage): false positive; prior `QVERIFY2` aborts on null.
         const QList<QAction *> actions = menu->actions();
         QCOMPARE(actions.size(), 2);
-        QVERIFY2(actions[0]->text().startsWith(QStringLiteral("Show only logs at or after this time")), "first action must be the 'at or after' entry");
-        QVERIFY2(actions[1]->text().startsWith(QStringLiteral("Show only logs at or before this time")), "second action must be the 'at or before' entry");
-        // The column label is interpolated into both entries so
-        // users see which time column the filter will bind to.
-        QVERIFY2(actions[0]->text().contains(QStringLiteral("timestamp")), "label must reference the time column");
-        QVERIFY2(actions[1]->text().contains(QStringLiteral("timestamp")), "label must reference the time column");
+        // Round-trip via `MainWindow::tr` so the assertion survives
+        // a future `QTranslator` install: production builds the label
+        // through the same `tr(...).arg(colLabel)` shape, so an exact
+        // compare is both stricter and translation-safe (the prior
+        // `startsWith("Show only logs...")` would silently break under
+        // any non-empty translator).
+        const QString afterLabel =
+            MainWindow::tr("Show only logs at or after this time (%1)").arg(QStringLiteral("timestamp"));
+        const QString beforeLabel =
+            MainWindow::tr("Show only logs at or before this time (%1)").arg(QStringLiteral("timestamp"));
+        QCOMPARE(actions[0]->text(), afterLabel);
+        QCOMPARE(actions[1]->text(), beforeLabel);
     }
 
     // When no `Type::Time` column is present the menu must return

--- a/test/app/src/main_window_test.cpp
+++ b/test/app/src/main_window_test.cpp
@@ -4872,7 +4872,7 @@ private slots:
         const int streamedColumn = StreamFixtureForColumnTests();
         QVERIFY2(streamedColumn >= 0, "streaming must complete before the row-menu probe");
 
-        QMenu *menu = mWindow->BuildRowContextMenu(/*sourceRow=*/0, nullptr);
+        const QMenu *menu = mWindow->BuildRowContextMenu(/*sourceRow=*/0, nullptr);
         QVERIFY2(menu == nullptr, "BuildRowContextMenu must return null when the model has no Type::Time column");
     }
 
@@ -4885,7 +4885,7 @@ private slots:
         // Fresh `mWindow` from `init()`; no streaming, no rows.
         QCOMPARE(mWindow->Model()->rowCount(), 0);
 
-        QMenu *menu = mWindow->BuildRowContextMenu(/*sourceRow=*/0, nullptr);
+        const QMenu *menu = mWindow->BuildRowContextMenu(/*sourceRow=*/0, nullptr);
         QVERIFY2(menu == nullptr, "BuildRowContextMenu must return null when the model is empty");
     }
 
@@ -4965,7 +4965,7 @@ private slots:
 
         // The middle row's slot is monostate; the menu must be
         // suppressed so the host never advertises a no-op action.
-        QMenu *middle = mWindow->BuildRowContextMenu(/*sourceRow=*/1, nullptr);
+        const QMenu *middle = mWindow->BuildRowContextMenu(/*sourceRow=*/1, nullptr);
         QVERIFY2(middle == nullptr, "row 1's monostate time slot must suppress the menu");
     }
 
@@ -5211,7 +5211,7 @@ private slots:
         editAction->trigger();
         QCoreApplication::processEvents();
 
-        FilterEditor *editor = nullptr;
+        const FilterEditor *editor = nullptr;
         for (QWidget *widget : QApplication::topLevelWidgets())
         {
             if (auto *e = qobject_cast<FilterEditor *>(widget))
@@ -5311,7 +5311,7 @@ private slots:
         editAction->trigger();
         QCoreApplication::processEvents();
 
-        FilterEditor *editor = nullptr;
+        const FilterEditor *editor = nullptr;
         for (QWidget *widget : QApplication::topLevelWidgets())
         {
             if (auto *e = qobject_cast<FilterEditor *>(widget))
@@ -5326,11 +5326,11 @@ private slots:
         // Step 3: the editor must reflect the loaded shape -- begin
         // unbounded, end bounded.
         QCheckBox *beginUnbounded = editor->BeginUnboundedCheckBox();
-        QCheckBox *endUnbounded = editor->EndUnboundedCheckBox();
-        QDateEdit *beginDate = editor->BeginDateEdit();
-        QTimeEdit *beginTime = editor->BeginTimeEdit();
-        QDateEdit *endDate = editor->EndDateEdit();
-        QTimeEdit *endTime = editor->EndTimeEdit();
+        const QCheckBox *endUnbounded = editor->EndUnboundedCheckBox();
+        const QDateEdit *beginDate = editor->BeginDateEdit();
+        const QTimeEdit *beginTime = editor->BeginTimeEdit();
+        const QDateEdit *endDate = editor->EndDateEdit();
+        const QTimeEdit *endTime = editor->EndTimeEdit();
         QVERIFY(beginUnbounded != nullptr);
         QVERIFY(endUnbounded != nullptr);
         QVERIFY(beginDate != nullptr);

--- a/test/lib/src/test_log_configuration.cpp
+++ b/test/lib/src/test_log_configuration.cpp
@@ -1362,36 +1362,28 @@ TEST_CASE("FirstTimeColumnIndex returns the first Type::Time column or -1", "[lo
 {
     using Type = LogConfiguration::Type;
 
-    // Empty column list -> -1 (sentinel) so callers can branch on
-    // "no time column" without inspecting `columns.size()`.
     const LogConfiguration empty;
     CHECK(FirstTimeColumnIndex(empty) == -1);
 
-    // No time column among other types -> -1.
     LogConfiguration noTime;
     noTime.columns.push_back({.header = "msg", .type = Type::String});
     noTime.columns.push_back({.header = "level", .type = Type::Level});
     CHECK(FirstTimeColumnIndex(noTime) == -1);
 
-    // Single time column -> its index.
     LogConfiguration single;
     single.columns.push_back({.header = "msg", .type = Type::String});
     single.columns.push_back({.header = "ts", .type = Type::Time});
     single.columns.push_back({.header = "level", .type = Type::Level});
     CHECK(FirstTimeColumnIndex(single) == 1);
 
-    // Two time columns -> the first one wins; callers explicitly
-    // rely on this "canonical column" behaviour (Record Details
-    // summary, row right-click time-filter menu).
+    // First wins: callers rely on this "canonical column" behaviour.
     LogConfiguration twoTimes;
     twoTimes.columns.push_back({.header = "started_at", .type = Type::Time});
     twoTimes.columns.push_back({.header = "msg", .type = Type::String});
     twoTimes.columns.push_back({.header = "ended_at", .type = Type::Time});
     CHECK(FirstTimeColumnIndex(twoTimes) == 0);
 
-    // Time column at index 0 is also returned (regression: a naive
-    // implementation seeded with `int timeCol = 0` instead of `-1`
-    // would still pass the cases above but break "no time column").
+    // Index 0 is a real result, not the "not found" sentinel.
     LogConfiguration headTime;
     headTime.columns.push_back({.header = "ts", .type = Type::Time});
     CHECK(FirstTimeColumnIndex(headTime) == 0);

--- a/test/lib/src/test_log_configuration.cpp
+++ b/test/lib/src/test_log_configuration.cpp
@@ -1364,7 +1364,7 @@ TEST_CASE("FirstTimeColumnIndex returns the first Type::Time column or -1", "[lo
 
     // Empty column list -> -1 (sentinel) so callers can branch on
     // "no time column" without inspecting `columns.size()`.
-    LogConfiguration empty;
+    const LogConfiguration empty;
     CHECK(FirstTimeColumnIndex(empty) == -1);
 
     // No time column among other types -> -1.

--- a/test/lib/src/test_log_configuration.cpp
+++ b/test/lib/src/test_log_configuration.cpp
@@ -1358,6 +1358,45 @@ TEST_CASE("IsLogLevelKey recognises canonical level aliases case-insensitively",
     CHECK_FALSE(IsLogLevelKey("level "));
 }
 
+TEST_CASE("FirstTimeColumnIndex returns the first Type::Time column or -1", "[log_configuration][time_column]")
+{
+    using Type = LogConfiguration::Type;
+
+    // Empty column list -> -1 (sentinel) so callers can branch on
+    // "no time column" without inspecting `columns.size()`.
+    LogConfiguration empty;
+    CHECK(FirstTimeColumnIndex(empty) == -1);
+
+    // No time column among other types -> -1.
+    LogConfiguration noTime;
+    noTime.columns.push_back({.header = "msg", .type = Type::String});
+    noTime.columns.push_back({.header = "level", .type = Type::Level});
+    CHECK(FirstTimeColumnIndex(noTime) == -1);
+
+    // Single time column -> its index.
+    LogConfiguration single;
+    single.columns.push_back({.header = "msg", .type = Type::String});
+    single.columns.push_back({.header = "ts", .type = Type::Time});
+    single.columns.push_back({.header = "level", .type = Type::Level});
+    CHECK(FirstTimeColumnIndex(single) == 1);
+
+    // Two time columns -> the first one wins; callers explicitly
+    // rely on this "canonical column" behaviour (Record Details
+    // summary, row right-click time-filter menu).
+    LogConfiguration twoTimes;
+    twoTimes.columns.push_back({.header = "started_at", .type = Type::Time});
+    twoTimes.columns.push_back({.header = "msg", .type = Type::String});
+    twoTimes.columns.push_back({.header = "ended_at", .type = Type::Time});
+    CHECK(FirstTimeColumnIndex(twoTimes) == 0);
+
+    // Time column at index 0 is also returned (regression: a naive
+    // implementation seeded with `int timeCol = 0` instead of `-1`
+    // would still pass the cases above but break "no time column").
+    LogConfiguration headTime;
+    headTime.columns.push_back({.header = "ts", .type = Type::Time});
+    CHECK(FirstTimeColumnIndex(headTime) == 0);
+}
+
 TEST_CASE(
     "LogConfiguration serialises Type::Level and Column::levelMapping round-trip",
     "[log_configuration][log_level][serialization]"

--- a/test/lib/src/test_log_filter.cpp
+++ b/test/lib/src/test_log_filter.cpp
@@ -705,18 +705,18 @@ TEST_CASE("TimeRangeRowPredicate rejects uint64_t slots above int64_t::max", "[l
     const TestLogFile fixture("log_filter_time_uint64_overflow.json");
     fixture.Write("");
     const std::vector<LogValue> values = {
-        uint64_t{500},                                                       // in range
-        static_cast<uint64_t>(std::numeric_limits<int64_t>::max()),          // boundary
-        static_cast<uint64_t>(std::numeric_limits<int64_t>::max()) + 1U,     // just past
-        std::numeric_limits<uint64_t>::max()                                 // far past
+        uint64_t{500},                                                   // in range
+        static_cast<uint64_t>(std::numeric_limits<int64_t>::max()),      // boundary
+        static_cast<uint64_t>(std::numeric_limits<int64_t>::max()) + 1U, // just past
+        std::numeric_limits<uint64_t>::max()                             // far past
     };
     const LogTable table = BuildSingleColumnTable(fixture, "ts", LogConfiguration::Type::Time, values);
 
     const TimeRangeRowPredicate predicate(0, /*begin=*/0, /*end=*/std::numeric_limits<int64_t>::max());
-    CHECK(predicate.MatchesRow(table, 0));        // in-range slot inside [0, INT64_MAX]
-    CHECK(predicate.MatchesRow(table, 1));        // INT64_MAX exactly
-    CHECK_FALSE(predicate.MatchesRow(table, 2));  // INT64_MAX + 1 -> nullopt-equivalent reject
-    CHECK_FALSE(predicate.MatchesRow(table, 3));  // UINT64_MAX -> rejected
+    CHECK(predicate.MatchesRow(table, 0));       // in-range slot inside [0, INT64_MAX]
+    CHECK(predicate.MatchesRow(table, 1));       // INT64_MAX exactly
+    CHECK_FALSE(predicate.MatchesRow(table, 2)); // INT64_MAX + 1 -> nullopt-equivalent reject
+    CHECK_FALSE(predicate.MatchesRow(table, 3)); // UINT64_MAX -> rejected
 }
 
 TEST_CASE("BoolRowPredicate selects by side", "[log_filter][boolean]")

--- a/test/lib/src/test_log_filter.cpp
+++ b/test/lib/src/test_log_filter.cpp
@@ -695,13 +695,10 @@ TEST_CASE("NumericRangeRowPredicate treats NaN bounds as unbounded", "[log_filte
 
 TEST_CASE("TimeRangeRowPredicate rejects uint64_t slots above int64_t::max", "[log_filter][time]")
 {
-    // Mirrors `loglib::AsEpochMicroseconds`: a `uint64_t` slot past
-    // `int64_t::max` can never represent a `TimeRangeRowPredicate`
-    // boundary (bounds are `int64_t`), so the predicate rejects it
-    // explicitly rather than relying on `uint64_t` arithmetic to
-    // accidentally produce the right answer. Keeps the row right-
-    // click time-filter menu and the predicate in lockstep on what
-    // counts as a "time" slot.
+    // Bounds are `int64_t`, so a `uint64_t` past `int64_t::max` can
+    // never be a meaningful match. Reject explicitly (matches
+    // `loglib::AsEpochMicroseconds`) rather than relying on uint
+    // arithmetic to accidentally produce the right answer.
     const TestLogFile fixture("log_filter_time_uint64_overflow.json");
     fixture.Write("");
     const std::vector<LogValue> values = {
@@ -713,10 +710,10 @@ TEST_CASE("TimeRangeRowPredicate rejects uint64_t slots above int64_t::max", "[l
     const LogTable table = BuildSingleColumnTable(fixture, "ts", LogConfiguration::Type::Time, values);
 
     const TimeRangeRowPredicate predicate(0, /*begin=*/0, /*end=*/std::numeric_limits<int64_t>::max());
-    CHECK(predicate.MatchesRow(table, 0));       // in-range slot inside [0, INT64_MAX]
-    CHECK(predicate.MatchesRow(table, 1));       // INT64_MAX exactly
-    CHECK_FALSE(predicate.MatchesRow(table, 2)); // INT64_MAX + 1 -> nullopt-equivalent reject
-    CHECK_FALSE(predicate.MatchesRow(table, 3)); // UINT64_MAX -> rejected
+    CHECK(predicate.MatchesRow(table, 0));
+    CHECK(predicate.MatchesRow(table, 1));
+    CHECK_FALSE(predicate.MatchesRow(table, 2));
+    CHECK_FALSE(predicate.MatchesRow(table, 3));
 }
 
 TEST_CASE("BoolRowPredicate selects by side", "[log_filter][boolean]")

--- a/test/lib/src/test_log_filter.cpp
+++ b/test/lib/src/test_log_filter.cpp
@@ -693,6 +693,32 @@ TEST_CASE("NumericRangeRowPredicate treats NaN bounds as unbounded", "[log_filte
     CHECK(predicate.MatchesRow(table, 2));
 }
 
+TEST_CASE("TimeRangeRowPredicate rejects uint64_t slots above int64_t::max", "[log_filter][time]")
+{
+    // Mirrors `loglib::AsEpochMicroseconds`: a `uint64_t` slot past
+    // `int64_t::max` can never represent a `TimeRangeRowPredicate`
+    // boundary (bounds are `int64_t`), so the predicate rejects it
+    // explicitly rather than relying on `uint64_t` arithmetic to
+    // accidentally produce the right answer. Keeps the row right-
+    // click time-filter menu and the predicate in lockstep on what
+    // counts as a "time" slot.
+    const TestLogFile fixture("log_filter_time_uint64_overflow.json");
+    fixture.Write("");
+    const std::vector<LogValue> values = {
+        uint64_t{500},                                                       // in range
+        static_cast<uint64_t>(std::numeric_limits<int64_t>::max()),          // boundary
+        static_cast<uint64_t>(std::numeric_limits<int64_t>::max()) + 1U,     // just past
+        std::numeric_limits<uint64_t>::max()                                 // far past
+    };
+    const LogTable table = BuildSingleColumnTable(fixture, "ts", LogConfiguration::Type::Time, values);
+
+    const TimeRangeRowPredicate predicate(0, /*begin=*/0, /*end=*/std::numeric_limits<int64_t>::max());
+    CHECK(predicate.MatchesRow(table, 0));        // in-range slot inside [0, INT64_MAX]
+    CHECK(predicate.MatchesRow(table, 1));        // INT64_MAX exactly
+    CHECK_FALSE(predicate.MatchesRow(table, 2));  // INT64_MAX + 1 -> nullopt-equivalent reject
+    CHECK_FALSE(predicate.MatchesRow(table, 3));  // UINT64_MAX -> rejected
+}
+
 TEST_CASE("BoolRowPredicate selects by side", "[log_filter][boolean]")
 {
     const TestLogFile fixture("log_filter_boolean.json");

--- a/test/lib/src/test_log_line.cpp
+++ b/test/lib/src/test_log_line.cpp
@@ -239,28 +239,22 @@ TEST_CASE("AsEpochMicroseconds matches the TimeRangeRowPredicate slot acceptance
 {
     using namespace std::chrono;
 
-    // `TimeStamp` slot returns its `time_since_epoch().count()`. The
-    // helper's whole purpose is to feed predicate / filter
-    // construction sites a single `int64_t` that round-trips with the
-    // predicate's own visit, so this is the load-bearing arm.
+    // `TimeStamp`: the dominant shape, returned as raw epoch micros.
     const TimeStamp ts{microseconds{1'700'000'123'456'789LL}};
     const auto fromTimestamp = AsEpochMicroseconds(LogValue{ts});
     REQUIRE(fromTimestamp.has_value());
     CHECK(*fromTimestamp == 1'700'000'123'456'789LL);
 
-    // Promoted-int slots (raw epoch microseconds parsed as integers
-    // before time promotion) ride along on the same path. Negative
-    // values pass through unchanged so pre-1970 timestamps survive.
+    // Promoted-int slots (epoch micros parsed as integers) pass
+    // through; negatives included so pre-1970 timestamps survive.
     CHECK(AsEpochMicroseconds(LogValue{int64_t{42}}) == int64_t{42});
     CHECK(AsEpochMicroseconds(LogValue{int64_t{-7}}) == int64_t{-7});
     CHECK(AsEpochMicroseconds(LogValue{int64_t{0}}) == int64_t{0});
     CHECK(AsEpochMicroseconds(LogValue{std::numeric_limits<int64_t>::max()}) == std::numeric_limits<int64_t>::max());
     CHECK(AsEpochMicroseconds(LogValue{std::numeric_limits<int64_t>::min()}) == std::numeric_limits<int64_t>::min());
 
-    // `uint64_t` <= INT64_MAX casts down. The ceiling matches the
-    // predicate's: out-of-range returns nullopt rather than wrapping
-    // to a negative int64, so callers see the same behaviour the
-    // persisted `LogFilter::filterBegin/End` enforce.
+    // `uint64_t` casts down up to INT64_MAX; out-of-range returns
+    // nullopt rather than wrapping to a negative int64.
     CHECK(AsEpochMicroseconds(LogValue{uint64_t{0}}) == int64_t{0});
     CHECK(AsEpochMicroseconds(LogValue{uint64_t{12345}}) == int64_t{12345});
     CHECK(
@@ -272,9 +266,7 @@ TEST_CASE("AsEpochMicroseconds matches the TimeRangeRowPredicate slot acceptance
     );
     CHECK_FALSE(AsEpochMicroseconds(LogValue{std::numeric_limits<uint64_t>::max()}).has_value());
 
-    // Non-time arms all return nullopt -- the contract the row
-    // right-click time-filter menu relies on to skip rows that
-    // can't carry a meaningful boundary.
+    // Non-time arms all return nullopt.
     CHECK_FALSE(AsEpochMicroseconds(LogValue{std::monostate{}}).has_value());
     CHECK_FALSE(AsEpochMicroseconds(LogValue{std::string_view{"2024-01-01"}}).has_value());
     CHECK_FALSE(AsEpochMicroseconds(LogValue{std::string{"2024-01-01"}}).has_value());

--- a/test/lib/src/test_log_line.cpp
+++ b/test/lib/src/test_log_line.cpp
@@ -267,7 +267,8 @@ TEST_CASE("AsEpochMicroseconds matches the TimeRangeRowPredicate slot acceptance
         AsEpochMicroseconds(LogValue{static_cast<uint64_t>(std::numeric_limits<int64_t>::max())}) ==
         std::numeric_limits<int64_t>::max()
     );
-    CHECK_FALSE(AsEpochMicroseconds(LogValue{static_cast<uint64_t>(std::numeric_limits<int64_t>::max()) + 1}).has_value()
+    CHECK_FALSE(
+        AsEpochMicroseconds(LogValue{static_cast<uint64_t>(std::numeric_limits<int64_t>::max()) + 1}).has_value()
     );
     CHECK_FALSE(AsEpochMicroseconds(LogValue{std::numeric_limits<uint64_t>::max()}).has_value());
 

--- a/test/lib/src/test_log_line.cpp
+++ b/test/lib/src/test_log_line.cpp
@@ -235,6 +235,53 @@ TEST_CASE("LogValueEquivalent treats string and string_view byte-equal as equiva
     CHECK_FALSE(LogValueEquivalent(LogValue{1.0}, LogValue{int64_t{1}}));
 }
 
+TEST_CASE("AsEpochMicroseconds matches the TimeRangeRowPredicate slot acceptance set", "[log_line][helpers][time]")
+{
+    using namespace std::chrono;
+
+    // `TimeStamp` slot returns its `time_since_epoch().count()`. The
+    // helper's whole purpose is to feed predicate / filter
+    // construction sites a single `int64_t` that round-trips with the
+    // predicate's own visit, so this is the load-bearing arm.
+    const TimeStamp ts{microseconds{1'700'000'123'456'789LL}};
+    const auto fromTimestamp = AsEpochMicroseconds(LogValue{ts});
+    REQUIRE(fromTimestamp.has_value());
+    CHECK(*fromTimestamp == 1'700'000'123'456'789LL);
+
+    // Promoted-int slots (raw epoch microseconds parsed as integers
+    // before time promotion) ride along on the same path. Negative
+    // values pass through unchanged so pre-1970 timestamps survive.
+    CHECK(AsEpochMicroseconds(LogValue{int64_t{42}}) == int64_t{42});
+    CHECK(AsEpochMicroseconds(LogValue{int64_t{-7}}) == int64_t{-7});
+    CHECK(AsEpochMicroseconds(LogValue{int64_t{0}}) == int64_t{0});
+    CHECK(AsEpochMicroseconds(LogValue{std::numeric_limits<int64_t>::max()}) == std::numeric_limits<int64_t>::max());
+    CHECK(AsEpochMicroseconds(LogValue{std::numeric_limits<int64_t>::min()}) == std::numeric_limits<int64_t>::min());
+
+    // `uint64_t` <= INT64_MAX casts down. The ceiling matches the
+    // predicate's: out-of-range returns nullopt rather than wrapping
+    // to a negative int64, so callers see the same behaviour the
+    // persisted `LogFilter::filterBegin/End` enforce.
+    CHECK(AsEpochMicroseconds(LogValue{uint64_t{0}}) == int64_t{0});
+    CHECK(AsEpochMicroseconds(LogValue{uint64_t{12345}}) == int64_t{12345});
+    CHECK(
+        AsEpochMicroseconds(LogValue{static_cast<uint64_t>(std::numeric_limits<int64_t>::max())}) ==
+        std::numeric_limits<int64_t>::max()
+    );
+    CHECK_FALSE(AsEpochMicroseconds(LogValue{static_cast<uint64_t>(std::numeric_limits<int64_t>::max()) + 1}).has_value()
+    );
+    CHECK_FALSE(AsEpochMicroseconds(LogValue{std::numeric_limits<uint64_t>::max()}).has_value());
+
+    // Non-time arms all return nullopt -- the contract the row
+    // right-click time-filter menu relies on to skip rows that
+    // can't carry a meaningful boundary.
+    CHECK_FALSE(AsEpochMicroseconds(LogValue{std::monostate{}}).has_value());
+    CHECK_FALSE(AsEpochMicroseconds(LogValue{std::string_view{"2024-01-01"}}).has_value());
+    CHECK_FALSE(AsEpochMicroseconds(LogValue{std::string{"2024-01-01"}}).has_value());
+    CHECK_FALSE(AsEpochMicroseconds(LogValue{1.5}).has_value());
+    CHECK_FALSE(AsEpochMicroseconds(LogValue{true}).has_value());
+    CHECK_FALSE(AsEpochMicroseconds(LogValue{false}).has_value());
+}
+
 // Fast path (`GetValue(KeyId)` over the sorted-by-id flat vector) and slow
 // path (`GetValue(string)` routing through the back-pointer) must observe
 // the same value regardless of which alternative the parser chose.


### PR DESCRIPTION
The Filters dialog could already produce a time-range filter, but only the long way around: open `Filters -> Add`, pick the time column, fiddle with two `QDateTimeEdit`s, click OK. A user looking at a specific log line and wanting *"hide everything from before this row"* (or after) had no direct gesture — they had to read the timestamp off the row, switch contexts, and re-type it into the editor.

Adding a row right-click affordance for that flow surfaced three latent bugs in the time-filter path that this PR fixes in the same branch:

1. **`INT64_MAX` / `INT64_MIN` leaked through the UI.** The predicate had always taken two `int64_t` bounds, so an "open" side was historically faked by passing the sentinel. With a one-sided filter now reachable from one click, the Filters menu rendered `294247-01-09 04:00:54 UTC` and `292277-01-09 BC` for the open side, and an `Edit -> OK` round-trip rewrote the open bound to whatever the `QDateTimeEdit`'s ceiling produced (year 9999 micros). The "unbounded" semantic survived exactly until the first edit.
2. **No way to widen a one-sided filter from the editor.** `SetBeginEnd` installed `setMinimumDateTime(beginDateTime)` / `setMaximumDateTime(endDateTime)` unconditionally, with the unbounded side seeded from the bounded side. Editing a `(nullopt, X)` filter pinned the begin widget to `[X, X]`: even after unchecking the "no begin limit" box, the leftover constraint prevented picking any value other than `X`.
3. **Two helpers for "what does this row's time slot look like?"** `BuildRecordDetailContent` carried its own anonymous-namespace `FindTimeColumn`; the per-row time-bound visitor lived only inside `TimeRangeRowPredicate`. The new row-menu code needed both, so the two helpers were lifted into `loglib::` and the predicate / menu / record-detail summary all consume the same definitions.

## What

A new **row right-click menu** on the log table, plus the surrounding time-filter cleanup the menu demanded. End-to-end:

### Row context menu (`MainWindow::BuildRowContextMenu` / `ShowRowContextMenu`)

- Right-clicking any row offers two inclusive actions pinned to the first `Type::Time` column:
  - **Show only newer logs (`<column>`)** — emits `(timestamp, nullopt)`.
  - **Show only older logs (`<column>`)** — emits `(nullopt, timestamp)`.
- Boundary is the clicked row's timestamp; each click creates an additive filter via the existing `FilterTimeStampSubmitted` path (fresh UUID, sibling to any existing time filter on the same column), mirroring how `BuildHeaderContextMenu` adds filters.
- Column label uses `ColumnMenuLabel(...)` so duplicate `Type::Time` headers disambiguate via `[key]` suffix, matching the header menu.
- Action lambdas capture stable **column keys** (not the index) and re-resolve via `FindColumnIndexByKeys` at trigger time, so a streaming-induced column reorder between popup and click still targets the correct column.
- Menu is split into `BuildRowContextMenu` (testable, returns the menu) and `ShowRowContextMenu` (live popup, `Qt::WA_DeleteOnClose`) so tests can inspect actions without spawning a real popup. Ownership contract is documented next to the declaration.
- **Returns null** when there is no time column, the row's time slot is `std::monostate`, the model is empty, the row is out of range, or the slot is a non-time-shaped `LogValue` — never installs a no-op `(nullopt, nullopt)` filter.
- **Not gated mid-stream.** Header reorder + right-click are gated because `LogModel::MoveColumn` races with `AppendKeys`; the row menu only mutates `mFilters` and is a useful live-tail workflow ("narrow to logs newer than this incident marker"). Documented in `SetConfigurationUiEnabled`.

### `std::optional<qint64>` for time-filter bounds end-to-end (`FilterEditor`, `MainWindow`)

- `FilterEditor::Load(int, std::optional<qint64>, std::optional<qint64>)` / `SetBeginEnd(...)` / `FilterTimeStampSubmitted` signal all carry optionals. `MainWindow::FilterTimeStampSubmitted` slot, `MainWindow::AddFilter` Time branch, and `BuildRowContextMenu` all emit `std::nullopt` for the open side instead of `INT64` sentinels.
- New **"No begin limit"** / **"No end limit"** checkboxes per side on the Time page disable the matching date/time edits when checked and make `OkClicked` emit `std::nullopt` for that bound.
- `OkClicked` rejects both-unbounded (would match every row) by painting both checkboxes red, mirroring the Number page's both-empty rejection. Inversion (`begin > end`) is only checked when both sides are bounded.
- `SetBeginEnd` now:
  - seeds each edit with a sensible value even when its side is unbounded (the user may uncheck the checkbox and start picking) — unbounded side reuses the bounded side's value, both-unbounded falls back to "now";
  - applies `setMinimumDateTime` / `setMaximumDateTime` *only* on the bounded side, and **explicitly clears** the constraint on the unbounded side. `SetBeginEnd` can run twice on the same editor (`UpdateSelectedColumn` seeds bounded min/max from the model, then `Load` overwrites with the actual filter shape), so a stale constraint from the first call would otherwise leak into the second;
  - keeps the per-widget `setDateTime` + `setMin/Max` interleaving from the original — batching all `setDateTime`s first and the constraints afterwards lets the cross-coupling cascade clamp values to unintended times.
- `UpdateFilters` Time branch substitutes `INT64_MIN` / `INT64_MAX` via `value_or` at predicate construction, so the runtime visitor stays a simple `>=` / `<=` pair while the title and editor keep `nullopt` as canonical.

### Title and validation

- `BuildFilterTitle` renders `nullopt` bounds as the literal word **"any"** instead of formatting the INT64 sentinels through the date library. The previous `Q_ASSERT` that both bounds were engaged is dropped: `ValidateFilterAgainstColumns` rejects both-nullopt upstream, but a hand-edited config / in-flight migration can still land a malformed filter, and the Release path already renders "any - any" gracefully — the assert now matches Release behaviour instead of crashing Debug.
- `ValidateFilterAgainstColumns` Time branch now mirrors Number's **"at least one bound has a value"** rule (was: both required). Behaviour unchanged today for every existing call site, but a hand-edited config with one open side now loads instead of being silently dropped.

### `loglib::FirstTimeColumnIndex`

- Hoisted from the anonymous-namespace `FindTimeColumn` in `record_detail_widget.cpp` to a public free function in `loglib::`. Single source of truth for "which column is the canonical timestamp"; the Record Details summary and the row right-click menu both consume it.

### `loglib::AsEpochMicroseconds`

- New free helper next to `AsStringView` extracting the per-row `LogValue -> int64_t` epoch-microseconds visitor. Accepts `TimeStamp`, `int64_t`, and `uint64_t` up to `int64_t::max`; rejects `monostate`, strings, doubles, bools, and out-of-range `uint64_t`. The row-menu code consumes the helper directly.
- **`TimeRangeRowPredicate` is now in lockstep with the helper.** The predicate's `uint64_t` arm previously relied on the comparison `alt <= hi` returning false because `hi` was capped at `int64_t::max` after the cast — correct in practice but not in spirit, and brittle against a future bound widening. The predicate now explicitly rejects `alt > int64_t::max` before the range check, with a cross-reference comment pointing both visitors at each other.

### Tests

~630 lines of new coverage across `test/app/src/main_window_test.cpp`, `test/lib/src/test_log_line.cpp`, `test/lib/src/test_log_filter.cpp`, and `test/lib/src/test_log_configuration.cpp`. Highlights:

- **Row menu shape:** offers `at-or-after` + `at-or-before` with `ColumnMenuLabel`-formatted titles, additive (sibling UUID survives a pre-seeded filter), `FilterTimeStampSubmitted` round-trip through the editor leaves `(nullopt, X)` / `(X, nullopt)` unchanged.
- **Row menu rejection paths:** returns null without a time column, on an empty model, on an out-of-range row (defensive cover for the race where `Reset` shrinks the model between popup and trigger), and on a `monostate` time slot (row with the timestamp key missing).
- **Column reorder between menu build and trigger** still targets the right column (the captured stable keys re-resolve via `FindColumnIndexByKeys`).
- **`SetBeginEnd` constraint-leak regression:** Edit on `(nullopt, X)` leaves `minimumDateTime` strictly less than the seed; unchecking the unbounded checkbox re-enables the edits; OK round-trips the bounded side unchanged.
- **`loglib::AsEpochMicroseconds`:** every variant arm covered including the `uint64_t == int64_t::max` boundary, `int64_t::max + 1`, and `UINT64_MAX`.
- **`TimeRangeRowPredicate` `uint64_t` boundary** matches the helper.
- **`loglib::FirstTimeColumnIndex`:** empty configuration, no-time-column, multi-time-column ordering.
- **`ValidateFilterAgainstColumns` Time:** at-least-one-bound rule.

## Non-changes

- `LogModel`, `LogConfiguration`, `LogFilterModel`, `RowOrderProxyModel`, `RecordDetailWidget`, `RecordDetailDock`, the columns manager, and the existing **header** context menu are unchanged.
- Per-row storage layout is unchanged; the wire-format `LogConfiguration::LogFilter` already carried `std::optional<int64_t>` bounds — this PR just stops papering over `nullopt` with sentinels at the boundaries.
- No new preferences, no new menu entries (the row right-click menu has no menu-bar equivalent — the header time-column menu's "Add Filter" still works the long way around).
- No theming changes; the unbounded checkboxes inherit the platform style.
