### PR TITLE
Cleanup: remove LTO-era test workarounds

### DIFF
--- a/app/include/column_editor.hpp
+++ b/app/include/column_editor.hpp
@@ -38,26 +38,6 @@ public:
         return mColumnIndex;
     }
 
-#ifdef LOGAPP_BUILD_TESTING
-    /// Test-only direct widget accessors. `findChild<>` lookups by
-    /// object name are unreliable on the GitHub-hosted Linux runner
-    /// with Qt 6.8 + offscreen QPA, so tests reach the form widgets
-    /// through these bypasses (mirrors the QAction workaround in
-    /// `FindActionByObjectName`).
-    [[nodiscard]] QLineEdit *HeaderEditForTest() const noexcept
-    {
-        return mHeaderEdit;
-    }
-    [[nodiscard]] QComboBox *TypeComboForTest() const noexcept
-    {
-        return mTypeCombo;
-    }
-    [[nodiscard]] QCheckBox *VisibleCheckForTest() const noexcept
-    {
-        return mVisibleCheck;
-    }
-#endif
-
 private:
     void Populate();
     void WriteBack();

--- a/app/include/columns_manager_dialog.hpp
+++ b/app/include/columns_manager_dialog.hpp
@@ -53,17 +53,6 @@ public:
     /// Idempotent.
     void RefreshPalette();
 
-#ifdef LOGAPP_BUILD_TESTING
-    /// Test-only direct accessor for the columns table widget.
-    /// `findChild<QTableWidget*>("columnsTable")` is unreliable on
-    /// the GitHub-hosted Linux runner with Qt 6.8 + offscreen QPA,
-    /// so tests reach the table through this bypass.
-    [[nodiscard]] QTableWidget *TableForTest() const noexcept
-    {
-        return mTable;
-    }
-#endif
-
 private slots:
     /// Slot for the in-row visibility checkbox; everything else on
     /// the row is read-only.

--- a/app/include/configuration_diagnostics_dialog.hpp
+++ b/app/include/configuration_diagnostics_dialog.hpp
@@ -30,16 +30,6 @@ public:
     /// data. Shared between the status-bar summary and the dialog.
     [[nodiscard]] static int MismatchedColumnCount(const LogModel &model);
 
-#ifdef LOGAPP_BUILD_TESTING
-    /// Test-only direct accessor. `findChild<QTableWidget*>` is
-    /// unreliable on the GitHub-hosted Linux runner with Qt 6.8 +
-    /// offscreen QPA, so tests reach the table through this bypass.
-    [[nodiscard]] QTableWidget *TableForTest() const noexcept
-    {
-        return mTable;
-    }
-#endif
-
 signals:
     /// Emitted when the user double-clicks a row. `MainWindow` opens
     /// the column editor in response.

--- a/app/include/filter_editor.hpp
+++ b/app/include/filter_editor.hpp
@@ -67,58 +67,6 @@ public:
     bool GetBooleanIncludeTrue() const;
     bool GetBooleanIncludeFalse() const;
 
-    /// Test-only accessors for the enum-picker page widgets. Tests cannot
-    /// rely on `findChildren<...>()` to locate them: on the Linux runner
-    /// with Qt 6.8 + offscreen QPA, QObject-tree traversal returns empty
-    /// for QDialog descendants the same way it does for `QAction`s in the
-    /// `MainWindow` `.ui` (see `MainWindow::FindUiAction`).
-    [[nodiscard]] QListView *EnumPickerView() const
-    {
-        return mEnumValuesView;
-    }
-    [[nodiscard]] QSortFilterProxyModel *EnumPickerProxy() const
-    {
-        return mEnumValuesProxy;
-    }
-    [[nodiscard]] QLineEdit *EnumSearchEdit() const
-    {
-        return mEnumSearchEdit;
-    }
-    [[nodiscard]] QLabel *EnumEmptyPlaceholder() const
-    {
-        return mEnumEmptyPlaceholder;
-    }
-    [[nodiscard]] QPushButton *OkButton() const
-    {
-        return mOkButton;
-    }
-    /// Test-only accessors for the time page widgets. Same offscreen-QPA
-    /// caveat as the enum-picker accessors above.
-    [[nodiscard]] QDateEdit *BeginDateEdit() const
-    {
-        return mBeginDateEdit;
-    }
-    [[nodiscard]] QTimeEdit *BeginTimeEdit() const
-    {
-        return mBeginTimeEdit;
-    }
-    [[nodiscard]] QDateEdit *EndDateEdit() const
-    {
-        return mEndDateEdit;
-    }
-    [[nodiscard]] QTimeEdit *EndTimeEdit() const
-    {
-        return mEndTimeEdit;
-    }
-    [[nodiscard]] QCheckBox *BeginUnboundedCheckBox() const
-    {
-        return mBeginUnboundedCheckBox;
-    }
-    [[nodiscard]] QCheckBox *EndUnboundedCheckBox() const
-    {
-        return mEndUnboundedCheckBox;
-    }
-
 signals:
     void FilterSubmitted(const QString &filterID, int row, const QString &filterString, int matchType);
     /// Time-range filter. `std::nullopt` bounds are unbounded; the slot

--- a/app/include/main_window.hpp
+++ b/app/include/main_window.hpp
@@ -199,29 +199,13 @@ public:
     /// Idempotent.
     void ApplyDisplayOrder();
 
-    /// Test-only `QAction` lookup by `objectName`; works around a Qt
-    /// 6.8 + offscreen-QPA `findChild<QAction*>` bug.
-    [[nodiscard]] QAction *FindUiAction(const QString &name) const;
-
-    /// Test-only accessors for the filter pipeline. The same Qt 6.8 +
-    /// offscreen-QPA traversal bug that motivates `FindUiAction` also
-    /// strands `findChild<QMenu*>("menuFilters")` and `findChildren<
-    /// QSortFilterProxyModel*>()` on the Linux runner; tests reach
-    /// these owned objects through the explicit getters instead.
+    /// Test-only direct accessor for the live filter proxy. Tests
+    /// inspect the filtered row count and column-rank state through
+    /// it; production wires the proxy into `mTableView` directly.
     [[nodiscard]] LogFilterModel *FilterModel() const
     {
         return mSortFilterProxyModel;
     }
-    [[nodiscard]] QMenu *FiltersMenu() const;
-
-    /// Test-only `View` menu accessor. Mirrors `FiltersMenu()`: the
-    /// Qt 6.8 + offscreen-QPA `findChild<QMenu*>` traversal bug also
-    /// strands `findChild<QMenu*>("menuView")` on the Linux runner.
-    [[nodiscard]] QMenu *ViewMenu() const;
-
-    /// Test-only `Recent Sessions` submenu accessor. Same Qt 6.8 +
-    /// offscreen-QPA traversal bug as `FiltersMenu()`.
-    [[nodiscard]] QMenu *RecentSessionsMenu() const;
 
     /// Toggle column visibility. Updates `Column::visible` and the
     /// header. No-op for an out-of-range index. Public for tests and
@@ -259,15 +243,10 @@ public:
     /// so. Idempotent.
     void ResetHeaderToIdentity();
 
-    /// Result of `BuildHeaderContextMenu`. `menu` is the caller-
-    /// owned root menu; `filterSubMenus` is a non-owning test seam
-    /// (the Linux Release offscreen-QPA toolchain strips `QMenu`
-    /// metaobject hooks, so tests can't recover submenus by walking
-    /// the tree). Production callers only need `menu`.
+    /// Result of `BuildHeaderContextMenu`. Caller owns `menu`.
     struct HeaderContextMenu
     {
         QMenu *menu = nullptr;
-        std::unordered_map<std::string, QMenu *> filterSubMenus;
     };
 
     /// Build the right-click header menu for @p logicalColumn.
@@ -295,16 +274,6 @@ public:
         return mFilters;
     }
 
-    /// Test-only direct lookup for a per-filter sub-menu by id.
-    /// Same Linux-Release-offscreen reason as `BuildHeaderContextMenu`'s
-    /// out-parameter: walking `ui->menuFilters->actions()` and calling
-    /// `QAction::menu()` -- or iterating `children()` and casting to
-    /// `QMenu*` -- both return null on that toolchain even though the
-    /// production code wires the submenu correctly. The map is
-    /// maintained by `AddLogFilter` / `ClearFilter` / `ClearAllFilters`
-    /// so the answer is the live submenu pointer.
-    [[nodiscard]] QMenu *FilterSubMenu(const QString &filterID) const;
-
     /// Owned `LogModel`; non-null after construction.
     [[nodiscard]] LogModel *Model() const
     {
@@ -312,32 +281,6 @@ public:
     }
 
 #ifdef LOGAPP_BUILD_TESTING
-    /// Test-only direct accessor for the Record Details dock.
-    /// Same Linux-Release-offscreen reason as `ViewMenu()` /
-    /// `FilterSubMenu()`: `findChild<RecordDetailDock*>()` on the
-    /// Linux Qt 6.8 + offscreen-QPA toolchain segfaults inside Qt's
-    /// child-traversal even though the dock is correctly parented to
-    /// `MainWindow` (production code never walks the tree this way).
-    [[nodiscard]] RecordDetailDock *RecordDetailDockForTest() const
-    {
-        return mRecordDetailDock;
-    }
-
-    /// Test-only direct accessor for the central log table view.
-    /// Same Linux-Release-offscreen reason as `RecordDetailDockForTest()`.
-    [[nodiscard]] LogTableView *TableViewForTest() const
-    {
-        return mTableView;
-    }
-
-    /// Test-only snapshot-window list. Same Linux-Release-offscreen
-    /// reason as `RecordDetailDockForTest()`: `findChildren` walks the
-    /// child tree and that path is the unreliable one. The internal
-    /// `QHash` is keyed by heap address; this view materialises the
-    /// live `RecordDetailWindow*` set in insertion order so tests can
-    /// observe both the count and the per-window state.
-    [[nodiscard]] QList<RecordDetailWindow *> RecordDetailWindowsForTest() const;
-
     /// Test-only session-mode override so display-order tests can
     /// exercise the `Static` branch without a real open flow.
     enum class TestSessionMode
@@ -366,8 +309,8 @@ public:
     void LoadConfigurationFromPathForTest(const QString &path);
 
     /// When true, `ShowDroppedFiltersDialog` skips the modal and
-    /// only updates the test counter (modals block the offscreen
-    /// QPA test thread). Default false.
+    /// only updates the test counter (modals block any headless
+    /// QtTest thread). Default false.
     void SetSuppressDialogsForTest(bool suppress);
 
     /// Filters dropped on the most recent
@@ -378,16 +321,6 @@ public:
     /// tests assert the descriptor round-trips through Save Session
     /// without running a real open path.
     void SetCurrentSourceForTest(std::optional<loglib::LogConfiguration::Source> source);
-
-    /// Test-only direct accessor for the diagnostics status-bar
-    /// button. `QObject::findChild<QPushButton*>("diagnosticsButton")`
-    /// is unreliable on the GitHub-hosted Linux runner with Qt 6.8 +
-    /// offscreen QPA (see `FindActionByObjectName` for the same
-    /// workaround applied to QActions); this bypasses the lookup.
-    [[nodiscard]] QPushButton *DiagnosticsButtonForTest() const noexcept
-    {
-        return mDiagnosticsButton;
-    }
 
     /// Test-only entry to the queued static-files open path,
     /// bypassing the file dialog and modifier sniff.
@@ -777,13 +710,6 @@ private:
     ThemeControl *mTheme;
     std::unordered_map<std::string, loglib::LogConfiguration::LogFilter> mFilters;
 
-    /// Per-filter `Filters` sub-menu pointers, keyed by filter id.
-    /// Maintained alongside `mFilters`; the test-only `FilterSubMenu()`
-    /// accessor reads from here because Qt 6.8 + offscreen QPA on the
-    /// Linux Release toolchain strips the metaobject hooks that make
-    /// `QAction::menu()` and `qobject_cast<QMenu*>(child)` work.
-    std::unordered_map<std::string, QMenu *> mFilterSubMenus;
-
     /// Status-bar label shown while a streaming session is active.
     QLabel *mStatusLabel = nullptr;
 
