### PR TITLE
ci: trigger Build workflow on release/** branches

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,11 +4,13 @@ on:
   push:
     branches:
       - main
+      - "release/**"
     tags:
       - "v*"
   pull_request:
     branches:
       - main
+      - "release/**"
 
 permissions:
   contents: read


### PR DESCRIPTION
## Summary

Extends the `Build` workflow's `push` and `pull_request` branch filters to also match `release/**` so that backport PRs and direct pushes to release branches get the same CI coverage as work on `main`.

## Why

The four LTO-fix backport PRs against `release/v0.X.x` branches (#45, #46, #47, #48) are currently firing zero checks because the workflow is gated to `push: main` / `pull_request: main` only. Without CI on those branches there's no evidence to gate merges on.

## What changed

- `.github/workflows/build.yml`: add `release/**` to both branch lists.

```yaml
on:
  push:
    branches:
      - main
      - "release/**"   # new
    tags:
      - "v*"
  pull_request:
    branches:
      - main
      - "release/**"   # new
```

Tags are unaffected (they already match `v*` regardless of branch).

## Plan after this lands

This change only takes effect on workflows evaluated from `main` (e.g. future PRs into main, or future release branches cut from main). The four already-existing release branches each have their own copy of `build.yml` from when they were branched, so the same 2-line patch needs to be applied to each `release/v0.X.x` and the open backport PRs rebased on top. That follow-up is tracked in the chat that opened this PR; will be done as soon as this lands.

## Test plan

- [x] Build matrix runs on this PR (proves the change doesn't break anything on `main` itself).
- [x] After merge + propagation to release branches, PRs #45 / #46 / #47 / #48 fire CI for the first time.
