### PR TITLE
fix(cmake): backport global PIC for LTO link (v0.6.2)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.28)
 
-project(structured_log_viewer VERSION 0.6.0 LANGUAGES CXX)
+project(structured_log_viewer VERSION 0.6.2 LANGUAGES CXX)
 
 # IPO/LTO for Release / RelWithDebInfo so the linker can inline across TUs.
 # Debug stays off for iteration speed.
@@ -28,6 +28,12 @@ set(CMAKE_LIBRARY_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/lib/${CMAKE_BUILD_TYPE})
 set(CMAKE_ARCHIVE_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/lib/${CMAKE_BUILD_TYPE})
 
 set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
+
+# PIC for every static input so the LTO link does not mix PIC / non-PIC bitcode
+# (LLVM #189203: spurious R_X86_64_COPY relocations against Qt's staticMetaObject
+# leave it zero-initialised -> SIGSEGV in QApplication construction). No-op on
+# Windows / MSVC. Must be set BEFORE FetchContent / add_subdirectory below.
+set(CMAKE_POSITION_INDEPENDENT_CODE ON)
 
 include(cmake/FetchDependencies.cmake)
 


### PR DESCRIPTION
## Summary

Backport of #44 (LTO PIC fix) to `release/v0.6.x`, shipping as v0.6.2. Same root cause and fix as #45 / #46 / #47; see #44 for the long-form analysis. The Linux AppImage shipped with v0.6.1 SegFaults at first launch inside `QGuiApplication::screenAdded` because the IPO/LTO link mixes PIC and non-PIC bitcode and triggers [LLVM #189203](https://github.com/llvm/llvm-project/issues/189203), corrupting Qt's `staticMetaObject` via spurious `R_X86_64_COPY` relocations.

(v0.6.0 is *not* affected — it predates IPO/LTO being enabled on Release builds, so its AppImage works.)

## What changed

- `CMakeLists.txt`: bump `project(... VERSION 0.6.2)` and add `set(CMAKE_POSITION_INDEPENDENT_CODE ON)` before the FetchContent / `add_subdirectory` calls.

7 insertions, 1 deletion. Same minimum diff as #45 / #46 / #47. (Note: v0.6.1 had been tagged with the project VERSION still set to `0.6.0`; this PR sets the right value for the v0.6.2 tag rather than first correcting via 0.6.1.)

## Test plan

- [ ] `build-linux` runs the test suite (note: v0.6.x's CI predates `apptest_theme` and the AppImage smoke launch; primary validation is to download the artifact and launch the corrected AppImage off-CI to confirm it no longer SegFaults).
- [ ] `Run parser benchmarks` recovers the LTO benefit on the loglib hot paths.
- [ ] `build-macos`, `build-windows`, `clang-ci` stay green.
- [ ] Once merged, tag `v0.6.2` from `release/v0.6.x` and let CI publish the corrected AppImage.

## Why a separate release branch

Same as #45 / #46 / #47: keep the patch release narrow against its own base. v0.6.x users get the smallest, obviously-correct hotfix.