@@ -931,8 +857,8 @@ private:
     bool mSessionSwitchInProgress = false;
 
 #ifdef LOGAPP_BUILD_TESTING
-    /// Skip `ShowDroppedFiltersDialog`'s modal so the test thread
-    /// is not blocked under offscreen QPA.
+    /// Skip `ShowDroppedFiltersDialog`'s modal so a headless test
+    /// thread is not blocked.
     bool mSuppressDialogsForTest = false;
     int mLastDroppedFilterCountForTest = 0;
 #endif

--- a/app/include/record_detail_widget.hpp
+++ b/app/include/record_detail_widget.hpp
@@ -84,35 +84,6 @@ public:
     /// item), so theme changes need this nudge. Idempotent.
     void RefreshPalette();
 
-#ifdef LOGAPP_BUILD_TESTING
-    /// Direct accessors. `findChild<>` by object name is unreliable
-    /// under Qt 6.8 + offscreen QPA on the Linux runner.
-    [[nodiscard]] QTableWidget *FieldsTableForTest() const noexcept
-    {
-        return mFieldsTable;
-    }
-    [[nodiscard]] QPlainTextEdit *RawEditForTest() const noexcept
-    {
-        return mRawEdit;
-    }
-    [[nodiscard]] QGroupBox *RawGroupForTest() const noexcept
-    {
-        return mRawGroup;
-    }
-    [[nodiscard]] QPushButton *CopyJsonButtonForTest() const noexcept
-    {
-        return mCopyJsonButton;
-    }
-    [[nodiscard]] QPushButton *CopyKeyValueButtonForTest() const noexcept
-    {
-        return mCopyKvButton;
-    }
-    [[nodiscard]] QPushButton *OpenInNewWindowButtonForTest() const noexcept
-    {
-        return mOpenInNewWindowButton;
-    }
-#endif
-
 signals:
     /// User clicked "Open in new window". The owner builds a snapshot
     /// `RecordDetailWindow`.

--- a/app/include/record_detail_window.hpp
+++ b/app/include/record_detail_window.hpp
@@ -23,13 +23,6 @@ public:
     /// `MainWindow`'s theme-change broadcast. Idempotent.
     void RefreshPalette();
 
-#ifdef LOGAPP_BUILD_TESTING
-    [[nodiscard]] RecordDetailWidget *WidgetForTest() const noexcept
-    {
-        return mWidget;
-    }
-#endif
-
 private:
     RecordDetailWidget *mWidget = nullptr;
 };

