### PR TITLE
fix(cmake): backport global PIC for LTO link (v0.9.1)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.28)
 
-project(structured_log_viewer VERSION 0.9.0 LANGUAGES CXX)
+project(structured_log_viewer VERSION 0.9.1 LANGUAGES CXX)
 
 # IPO/LTO on for Release / RelWithDebInfo, off for Debug. `NOT DEFINED` gates
 # let sanitizer presets override via the cache; a plain `set(... ON)` would
@@ -38,6 +38,12 @@ set(CMAKE_LIBRARY_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/lib/${CMAKE_BUILD_TYPE})
 set(CMAKE_ARCHIVE_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/lib/${CMAKE_BUILD_TYPE})
 
 set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
+
+# PIC for every static input so the LTO link does not mix PIC / non-PIC bitcode
+# (LLVM #189203: spurious R_X86_64_COPY relocations against Qt's staticMetaObject
+# leave it zero-initialised -> SIGSEGV in QApplication construction). No-op on
+# Windows / MSVC. Must be set BEFORE FetchContent / add_subdirectory below.
+set(CMAKE_POSITION_INDEPENDENT_CODE ON)
 
 include(cmake/FetchDependencies.cmake)
 


### PR DESCRIPTION
## Summary

Backport of #44 (LTO PIC fix) to `release/v0.9.x`, shipping as v0.9.1.

The Linux AppImage shipped with v0.9.0 crashes at first launch on every distro: `QApplication` construction SegFaults inside `QGuiApplication::screenAdded` because the IPO/LTO link mixes PIC inputs (Qt-linked targets) with non-PIC inputs (`loglib` + third-party FetchContent static libs), tripping the toolchain-wide [LLVM #189203](https://github.com/llvm/llvm-project/issues/189203) / [Arch FS#78006](https://bugs.archlinux.org/task/78006) defect — spurious `R_X86_64_COPY` relocations against Qt's `staticMetaObject` leave the metaobject zero-initialised at runtime. Same root cause and same fix as on `main`, just shrunk to the minimum diff against the v0.9.0 base.

## What changed

- `CMakeLists.txt`: bump `project(... VERSION 0.9.1)` and add `set(CMAKE_POSITION_INDEPENDENT_CODE ON)` before the FetchContent / `add_subdirectory` calls.

That's the entire diff — 7 insertions, 1 deletion. None of the comment-tightening, AppImage `continue-on-error` removal, or sanitizer-preset note refactors from the main-branch fix are carried over; this branch is a hotfix, not a sync.

## Test plan

- [ ] `build-linux` runs `apptest_theme` to completion under IPO/LTO ON (regression gate from `main`'s PR).
- [ ] `Run parser benchmarks` recovers the LTO benefit on the loglib hot paths versus the prior shipped v0.9.0 baseline.
- [ ] `build-macos`, `build-windows`, `clang-ci` stay green.
- [ ] Once merged, tag `v0.9.1` from `release/v0.9.x` and let CI publish the corrected AppImage.

## Why a separate release branch

`main` is already past v0.9.0 and includes follow-up work (comment tightening, doc cleanup, `continue-on-error` removal) that we don't want to ship into a v0.9.1 hotfix. Cutting `release/v0.9.x` from the v0.9.0 tag and applying just the PIC fix keeps the patch release narrow and obviously-correct.
