### PR TITLE
fix(cmake): backport global PIC for LTO link (v0.7.1)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.28)
 
-project(structured_log_viewer VERSION 0.7.0 LANGUAGES CXX)
+project(structured_log_viewer VERSION 0.7.1 LANGUAGES CXX)
 
 # IPO/LTO for Release / RelWithDebInfo so the linker can inline across TUs.
 # Debug stays off for iteration speed.
@@ -28,6 +28,12 @@ set(CMAKE_LIBRARY_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/lib/${CMAKE_BUILD_TYPE})
 set(CMAKE_ARCHIVE_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/lib/${CMAKE_BUILD_TYPE})
 
 set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
+
+# PIC for every static input so the LTO link does not mix PIC / non-PIC bitcode
+# (LLVM #189203: spurious R_X86_64_COPY relocations against Qt's staticMetaObject
+# leave it zero-initialised -> SIGSEGV in QApplication construction). No-op on
+# Windows / MSVC. Must be set BEFORE FetchContent / add_subdirectory below.
+set(CMAKE_POSITION_INDEPENDENT_CODE ON)
 
 include(cmake/FetchDependencies.cmake)
 


### PR DESCRIPTION
## Summary

Backport of #44 (LTO PIC fix) to `release/v0.7.x`, shipping as v0.7.1. Same root cause and fix as #45 (v0.9.1) and #46 (v0.8.1); see #44 for the long-form analysis. The Linux AppImage shipped with v0.7.0 SegFaults at first launch inside `QGuiApplication::screenAdded` because the IPO/LTO link mixes PIC and non-PIC bitcode and triggers [LLVM #189203](https://github.com/llvm/llvm-project/issues/189203), corrupting Qt's `staticMetaObject` via spurious `R_X86_64_COPY` relocations.

## What changed

- `CMakeLists.txt`: bump `project(... VERSION 0.7.1)` and add `set(CMAKE_POSITION_INDEPENDENT_CODE ON)` before the FetchContent / `add_subdirectory` calls.

7 insertions, 1 deletion. Same minimum diff as #45 / #46 (the v0.7.0 base has the older unconditional IPO form without the `NOT DEFINED` cache-override gates, but that does not affect the PIC fix's correctness — sanitizer presets aren't relevant for a release-asset point bump).

## Test plan

- [ ] `build-linux` runs the test suite (note: v0.7.0's CI predates `apptest_theme` and the AppImage smoke launch; the test that exercises the bug here is the AppImage smoke step itself, which on this base sits behind `continue-on-error: true`. So validation is: package the AppImage, download the artifact, launch under `offscreen` QPA off-CI to confirm exit 0).
- [ ] `Run parser benchmarks` recovers the LTO benefit on the loglib hot paths.
- [ ] `build-macos`, `build-windows`, `clang-ci` stay green.
- [ ] Once merged, tag `v0.7.1` from `release/v0.7.x` and let CI publish the corrected AppImage.

## Why a separate release branch

Same as #45 / #46: keep the patch release narrow against its own base. v0.7.x users get the smallest, obviously-correct hotfix.