--- a/app/src/filter_editor.cpp
+++ b/app/src/filter_editor.cpp
@@ -85,12 +85,18 @@ FilterEditor::FilterEditor(const LogModel &model, QString filterID, ThemeControl
     mMatchTypeComboBox = new QComboBox(this);
 
     mBeginDateEdit = new QDateEdit(this);
+    mBeginDateEdit->setObjectName(QStringLiteral("beginDateEdit"));
     mBeginTimeEdit = new QTimeEdit(this);
+    mBeginTimeEdit->setObjectName(QStringLiteral("beginTimeEdit"));
     mEndDateEdit = new QDateEdit(this);
+    mEndDateEdit->setObjectName(QStringLiteral("endDateEdit"));
     mEndTimeEdit = new QTimeEdit(this);
+    mEndTimeEdit->setObjectName(QStringLiteral("endTimeEdit"));
 
     mBeginUnboundedCheckBox = new QCheckBox("No begin limit", this);
+    mBeginUnboundedCheckBox->setObjectName(QStringLiteral("beginUnboundedCheckBox"));
     mEndUnboundedCheckBox = new QCheckBox("No end limit", this);
+    mEndUnboundedCheckBox->setObjectName(QStringLiteral("endUnboundedCheckBox"));
 
     mStackedWidget = new QStackedWidget(this);
 
@@ -110,6 +116,7 @@ FilterEditor::FilterEditor(const LogModel &model, QString filterID, ThemeControl
     mEnumValuesView->setMaximumHeight(ENUM_PICKER_MAX_HEIGHT_PX);
 
     mEnumSearchEdit = new QLineEdit(this);
+    mEnumSearchEdit->setObjectName(QStringLiteral("enumSearchEdit"));
     mEnumSearchEdit->setPlaceholderText("Filter values...");
     mEnumSearchEdit->setClearButtonEnabled(true);
 
@@ -117,6 +124,7 @@ FilterEditor::FilterEditor(const LogModel &model, QString filterID, ThemeControl
     mEnumClearAllButton = new QPushButton("Clear All", this);
     mEnumSelectionCount = new QLabel("0 of 0 selected", this);
     mEnumEmptyPlaceholder = new QLabel("No values observed for this column yet.", this);
+    mEnumEmptyPlaceholder->setObjectName(QStringLiteral("enumEmptyPlaceholder"));
     mEnumEmptyPlaceholder->setAlignment(Qt::AlignCenter);
     mEnumEmptyPlaceholder->setWordWrap(true);
     mEnumEmptyPlaceholder->hide();
@@ -141,6 +149,7 @@ FilterEditor::FilterEditor(const LogModel &model, QString filterID, ThemeControl
     mBoolIncludeFalse = new QCheckBox("Include false", this);
 
     mOkButton = new QPushButton("Ok", this);
+    mOkButton->setObjectName(QStringLiteral("okButton"));
     mCancelButton = new QPushButton("Cancel", this);
 
     for (const auto &column : mModel.Configuration().columns)

--- a/app/src/main_window.cpp
+++ b/app/src/main_window.cpp
@@ -2850,13 +2850,14 @@ void MainWindow::ShowRecordDetailsForProxyIndex(const QModelIndex &proxyIndex)
         return;
     }
     mRecordDetailDock->ShowSourceRow(sourceRow);
-    // `isHidden()` probes the dock's own explicit-hide flag (the
+    // `isHidden()` probes the dock's own explicit-hide flag; the
     // ancestor `isVisible()` is also false until `show()` has been
-    // called on the main window). The `isVisible()` guard on `this`
-    // avoids a Qt 6.8.3 + offscreen-QPA crash where
-    // `QDockWidget::setVisible(true)` dereferences uninitialised
-    // QMainWindowLayout dock-area state when the host has never been
-    // shown. Production callers always see a visible main window.
+    // called on the host. The `isVisible()` guard on `this` is
+    // defense-in-depth for unit tests that drive this slot without
+    // realising the main window: `QDockWidget::setVisible(true)`
+    // walks `QMainWindowLayout`'s dock-area state, which is only
+    // wired up by the host's first paint cycle. Production callers
+    // always see a visible main window.
     if (mRecordDetailDock->isHidden() && isVisible())
     {
         mRecordDetailDock->setVisible(true);
@@ -3657,10 +3658,8 @@ void MainWindow::AddLogFilter(const QString &id, const loglib::LogConfiguration:
     const QString title = BuildFilterTitle(filter);
 
     QMenu *menuItem = ui->menuFilters->addMenu(title);
+    menuItem->setObjectName(id);
     menuItem->menuAction()->setData(QVariant(id));
-    // Track the submenu pointer so tests can find it without going
-    // through `QAction::menu()` or `qobject_cast<QMenu*>(child)` --
-    // both fail under the Linux Release offscreen-QPA toolchain.
     mFilterSubMenus[id.toStdString()] = menuItem;
 
     const QAction *editAction = menuItem->addAction(tr("Edit"));
@@ -4450,6 +4449,7 @@ MainWindow::HeaderContextMenu MainWindow::BuildHeaderContextMenu(int logicalColu
     {
         const QString filterId = QString::fromStdString(entry.id);
         QMenu *filterSubMenu = menu->addMenu(entry.title);
+        filterSubMenu->setObjectName(filterId);
         result.filterSubMenus[entry.id] = filterSubMenu;
         QAction *editAction = filterSubMenu->addAction(tr("Edit"));
         editAction->setEnabled(modelHasRows);

--- a/app/src/main_window.cpp
+++ b/app/src/main_window.cpp
@@ -2203,128 +2203,7 @@ void MainWindow::ApplyStreamingRetention()
     mModel->SetRetentionCap(StreamingControl::RetentionLines());
 }
 
-QAction *MainWindow::FindUiAction(const QString &name) const
-{
-    // Must stay in sync with `main_window.ui`.
-    if (name == QStringLiteral("actionNewSession"))
-    {
-        return ui->actionNewSession;
-    }
-    if (name == QStringLiteral("actionNewWindow"))
-    {
-        return ui->actionNewWindow;
-    }
-    if (name == QStringLiteral("actionOpen"))
-    {
-        return ui->actionOpen;
-    }
-    if (name == QStringLiteral("actionOpenLogStream"))
-    {
-        return ui->actionOpenLogStream;
-    }
-    if (name == QStringLiteral("actionOpenNetworkStream"))
-    {
-        return ui->actionOpenNetworkStream;
-    }
-    if (name == QStringLiteral("actionSaveConfiguration"))
-    {
-        return ui->actionSaveConfiguration;
-    }
-    if (name == QStringLiteral("actionSaveSession"))
-    {
-        return ui->actionSaveSession;
-    }
-    if (name == QStringLiteral("actionLoadConfiguration"))
-    {
-        return ui->actionLoadConfiguration;
-    }
-    if (name == QStringLiteral("actionExit"))
-    {
-        return ui->actionExit;
-    }
-    if (name == QStringLiteral("actionCopy"))
-    {
-        return ui->actionCopy;
-    }
-    if (name == QStringLiteral("actionFind"))
-    {
-        return ui->actionFind;
-    }
-    if (name == QStringLiteral("actionAddFilter"))
-    {
-        return ui->actionAddFilter;
-    }
-    if (name == QStringLiteral("actionClearAllFilters"))
-    {
-        return ui->actionClearAllFilters;
-    }
-    if (name == QStringLiteral("actionPauseStream"))
-    {
-        return ui->actionPauseStream;
-    }
-    if (name == QStringLiteral("actionFollowTail"))
-    {
-        return ui->actionFollowTail;
-    }
-    if (name == QStringLiteral("actionStopStream"))
-    {
-        return ui->actionStopStream;
-    }
-    if (name == QStringLiteral("actionPreferences"))
-    {
-        return ui->actionPreferences;
-    }
-    if (name == QStringLiteral("actionToggleRecordDetails"))
-    {
-        return ui->actionToggleRecordDetails;
-    }
-    return nullptr;
-}
-
-QMenu *MainWindow::FiltersMenu() const
-{
-    return ui->menuFilters;
-}
-
-QMenu *MainWindow::ViewMenu() const
-{
-    return ui->menuView;
-}
-
-QMenu *MainWindow::RecentSessionsMenu() const
-{
-    return ui->menuRecentSessions;
-}
-
-QMenu *MainWindow::FilterSubMenu(const QString &filterID) const
-{
-    const auto it = mFilterSubMenus.find(filterID.toStdString());
-    if (it == mFilterSubMenus.end())
-    {
-        return nullptr;
-    }
-    return it->second;
-}
-
 #ifdef LOGAPP_BUILD_TESTING
-QList<RecordDetailWindow *> MainWindow::RecordDetailWindowsForTest() const
-{
-    // Materialise the live snapshot-window set out of the heap-keyed
-    // tracker. The tracker is keyed on the original heap address (a
-    // `quintptr`) but iteration order isn't stable across runs; tests
-    // only assert on count and per-window state, never on identity.
-    QList<RecordDetailWindow *> windows;
-    windows.reserve(mRecordDetailWindows.size());
-    for (const auto &entry : std::as_const(mRecordDetailWindows))
-    {
-        if (!entry.window.isNull())
-        {
-            windows.append(entry.window.data());
-        }
-    }
-    return windows;
-}
-
 void MainWindow::SetSessionModeForTest(TestSessionMode mode)
 {
     switch (mode)
@@ -3360,7 +3239,6 @@ void MainWindow::AddFilter(
 void MainWindow::ClearAllFilters()
 {
     mFilters.clear();
-    mFilterSubMenus.clear();
     MirrorSessionStateToConfiguration();
     mSortFilterProxyModel->SetFilterRules({});
 
@@ -3379,7 +3257,6 @@ void MainWindow::ClearAllFilters()
 void MainWindow::ClearFilter(const QString &filterID, bool deferSync)
 {
     mFilters.erase(filterID.toStdString());
-    mFilterSubMenus.erase(filterID.toStdString());
     if (!deferSync)
     {
         MirrorSessionStateToConfiguration();
@@ -3660,7 +3537,6 @@ void MainWindow::AddLogFilter(const QString &id, const loglib::LogConfiguration:
     QMenu *menuItem = ui->menuFilters->addMenu(title);
     menuItem->setObjectName(id);
     menuItem->menuAction()->setData(QVariant(id));
-    mFilterSubMenus[id.toStdString()] = menuItem;
 
     const QAction *editAction = menuItem->addAction(tr("Edit"));
     // Capture only the id and re-resolve the live filter at trigger
@@ -4450,7 +4326,6 @@ MainWindow::HeaderContextMenu MainWindow::BuildHeaderContextMenu(int logicalColu
         const QString filterId = QString::fromStdString(entry.id);
         QMenu *filterSubMenu = menu->addMenu(entry.title);
         filterSubMenu->setObjectName(filterId);
-        result.filterSubMenus[entry.id] = filterSubMenu;
         QAction *editAction = filterSubMenu->addAction(tr("Edit"));
         editAction->setEnabled(modelHasRows);
         // Same id-resolve-on-trigger pattern as the Filters-menu

--- a/test/app/src/main_window_test.cpp
+++ b/test/app/src/main_window_test.cpp
@@ -3194,13 +3194,13 @@ private slots:
         // runner with Qt 6.8 + offscreen QPA, `findChildren<QListView*>`
         // strands these widgets the same way it strands `QAction`s in
         // the `MainWindow` `.ui` (see `MainWindow::FindUiAction`).
-        const QListView *picker = editor.EnumPickerView();
-        const QSortFilterProxyModel *proxy = editor.EnumPickerProxy();
+        const QListView *picker = editor.findChild<QListView *>();
+        const QSortFilterProxyModel *proxy = editor.findChild<QSortFilterProxyModel *>();
         QVERIFY2(picker != nullptr, "FilterEditor must expose its enum picker QListView");
         QVERIFY2(proxy != nullptr, "picker must wrap a QSortFilterProxyModel");
         QCOMPARE(proxy->rowCount(), 5);
 
-        QLineEdit *searchBox = editor.EnumSearchEdit();
+        QLineEdit *searchBox = editor.findChild<QLineEdit *>(QStringLiteral("enumSearchEdit"));
         QVERIFY2(searchBox != nullptr, "FilterEditor must expose the picker search QLineEdit");
 
         searchBox->setText(QStringLiteral("err"));
@@ -5225,7 +5225,7 @@ private slots:
 
         // Step 3: click OK without touching anything. The editor must
         // read the open-bound state and emit `nullopt` back.
-        QPushButton *ok = editor->OkButton();
+        QPushButton *ok = editor->findChild<QPushButton *>(QStringLiteral("okButton"));
         QVERIFY2(ok != nullptr, "FilterEditor must expose its OK button");
         // NOLINTNEXTLINE(clang-analyzer-core.CallAndMessage): false positive; prior `QVERIFY2` aborts on null.
         ok->click();
@@ -5313,12 +5313,12 @@ private slots:
 
         // Step 3: editor must reflect the loaded shape: begin
         // unbounded, end bounded.
-        QCheckBox *beginUnbounded = editor->BeginUnboundedCheckBox();
-        const QCheckBox *endUnbounded = editor->EndUnboundedCheckBox();
-        const QDateEdit *beginDate = editor->BeginDateEdit();
-        const QTimeEdit *beginTime = editor->BeginTimeEdit();
-        const QDateEdit *endDate = editor->EndDateEdit();
-        const QTimeEdit *endTime = editor->EndTimeEdit();
+        QCheckBox *beginUnbounded = editor->findChild<QCheckBox *>(QStringLiteral("beginUnboundedCheckBox"));
+        const QCheckBox *endUnbounded = editor->findChild<QCheckBox *>(QStringLiteral("endUnboundedCheckBox"));
+        const QDateEdit *beginDate = editor->findChild<QDateEdit *>(QStringLiteral("beginDateEdit"));
+        const QTimeEdit *beginTime = editor->findChild<QTimeEdit *>(QStringLiteral("beginTimeEdit"));
+        const QDateEdit *endDate = editor->findChild<QDateEdit *>(QStringLiteral("endDateEdit"));
+        const QTimeEdit *endTime = editor->findChild<QTimeEdit *>(QStringLiteral("endTimeEdit"));
         QVERIFY(beginUnbounded != nullptr);
         QVERIFY(endUnbounded != nullptr);
         QVERIFY(beginDate != nullptr);
@@ -5352,7 +5352,7 @@ private slots:
         // nullopt) and round-trip the original end. The test asserts
         // the *ability* to widen; the actual widening is straight
         // QDateTimeEdit usage once the minimum is clear.
-        QPushButton *ok = editor->OkButton();
+        QPushButton *ok = editor->findChild<QPushButton *>(QStringLiteral("okButton"));
         QVERIFY(ok != nullptr);
         // NOLINTNEXTLINE(clang-analyzer-core.CallAndMessage): false positive; prior `QVERIFY` aborts on null.
         ok->click();
@@ -6823,7 +6823,7 @@ private slots:
         // Bypass `findChild` to dodge the Qt 6.8 + offscreen-QPA
         // traversal bug on the Linux runner (see the diagnostics-button
         // test for the same workaround applied to MainWindow).
-        const auto *table = dialog.TableForTest();
+        const auto *table = dialog.findChild<QTableWidget *>();
         QVERIFY2(table != nullptr, "Dialog must own a diagnosticsTable widget");
         // NOLINTNEXTLINE(clang-analyzer-core.CallAndMessage): prior QVERIFY2 aborts on null.
         QCOMPARE(table->rowCount(), static_cast<int>(model->Configuration().columns.size()));
@@ -6875,9 +6875,9 @@ private slots:
         // Direct accessors instead of `findChild` -- Linux Qt 6.8 +
         // offscreen QPA strands the lookup for child widgets the same
         // way it does for QActions (see `FindActionByObjectName`).
-        auto *headerEdit = editor.HeaderEditForTest();
-        auto *typeCombo = editor.TypeComboForTest();
-        auto *visibleCheck = editor.VisibleCheckForTest();
+        auto *headerEdit = editor.findChild<QLineEdit *>();
+        auto *typeCombo = editor.findChild<QComboBox *>();
+        auto *visibleCheck = editor.findChild<QCheckBox *>();
         QVERIFY(headerEdit != nullptr);
         QVERIFY(typeCombo != nullptr);
         QVERIFY(visibleCheck != nullptr);
@@ -6947,7 +6947,7 @@ private slots:
             const QSignalSpy enumSpy(model, &LogModel::enumColumnsChanged);
             QVERIFY(enumSpy.isValid());
             ColumnEditor editor(model, levelCol);
-            auto *typeCombo = editor.TypeComboForTest();
+            auto *typeCombo = editor.findChild<QComboBox *>();
             QVERIFY(typeCombo != nullptr);
             // Index 2 is "String" -- mirrors TypeChoices() in
             // column_editor.cpp; same convention as the other editor
@@ -6984,7 +6984,7 @@ private slots:
             const QSignalSpy enumSpy(model, &LogModel::enumColumnsChanged);
             QVERIFY(enumSpy.isValid());
             ColumnEditor editor(model, levelCol);
-            auto *typeCombo = editor.TypeComboForTest();
+            auto *typeCombo = editor.findChild<QComboBox *>();
             QVERIFY(typeCombo != nullptr);
             constexpr int ENUMERATION_CHOICE_INDEX = 8;
             // NOLINTNEXTLINE(clang-analyzer-core.CallAndMessage): prior QVERIFY aborts on null.
@@ -7057,7 +7057,7 @@ private slots:
         QVERIFY2(preEdit.autoDetect, "streaming auto-promotion must leave autoDetect=true");
 
         ColumnEditor editor(model, categoryCol);
-        auto *typeCombo = editor.TypeComboForTest();
+        auto *typeCombo = editor.findChild<QComboBox *>();
         QVERIFY(typeCombo != nullptr);
         // (1) Combo must show the resolved type. Index 8 is
         // "Enumeration" in `TypeChoices()`. Index 0 (the auto-detect
@@ -7107,7 +7107,7 @@ private slots:
         model->ConfigurationManager().SetColumnAutoDetect(static_cast<size_t>(msgCol), false);
 
         ColumnEditor editor(model, msgCol);
-        auto *typeCombo = editor.TypeComboForTest();
+        auto *typeCombo = editor.findChild<QComboBox *>();
         QVERIFY(typeCombo != nullptr);
         // NOLINTNEXTLINE(clang-analyzer-core.CallAndMessage): prior QVERIFY aborts on null.
         typeCombo->setCurrentIndex(0); // "Auto-detect"
@@ -7156,7 +7156,7 @@ private slots:
         );
 
         ColumnEditor editor(model, categoryCol);
-        auto *typeCombo = editor.TypeComboForTest();
+        auto *typeCombo = editor.findChild<QComboBox *>();
         QVERIFY(typeCombo != nullptr);
         // NOLINTNEXTLINE(clang-analyzer-core.CallAndMessage): prior QVERIFY aborts on null.
         typeCombo->setCurrentIndex(0); // "Auto-detect"
@@ -7186,7 +7186,7 @@ private slots:
         const ConfigurationDiagnosticsDialog dialog(model);
         QSignalSpy editSpy(&dialog, &ConfigurationDiagnosticsDialog::editColumnRequested);
 
-        auto *table = dialog.TableForTest();
+        auto *table = dialog.findChild<QTableWidget *>();
         QVERIFY(table != nullptr);
 
         // Find the row corresponding to `msg` (sorting may rearrange
@@ -7226,7 +7226,7 @@ private slots:
 
         const ColumnsManagerDialog dialog(model, mWindow);
 
-        auto *table = dialog.TableForTest();
+        auto *table = dialog.findChild<QTableWidget *>();
         QVERIFY(table != nullptr);
         // NOLINTNEXTLINE(clang-analyzer-core.CallAndMessage): prior QVERIFY aborts on null.
         QCOMPARE(table->rowCount(), static_cast<int>(model->Configuration().columns.size()));
@@ -7262,7 +7262,7 @@ private slots:
         QVERIFY(model->Configuration().columns[static_cast<size_t>(msgCol)].visible);
 
         const ColumnsManagerDialog dialog(model, mWindow);
-        auto *table = dialog.TableForTest();
+        auto *table = dialog.findChild<QTableWidget *>();
         QVERIFY(table != nullptr);
 
         constexpr int VISIBLE_COL = 4;
@@ -7307,7 +7307,7 @@ private slots:
         QVERIFY2(!firstKeys.empty() && !secondKeys.empty(), "fixture columns must carry stable keys");
 
         ColumnsManagerDialog dialog(model, mWindow);
-        auto *table = dialog.TableForTest();
+        auto *table = dialog.findChild<QTableWidget *>();
         QVERIFY(table != nullptr);
         // NOLINTNEXTLINE(clang-analyzer-core.CallAndMessage): prior QVERIFY aborts on null.
         table->selectRow(0);
@@ -7338,7 +7338,7 @@ private slots:
         QVERIFY2(initialColumns.size() >= 2, "fixture must yield at least two columns");
 
         ColumnsManagerDialog dialog(model, mWindow);
-        auto *table = dialog.TableForTest();
+        auto *table = dialog.findChild<QTableWidget *>();
         QVERIFY(table != nullptr);
 
         // Top row: Move up is a no-op.
@@ -7378,7 +7378,7 @@ private slots:
 
         ColumnsManagerDialog dialog(model, mWindow);
         dialog.show();
-        auto *table = dialog.TableForTest();
+        auto *table = dialog.findChild<QTableWidget *>();
         QVERIFY(table != nullptr);
 
         // Snapshot the pre-move dialog row 0 / row 1 headers so the
@@ -8329,14 +8329,14 @@ private slots:
         // Reach widgets via the explicit accessors: see the comment on
         // `MainWindow::FindUiAction` for why `findChildren<...>` is
         // unreliable on the Linux runner with Qt 6.8 + offscreen QPA.
-        const QPushButton *okButton = editor.OkButton();
+        const QPushButton *okButton = editor.findChild<QPushButton *>(QStringLiteral("okButton"));
         QVERIFY2(okButton != nullptr, "FilterEditor must expose an OK button");
         // clang-analyzer does not model `QVERIFY2`'s test-aborting behaviour,
         // so it still considers `okButton` potentially null on the next line.
         // NOLINTNEXTLINE(clang-analyzer-core.CallAndMessage)
         QVERIFY2(!okButton->isEnabled(), "OK must be disabled when the picker dictionary is empty");
 
-        const QLabel *placeholder = editor.EnumEmptyPlaceholder();
+        const QLabel *placeholder = editor.findChild<QLabel *>(QStringLiteral("enumEmptyPlaceholder"));
         QVERIFY2(placeholder != nullptr, "FilterEditor must expose the empty-picker placeholder");
         QVERIFY2(
             placeholder->text().contains(QStringLiteral("No values observed"), Qt::CaseInsensitive),
@@ -9988,7 +9988,7 @@ private slots:
         content.formattedJson = QStringLiteral("{\n  \"level\": \"info\",\n  \"message\": \"hello\"\n}");
         widget.SetContent(content);
 
-        const QTableWidget *table = widget.FieldsTableForTest();
+        const QTableWidget *table = widget.findChild<QTableWidget *>();
         QVERIFY(table != nullptr);
         QCOMPARE(table->rowCount(), 2);
         QCOMPARE(table->item(0, 0)->text(), QStringLiteral("level"));
@@ -10000,7 +10000,7 @@ private slots:
         QVERIFY2(!table->isHidden(), "fields table must be explicitly shown when content is valid");
 
         // The edit shows the *formatted* JSON, not the compact bytes.
-        const QPlainTextEdit *rawEdit = widget.RawEditForTest();
+        const QPlainTextEdit *rawEdit = widget.findChild<QPlainTextEdit *>();
         QVERIFY(rawEdit != nullptr);
         QCOMPARE(rawEdit->toPlainText(), content.formattedJson);
 
@@ -10013,7 +10013,7 @@ private slots:
         QCOMPARE(rawEdit->toPlainText(), QString());
 
         // Snapshot windows hide the "Open in new window" button.
-        const QPushButton *popOutButton = widget.OpenInNewWindowButtonForTest();
+        const QPushButton *popOutButton = widget.findChild<QPushButton *>(QStringLiteral("openInNewWindowButton"));
         QVERIFY(popOutButton != nullptr);
         QVERIFY(popOutButton->isVisibleTo(&widget));
         widget.SetOpenInNewWindowVisible(false);
@@ -10038,7 +10038,7 @@ private slots:
         QVERIFY(clipboard != nullptr);
         clipboard->clear();
 
-        QPushButton *copyButton = widget.CopyJsonButtonForTest();
+        QPushButton *copyButton = widget.findChild<QPushButton *>(QStringLiteral("copyJsonButton"));
         QVERIFY(copyButton != nullptr);
 
         const QString pasted = ClickAndReadClipboardWithRetry(clipboard, copyButton, content.rawJson);
@@ -10066,7 +10066,7 @@ private slots:
         QVERIFY(clipboard != nullptr);
         clipboard->clear();
 
-        QPushButton *copyButton = widget.CopyKeyValueButtonForTest();
+        QPushButton *copyButton = widget.findChild<QPushButton *>(QStringLiteral("copyKeyValueButton"));
         QVERIFY(copyButton != nullptr);
         // NOLINTNEXTLINE(clang-analyzer-core.CallAndMessage)
         QVERIFY(copyButton->isEnabled());
@@ -10091,8 +10091,8 @@ private slots:
         content.formattedJson = QString();
         widget.SetContent(content);
 
-        const QPushButton *rawButton = widget.CopyJsonButtonForTest();
-        const QPushButton *kvButton = widget.CopyKeyValueButtonForTest();
+        const QPushButton *rawButton = widget.findChild<QPushButton *>(QStringLiteral("copyJsonButton"));
+        const QPushButton *kvButton = widget.findChild<QPushButton *>(QStringLiteral("copyKeyValueButton"));
         QVERIFY(rawButton != nullptr);
         QVERIFY(kvButton != nullptr);
         QVERIFY2(!rawButton->isEnabled(), "Copy raw JSON must be disabled when there's no raw text");
@@ -10102,7 +10102,7 @@ private slots:
         // a follow-up `SetContent` with bytes must restore both.
         // Direct accessor (not `findChild`) -- the latter is unreliable
         // under Qt 6.8 + offscreen QPA on the Linux runner.
-        const auto *rawGroup = widget.RawGroupForTest();
+        const auto *rawGroup = widget.findChild<QGroupBox *>();
         QVERIFY(rawGroup != nullptr);
         QVERIFY2(!rawGroup->isEnabled(), "Raw JSON group must be disabled when no raw bytes are available");
         QVERIFY2(
@@ -10149,7 +10149,9 @@ private slots:
         clipboard->clear();
 
         const QString pasted = ClickAndReadClipboardWithRetry(
-            clipboard, widget.CopyKeyValueButtonForTest(), QStringLiteral("multiline: line1\\nline2")
+            clipboard,
+            widget.findChild<QPushButton *>(QStringLiteral("copyKeyValueButton")),
+            QStringLiteral("multiline: line1\\nline2")
         );
         const QStringList lines = pasted.split(QLatin1Char('\n'));
         // One line per field; no real newline mid-entry.
@@ -10180,7 +10182,9 @@ private slots:
         clipboard->clear();
 
         const QString pasted = ClickAndReadClipboardWithRetry(
-            clipboard, widget.CopyKeyValueButtonForTest(), QStringLiteral("key\\nwith\\nnewlines: v")
+            clipboard,
+            widget.findChild<QPushButton *>(QStringLiteral("copyKeyValueButton")),
+            QStringLiteral("key\\nwith\\nnewlines: v")
         );
         const QStringList lines = pasted.split(QLatin1Char('\n'));
         QCOMPARE(lines.size(), content.fields.size());
@@ -10205,7 +10209,7 @@ private slots:
         content.fields.append({QStringLiteral("dashy"), QStringLiteral("\u2014")});
         widget.SetContent(content);
 
-        const QTableWidget *table = widget.FieldsTableForTest();
+        const QTableWidget *table = widget.findChild<QTableWidget *>();
         QVERIFY(table != nullptr);
         QCOMPARE(table->rowCount(), 3);
 
@@ -10254,7 +10258,7 @@ private slots:
         withEmpty.fields.append({QStringLiteral("k"), QString()});
         widget.SetContent(withEmpty);
 
-        const QTableWidget *table = widget.FieldsTableForTest();
+        const QTableWidget *table = widget.findChild<QTableWidget *>();
         QVERIFY(table != nullptr);
         QCOMPARE(table->rowCount(), 1);
         const QTableWidgetItem *valueItem = table->item(0, 1);
@@ -10300,7 +10304,7 @@ private slots:
         content.fields.append({QStringLiteral("gamma"), QStringLiteral("3")});
         widget.SetContent(content);
 
-        QTableWidget *table = widget.FieldsTableForTest();
+        QTableWidget *table = widget.findChild<QTableWidget *>();
         QVERIFY(table != nullptr);
         QCOMPARE(table->rowCount(), 3);
 
@@ -10418,7 +10422,7 @@ private slots:
             }
         });
 
-        const RecordDetailContent &shown = window->WidgetForTest()->Content();
+        const RecordDetailContent &shown = window->findChild<RecordDetailWidget *>()->Content();
         QVERIFY(shown.valid);
         QCOMPARE(shown.fields.size(), snapshot.fields.size());
         bool sawMsg = false;
@@ -10431,9 +10435,11 @@ private slots:
         }
         QVERIFY(sawMsg);
         // Pop-outs hide their own "Open in new window" button.
-        const QPushButton *popOutButton = window->WidgetForTest()->OpenInNewWindowButtonForTest();
+        const QPushButton *popOutButton =
+            window->findChild<RecordDetailWidget *>()->findChild<QPushButton *>(QStringLiteral("openInNewWindowButton")
+            );
         QVERIFY(popOutButton != nullptr);
-        QVERIFY(!popOutButton->isVisibleTo(window->WidgetForTest()));
+        QVERIFY(!popOutButton->isVisibleTo(window->findChild<RecordDetailWidget *>()));
     }
     // NOLINTEND(clang-analyzer-cplusplus.NewDeleteLeaks)
 
@@ -10591,7 +10597,7 @@ private slots:
         for (const RecordDetailWindow *window : windows)
         {
             QVERIFY(window->testAttribute(Qt::WA_DeleteOnClose));
-            QVERIFY(window->WidgetForTest()->Content().valid);
+            QVERIFY(window->findChild<RecordDetailWidget *>()->Content().valid);
         }
 
         // Out-of-range -> no-op.

--- a/test/app/src/main_window_test.cpp
+++ b/test/app/src/main_window_test.cpp
@@ -448,45 +448,24 @@ loglib::StreamedBatch MakeSyntheticBatch(
     return batch;
 }
 
-// Locate a UI-file-declared `QAction` by `objectName`.
-//
-// The primary path goes through `MainWindow::FindUiAction`, which
-// forwards directly to the `ui->actionXxx` pointer and bypasses the
-// QObject-tree lookup altogether. This is necessary because on the
-// GitHub-hosted Linux runner with Qt 6.8 + the offscreen QPA plugin,
-// `QObject::findChild<QAction*>` — and, in fact, every form of
-// QObject-tree traversal we tried (findChildren<QAction*>, walking
-// findChildren<QWidget*>() and inspecting each widget's actions(),
-// and even `QMainWindow::actions()`) — returns null for actions
-// declared inside `<widget class="QMainWindow">` even though the
-// `ui->actionXxx` pointer is valid and wired into menus / toolbars.
-// Windows and macOS with the same Qt build are unaffected.
-//
-// The `findChild` fallback remains as a safety net for QMainWindow
-// subclasses we don't know about (the helper is generic and might
-// be reused in other test TUs).
+// Locate a UI-file-declared `QAction` by `objectName`. Thin wrapper
+// over `findChild<QAction*>` so call sites read intent rather than the
+// generic Qt API.
 QAction *FindActionByObjectName(QMainWindow *window, const QString &name)
 {
-    if (auto *mainWindow = qobject_cast<MainWindow *>(window))
-    {
-        if (QAction *uiAction = mainWindow->FindUiAction(name))
-        {
-            return uiAction;
-        }
-    }
     return window->findChild<QAction *>(name);
 }
 
-// Why tests drive `RecordDetailDock` visibility via `emit
-// visibilityChanged(...)` instead of `dock.show()` / `dock.hide()`:
-// the build-linux runner (Ubuntu 22.04 / Qt 6.8.3 / GCC-13 /
-// offscreen QPA) SIGSEGVs deep inside `QDockWidget::setVisible(true)`
-// when the host main window has never been `show()`n -- it walks an
-// uninitialised QMainWindowLayout dock-area. `RecordDetailDock`'s
-// refresh gate keys off `mPerceivedVisible`, which is fed by the
-// `visibilityChanged` signal, so emitting it directly exercises the
-// same gate without crashing. Production code is unaffected because
-// the main window is always shown before the user opens the dock.
+// Tests drive `RecordDetailDock` visibility via `emit
+// visibilityChanged(...)` instead of `dock.show()` / `dock.hide()`
+// because the dock's refresh gate keys off `mPerceivedVisible`, which
+// is fed by the `visibilityChanged` signal -- this lets tests simulate
+// "buried tab" transitions where the perceived-visible flag flips
+// without the explicit-hide flag flipping (the dock isn't actually
+// hidden, just covered). Tests that attach the dock to an unrealised
+// `QMainWindow` also avoid `QDockWidget::setVisible(true)` walking
+// `QMainWindowLayout`'s dock-area state, which is only wired up by
+// the host's first paint cycle.
 
 } // namespace
 
@@ -1682,17 +1661,16 @@ private slots:
         QVERIFY(!model.IsStreamingActive());
     }
 
-    // The `actionOpenNetworkStream` UI entry must be reachable via
-    // `FindUiAction` so apptest harnesses can locate it without going
-    // through the QObject tree (the workaround documented in
-    // `MainWindow::FindUiAction`).
+    // The `actionOpenNetworkStream` UI entry must be reachable by
+    // `objectName` so apptest harnesses (and any future tooling that
+    // walks the menu tree) can locate it without poking `ui->`.
     static void TestActionOpenNetworkStreamIsExposed()
     {
         // Local variable name avoids the `MainWindowTest::window`
         // member-shadow C4458 warning under MSVC.
         const MainWindow mainWindow;
-        const QAction *action = mainWindow.FindUiAction(QStringLiteral("actionOpenNetworkStream"));
-        QVERIFY2(action != nullptr, "actionOpenNetworkStream must be reachable via FindUiAction");
+        const QAction *action = mainWindow.findChild<QAction *>(QStringLiteral("actionOpenNetworkStream"));
+        QVERIFY2(action != nullptr, "actionOpenNetworkStream must be reachable via objectName");
         // Ctrl+Shift+N was reassigned to File -> New Window; the
         // network-stream action moved to Ctrl+Shift+L.
         QCOMPARE(action->shortcut(), QKeySequence(QStringLiteral("Ctrl+Shift+L")));
@@ -3190,10 +3168,6 @@ private slots:
         FilterEditor editor(*run.model, QStringLiteral("test-filter"));
         editor.Load(levelCol, QStringList{});
 
-        // Reach the picker through the explicit accessor: on the Linux
-        // runner with Qt 6.8 + offscreen QPA, `findChildren<QListView*>`
-        // strands these widgets the same way it strands `QAction`s in
-        // the `MainWindow` `.ui` (see `MainWindow::FindUiAction`).
         const QListView *picker = editor.findChild<QListView *>();
         const QSortFilterProxyModel *proxy = editor.findChild<QSortFilterProxyModel *>();
         QVERIFY2(picker != nullptr, "FilterEditor must expose its enum picker QListView");
@@ -3469,12 +3443,8 @@ private slots:
         QCOMPARE(columns[static_cast<size_t>(levelCol)].type, loglib::LogConfiguration::Type::Enumeration);
 
         // Find the Filters-menu action whose data matches `filterId`.
-        // Reach the menu via `MainWindow::FiltersMenu()` rather than
-        // `findChild`: the Linux Qt 6.8 + offscreen-QPA traversal bug
-        // strands `findChild<QMenu*>("menuFilters")` the same way it
-        // strands `QAction` lookups (see `MainWindow::FindUiAction`).
         const auto findFilterMenuAction = [&](const QString &filterId) -> QAction * {
-            const auto *menu = mWindow->FiltersMenu();
+            const auto *menu = mWindow->findChild<QMenu *>(QStringLiteral("menuFilters"));
             if (menu == nullptr)
             {
                 return nullptr;
@@ -4492,11 +4462,12 @@ private slots:
         QVERIFY2(built.menu != nullptr, "BuildHeaderContextMenu must return a menu");
         const QScopeGuard menuDeleter([&built]() { built.menu->deleteLater(); });
 
-        QCOMPARE(built.filterSubMenus.size(), static_cast<size_t>(2));
-        QVERIFY2(built.filterSubMenus.contains(levelFilter1.toStdString()), "level-filter-1 submenu must be exposed");
-        QVERIFY2(built.filterSubMenus.contains(levelFilter2.toStdString()), "level-filter-2 submenu must be exposed");
+        const QList<QMenu *> subMenus = built.menu->findChildren<QMenu *>();
+        QCOMPARE(subMenus.size(), 2);
+        QVERIFY2(built.menu->findChild<QMenu *>(levelFilter1) != nullptr, "level-filter-1 submenu must be exposed");
+        QVERIFY2(built.menu->findChild<QMenu *>(levelFilter2) != nullptr, "level-filter-2 submenu must be exposed");
         QVERIFY2(
-            !built.filterSubMenus.contains(msgFilter.toStdString()),
+            built.menu->findChild<QMenu *>(msgFilter) == nullptr,
             "filters on a different column must not appear in this header menu"
         );
 
@@ -4505,7 +4476,7 @@ private slots:
         // this assertion.
         const QString editLabel = MainWindow::tr("Edit");
         const QString removeLabel = MainWindow::tr("Remove");
-        for (const auto &[id, subMenu] : built.filterSubMenus)
+        for (const QMenu *subMenu : subMenus)
         {
             QVERIFY2(subMenu != nullptr, "filter sub-menu pointer must be non-null");
             const QList<QAction *> actions = subMenu->actions();
@@ -4546,7 +4517,7 @@ private slots:
         QVERIFY2(built.menu != nullptr, "BuildHeaderContextMenu must return a menu");
         const QScopeGuard menuDeleter([&built]() { built.menu->deleteLater(); });
 
-        const QMenu *subMenu = built.filterSubMenus.at(filterId.toStdString());
+        const QMenu *subMenu = built.menu->findChild<QMenu *>(filterId);
         QVERIFY2(subMenu != nullptr, "filter sub-menu must be exposed via the struct");
         QAction *removeAction = nullptr;
         const QString removeLabel = MainWindow::tr("Remove");
@@ -4593,7 +4564,7 @@ private slots:
         QVERIFY2(built.menu != nullptr, "BuildHeaderContextMenu must return a menu");
         const QScopeGuard menuDeleter([&built]() { built.menu->deleteLater(); });
 
-        const QMenu *subMenu = built.filterSubMenus.at(filterId.toStdString());
+        const QMenu *subMenu = built.menu->findChild<QMenu *>(filterId);
         QVERIFY2(subMenu != nullptr, "filter sub-menu must be exposed");
         QAction *editAction = nullptr;
         const QString editLabel = MainWindow::tr("Edit");
@@ -4816,7 +4787,7 @@ private slots:
         // NOLINTNEXTLINE(clang-analyzer-core.CallAndMessage): false positive; prior `QVERIFY2` aborts on null.
         QVERIFY2(!addFilterAction->isEnabled(), "Add filter must be disabled when the model has no rows");
 
-        const QMenu *subMenu = built.filterSubMenus.at(filterId.toStdString());
+        const QMenu *subMenu = built.menu->findChild<QMenu *>(filterId);
         QVERIFY2(subMenu != nullptr, "filter sub-menu must be exposed");
         const QString editLabel = MainWindow::tr("Edit");
         const QString removeLabel = MainWindow::tr("Remove");
@@ -5192,7 +5163,7 @@ private slots:
         auto built = mWindow->BuildHeaderContextMenu(timeCol, nullptr);
         QVERIFY2(built.menu != nullptr, "BuildHeaderContextMenu must return a menu");
         const QScopeGuard headerMenuDeleter([&built]() { built.menu->deleteLater(); });
-        const QMenu *subMenu = built.filterSubMenus.at(filterId.toStdString());
+        const QMenu *subMenu = built.menu->findChild<QMenu *>(filterId);
         QVERIFY2(subMenu != nullptr, "filter sub-menu must be exposed");
         QAction *editAction = nullptr;
         const QString editLabel = MainWindow::tr("Edit");
@@ -5281,7 +5252,7 @@ private slots:
         auto built = mWindow->BuildHeaderContextMenu(timeCol, nullptr);
         QVERIFY2(built.menu != nullptr, "BuildHeaderContextMenu must return a menu");
         const QScopeGuard headerMenuDeleter([&built]() { built.menu->deleteLater(); });
-        const QMenu *subMenu = built.filterSubMenus.at(filterId.toStdString());
+        const QMenu *subMenu = built.menu->findChild<QMenu *>(filterId);
         QVERIFY2(subMenu != nullptr, "filter sub-menu must be exposed");
         QAction *editAction = nullptr;
         const QString editLabel = MainWindow::tr("Edit");
@@ -5733,11 +5704,7 @@ private slots:
         QVERIFY2(levelCol >= 0, "level column must exist after streaming");
         auto *model = mWindow->Model();
 
-        // The Qt 6.8 + offscreen-QPA `findChild<QMenu*>` traversal
-        // bug strands `findChild<QMenu*>("menuView")` on the Linux
-        // runner; reach the View menu through `ViewMenu()` instead
-        // (mirrors the `FiltersMenu()` workaround).
-        auto *viewMenu = mWindow->ViewMenu();
+        auto *viewMenu = mWindow->findChild<QMenu *>(QStringLiteral("menuView"));
         QVERIFY2(viewMenu != nullptr, "View menu must exist");
 
         emit viewMenu->aboutToShow();
@@ -5853,15 +5820,7 @@ private slots:
         QVERIFY2(mWindow->Filters().contains(filterKey), "filter must survive the reorder");
         QCOMPARE(mWindow->Filters().at(filterKey).row, dest);
 
-        // The Filters-menu lookup needs two test seams to work under
-        // the Linux Release offscreen-QPA toolchain:
-        //   * `FiltersMenu()` substitutes for `findChild<QMenu*>`,
-        //     which traverses no children there.
-        //   * `FilterSubMenu(id)` substitutes for `QAction::menu()`
-        //     and any `qobject_cast<QMenu*>(child)` walk -- both
-        //     return null on that toolchain even though the submenu
-        //     was wired by `ui->menuFilters->addMenu(title)`.
-        const QMenu *filtersMenu = mWindow->FiltersMenu();
+        const QMenu *filtersMenu = mWindow->findChild<QMenu *>(QStringLiteral("menuFilters"));
         QVERIFY2(filtersMenu != nullptr, "MainWindow must expose its Filters menu");
         const QAction *filterMenuAction = nullptr;
         // NOLINTNEXTLINE(clang-analyzer-core.CallAndMessage): false positive; prior `QVERIFY2` aborts on null.
@@ -5875,7 +5834,7 @@ private slots:
         }
         QVERIFY2(filterMenuAction != nullptr, "active filter must have a Filters-menu entry");
 
-        const QMenu *filterSubMenu = mWindow->FilterSubMenu(filterId);
+        const QMenu *filterSubMenu = filtersMenu->findChild<QMenu *>(filterId);
         QVERIFY2(filterSubMenu != nullptr, "filter menu entry must own an Edit/Remove sub-menu");
         QAction *editAction = nullptr;
         // NOLINTNEXTLINE(clang-analyzer-core.CallAndMessage): false positive; prior `QVERIFY2` aborts on null.
@@ -6073,7 +6032,7 @@ private slots:
         QVERIFY2(sawEnum, "enum filter on level must revive");
 
         // Filters menu must hold one sub-menu per revived filter.
-        const QMenu *filtersMenu = mWindow->FiltersMenu();
+        const QMenu *filtersMenu = mWindow->findChild<QMenu *>(QStringLiteral("menuFilters"));
         QVERIFY2(filtersMenu != nullptr, "MainWindow must expose its Filters menu");
         int subMenuCount = 0;
         // NOLINTNEXTLINE(clang-analyzer-core.CallAndMessage): false positive; prior `QVERIFY2` aborts on null.
@@ -6642,7 +6601,8 @@ private slots:
 
     // `actionNewSession` clears rows, runtime filters, the persisted
     // column configuration, and session mode. Reached through
-    // `FindUiAction` so the action wiring is covered too.
+    // `findChild<QAction*>("actionNewSession")` so the action wiring
+    // is covered too.
     void TestNewSessionActionResetsState()
     {
         auto *model = mWindow->Model();
@@ -6668,12 +6628,12 @@ private slots:
         // otherwise the post-condition holds trivially.
         const int categoryCol = ColumnByHeader(*model, QStringLiteral("category"));
         QVERIFY2(categoryCol >= 0, "category column must exist after streaming");
-        mWindow->TableViewForTest()->sortByColumn(categoryCol, Qt::DescendingOrder);
+        mWindow->findChild<LogTableView *>()->sortByColumn(categoryCol, Qt::DescendingOrder);
         QCoreApplication::processEvents();
         QCOMPARE(mWindow->FilterModel()->SortColumn(), categoryCol);
 
-        QAction *action = mWindow->FindUiAction(QStringLiteral("actionNewSession"));
-        QVERIFY2(action != nullptr, "actionNewSession must be exposed via FindUiAction");
+        QAction *action = mWindow->findChild<QAction *>(QStringLiteral("actionNewSession"));
+        QVERIFY2(action != nullptr, "actionNewSession must be reachable via objectName");
         action->trigger();
         QCoreApplication::processEvents();
 
@@ -6771,12 +6731,7 @@ private slots:
         // auto-detected to a matching type or stayed Any; zero
         // mismatches.
         QCOMPARE(ConfigurationDiagnosticsDialog::MismatchedColumnCount(*model), 0);
-        // `findChild<QPushButton*>("diagnosticsButton")` is unreliable
-        // on the GitHub-hosted Linux runner with Qt 6.8 + offscreen QPA
-        // (same traversal bug that strands `findChild<QMenu*>` and
-        // `findChild<QAction*>`; see `FindActionByObjectName` above).
-        // Use the direct test-only accessor so the lookup is bypassed.
-        auto *button = mWindow->DiagnosticsButtonForTest();
+        auto *button = mWindow->findChild<QPushButton *>(QStringLiteral("diagnosticsButton"));
         QVERIFY2(button != nullptr, "MainWindow must own the diagnostics status-bar button");
         // Offscreen-QPA leaves the parent window hidden, which would
         // collapse `isVisible` to false regardless of the slot's
@@ -6820,9 +6775,6 @@ private slots:
         model->RefreshColumnHealth();
 
         const ConfigurationDiagnosticsDialog dialog(model);
-        // Bypass `findChild` to dodge the Qt 6.8 + offscreen-QPA
-        // traversal bug on the Linux runner (see the diagnostics-button
-        // test for the same workaround applied to MainWindow).
         const auto *table = dialog.findChild<QTableWidget *>();
         QVERIFY2(table != nullptr, "Dialog must own a diagnosticsTable widget");
         // NOLINTNEXTLINE(clang-analyzer-core.CallAndMessage): prior QVERIFY2 aborts on null.
@@ -7423,7 +7375,7 @@ private slots:
         const int levelCol = StreamFixtureForColumnTests();
         QVERIFY2(levelCol >= 0, "level column must exist after streaming");
 
-        QMenu *viewMenu = mWindow->ViewMenu();
+        QMenu *viewMenu = mWindow->findChild<QMenu *>(QStringLiteral("menuView"));
         QVERIFY2(viewMenu != nullptr, "MainWindow must expose its View menu");
         // NOLINTNEXTLINE(clang-analyzer-core.CallAndMessage): prior QVERIFY aborts on null.
         emit viewMenu->aboutToShow();
@@ -7597,10 +7549,7 @@ private slots:
         QVERIFY(mWindow->TryLoadAsConfigurationForTest(cfgPath));
         QCoreApplication::processEvents();
 
-        // Rebuild the View menu through the production path. The
-        // `findChild<QMenu*>` traversal is broken under the offscreen
-        // QPA on Linux; `ViewMenu()` reaches `ui->menuView` directly.
-        auto *viewMenu = mWindow->ViewMenu();
+        auto *viewMenu = mWindow->findChild<QMenu *>(QStringLiteral("menuView"));
         QVERIFY2(viewMenu != nullptr, "View menu must exist");
         emit viewMenu->aboutToShow();
 
@@ -8326,9 +8275,6 @@ private slots:
         const FilterEditor editor(*model, QStringLiteral("test-empty-enum"));
         // `UpdateSelectedColumn(0)` settles the OK / placeholder state.
 
-        // Reach widgets via the explicit accessors: see the comment on
-        // `MainWindow::FindUiAction` for why `findChildren<...>` is
-        // unreliable on the Linux runner with Qt 6.8 + offscreen QPA.
         const QPushButton *okButton = editor.findChild<QPushButton *>(QStringLiteral("okButton"));
         QVERIFY2(okButton != nullptr, "FilterEditor must expose an OK button");
         // clang-analyzer does not model `QVERIFY2`'s test-aborting behaviour,
@@ -8416,14 +8362,11 @@ private slots:
         );
 
         // Unfiltered total: the empty enum filter never became active.
-        // Reach the proxy and menu via the explicit accessors: see
-        // `MainWindow::FindUiAction` for the offscreen-QPA traversal
-        // bug that strands `findChild`/`findChildren` here.
         const LogFilterModel *filterModel = mWindow->FilterModel();
         QVERIFY(filterModel != nullptr);
         QCOMPARE(filterModel->rowCount(), 320);
 
-        const auto *menu = mWindow->FiltersMenu();
+        const auto *menu = mWindow->findChild<QMenu *>(QStringLiteral("menuFilters"));
         QVERIFY(menu != nullptr);
         for (const QAction *action : menu->actions())
         {
@@ -9751,7 +9694,7 @@ private slots:
         QCoreApplication::processEvents();
 
         const auto findFilterMenuAction = [&](const QString &id) -> QAction * {
-            const auto *menu = mWindow->FiltersMenu();
+            const auto *menu = mWindow->findChild<QMenu *>(QStringLiteral("menuFilters"));
             if (menu == nullptr)
             {
                 return nullptr;
@@ -10100,8 +10043,6 @@ private slots:
 
         // Raw group is disabled + retitled when there are no bytes;
         // a follow-up `SetContent` with bytes must restore both.
-        // Direct accessor (not `findChild`) -- the latter is unreliable
-        // under Qt 6.8 + offscreen QPA on the Linux runner.
         const auto *rawGroup = widget.findChild<QGroupBox *>();
         QVERIFY(rawGroup != nullptr);
         QVERIFY2(!rawGroup->isEnabled(), "Raw JSON group must be disabled when no raw bytes are available");
@@ -10452,11 +10393,6 @@ private slots:
             QStringLiteral(R"({"k": "beta"})"),
             QStringLiteral(R"({"k": "gamma"})"),
         });
-        // Direct accessors (not `findChild<...>()`). `findChild` walks
-        // the QObject child tree and that traversal is the path that
-        // segfaults inside Qt on the ubuntu-22.04 / Qt 6.8.3 release
-        // runner -- the existing `ViewMenu()` / `FilterSubMenu()`
-        // accessors hit the same toolchain bug for `QMenu`.
         auto *model = mWindow->Model();
         QVERIFY(model != nullptr);
 
@@ -10476,14 +10412,14 @@ private slots:
         QVERIFY(finishedSpy.count() > 0 || finishedSpy.wait(5000));
         QCOMPARE(model->rowCount(), 3);
 
-        auto *dock = mWindow->RecordDetailDockForTest();
+        auto *dock = mWindow->findChild<RecordDetailDock *>();
         QVERIFY2(dock != nullptr, "Record Details dock must be owned by MainWindow");
         // Probe `isHidden()` (parent is never `show()`n under
         // offscreen QPA, so `isVisible()` is always false).
         QVERIFY2(dock->isHidden(), "dock starts hidden");
 
         // Default sort (-1) -> proxy row == source row. Pick row 1.
-        auto *table = mWindow->TableViewForTest();
+        auto *table = mWindow->findChild<LogTableView *>();
         QVERIFY(table != nullptr);
         const QAbstractItemModel *proxyModel = table->model();
         QVERIFY(proxyModel != nullptr);
@@ -10519,7 +10455,7 @@ private slots:
         QVERIFY2(toggleAction != nullptr, "actionToggleRecordDetails must be wired");
         QVERIFY(toggleAction->isCheckable());
 
-        auto *dock = mWindow->RecordDetailDockForTest();
+        auto *dock = mWindow->findChild<RecordDetailDock *>();
         QVERIFY2(dock != nullptr, "Record Details dock must be owned by MainWindow");
         // clang-analyzer doesn't model `QVERIFY2`'s fail-fast return.
         // NOLINTNEXTLINE(clang-analyzer-core.CallAndMessage)
@@ -10587,12 +10523,12 @@ private slots:
         QVERIFY(finishedSpy.count() > 0 || finishedSpy.wait(5000));
         QCOMPARE(model->rowCount(), 2);
 
-        QVERIFY(mWindow->RecordDetailWindowsForTest().isEmpty());
+        QVERIFY(mWindow->findChildren<RecordDetailWindow *>().isEmpty());
 
         mWindow->OpenRecordDetailWindow(0);
         mWindow->OpenRecordDetailWindow(1);
 
-        const auto windows = mWindow->RecordDetailWindowsForTest();
+        const auto windows = mWindow->findChildren<RecordDetailWindow *>();
         QCOMPARE(windows.size(), 2);
         for (const RecordDetailWindow *window : windows)
         {
@@ -10602,7 +10538,7 @@ private slots:
 
         // Out-of-range -> no-op.
         mWindow->OpenRecordDetailWindow(99);
-        QCOMPARE(mWindow->RecordDetailWindowsForTest().size(), 2);
+        QCOMPARE(mWindow->findChildren<RecordDetailWindow *>().size(), 2);
 
         for (RecordDetailWindow *window : windows)
         {
@@ -10635,8 +10571,8 @@ private slots:
         loglib::JsonParser::ParseStreaming(*fileSourcePtr, *model->Sink(), options, advanced);
         QVERIFY(finishedSpy.count() > 0 || finishedSpy.wait(5000));
 
-        auto *dock = mWindow->RecordDetailDockForTest();
-        auto *table = mWindow->TableViewForTest();
+        auto *dock = mWindow->findChild<RecordDetailDock *>();
+        auto *table = mWindow->findChild<LogTableView *>();
         QVERIFY(dock != nullptr);
         QVERIFY(table != nullptr);
         QVERIFY(dock->isHidden());
@@ -10850,11 +10786,11 @@ private slots:
         loglib::JsonParser::ParseStreaming(*fileSourcePtr, *model->Sink(), options, advanced);
         QVERIFY(finishedSpy.count() > 0 || finishedSpy.wait(5000));
 
-        QVERIFY(mWindow->RecordDetailWindowsForTest().isEmpty());
+        QVERIFY(mWindow->findChildren<RecordDetailWindow *>().isEmpty());
 
         mWindow->OpenRecordDetailWindow(0);
         mWindow->OpenRecordDetailWindow(0);
-        auto windows = mWindow->RecordDetailWindowsForTest();
+        auto windows = mWindow->findChildren<RecordDetailWindow *>();
         QCOMPARE(windows.size(), 2);
         for (RecordDetailWindow *window : windows)
         {
@@ -10866,7 +10802,7 @@ private slots:
         QCoreApplication::processEvents();
 
         QVERIFY2(
-            mWindow->RecordDetailWindowsForTest().isEmpty(),
+            mWindow->findChildren<RecordDetailWindow *>().isEmpty(),
             "closed snapshots must have been deleted, no live children remain"
         );
 
@@ -11009,8 +10945,8 @@ private slots:
         QVERIFY(finishedSpy.count() > 0 || finishedSpy.wait(5000));
         QCOMPARE(model->rowCount(), 3);
 
-        auto *dock = mWindow->RecordDetailDockForTest();
-        auto *table = mWindow->TableViewForTest();
+        auto *dock = mWindow->findChild<RecordDetailDock *>();
+        auto *table = mWindow->findChild<LogTableView *>();
         QVERIFY(dock != nullptr);
         QVERIFY(table != nullptr);
 
@@ -11162,7 +11098,7 @@ private slots:
         QVERIFY2(toggleAction != nullptr, "actionToggleRecordDetails must be wired");
         QVERIFY(toggleAction->isCheckable());
 
-        auto *dock = mWindow->RecordDetailDockForTest();
+        auto *dock = mWindow->findChild<RecordDetailDock *>();
         QVERIFY(dock != nullptr);
         QVERIFY2(dock->isHidden(), "dock starts hidden");
         QVERIFY(!toggleAction->isChecked());
@@ -11426,7 +11362,7 @@ private slots:
         const int mainsBefore = countMainWindows();
         const QList<QWidget *> topLevelBefore = QApplication::topLevelWidgets();
 
-        primary->FindUiAction(QStringLiteral("actionNewWindow"))->trigger();
+        primary->findChild<QAction *>(QStringLiteral("actionNewWindow"))->trigger();
         QCoreApplication::processEvents();
 
         QCOMPARE(countMainWindows(), mainsBefore + 1);
@@ -11540,7 +11476,7 @@ private slots:
         const QString uuid = manager.List().front().uuid;
 
         // Tear the session down so the menu reopen has work to do.
-        wired->FindUiAction(QStringLiteral("actionNewSession"))->trigger();
+        wired->findChild<QAction *>(QStringLiteral("actionNewSession"))->trigger();
         QCoreApplication::processEvents();
         QCOMPARE(wired->Model()->rowCount(), 0);
 
@@ -11548,7 +11484,7 @@ private slots:
         // Reach for the menu via the explicit accessor: the Qt 6.8 +
         // offscreen-QPA `findChild<QMenu*>` traversal bug strands the
         // by-objectName lookup on the Linux runner.
-        auto *recentsMenu = wired->RecentSessionsMenu();
+        auto *recentsMenu = wired->findChild<QMenu *>(QStringLiteral("menuRecentSessions"));
         QVERIFY2(recentsMenu != nullptr, "menuRecentSessions must exist");
         emit recentsMenu->aboutToShow();
 
@@ -12589,7 +12525,7 @@ private slots:
 
         // Discard the active session. After this, opening a new file
         // must NOT reuse uuidA.
-        wired->FindUiAction(QStringLiteral("actionNewSession"))->trigger();
+        wired->findChild<QAction *>(QStringLiteral("actionNewSession"))->trigger();
         QCoreApplication::processEvents();
 
         finishedSpy.clear();
@@ -12851,7 +12787,7 @@ private slots:
 
         // Pin a deterministic sort so the indicator preservation is
         // also observable.
-        wired->TableViewForTest()->sortByColumn(msgCol, Qt::DescendingOrder);
+        wired->findChild<LogTableView *>()->sortByColumn(msgCol, Qt::DescendingOrder);
         QCoreApplication::processEvents();
         QCOMPARE(filterModel->SortColumn(), msgCol);
         QCOMPARE(filterModel->SortOrder(), Qt::DescendingOrder);
@@ -12949,7 +12885,7 @@ private slots:
 
         // The Full-scope sort survived: the table view is sorting
         // by `category` descending.
-        const auto *header = wired->TableViewForTest()->horizontalHeader();
+        const auto *header = wired->findChild<LogTableView *>()->horizontalHeader();
         QVERIFY(header != nullptr);
         QCOMPARE(header->sortIndicatorSection(), 0);
         QCOMPARE(header->sortIndicatorOrder(), Qt::DescendingOrder);
@@ -13324,7 +13260,7 @@ private slots:
         }
         QVERIFY(afterAuto.contains(uuid));
 
-        wired->FindUiAction(QStringLiteral("actionNewSession"))->trigger();
+        wired->findChild<QAction *>(QStringLiteral("actionNewSession"))->trigger();
         QCoreApplication::processEvents();
 
         QVERIFY2(

--- a/test/app/src/main_window_test.cpp
+++ b/test/app/src/main_window_test.cpp
@@ -1669,7 +1669,7 @@ private slots:
         // Local variable name avoids the `MainWindowTest::window`
         // member-shadow C4458 warning under MSVC.
         const MainWindow mainWindow;
-        const QAction *action = mainWindow.findChild<QAction *>(QStringLiteral("actionOpenNetworkStream"));
+        const auto *action = mainWindow.findChild<QAction *>(QStringLiteral("actionOpenNetworkStream"));
         QVERIFY2(action != nullptr, "actionOpenNetworkStream must be reachable via objectName");
         // Ctrl+Shift+N was reassigned to File -> New Window; the
         // network-stream action moved to Ctrl+Shift+L.
@@ -3168,13 +3168,13 @@ private slots:
         FilterEditor editor(*run.model, QStringLiteral("test-filter"));
         editor.Load(levelCol, QStringList{});
 
-        const QListView *picker = editor.findChild<QListView *>();
-        const QSortFilterProxyModel *proxy = editor.findChild<QSortFilterProxyModel *>();
+        const auto *picker = editor.findChild<QListView *>();
+        const auto *proxy = editor.findChild<QSortFilterProxyModel *>();
         QVERIFY2(picker != nullptr, "FilterEditor must expose its enum picker QListView");
         QVERIFY2(proxy != nullptr, "picker must wrap a QSortFilterProxyModel");
         QCOMPARE(proxy->rowCount(), 5);
 
-        QLineEdit *searchBox = editor.findChild<QLineEdit *>(QStringLiteral("enumSearchEdit"));
+        auto *searchBox = editor.findChild<QLineEdit *>(QStringLiteral("enumSearchEdit"));
         QVERIFY2(searchBox != nullptr, "FilterEditor must expose the picker search QLineEdit");
 
         searchBox->setText(QStringLiteral("err"));
@@ -5196,7 +5196,7 @@ private slots:
 
         // Step 3: click OK without touching anything. The editor must
         // read the open-bound state and emit `nullopt` back.
-        QPushButton *ok = editor->findChild<QPushButton *>(QStringLiteral("okButton"));
+        auto *ok = editor->findChild<QPushButton *>(QStringLiteral("okButton"));
         QVERIFY2(ok != nullptr, "FilterEditor must expose its OK button");
         // NOLINTNEXTLINE(clang-analyzer-core.CallAndMessage): false positive; prior `QVERIFY2` aborts on null.
         ok->click();
@@ -5284,12 +5284,12 @@ private slots:
 
         // Step 3: editor must reflect the loaded shape: begin
         // unbounded, end bounded.
-        QCheckBox *beginUnbounded = editor->findChild<QCheckBox *>(QStringLiteral("beginUnboundedCheckBox"));
-        const QCheckBox *endUnbounded = editor->findChild<QCheckBox *>(QStringLiteral("endUnboundedCheckBox"));
-        const QDateEdit *beginDate = editor->findChild<QDateEdit *>(QStringLiteral("beginDateEdit"));
-        const QTimeEdit *beginTime = editor->findChild<QTimeEdit *>(QStringLiteral("beginTimeEdit"));
-        const QDateEdit *endDate = editor->findChild<QDateEdit *>(QStringLiteral("endDateEdit"));
-        const QTimeEdit *endTime = editor->findChild<QTimeEdit *>(QStringLiteral("endTimeEdit"));
+        auto *beginUnbounded = editor->findChild<QCheckBox *>(QStringLiteral("beginUnboundedCheckBox"));
+        const auto *endUnbounded = editor->findChild<QCheckBox *>(QStringLiteral("endUnboundedCheckBox"));
+        const auto *beginDate = editor->findChild<QDateEdit *>(QStringLiteral("beginDateEdit"));
+        const auto *beginTime = editor->findChild<QTimeEdit *>(QStringLiteral("beginTimeEdit"));
+        const auto *endDate = editor->findChild<QDateEdit *>(QStringLiteral("endDateEdit"));
+        const auto *endTime = editor->findChild<QTimeEdit *>(QStringLiteral("endTimeEdit"));
         QVERIFY(beginUnbounded != nullptr);
         QVERIFY(endUnbounded != nullptr);
         QVERIFY(beginDate != nullptr);
@@ -5323,7 +5323,7 @@ private slots:
         // nullopt) and round-trip the original end. The test asserts
         // the *ability* to widen; the actual widening is straight
         // QDateTimeEdit usage once the minimum is clear.
-        QPushButton *ok = editor->findChild<QPushButton *>(QStringLiteral("okButton"));
+        auto *ok = editor->findChild<QPushButton *>(QStringLiteral("okButton"));
         QVERIFY(ok != nullptr);
         // NOLINTNEXTLINE(clang-analyzer-core.CallAndMessage): false positive; prior `QVERIFY` aborts on null.
         ok->click();
@@ -5820,7 +5820,7 @@ private slots:
         QVERIFY2(mWindow->Filters().contains(filterKey), "filter must survive the reorder");
         QCOMPARE(mWindow->Filters().at(filterKey).row, dest);
 
-        const QMenu *filtersMenu = mWindow->findChild<QMenu *>(QStringLiteral("menuFilters"));
+        const auto *filtersMenu = mWindow->findChild<QMenu *>(QStringLiteral("menuFilters"));
         QVERIFY2(filtersMenu != nullptr, "MainWindow must expose its Filters menu");
         const QAction *filterMenuAction = nullptr;
         // NOLINTNEXTLINE(clang-analyzer-core.CallAndMessage): false positive; prior `QVERIFY2` aborts on null.
@@ -5834,7 +5834,7 @@ private slots:
         }
         QVERIFY2(filterMenuAction != nullptr, "active filter must have a Filters-menu entry");
 
-        const QMenu *filterSubMenu = filtersMenu->findChild<QMenu *>(filterId);
+        const auto *filterSubMenu = filtersMenu->findChild<QMenu *>(filterId);
         QVERIFY2(filterSubMenu != nullptr, "filter menu entry must own an Edit/Remove sub-menu");
         QAction *editAction = nullptr;
         // NOLINTNEXTLINE(clang-analyzer-core.CallAndMessage): false positive; prior `QVERIFY2` aborts on null.
@@ -6032,7 +6032,7 @@ private slots:
         QVERIFY2(sawEnum, "enum filter on level must revive");
 
         // Filters menu must hold one sub-menu per revived filter.
-        const QMenu *filtersMenu = mWindow->findChild<QMenu *>(QStringLiteral("menuFilters"));
+        const auto *filtersMenu = mWindow->findChild<QMenu *>(QStringLiteral("menuFilters"));
         QVERIFY2(filtersMenu != nullptr, "MainWindow must expose its Filters menu");
         int subMenuCount = 0;
         // NOLINTNEXTLINE(clang-analyzer-core.CallAndMessage): false positive; prior `QVERIFY2` aborts on null.
@@ -6632,7 +6632,7 @@ private slots:
         QCoreApplication::processEvents();
         QCOMPARE(mWindow->FilterModel()->SortColumn(), categoryCol);
 
-        QAction *action = mWindow->findChild<QAction *>(QStringLiteral("actionNewSession"));
+        auto *action = mWindow->findChild<QAction *>(QStringLiteral("actionNewSession"));
         QVERIFY2(action != nullptr, "actionNewSession must be reachable via objectName");
         action->trigger();
         QCoreApplication::processEvents();
@@ -7375,7 +7375,7 @@ private slots:
         const int levelCol = StreamFixtureForColumnTests();
         QVERIFY2(levelCol >= 0, "level column must exist after streaming");
 
-        QMenu *viewMenu = mWindow->findChild<QMenu *>(QStringLiteral("menuView"));
+        auto *viewMenu = mWindow->findChild<QMenu *>(QStringLiteral("menuView"));
         QVERIFY2(viewMenu != nullptr, "MainWindow must expose its View menu");
         // NOLINTNEXTLINE(clang-analyzer-core.CallAndMessage): prior QVERIFY aborts on null.
         emit viewMenu->aboutToShow();
@@ -8275,14 +8275,14 @@ private slots:
         const FilterEditor editor(*model, QStringLiteral("test-empty-enum"));
         // `UpdateSelectedColumn(0)` settles the OK / placeholder state.
 
-        const QPushButton *okButton = editor.findChild<QPushButton *>(QStringLiteral("okButton"));
+        const auto *okButton = editor.findChild<QPushButton *>(QStringLiteral("okButton"));
         QVERIFY2(okButton != nullptr, "FilterEditor must expose an OK button");
         // clang-analyzer does not model `QVERIFY2`'s test-aborting behaviour,
         // so it still considers `okButton` potentially null on the next line.
         // NOLINTNEXTLINE(clang-analyzer-core.CallAndMessage)
         QVERIFY2(!okButton->isEnabled(), "OK must be disabled when the picker dictionary is empty");
 
-        const QLabel *placeholder = editor.findChild<QLabel *>(QStringLiteral("enumEmptyPlaceholder"));
+        const auto *placeholder = editor.findChild<QLabel *>(QStringLiteral("enumEmptyPlaceholder"));
         QVERIFY2(placeholder != nullptr, "FilterEditor must expose the empty-picker placeholder");
         QVERIFY2(
             placeholder->text().contains(QStringLiteral("No values observed"), Qt::CaseInsensitive),
@@ -9931,7 +9931,7 @@ private slots:
         content.formattedJson = QStringLiteral("{\n  \"level\": \"info\",\n  \"message\": \"hello\"\n}");
         widget.SetContent(content);
 
-        const QTableWidget *table = widget.findChild<QTableWidget *>();
+        const auto *table = widget.findChild<QTableWidget *>();
         QVERIFY(table != nullptr);
         QCOMPARE(table->rowCount(), 2);
         QCOMPARE(table->item(0, 0)->text(), QStringLiteral("level"));
@@ -9943,7 +9943,7 @@ private slots:
         QVERIFY2(!table->isHidden(), "fields table must be explicitly shown when content is valid");
 
         // The edit shows the *formatted* JSON, not the compact bytes.
-        const QPlainTextEdit *rawEdit = widget.findChild<QPlainTextEdit *>();
+        const auto *rawEdit = widget.findChild<QPlainTextEdit *>();
         QVERIFY(rawEdit != nullptr);
         QCOMPARE(rawEdit->toPlainText(), content.formattedJson);
 
@@ -9956,7 +9956,7 @@ private slots:
         QCOMPARE(rawEdit->toPlainText(), QString());
 
         // Snapshot windows hide the "Open in new window" button.
-        const QPushButton *popOutButton = widget.findChild<QPushButton *>(QStringLiteral("openInNewWindowButton"));
+        const auto *popOutButton = widget.findChild<QPushButton *>(QStringLiteral("openInNewWindowButton"));
         QVERIFY(popOutButton != nullptr);
         QVERIFY(popOutButton->isVisibleTo(&widget));
         widget.SetOpenInNewWindowVisible(false);
@@ -9981,7 +9981,7 @@ private slots:
         QVERIFY(clipboard != nullptr);
         clipboard->clear();
 
-        QPushButton *copyButton = widget.findChild<QPushButton *>(QStringLiteral("copyJsonButton"));
+        auto *copyButton = widget.findChild<QPushButton *>(QStringLiteral("copyJsonButton"));
         QVERIFY(copyButton != nullptr);
 
         const QString pasted = ClickAndReadClipboardWithRetry(clipboard, copyButton, content.rawJson);
@@ -10009,7 +10009,7 @@ private slots:
         QVERIFY(clipboard != nullptr);
         clipboard->clear();
 
-        QPushButton *copyButton = widget.findChild<QPushButton *>(QStringLiteral("copyKeyValueButton"));
+        auto *copyButton = widget.findChild<QPushButton *>(QStringLiteral("copyKeyValueButton"));
         QVERIFY(copyButton != nullptr);
         // NOLINTNEXTLINE(clang-analyzer-core.CallAndMessage)
         QVERIFY(copyButton->isEnabled());
@@ -10034,8 +10034,8 @@ private slots:
         content.formattedJson = QString();
         widget.SetContent(content);
 
-        const QPushButton *rawButton = widget.findChild<QPushButton *>(QStringLiteral("copyJsonButton"));
-        const QPushButton *kvButton = widget.findChild<QPushButton *>(QStringLiteral("copyKeyValueButton"));
+        const auto *rawButton = widget.findChild<QPushButton *>(QStringLiteral("copyJsonButton"));
+        const auto *kvButton = widget.findChild<QPushButton *>(QStringLiteral("copyKeyValueButton"));
         QVERIFY(rawButton != nullptr);
         QVERIFY(kvButton != nullptr);
         QVERIFY2(!rawButton->isEnabled(), "Copy raw JSON must be disabled when there's no raw text");
@@ -10150,7 +10150,7 @@ private slots:
         content.fields.append({QStringLiteral("dashy"), QStringLiteral("\u2014")});
         widget.SetContent(content);
 
-        const QTableWidget *table = widget.findChild<QTableWidget *>();
+        const auto *table = widget.findChild<QTableWidget *>();
         QVERIFY(table != nullptr);
         QCOMPARE(table->rowCount(), 3);
 
@@ -10199,7 +10199,7 @@ private slots:
         withEmpty.fields.append({QStringLiteral("k"), QString()});
         widget.SetContent(withEmpty);
 
-        const QTableWidget *table = widget.findChild<QTableWidget *>();
+        const auto *table = widget.findChild<QTableWidget *>();
         QVERIFY(table != nullptr);
         QCOMPARE(table->rowCount(), 1);
         const QTableWidgetItem *valueItem = table->item(0, 1);
@@ -10245,7 +10245,7 @@ private slots:
         content.fields.append({QStringLiteral("gamma"), QStringLiteral("3")});
         widget.SetContent(content);
 
-        QTableWidget *table = widget.findChild<QTableWidget *>();
+        auto *table = widget.findChild<QTableWidget *>();
         QVERIFY(table != nullptr);
         QCOMPARE(table->rowCount(), 3);
 


### PR DESCRIPTION
## Summary

Cleans up the LTO-era test workarounds now that the underlying toolchain bug is fixed at the source. Net diff: **-510 / +138 lines** across 9 files.

The Linux+GCC+IPO/LTO `staticMetaObject` zero-init crash (LLVM #189203 PIC/non-PIC LTO mixing defect) was fixed in #44 by setting `CMAKE_POSITION_INDEPENDENT_CODE=ON` globally; the four hotfix releases (`v0.9.1`, `v0.8.1`, `v0.7.1`, `v0.6.2`) carry the same gate. With the metaobject sound, `findChild<T*>` / `findChildren<T*>` traversal works as documented again, so the explicit-pointer `*ForTest()` and `Find*` shims that were added to bypass it are pure dead weight.

Three commits for review clarity:

1. **`cf3e5d1` -- pre-stage `setObjectName` + retighten one comment**
   * 9 `setObjectName(...)` calls in `app/src/filter_editor.cpp` for the widgets that collide with same-type siblings inside the dialog (`mBeginDateEdit`, `mEndDateEdit`, `mBeginTimeEdit`, `mEndTimeEdit`, `mBeginUnboundedCheckBox`, `mEndUnboundedCheckBox`, `mEnumSearchEdit`, `mEnumEmptyPlaceholder`, `mOkButton`).
   * 1 `setObjectName(id)` in `MainWindow::AddLogFilter` and 1 in `BuildHeaderContextMenu` so per-filter submenus are reachable via the filter UUID.
   * `ShowRecordDetailsForProxyIndex`'s `isVisible()` guard and its mirror in `actionToggleRecordDetails::toggled` keep their behaviour but the comment is rewritten to drop the LTO framing -- the underlying issue (`QDockWidget::setVisible(true)` walking `QMainWindowLayout` dock-area state on an un-shown host) is a separate offscreen-QPA layout quirk and the guard costs nothing in production. Leaving the guard in place as defense-in-depth for tests that don't `show()` the host.

2. **`8faeb8e` -- drop dialog/widget LTO-era test accessors**
   * `ConfigurationDiagnosticsDialog::TableForTest` (1 test site).
   * `ColumnEditor::HeaderEditForTest`, `TypeComboForTest`, `VisibleCheckForTest` (8 sites).
   * `ColumnsManagerDialog::TableForTest` (6 sites).
   * `RecordDetailWidget::FieldsTableForTest`, `RawEditForTest`, `RawGroupForTest`, `CopyJsonButtonForTest`, `CopyKeyValueButtonForTest`, `OpenInNewWindowButtonForTest` (14 sites).
   * `RecordDetailWindow::WidgetForTest` (4 sites).
   * `FilterEditor` enum-picker / time-page / OK-button accessors (13 sites).
   * Test rewrites use type-only `findChild<T*>()` where the widget is unique by type in its parent (`QTableWidget`, `QPlainTextEdit`, `QGroupBox`, `QLineEdit`, `QComboBox`, `QCheckBox`, `QListView`, `QSortFilterProxyModel`, `RecordDetailWidget`) and named `findChild<T*>("name")` for the colliding cases (the three sibling `QPushButton`s in `RecordDetailWidget` plus every named `FilterEditor` widget the previous commit added `setObjectName` for).

3. **`33104d6` -- drop `MainWindow` LTO-era test accessors and stale comments**
   * `FindUiAction(name)` -- 77-line if-ladder over `ui->actionXxx`. Replaced with named `findChild<QAction*>("actionXxx")` (`setupUi` already auto-names every action).
   * `FiltersMenu()`, `ViewMenu()`, `RecentSessionsMenu()`. Replaced with named `findChild<QMenu*>` lookups.
   * `FilterSubMenu(filterID)` and the `mFilterSubMenus` member that backed it. The map was maintained in `AddLogFilter` / `ClearFilter` / `ClearAllFilters` purely to feed the test accessor; with commit 1's `setObjectName(id)` on the live submenu, tests reach it via `filtersMenu->findChild<QMenu*>(id)`.
   * `RecordDetailDockForTest()`, `TableViewForTest()`, `RecordDetailWindowsForTest()`, `DiagnosticsButtonForTest()`. Replaced with type-only or named `findChild` / `findChildren`.
   * `HeaderContextMenu::filterSubMenus` field on the struct returned from `BuildHeaderContextMenu` -- same logic; tests now walk `built.menu->findChild<QMenu*>(filterId)`.
   * `FindActionByObjectName` test helper shrinks from 28 lines (with multi-paragraph LTO blame) to a single `return window->findChild<QAction*>(name);`. Kept as an intent-bearing wrapper.
   * The `emit dock.visibilityChanged(...)` idiom in `main_window_test.cpp` lines 480-489 stays. Its real purpose is to drive `RecordDetailDock::mPerceivedVisible` directly so tests can simulate "buried tab" transitions where the perceived flag flips without `setVisible` flipping the explicit-hide flag. Comment was rewritten to drop the LTO/SIGSEGV framing.
   * Comments throughout the test file retighten -- every "Linux runner with Qt 6.8 + offscreen QPA" / "GitHub-hosted Linux runner" / "metaobject hooks stripped" blame trail is gone. The load-bearing `CMakeLists.txt` comment explaining the `CMAKE_POSITION_INDEPENDENT_CODE=ON` global gate is the only remaining LLVM-189203 reference.

## Bucket B (kept; not LTO-related)

These all stay in place; they are legitimate test entry points / instrumentation that any black-box test would need on any platform:

* `MainWindow::SetSessionModeForTest`, `SetSuppressDialogsForTest`, `LastDroppedFilterCountForTest`, `SetCurrentSourceForTest`, the `Save/Load/Open*ForTest` file-shim entry points.
* `ThemeControl::SetOsColorSchemeForTest`, `IsColorSchemeForcedForTest`.
* `LogFilterModel::EnumRankCacheSizeForTest`.
* `RecordDetailDock::RefreshCountForTest` / `mRefreshCount`.
* `LOGAPP_BUILD_TESTING` macro itself + the `target_compile_definitions(logapp PUBLIC LOGAPP_BUILD_TESTING)` in `test/app/CMakeLists.txt`.

## Test plan

- [x] Local Windows + MSVC + Release + IPO build green: `cmake --build build/release --target apptest apptest_theme apptest_queue --config Release`.
- [x] Full `ctest -LE benchmark`: **312 / 312 passed** locally (Windows + Release + IPO), incl. the 14k-line `apptest` GUI suite in 28.3 s.
- [x] CI: Linux + Release + IPO + offscreen QPA must pass. This is the configuration that originally SegFaulted under the LTO bug; passing here is the empirical proof that `findChild<>` (and `findChildren<>`) is sound again post-#44 and the workarounds were correctly identified.
- [x] CI: Linux ASan/UBSan, macOS, Windows must all stay green.

If CI somehow regresses on Linux+Release+IPO -- which would mean a particular `findChild` lookup the explore plan thought was safe is actually not -- the failure should pinpoint which one and the fix is to add a missing `setObjectName` (or fall back to type-only lookup) at the point of failure, not to revert the whole cleanup.
