### PR TITLE
Bump version to 0.9.0

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.28)
 
-project(structured_log_viewer VERSION 0.8.0 LANGUAGES CXX)
+project(structured_log_viewer VERSION 0.9.0 LANGUAGES CXX)
 
 # IPO/LTO on for Release / RelWithDebInfo, off for Debug. `NOT DEFINED` gates
 # let sanitizer presets override via the cache; a plain `set(... ON)` would


### PR DESCRIPTION
Bumps the project version from `0.8.0` to `0.9.0` in the top-level `CMakeLists.txt` to cut a new release. Once this PR merges to `main`, tagging the merge commit `v0.9.0` will trigger the `Build` workflow to package and publish AppImage / zip / dmg artifacts to the GitHub Release.

### Changes since v0.8.0

- Column Management (#32)
- Column Filter Menu (#33)
- Log Level Detection (#34)
- Column UI Configuration (#35)
- Record Details Pane (#36)
- Bump the actions group with 2 updates (#37)
- Append-open, session history, single-instance coordination (#38)
- Row Right-Click Time-Range Filter (#39)
