### PR TITLE
GUI polish: modern find bar + dockable Find / Parse Errors panels

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -178,8 +178,11 @@ jobs:
         # fail_ci_if_error: a broken upload (e.g. app uninstalled) fails the leg
         # loudly instead of silently producing zero-coverage runs.
         # SHA-pinned so a tag re-cut can't change what we run.
+        # v7.0.0: ships the new `codecovsecops` GPG key after Codecov's
+        # `codecovsecurity` keybase migration left the wrapper unable to verify
+        # the uploader binary's signature on `v6.0.1` and earlier.
         if: matrix.mode == 'coverage'
-        uses: codecov/codecov-action@e79a6962e0d4c0c17b229090214935d2e33f8354 # v6.0.1
+        uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
         with:
           files: ./coverage.lcov
           fail_ci_if_error: true

--- a/app/CMakeLists.txt
+++ b/app/CMakeLists.txt
@@ -27,6 +27,10 @@ set(PROJECT_SOURCES
     include/log_table_view.hpp
     src/find_record_widget.cpp
     include/find_record_widget.hpp
+    src/find_dock.cpp
+    include/find_dock.hpp
+    src/parse_errors_dock.cpp
+    include/parse_errors_dock.hpp
     src/log_filter_model.cpp
     include/log_filter_model.hpp
     src/row_order_proxy_model.cpp

--- a/app/include/anchors_dock.hpp
+++ b/app/include/anchors_dock.hpp
@@ -42,18 +42,12 @@ signals:
     /// Argument is -1 when the anchor key has no live row.
     void jumpToAnchorRequested(int sourceRow);
 
-    /// Emitted when the user actually dismisses the dock (X
-    /// button, system close). Not emitted on tab inactivation,
-    /// so the View-menu toggle keyed off this signal stays
-    /// accurate even when the dock is tabified with another.
+    /// Emitted on genuine user dismissal (X button, system close).
+    /// Distinct from `visibilityChanged(false)`, which also fires on
+    /// tab inactivation in a tabified group.
     void closed();
 
 protected:
-    /// Emit `closed` after the base class accepts the close so
-    /// `QDockWidget::visibilityChanged(false)` -- which also
-    /// fires on tab switches -- doesn't have to disambiguate
-    /// "user closed me" from "I'm just buried under a sibling
-    /// tab".
     void closeEvent(QCloseEvent *event) override;
 
 #ifdef LOGAPP_BUILD_TESTING

--- a/app/include/anchors_dock.hpp
+++ b/app/include/anchors_dock.hpp
@@ -7,6 +7,7 @@
 
 class LogModel;
 class ThemeControl;
+class QCloseEvent;
 class QListWidget;
 class QListWidgetItem;
 class QPushButton;
@@ -40,6 +41,20 @@ signals:
     /// User asked to navigate to source-model row @p sourceRow.
     /// Argument is -1 when the anchor key has no live row.
     void jumpToAnchorRequested(int sourceRow);
+
+    /// Emitted when the user actually dismisses the dock (X
+    /// button, system close). Not emitted on tab inactivation,
+    /// so the View-menu toggle keyed off this signal stays
+    /// accurate even when the dock is tabified with another.
+    void closed();
+
+protected:
+    /// Emit `closed` after the base class accepts the close so
+    /// `QDockWidget::visibilityChanged(false)` -- which also
+    /// fires on tab switches -- doesn't have to disambiguate
+    /// "user closed me" from "I'm just buried under a sibling
+    /// tab".
+    void closeEvent(QCloseEvent *event) override;
 
 #ifdef LOGAPP_BUILD_TESTING
 public:

--- a/app/include/configuration_diagnostics_dialog.hpp
+++ b/app/include/configuration_diagnostics_dialog.hpp
@@ -31,11 +31,8 @@ public:
     [[nodiscard]] static int MismatchedColumnCount(const LogModel &model);
 
 protected:
-    /// Re-run `Refresh()` whenever the palette/style flips so the
-    /// theme-aware warning-row highlight tracks Light <-> Dark
-    /// switches while the dialog is open. Without this, the cell
-    /// brushes stay frozen at whatever colour they were when the
-    /// dialog was first populated.
+    /// Re-render so the warning-row tint follows Light <-> Dark
+    /// switches while the dialog is open.
     void changeEvent(QEvent *event) override;
 
 signals:

--- a/app/include/configuration_diagnostics_dialog.hpp
+++ b/app/include/configuration_diagnostics_dialog.hpp
@@ -30,6 +30,14 @@ public:
     /// data. Shared between the status-bar summary and the dialog.
     [[nodiscard]] static int MismatchedColumnCount(const LogModel &model);
 
+protected:
+    /// Re-run `Refresh()` whenever the palette/style flips so the
+    /// theme-aware warning-row highlight tracks Light <-> Dark
+    /// switches while the dialog is open. Without this, the cell
+    /// brushes stay frozen at whatever colour they were when the
+    /// dialog was first populated.
+    void changeEvent(QEvent *event) override;
+
 signals:
     /// Emitted when the user double-clicks a row. `MainWindow` opens
     /// the column editor in response.

--- a/app/include/find_dock.hpp
+++ b/app/include/find_dock.hpp
@@ -8,17 +8,11 @@ class QCloseEvent;
 class QShowEvent;
 class QWidget;
 
-/// Dockable host for `FindRecordWidget`.
+/// Dockable host for `FindRecordWidget`. Position persists via
+/// `QMainWindow::saveState()` / `restoreState()`.
 ///
-/// Promotes the find bar to first-class window furniture matching
-/// `RecordDetailDock` and the anchors dock: free floating /
-/// dockable / closable chrome, with position persisted via
-/// `QMainWindow::saveState()` / `restoreState()` (keyed on the
-/// dock's `objectName`).
-///
-/// Allowed areas are top + bottom only — find bars are horizontal
-/// strips by convention; a vertical side dock would force the
-/// search field into an unnatural narrow column.
+/// Allowed areas are top + bottom only; a vertical side dock would
+/// squeeze the search field into an unusable narrow column.
 class FindDock : public QDockWidget
 {
     Q_OBJECT
@@ -32,67 +26,34 @@ public:
         return mWidget;
     }
 
-    /// Show + raise the dock and focus the embedded line edit so
-    /// the next keystroke lands in the search field. Idempotent.
-    ///
-    /// Re-stashes the currently-focused widget on *every* call
-    /// whose source focus is outside our subtree, so a Ctrl+F
-    /// invoked while the bar is already on-screen but the user
-    /// had clicked back into the table view picks up the most
-    /// recent target (rather than holding the original from the
-    /// very first reveal). The ancestor guard keeps a focus that
-    /// already lives inside the bar from stashing itself --
-    /// otherwise dismissing the bar would just bounce focus back
-    /// into the bar's own widget tree.
+    /// Show + raise the dock and focus the search field. Idempotent.
+    /// On every call, stashes the previously-focused widget (when
+    /// outside our subtree) so dismissing the bar can restore it.
     void RevealAndFocus();
 
 signals:
-    /// Emitted whenever the user actually closes the dock (X
-    /// button, `close()` from `DismissBar`, or system close). Not
-    /// emitted when the dock is merely hidden as the inactive tab
-    /// of a tabified group -- `visibilityChanged(false)` fires on
-    /// tab switches too, so the menu toggle uses this signal to
-    /// distinguish "user dismissed me" from "I'm just buried".
+    /// Emitted on genuine user dismissal (X button, `close()` from
+    /// `DismissBar`, system close). Distinct from
+    /// `visibilityChanged(false)`, which also fires on tab inactivation.
     void closed();
 
-    /// Emitted when the dock becomes visible to the user, whether
-    /// from a cold reveal or a tab activation. Mirrors
-    /// `QDockWidget::visibilityChanged(true)` but is documented as
-    /// the canonical "the user is looking at the find bar now"
-    /// hook so `MainWindow` can refresh the match count after
-    /// model activity that happened while the bar was buried.
+    /// Emitted when the bar becomes visible (cold reveal or tab
+    /// activation). Named alias for `visibilityChanged(true)` that
+    /// keeps the wiring self-documenting.
     void revealed();
 
 protected:
-    /// Restore focus to whatever held it before the bar opened,
-    /// then emit `closed`. Both live here (rather than in
-    /// `hideEvent`) so tab inactivation in a tabified group
-    /// does not steal focus from the newly-active sibling tab:
-    /// `hideEvent` fires on every tab switch, `closeEvent` only on
-    /// genuine dismissal (X button, Escape via `DismissBar`, View
-    /// menu toggle off -- all of which route through `close()`).
-    ///
-    /// `QPointer` on `mFocusBeforeReveal` covers the case where
-    /// the prior focus widget was deleted while the bar was open
-    /// (e.g. a config reload tore down the table view).
+    /// Restore focus to the stashed widget, then emit `closed`.
     void closeEvent(QCloseEvent *event) override;
 
-    /// Emit `revealed` so `MainWindow` can refresh the match
-    /// count if model / proxy activity invalidated it while the
-    /// bar was hidden or tab-buried. Connecting to plain
-    /// `QDockWidget::visibilityChanged(true)` would work too, but
-    /// keeping a named signal keeps the wiring self-documenting
-    /// at the call site.
+    /// Emit `revealed` so listeners can refresh state that went stale
+    /// while the bar was hidden / tab-buried.
     void showEvent(QShowEvent *event) override;
 
 private:
     FindRecordWidget *mWidget = nullptr;
 
-    /// Stashed focus target refreshed by every `RevealAndFocus`
-    /// whose source focus is outside the bar's subtree (see
-    /// `RevealAndFocus` for the full rationale). Cleared when
-    /// consumed by `closeEvent` so a second close (after a
-    /// second reveal without a fresh focus target) can't restore
-    /// to a stale pointer.
+    /// Widget that held focus before the last reveal. `QPointer`
+    /// guards against the widget being destroyed while the bar is open.
     QPointer<QWidget> mFocusBeforeReveal;
 };

--- a/app/include/find_dock.hpp
+++ b/app/include/find_dock.hpp
@@ -5,6 +5,7 @@
 
 class FindRecordWidget;
 class QCloseEvent;
+class QShowEvent;
 class QWidget;
 
 /// Dockable host for `FindRecordWidget`.
@@ -49,28 +50,42 @@ signals:
     /// distinguish "user dismissed me" from "I'm just buried".
     void closed();
 
-protected:
-    /// Restore focus to whatever held it before the bar opened.
-    /// Wired to `hideEvent` rather than `closeEvent` so every
-    /// dismissal path covers it: the dock's "X" button, Escape
-    /// (via `DismissBar`), the View menu toggle (which calls
-    /// `hide()`, bypassing `closeEvent`), and `restoreState`.
-    /// `QPointer` covers the case where the prior focus widget
-    /// was deleted while the bar was open (e.g. a config reload
-    /// tore down the table view).
-    void hideEvent(QHideEvent *event) override;
+    /// Emitted when the dock becomes visible to the user, whether
+    /// from a cold reveal or a tab activation. Mirrors
+    /// `QDockWidget::visibilityChanged(true)` but is documented as
+    /// the canonical "the user is looking at the find bar now"
+    /// hook so `MainWindow` can refresh the match count after
+    /// model activity that happened while the bar was buried.
+    void revealed();
 
-    /// Emit `closed` after the base class accepts the event so
-    /// the menu toggle can drop the checkmark even when the dock
-    /// is tabified (`visibilityChanged(false)` alone fires on tab
-    /// inactivation, which would otherwise un-check the menu
-    /// entry every time the user switches tabs).
+protected:
+    /// Restore focus to whatever held it before the bar opened,
+    /// then emit `closed`. Both live here (rather than in
+    /// `hideEvent`) so tab inactivation in a tabified group
+    /// does not steal focus from the newly-active sibling tab:
+    /// `hideEvent` fires on every tab switch, `closeEvent` only on
+    /// genuine dismissal (X button, Escape via `DismissBar`, View
+    /// menu toggle off -- all of which route through `close()`).
+    ///
+    /// `QPointer` on `mFocusBeforeReveal` covers the case where
+    /// the prior focus widget was deleted while the bar was open
+    /// (e.g. a config reload tore down the table view).
     void closeEvent(QCloseEvent *event) override;
+
+    /// Emit `revealed` so `MainWindow` can refresh the match
+    /// count if model / proxy activity invalidated it while the
+    /// bar was hidden or tab-buried. Connecting to plain
+    /// `QDockWidget::visibilityChanged(true)` would work too, but
+    /// keeping a named signal keeps the wiring self-documenting
+    /// at the call site.
+    void showEvent(QShowEvent *event) override;
 
 private:
     FindRecordWidget *mWidget = nullptr;
 
     /// Stashed focus target captured by `RevealAndFocus`. Cleared
-    /// on `hideEvent` so a second hide can't re-steal focus.
+    /// when consumed by `closeEvent` so a second close (after a
+    /// second reveal without a fresh focus target) can't restore
+    /// to a stale pointer.
     QPointer<QWidget> mFocusBeforeReveal;
 };

--- a/app/include/find_dock.hpp
+++ b/app/include/find_dock.hpp
@@ -1,0 +1,37 @@
+#pragma once
+
+#include <QDockWidget>
+
+class FindRecordWidget;
+
+/// Dockable host for `FindRecordWidget`.
+///
+/// Promotes the find bar to first-class window furniture matching
+/// `RecordDetailDock` and the anchors dock: free floating /
+/// dockable / closable chrome, with position persisted via
+/// `QMainWindow::saveState()` / `restoreState()` (keyed on the
+/// dock's `objectName`).
+///
+/// Allowed areas are top + bottom only — find bars are horizontal
+/// strips by convention; a vertical side dock would force the
+/// search field into an unnatural narrow column.
+class FindDock : public QDockWidget
+{
+    Q_OBJECT
+
+public:
+    explicit FindDock(QWidget *parent = nullptr);
+
+    /// The hosted find widget. Borrow only; the dock owns it.
+    [[nodiscard]] FindRecordWidget *Widget() const noexcept
+    {
+        return mWidget;
+    }
+
+    /// Show + raise the dock and focus the embedded line edit so
+    /// the next keystroke lands in the search field. Idempotent.
+    void RevealAndFocus();
+
+private:
+    FindRecordWidget *mWidget = nullptr;
+};

--- a/app/include/find_dock.hpp
+++ b/app/include/find_dock.hpp
@@ -35,10 +35,15 @@ public:
     /// Show + raise the dock and focus the embedded line edit so
     /// the next keystroke lands in the search field. Idempotent.
     ///
-    /// Captures the currently-focused widget so a subsequent
-    /// `hideEvent` (Esc, "X" button, View menu toggle off) can
-    /// hand focus back to it. Without this, dismissing the bar
-    /// leaves focus dangling on whatever Qt picks next.
+    /// Re-stashes the currently-focused widget on *every* call
+    /// whose source focus is outside our subtree, so a Ctrl+F
+    /// invoked while the bar is already on-screen but the user
+    /// had clicked back into the table view picks up the most
+    /// recent target (rather than holding the original from the
+    /// very first reveal). The ancestor guard keeps a focus that
+    /// already lives inside the bar from stashing itself --
+    /// otherwise dismissing the bar would just bounce focus back
+    /// into the bar's own widget tree.
     void RevealAndFocus();
 
 signals:
@@ -83,8 +88,10 @@ protected:
 private:
     FindRecordWidget *mWidget = nullptr;
 
-    /// Stashed focus target captured by `RevealAndFocus`. Cleared
-    /// when consumed by `closeEvent` so a second close (after a
+    /// Stashed focus target refreshed by every `RevealAndFocus`
+    /// whose source focus is outside the bar's subtree (see
+    /// `RevealAndFocus` for the full rationale). Cleared when
+    /// consumed by `closeEvent` so a second close (after a
     /// second reveal without a fresh focus target) can't restore
     /// to a stale pointer.
     QPointer<QWidget> mFocusBeforeReveal;

--- a/app/include/find_dock.hpp
+++ b/app/include/find_dock.hpp
@@ -1,8 +1,10 @@
 #pragma once
 
 #include <QDockWidget>
+#include <QPointer>
 
 class FindRecordWidget;
+class QWidget;
 
 /// Dockable host for `FindRecordWidget`.
 ///
@@ -30,8 +32,28 @@ public:
 
     /// Show + raise the dock and focus the embedded line edit so
     /// the next keystroke lands in the search field. Idempotent.
+    ///
+    /// Captures the currently-focused widget so a subsequent
+    /// `hideEvent` (Esc, "X" button, View menu toggle off) can
+    /// hand focus back to it. Without this, dismissing the bar
+    /// leaves focus dangling on whatever Qt picks next.
     void RevealAndFocus();
+
+protected:
+    /// Restore focus to whatever held it before the bar opened.
+    /// Wired to `hideEvent` rather than `closeEvent` so every
+    /// dismissal path covers it: the dock's "X" button, Escape
+    /// (via `DismissBar`), the View menu toggle (which calls
+    /// `hide()`, bypassing `closeEvent`), and `restoreState`.
+    /// `QPointer` covers the case where the prior focus widget
+    /// was deleted while the bar was open (e.g. a config reload
+    /// tore down the table view).
+    void hideEvent(QHideEvent *event) override;
 
 private:
     FindRecordWidget *mWidget = nullptr;
+
+    /// Stashed focus target captured by `RevealAndFocus`. Cleared
+    /// on `hideEvent` so a second hide can't re-steal focus.
+    QPointer<QWidget> mFocusBeforeReveal;
 };

--- a/app/include/find_dock.hpp
+++ b/app/include/find_dock.hpp
@@ -4,6 +4,7 @@
 #include <QPointer>
 
 class FindRecordWidget;
+class QCloseEvent;
 class QWidget;
 
 /// Dockable host for `FindRecordWidget`.
@@ -39,6 +40,15 @@ public:
     /// leaves focus dangling on whatever Qt picks next.
     void RevealAndFocus();
 
+signals:
+    /// Emitted whenever the user actually closes the dock (X
+    /// button, `close()` from `DismissBar`, or system close). Not
+    /// emitted when the dock is merely hidden as the inactive tab
+    /// of a tabified group -- `visibilityChanged(false)` fires on
+    /// tab switches too, so the menu toggle uses this signal to
+    /// distinguish "user dismissed me" from "I'm just buried".
+    void closed();
+
 protected:
     /// Restore focus to whatever held it before the bar opened.
     /// Wired to `hideEvent` rather than `closeEvent` so every
@@ -49,6 +59,13 @@ protected:
     /// was deleted while the bar was open (e.g. a config reload
     /// tore down the table view).
     void hideEvent(QHideEvent *event) override;
+
+    /// Emit `closed` after the base class accepts the event so
+    /// the menu toggle can drop the checkmark even when the dock
+    /// is tabified (`visibilityChanged(false)` alone fires on tab
+    /// inactivation, which would otherwise un-check the menu
+    /// entry every time the user switches tabs).
+    void closeEvent(QCloseEvent *event) override;
 
 private:
     FindRecordWidget *mWidget = nullptr;

--- a/app/include/find_record_widget.hpp
+++ b/app/include/find_record_widget.hpp
@@ -59,7 +59,12 @@ public slots:
     /// - `total <= 0`: hides the label entirely (empty needle).
     /// - `current <= 0`: shows "%n matches" (no current pin yet).
     /// - `current > 0`: shows "%1 of %2".
-    void SetMatchInfo(int current, int total);
+    /// - `overflowed = true`: appends a `+` to the total ("10,000+
+    ///   matches", "1 of 10,000+") so the user sees that the
+    ///   parent capped the scan rather than that they happened to
+    ///   land at exactly the cap. The cap lives on the parent;
+    ///   this widget only renders the flag.
+    void SetMatchInfo(int current, int total, bool overflowed = false);
 
     /// Close the host `QDockWidget` so `visibilityChanged`
     /// mirrors the View-menu toggle and a subsequent
@@ -124,4 +129,16 @@ private:
     /// scan instead of N. Plain `QTimer::singleShot` does not
     /// coalesce (each call schedules a fresh fire).
     QTimer *mMatchCountTimer = nullptr;
+
+    /// Maximum-age timer. `mMatchCountTimer` restarts on every
+    /// keystroke / model bump and never fires under continuous
+    /// activity (live-tail streaming, fast typing). This timer
+    /// is started once when the trailing timer first arms and is
+    /// *not* restarted by subsequent bumps -- so it forces an
+    /// emit after at most `MATCH_COUNT_MAX_AGE_MS`, keeping the
+    /// "*i* of *N*" indicator usable during continuous streaming
+    /// instead of stranding the value from before the stream
+    /// started. Both timers' `timeout` route through
+    /// `EmitMatchCountRequest`, which stops both.
+    QTimer *mMatchCountMaxAgeTimer = nullptr;
 };

--- a/app/include/find_record_widget.hpp
+++ b/app/include/find_record_widget.hpp
@@ -12,28 +12,37 @@ class QObject;
 class QTimer;
 class QToolButton;
 
-/// Modern incremental find bar.
+/// Modern incremental find bar, in the spirit of VS Code,
+/// QtCreator and Kate. The bar is a horizontal `QLineEdit` flanked
+/// by:
+///   - flat `QToolButton`s for the regex (`.*`) and wildcard
+///     (`*?`) match modes (mutually exclusive -- toggling one
+///     un-toggles the other),
+///   - a `QLabel` showing "*i* of *N*" or "*N* matches" live,
+///   - Up / Down arrow `QToolButton`s for find-prev / find-next.
 ///
-/// Looks and feels like the find bar in VS Code, QtCreator, and
-/// Kate:
-///   - leading magnifying-glass icon and trailing clear button
-///     inside the `QLineEdit`,
-///   - trailing toggle "buttons" (regex / wildcards) embedded in
-///     the line edit via `QLineEdit::addAction(...,
-///     TrailingPosition)`,
-///   - Up / Down arrow `QToolButton`s for find-prev / find-next,
-///   - `QLabel` showing "*i* of *N*" or "*N* matches" live,
-///   - `Escape` closes the host dock (no literal "X" button),
-///   - `Return` triggers find-next, `Shift+Return` find-prev
-///     (Chromium / VS Code convention).
+/// The `QLineEdit` itself provides the trailing clear button via
+/// `setClearButtonEnabled(true)`. The toggles are *not* embedded
+/// in the line edit via `QLineEdit::addAction(..., TrailingPosition)`
+/// because that path renders the action's icon only -- the `.*`
+/// and `*?` glyphs would be invisible and no `QStyle::SP_*` icon
+/// reads unambiguously as regex or wildcard.
+///
+/// Keys (Chromium / VS Code convention):
+///   - `Return`        -> find-next,
+///   - `Shift+Return`  -> find-previous,
+///   - `Escape`        -> dismiss the host dock.
+/// There is no literal "X" button -- the host `QDockWidget`'s
+/// title-bar X is the canonical close affordance.
 ///
 /// Live match counts are driven by the parent: the widget emits
 /// `MatchCountRequested` whenever the search text or its toggles
-/// change, and the parent answers via `SetMatchInfo`. The
-/// `FindRecords` signal still drives the "jump to next / prev"
-/// behaviour, which the parent answers by updating the table view
-/// selection and (optionally) calling `SetMatchInfo` with the new
-/// position.
+/// change, debounced through an owned `QTimer` so a fast typist
+/// doesn't trigger a full-table scan on every keystroke. The
+/// parent answers via `SetMatchInfo`. The `FindRecords` signal
+/// still drives the "jump to next / prev" behaviour, which the
+/// parent answers by updating the table view selection and
+/// (optionally) calling `SetMatchInfo` with the new position.
 class FindRecordWidget : public QWidget
 {
     Q_OBJECT

--- a/app/include/find_record_widget.hpp
+++ b/app/include/find_record_widget.hpp
@@ -13,37 +13,20 @@ class QObject;
 class QTimer;
 class QToolButton;
 
-/// Modern incremental find bar, in the spirit of VS Code,
-/// QtCreator and Kate. The bar is a horizontal `QLineEdit` flanked
-/// by:
-///   - flat `QToolButton`s for the regex (`.*`) and wildcard
-///     (`*?`) match modes (mutually exclusive -- toggling one
-///     un-toggles the other),
-///   - a `QLabel` showing "*i* of *N*" or "*N* matches" live,
-///   - Up / Down arrow `QToolButton`s for find-prev / find-next.
-///
-/// The `QLineEdit` itself provides the trailing clear button via
-/// `setClearButtonEnabled(true)`. The toggles are *not* embedded
-/// in the line edit via `QLineEdit::addAction(..., TrailingPosition)`
-/// because that path renders the action's icon only -- the `.*`
-/// and `*?` glyphs would be invisible and no `QStyle::SP_*` icon
-/// reads unambiguously as regex or wildcard.
+/// Modern incremental find bar in the spirit of VS Code, QtCreator,
+/// and Kate. Layout: search field with built-in clear button, regex
+/// (`.*`) and wildcard (`*?`) toggles (mutually exclusive), live
+/// "*i* of *N*" label, and prev / next arrow buttons.
 ///
 /// Keys (Chromium / VS Code convention):
-///   - `Return`        -> find-next,
-///   - `Shift+Return`  -> find-previous,
-///   - `Escape`        -> dismiss the host dock.
-/// There is no literal "X" button -- the host `QDockWidget`'s
-/// title-bar X is the canonical close affordance.
+///   - `Return`        -> find-next
+///   - `Shift+Return`  -> find-previous
+///   - `Escape`        -> dismiss the host dock
 ///
-/// Live match counts are driven by the parent: the widget emits
-/// `MatchCountRequested` whenever the search text or its toggles
-/// change, debounced through an owned `QTimer` so a fast typist
-/// doesn't trigger a full-table scan on every keystroke. The
-/// parent answers via `SetMatchInfo`. The `FindRecords` signal
-/// still drives the "jump to next / prev" behaviour, which the
-/// parent answers by updating the table view selection and
-/// (optionally) calling `SetMatchInfo` with the new position.
+/// Match counts are driven by the parent: the widget emits
+/// `MatchCountRequested` whenever the query changes (debounced), and
+/// the parent answers via `SetMatchInfo`. `FindRecords` still drives
+/// jump-to-next/prev.
 class FindRecordWidget : public QWidget
 {
     Q_OBJECT
@@ -51,90 +34,61 @@ public:
     explicit FindRecordWidget(QWidget *parent = nullptr);
 
 public slots:
-    /// Focus the search field and select its contents so the next
-    /// keystroke replaces them.
+    /// Focus the search field and select its contents.
     void SetEditFocus();
 
     /// Update the "*i* of *N*" / "*N* matches" indicator.
     ///
-    /// - `total <= 0`: blanks the label text (empty needle). The
-    ///   label stays in the layout with its reserved minimum
-    ///   width so the trailing arrow buttons don't jitter every
-    ///   time the indicator appears or disappears.
-    /// - `current <= 0`: shows "%Ln matches" (no current pin yet).
-    /// - `current > 0`: shows "%1 of %2".
-    /// - `overflowed = true`: appends a `+` to the total ("10,000+
-    ///   matches", "1 of 10,000+") so the user sees that the
-    ///   parent capped the scan rather than that they happened to
-    ///   land at exactly the cap. The cap lives on the parent;
-    ///   this widget only renders the flag.
+    /// - `total <= 0`: blanks the label (slot stays reserved so arrow
+    ///   buttons don't jitter).
+    /// - `current <= 0`: shows "*N* matches".
+    /// - `current > 0`: shows "*i* of *N*".
+    /// - `overflowed`: appends "+" so the user can tell the count was
+    ///   capped rather than landing exactly at the cap.
     void SetMatchInfo(int current, int total, bool overflowed = false);
 
-    /// Close the host `QDockWidget` so `visibilityChanged`
-    /// mirrors the View-menu toggle and a subsequent
-    /// `RevealAndFocus` properly re-shows everything. No-op when
-    /// the bar isn't in a dock or the dock is already hidden.
-    /// Wired to the Escape shortcut.
+    /// Close the host `QDockWidget`. Wired to Escape; no-op when not
+    /// hosted in a dock.
     void DismissBar();
 
     /// Re-arm the debounce timer so a `MatchCountRequested` fires
-    /// once after the next quiet window. Used by `MainWindow` to
-    /// react to model / proxy mutations (filter changes, streaming
-    /// batches) without doing a full-table scan on every signal:
-    /// activity in the underlying model just keeps resetting the
-    /// timer until things settle. No-op for an empty needle.
+    /// once after the next quiet window. Lets `MainWindow` invalidate
+    /// the count on model / proxy mutations without scanning per signal.
     void BumpMatchCountDebounce();
 
 signals:
     void FindRecords(const QString &text, bool next, bool wildcards, bool regularExpressions);
 
-    /// Emitted on text change or toggle change so the parent can
-    /// recompute the total match count and answer via
-    /// `SetMatchInfo`. Empty `text` means "no needle"; parents
-    /// should respond with `SetMatchInfo(0, 0)`.
+    /// Fired on text / toggle changes; the parent answers with
+    /// `SetMatchInfo`. Empty `text` means "no needle".
     void MatchCountRequested(const QString &text, bool wildcards, bool regularExpressions);
 
 protected:
     void keyPressEvent(QKeyEvent *event) override;
 
-    /// Intercept `Shift+Return` / `Shift+Enter` on `mEdit` before
-    /// `QLineEdit` swallows it. Plain `QLineEdit::returnPressed`
-    /// fires modifier-agnostic, and `QLineEdit::keyPressEvent`
-    /// accepts the event without bubbling, so the parent's
-    /// `keyPressEvent` never sees Shift+Return. The filter is the
-    /// only reliable point to wire find-previous (Chromium /
-    /// VS Code convention).
+    /// Catches `Shift+Return` on `mEdit` before `QLineEdit` swallows
+    /// it; `returnPressed` is modifier-agnostic and `keyPressEvent`
+    /// doesn't bubble, so the filter is the only way to wire find-prev.
     bool eventFilter(QObject *watched, QEvent *event) override;
 
-    /// Re-paint the next / previous arrow icons whenever the
-    /// application palette or style changes -- the icons are
-    /// painted in `palette().color(WindowText)` so a switch from
-    /// the Light theme to the Dark theme has to refresh them or
-    /// the previously-baked black glyphs stay invisible on the
-    /// new dark background. `QEvent::PaletteChange` covers theme
-    /// switches; `QEvent::StyleChange` covers the parallel
-    /// style swap a theme can apply via `qApp->setStyle`.
+    /// Re-paint arrow icons on palette / style change; the default
+    /// `SP_ArrowUp/Down` pixmaps are baked black and vanish on dark.
     void changeEvent(QEvent *event) override;
 
-    /// Catch device-pixel-ratio changes when the bar moves between
-    /// monitors of different DPI. The icon's backing pixmap is
-    /// allocated at the current `devicePixelRatioF()`; without
-    /// this hook a drag from a 100% to a 200% display would leave
-    /// the chevrons rasterised at the lower resolution and Qt
-    /// would up-scale them.
+    /// Catches `DevicePixelRatioChange` when the bar moves between
+    /// monitors of different DPI; without this the arrow icons stay
+    /// rasterised at the previous DPR.
     bool event(QEvent *event) override;
 
 private slots:
     void FindNext();
     void FindPrevious();
 
-    /// Coalesces text / toggle changes into one `MatchCountRequested`
-    /// emit via a small debounce so a fast typist doesn't trigger
-    /// a full-table scan on every keystroke.
+    /// Restart the debounce; coalesces a burst of text / toggle changes
+    /// into one `MatchCountRequested` emit.
     void RequestMatchCountSoon();
 
-    /// Fires `MatchCountRequested` immediately. Used by the
-    /// debounce timer.
+    /// Fires `MatchCountRequested` now. Used by both debounce timers.
     void EmitMatchCountRequest();
 
 private:
@@ -145,42 +99,21 @@ private:
     QToolButton *mButtonPrevious = nullptr;
     QLabel *mMatchCountLabel = nullptr;
 
-    /// Real debounce timer for `MatchCountRequested`. A single
-    /// owned `QTimer::start()` per keystroke restarts the
-    /// countdown so a fast typist coalesces into one match-count
-    /// scan instead of N. Plain `QTimer::singleShot` does not
-    /// coalesce (each call schedules a fresh fire).
+    /// Trailing-edge debounce: restarted on every keystroke / bump so
+    /// a fast typist coalesces N keystrokes into one match-count scan.
     QTimer *mMatchCountTimer = nullptr;
 
-    /// Maximum-age timer. `mMatchCountTimer` restarts on every
-    /// keystroke / model bump and never fires under continuous
-    /// activity (live-tail streaming, fast typing). This timer
-    /// is started once when the trailing timer first arms and is
-    /// *not* restarted by subsequent bumps -- so it forces an
-    /// emit after at most `MATCH_COUNT_MAX_AGE_MS`, keeping the
-    /// "*i* of *N*" indicator usable during continuous streaming
-    /// instead of stranding the value from before the stream
-    /// started. Both timers' `timeout` route through
-    /// `EmitMatchCountRequest`, which stops both.
+    /// Max-age timer: armed once alongside `mMatchCountTimer` and
+    /// never restarted, so continuous activity (live-tail streaming,
+    /// held keys) can't strand the indicator at a pre-activity value.
     QTimer *mMatchCountMaxAgeTimer = nullptr;
 
-    /// Re-entrancy guard for `EmitMatchCountRequest`. Both timers
-    /// route to the same slot; when their intervals elapse on the
-    /// same event-loop pass, Qt enqueues two `timeout` events.
-    /// The first invocation stops both timers, but the second
-    /// event is already in the queue and would emit a duplicate
-    /// `MatchCountRequested`. The guard collapses the duplicate.
-    /// The recount is idempotent so this is purely a "don't pay
-    /// twice" optimisation.
+    /// Re-entrancy guard: both timers route to the same slot, and a
+    /// simultaneous `timeout` would otherwise double-emit.
     bool mEmittingMatchCountRequest = false;
 
-    /// Paint a small upward / downward chevron in the current
-    /// palette's `WindowText` colour and assign it to the
-    /// respective arrow button. Replaces `QStyle::SP_ArrowUp` /
-    /// `SP_ArrowDown` -- those standard pixmaps are baked black
-    /// on Windows and become invisible on a dark theme.
-    /// `changeEvent` re-runs this on `PaletteChange` /
-    /// `StyleChange` so a theme switch refreshes the glyphs in
-    /// place.
+    /// Repaint the prev/next arrow icons in the current palette's
+    /// `WindowText` colour. Replaces `SP_ArrowUp/Down`, which are
+    /// baked black and invisible on dark themes.
     void RefreshArrowIcons();
 };

--- a/app/include/find_record_widget.hpp
+++ b/app/include/find_record_widget.hpp
@@ -144,4 +144,14 @@ private:
     /// started. Both timers' `timeout` route through
     /// `EmitMatchCountRequest`, which stops both.
     QTimer *mMatchCountMaxAgeTimer = nullptr;
+
+    /// Re-entrancy guard for `EmitMatchCountRequest`. Both timers
+    /// route to the same slot; when their intervals elapse on the
+    /// same event-loop pass, Qt enqueues two `timeout` events.
+    /// The first invocation stops both timers, but the second
+    /// event is already in the queue and would emit a duplicate
+    /// `MatchCountRequested`. The guard collapses the duplicate.
+    /// The recount is idempotent so this is purely a "don't pay
+    /// twice" optimisation.
+    bool mEmittingMatchCountRequest = false;
 };

--- a/app/include/find_record_widget.hpp
+++ b/app/include/find_record_widget.hpp
@@ -60,7 +60,32 @@ public slots:
 
     /// Animated hide. The widget remains in the layout but its
     /// `maximumHeight` is driven to 0 before `hide()`.
+    ///
+    /// Only safe for the legacy in-layout host. When hosted in a
+    /// `QDockWidget`, prefer `DismissBar` (or close the dock
+    /// directly): hiding the inner widget while the dock stays
+    /// visible leaves the dock title bar floating above an empty
+    /// body, and a later `show()` on the dock won't un-hide an
+    /// explicitly-hidden child.
     void HideAnimated();
+
+    /// Close the bar in a host-aware way.
+    ///
+    /// - When parented to a `QDockWidget`, calls `close()` on the
+    ///   dock so `visibilityChanged` mirrors the toggle action and
+    ///   subsequent reveals properly re-show the inner widget.
+    /// - Otherwise falls back to `HideAnimated` (in-layout host).
+    ///
+    /// Idempotent: a no-op when the bar is already hidden.
+    void DismissBar();
+
+    /// Re-arm the debounce timer so a `MatchCountRequested` fires
+    /// once after the next quiet window. Used by `MainWindow` to
+    /// react to model / proxy mutations (filter changes, streaming
+    /// batches) without doing a full-table scan on every signal:
+    /// activity in the underlying model just keeps resetting the
+    /// timer until things settle. No-op for an empty needle.
+    void BumpMatchCountDebounce();
 
 signals:
     void FindRecords(const QString &text, bool next, bool wildcards, bool regularExpressions);
@@ -100,4 +125,11 @@ private:
     /// target for `RevealAnimated`.
     int mNaturalHeight = 0;
     QPointer<QPropertyAnimation> mAnimation;
+
+    /// Real debounce timer for `MatchCountRequested`. A single
+    /// owned `QTimer::start()` per keystroke restarts the
+    /// countdown so a fast typist coalesces into one match-count
+    /// scan instead of N. Plain `QTimer::singleShot` does not
+    /// coalesce (each call schedules a fresh fire).
+    QTimer *mMatchCountTimer = nullptr;
 };

--- a/app/include/find_record_widget.hpp
+++ b/app/include/find_record_widget.hpp
@@ -1,11 +1,41 @@
 #pragma once
 
-#include <QCheckBox>
-#include <QLineEdit>
-#include <QPushButton>
-#include <QToolButton>
+#include <QPointer>
+#include <QString>
 #include <QWidget>
 
+class QAction;
+class QKeyEvent;
+class QLabel;
+class QLineEdit;
+class QPropertyAnimation;
+class QShowEvent;
+class QToolButton;
+
+/// Modern incremental find bar.
+///
+/// Looks and feels like the find bar in VS Code, QtCreator, and
+/// Kate:
+///   - leading magnifying-glass icon and trailing clear button
+///     inside the `QLineEdit`,
+///   - trailing toggle "buttons" (regex / wildcards) embedded in
+///     the line edit via `QLineEdit::addAction(...,
+///     TrailingPosition)`,
+///   - Up / Down arrow `QToolButton`s for find-prev / find-next,
+///   - `QLabel` showing "*i* of *N*" or "*N* matches" live,
+///   - `Escape` hides the bar (no literal "X" button),
+///   - `Return` triggers find-next, `Shift+Return` find-prev
+///     (Chromium / VS Code convention),
+///   - slide-in / slide-out animated via `QPropertyAnimation` on
+///     `maximumHeight`.
+///
+/// Live match counts are driven by the parent: the widget emits
+/// `MatchCountRequested` whenever the search text or its toggles
+/// change, and the parent answers via `SetMatchInfo`. The
+/// `FindRecords` signal still drives the "jump to next / prev"
+/// behaviour, which the parent answers by updating the table view
+/// selection and (optionally) calling `SetMatchInfo` with the new
+/// position.
 class FindRecordWidget : public QWidget
 {
     Q_OBJECT
@@ -13,24 +43,61 @@ public:
     explicit FindRecordWidget(QWidget *parent = nullptr);
 
 public slots:
+    /// Focus the search field and select its contents so the next
+    /// keystroke replaces them.
     void SetEditFocus();
 
-protected:
-    void closeEvent(QCloseEvent *event) override;
+    /// Update the "*i* of *N*" / "*N* matches" indicator.
+    ///
+    /// - `total <= 0`: hides the label entirely (empty needle).
+    /// - `current <= 0`: shows "%n matches" (no current pin yet).
+    /// - `current > 0`: shows "%1 of %2".
+    void SetMatchInfo(int current, int total);
+
+    /// Animated reveal. Use this from the parent instead of
+    /// `show()` so the slide-in transition runs.
+    void RevealAnimated();
+
+    /// Animated hide. The widget remains in the layout but its
+    /// `maximumHeight` is driven to 0 before `hide()`.
+    void HideAnimated();
 
 signals:
     void FindRecords(const QString &text, bool next, bool wildcards, bool regularExpressions);
-    void Closed();
+
+    /// Emitted on text change or toggle change so the parent can
+    /// recompute the total match count and answer via
+    /// `SetMatchInfo`. Empty `text` means "no needle"; parents
+    /// should respond with `SetMatchInfo(0, 0)`.
+    void MatchCountRequested(const QString &text, bool wildcards, bool regularExpressions);
+
+protected:
+    void keyPressEvent(QKeyEvent *event) override;
+    void showEvent(QShowEvent *event) override;
 
 private slots:
     void FindNext();
     void FindPrevious();
 
+    /// Coalesces text / toggle changes into one `MatchCountRequested`
+    /// emit via a small debounce so a fast typist doesn't trigger
+    /// a full-table scan on every keystroke.
+    void RequestMatchCountSoon();
+
+    /// Fires `MatchCountRequested` immediately. Used by the
+    /// debounce timer.
+    void EmitMatchCountRequest();
+
 private:
-    QLineEdit *mEdit;
-    QCheckBox *mCheckBoxWildcards;
-    QCheckBox *mCheckBoxRegularExpressions;
-    QPushButton *mButtonNext;
-    QPushButton *mButtonPrevious;
-    QToolButton *mButtonClose;
+    QLineEdit *mEdit = nullptr;
+    QAction *mWildcardsAction = nullptr;
+    QAction *mRegexAction = nullptr;
+    QToolButton *mButtonNext = nullptr;
+    QToolButton *mButtonPrevious = nullptr;
+    QLabel *mMatchCountLabel = nullptr;
+
+    /// Last expanded height captured in `showEvent`, used as the
+    /// target for `RevealAnimated`.
+    int mNaturalHeight = 0;
+    QPointer<QPropertyAnimation> mAnimation;
 };

--- a/app/include/find_record_widget.hpp
+++ b/app/include/find_record_widget.hpp
@@ -56,8 +56,11 @@ public slots:
 
     /// Update the "*i* of *N*" / "*N* matches" indicator.
     ///
-    /// - `total <= 0`: hides the label entirely (empty needle).
-    /// - `current <= 0`: shows "%n matches" (no current pin yet).
+    /// - `total <= 0`: blanks the label text (empty needle). The
+    ///   label stays in the layout with its reserved minimum
+    ///   width so the trailing arrow buttons don't jitter every
+    ///   time the indicator appears or disappears.
+    /// - `current <= 0`: shows "%Ln matches" (no current pin yet).
     /// - `current > 0`: shows "%1 of %2".
     /// - `overflowed = true`: appends a `+` to the total ("10,000+
     ///   matches", "1 of 10,000+") so the user sees that the

--- a/app/include/find_record_widget.hpp
+++ b/app/include/find_record_widget.hpp
@@ -1,15 +1,15 @@
 #pragma once
 
-#include <QPointer>
 #include <QString>
 #include <QWidget>
 
 class QAction;
+class QEvent;
 class QKeyEvent;
 class QLabel;
 class QLineEdit;
-class QPropertyAnimation;
-class QShowEvent;
+class QObject;
+class QTimer;
 class QToolButton;
 
 /// Modern incremental find bar.
@@ -23,11 +23,9 @@ class QToolButton;
 ///     TrailingPosition)`,
 ///   - Up / Down arrow `QToolButton`s for find-prev / find-next,
 ///   - `QLabel` showing "*i* of *N*" or "*N* matches" live,
-///   - `Escape` hides the bar (no literal "X" button),
+///   - `Escape` closes the host dock (no literal "X" button),
 ///   - `Return` triggers find-next, `Shift+Return` find-prev
-///     (Chromium / VS Code convention),
-///   - slide-in / slide-out animated via `QPropertyAnimation` on
-///     `maximumHeight`.
+///     (Chromium / VS Code convention).
 ///
 /// Live match counts are driven by the parent: the widget emits
 /// `MatchCountRequested` whenever the search text or its toggles
@@ -54,29 +52,11 @@ public slots:
     /// - `current > 0`: shows "%1 of %2".
     void SetMatchInfo(int current, int total);
 
-    /// Animated reveal. Use this from the parent instead of
-    /// `show()` so the slide-in transition runs.
-    void RevealAnimated();
-
-    /// Animated hide. The widget remains in the layout but its
-    /// `maximumHeight` is driven to 0 before `hide()`.
-    ///
-    /// Only safe for the legacy in-layout host. When hosted in a
-    /// `QDockWidget`, prefer `DismissBar` (or close the dock
-    /// directly): hiding the inner widget while the dock stays
-    /// visible leaves the dock title bar floating above an empty
-    /// body, and a later `show()` on the dock won't un-hide an
-    /// explicitly-hidden child.
-    void HideAnimated();
-
-    /// Close the bar in a host-aware way.
-    ///
-    /// - When parented to a `QDockWidget`, calls `close()` on the
-    ///   dock so `visibilityChanged` mirrors the toggle action and
-    ///   subsequent reveals properly re-show the inner widget.
-    /// - Otherwise falls back to `HideAnimated` (in-layout host).
-    ///
-    /// Idempotent: a no-op when the bar is already hidden.
+    /// Close the host `QDockWidget` so `visibilityChanged`
+    /// mirrors the View-menu toggle and a subsequent
+    /// `RevealAndFocus` properly re-shows everything. No-op when
+    /// the bar isn't in a dock or the dock is already hidden.
+    /// Wired to the Escape shortcut.
     void DismissBar();
 
     /// Re-arm the debounce timer so a `MatchCountRequested` fires
@@ -98,7 +78,15 @@ signals:
 
 protected:
     void keyPressEvent(QKeyEvent *event) override;
-    void showEvent(QShowEvent *event) override;
+
+    /// Intercept `Shift+Return` / `Shift+Enter` on `mEdit` before
+    /// `QLineEdit` swallows it. Plain `QLineEdit::returnPressed`
+    /// fires modifier-agnostic, and `QLineEdit::keyPressEvent`
+    /// accepts the event without bubbling, so the parent's
+    /// `keyPressEvent` never sees Shift+Return. The filter is the
+    /// only reliable point to wire find-previous (Chromium /
+    /// VS Code convention).
+    bool eventFilter(QObject *watched, QEvent *event) override;
 
 private slots:
     void FindNext();
@@ -120,11 +108,6 @@ private:
     QToolButton *mButtonNext = nullptr;
     QToolButton *mButtonPrevious = nullptr;
     QLabel *mMatchCountLabel = nullptr;
-
-    /// Last expanded height captured in `showEvent`, used as the
-    /// target for `RevealAnimated`.
-    int mNaturalHeight = 0;
-    QPointer<QPropertyAnimation> mAnimation;
 
     /// Real debounce timer for `MatchCountRequested`. A single
     /// owned `QTimer::start()` per keystroke restarts the

--- a/app/include/find_record_widget.hpp
+++ b/app/include/find_record_widget.hpp
@@ -116,6 +116,14 @@ protected:
     /// style swap a theme can apply via `qApp->setStyle`.
     void changeEvent(QEvent *event) override;
 
+    /// Catch device-pixel-ratio changes when the bar moves between
+    /// monitors of different DPI. The icon's backing pixmap is
+    /// allocated at the current `devicePixelRatioF()`; without
+    /// this hook a drag from a 100% to a 200% display would leave
+    /// the chevrons rasterised at the lower resolution and Qt
+    /// would up-scale them.
+    bool event(QEvent *event) override;
+
 private slots:
     void FindNext();
     void FindPrevious();

--- a/app/include/find_record_widget.hpp
+++ b/app/include/find_record_widget.hpp
@@ -63,13 +63,15 @@ signals:
     /// `SetMatchInfo`. Empty `text` means "no needle".
     void MatchCountRequested(const QString &text, bool wildcards, bool regularExpressions);
 
-protected:
-    void keyPressEvent(QKeyEvent *event) override;
-
+public:
     /// Catches `Shift+Return` on `mEdit` before `QLineEdit` swallows
     /// it; `returnPressed` is modifier-agnostic and `keyPressEvent`
     /// doesn't bubble, so the filter is the only way to wire find-prev.
+    /// Public to match `QObject::eventFilter`'s visibility.
     bool eventFilter(QObject *watched, QEvent *event) override;
+
+protected:
+    void keyPressEvent(QKeyEvent *event) override;
 
     /// Re-paint arrow icons on palette / style change; the default
     /// `SP_ArrowUp/Down` pixmaps are baked black and vanish on dark.

--- a/app/include/find_record_widget.hpp
+++ b/app/include/find_record_widget.hpp
@@ -5,6 +5,7 @@
 
 class QAction;
 class QEvent;
+class QIcon;
 class QKeyEvent;
 class QLabel;
 class QLineEdit;
@@ -105,6 +106,16 @@ protected:
     /// VS Code convention).
     bool eventFilter(QObject *watched, QEvent *event) override;
 
+    /// Re-paint the next / previous arrow icons whenever the
+    /// application palette or style changes -- the icons are
+    /// painted in `palette().color(WindowText)` so a switch from
+    /// the Light theme to the Dark theme has to refresh them or
+    /// the previously-baked black glyphs stay invisible on the
+    /// new dark background. `QEvent::PaletteChange` covers theme
+    /// switches; `QEvent::StyleChange` covers the parallel
+    /// style swap a theme can apply via `qApp->setStyle`.
+    void changeEvent(QEvent *event) override;
+
 private slots:
     void FindNext();
     void FindPrevious();
@@ -154,4 +165,14 @@ private:
     /// The recount is idempotent so this is purely a "don't pay
     /// twice" optimisation.
     bool mEmittingMatchCountRequest = false;
+
+    /// Paint a small upward / downward chevron in the current
+    /// palette's `WindowText` colour and assign it to the
+    /// respective arrow button. Replaces `QStyle::SP_ArrowUp` /
+    /// `SP_ArrowDown` -- those standard pixmaps are baked black
+    /// on Windows and become invisible on a dark theme.
+    /// `changeEvent` re-runs this on `PaletteChange` /
+    /// `StyleChange` so a theme switch refreshes the glyphs in
+    /// place.
+    void RefreshArrowIcons();
 };

--- a/app/include/log_filter_model.hpp
+++ b/app/include/log_filter_model.hpp
@@ -49,23 +49,14 @@ public:
     /// Sentinel `hits` value meaning "return every match".
     static constexpr int UNLIMITED_HITS = -1;
 
-    /// Build the `Qt::MatchFlags` for an incremental find query.
+    /// Build `Qt::MatchFlags` for an incremental find query.
     ///
-    /// The match-type values in `Qt::MatchFlag` are *alternatives*,
-    /// not bit-mask modifiers (`Matches` masks the type field and
-    /// dispatches with a switch), so OR-ing `MatchContains` next
-    /// to `MatchWildcard` / `MatchRegularExpression` silently
-    /// demotes the search to plain substring matching -- the
-    /// regex / wildcard toggles look enabled but match like
-    /// they're off. Routing every find call site through this
-    /// helper guarantees the flag composition stays in lock-step
-    /// with the dispatch in `Matches`.
-    ///
-    /// `MatchWrap | MatchRecursive` are always set so the find
-    /// bar wraps around the table and recurses into proxy
-    /// children. Exactly one of `MatchRegularExpression`,
-    /// `MatchWildcard`, `MatchContains` is added based on the UI
-    /// toggles, in that priority order.
+    /// Single source of truth for find call sites: the match-type
+    /// values in `Qt::MatchFlag` are alternatives (not bit-mask
+    /// modifiers), so OR-ing `MatchContains` with `MatchWildcard` /
+    /// `MatchRegularExpression` silently demotes to substring matching.
+    /// Always sets `MatchWrap | MatchRecursive`; picks exactly one of
+    /// regex / wildcard / contains based on the UI toggles.
     [[nodiscard]] static Qt::MatchFlags ComposeFindFlags(bool wildcards, bool regularExpressions);
 
     /// Find proxy-coord rows whose cell matches @p value under @p role.

--- a/app/include/log_filter_model.hpp
+++ b/app/include/log_filter_model.hpp
@@ -49,6 +49,25 @@ public:
     /// Sentinel `hits` value meaning "return every match".
     static constexpr int UNLIMITED_HITS = -1;
 
+    /// Build the `Qt::MatchFlags` for an incremental find query.
+    ///
+    /// The match-type values in `Qt::MatchFlag` are *alternatives*,
+    /// not bit-mask modifiers (`Matches` masks the type field and
+    /// dispatches with a switch), so OR-ing `MatchContains` next
+    /// to `MatchWildcard` / `MatchRegularExpression` silently
+    /// demotes the search to plain substring matching -- the
+    /// regex / wildcard toggles look enabled but match like
+    /// they're off. Routing every find call site through this
+    /// helper guarantees the flag composition stays in lock-step
+    /// with the dispatch in `Matches`.
+    ///
+    /// `MatchWrap | MatchRecursive` are always set so the find
+    /// bar wraps around the table and recurses into proxy
+    /// children. Exactly one of `MatchRegularExpression`,
+    /// `MatchWildcard`, `MatchContains` is added based on the UI
+    /// toggles, in that priority order.
+    [[nodiscard]] static Qt::MatchFlags ComposeFindFlags(bool wildcards, bool regularExpressions);
+
     /// Find proxy-coord rows whose cell matches @p value under @p role.
     /// Returns up to @p hits matches (all when `UNLIMITED_HITS`).
     QList<QModelIndex> MatchRow(

--- a/app/include/log_model.hpp
+++ b/app/include/log_model.hpp
@@ -259,6 +259,19 @@ public:
     /// per-emission work -- nothing semantic actually changed.
     void RefreshAllRowStyles();
 
+    /// True iff @p roles is non-empty AND every entry is a purely
+    /// decorative role (`BackgroundRole`, `ForegroundRole`,
+    /// `FontRole`, `DecorationRole`). Used by `dataChanged`
+    /// listeners that only care about value-affecting changes
+    /// (find cache, record-detail pane) to filter out the
+    /// theme-refresh notifications emitted by
+    /// `RefreshAllRowStyles`.
+    ///
+    /// An empty `roles` is Qt's "I don't know what changed"
+    /// sentinel; this helper reports `false` for it so callers
+    /// conservatively refresh on the sentinel.
+    [[nodiscard]] static bool IsStyleOnlyRoleChange(const QList<int> &roles) noexcept;
+
 signals:
     /// Cumulative error count, emitted when a batch carries errors.
     void errorCountChanged(qsizetype count);

--- a/app/include/log_model.hpp
+++ b/app/include/log_model.hpp
@@ -247,39 +247,23 @@ public:
     ) const noexcept;
 
     /// Emit `dataChanged` for the theme-derived style roles
-    /// (Background, Foreground, Font) across the whole visible
-    /// table. `MainWindow::OnThemeChanged` calls this so a Light
-    /// <-> Dark flip refreshes the rendered row tints. A bare
-    /// `viewport()->update()` does not reliably invalidate the
-    /// view's per-item style cache in every Qt 6 release; emitting
-    /// `dataChanged` forces every visible delegate to re-query the
-    /// new brushes. Roles are restricted to the styled set so the
-    /// existing `dataChanged` listeners (find-cache, record-detail
-    /// pane) can filter the notification out and skip their own
-    /// per-emission work -- nothing semantic actually changed.
+    /// (Background, Foreground, Font) across the whole table.
+    /// `MainWindow::OnThemeChanged` calls this on Light <-> Dark
+    /// flips; `viewport()->update()` alone doesn't reliably
+    /// invalidate the view's per-item style cache.
     void RefreshAllRowStyles();
 
-    /// True iff @p roles is non-empty AND every entry is a purely
-    /// decorative role (`BackgroundRole`, `ForegroundRole`,
-    /// `FontRole`, `DecorationRole`). Used by `dataChanged`
-    /// listeners that only care about value-affecting changes
-    /// (find cache, record-detail pane) to filter out the
-    /// theme-refresh notifications emitted by
-    /// `RefreshAllRowStyles`.
+    /// True iff @p roles is non-empty AND every entry is purely
+    /// decorative (Background / Foreground / Font / Decoration).
+    /// Listeners that only care about value-affecting changes
+    /// (find cache, record-detail pane) use this to filter out
+    /// theme-refresh emits from `RefreshAllRowStyles`.
     ///
-    /// An empty `roles` is Qt's "I don't know what changed"
-    /// sentinel; this helper reports `false` for it so callers
-    /// conservatively refresh on the sentinel.
+    /// Empty `roles` is Qt's "I don't know what changed" sentinel;
+    /// this helper reports `false` so callers conservatively refresh.
     ///
-    /// Emitter contract: any `dataChanged` that lists *only*
-    /// these four roles MUST NOT mutate `Qt::DisplayRole` /
-    /// `Qt::EditRole` (or any other value-bearing role) for the
-    /// emitted range -- if it does, the listeners that filter via
-    /// this helper will fall out of sync with the underlying
-    /// data. `RefreshAllRowStyles` upholds the contract for its
-    /// own emit; future style-only emits must do the same or add
-    /// the appropriate value role to the list so listeners
-    /// refresh.
+    /// Emitter contract: any `dataChanged` listing only these roles
+    /// MUST NOT mutate value-bearing roles for the emitted range.
     [[nodiscard]] static bool IsStyleOnlyRoleChange(const QList<int> &roles) noexcept;
 
 signals:

--- a/app/include/log_model.hpp
+++ b/app/include/log_model.hpp
@@ -270,6 +270,16 @@ public:
     /// An empty `roles` is Qt's "I don't know what changed"
     /// sentinel; this helper reports `false` for it so callers
     /// conservatively refresh on the sentinel.
+    ///
+    /// Emitter contract: any `dataChanged` that lists *only*
+    /// these four roles MUST NOT mutate `Qt::DisplayRole` /
+    /// `Qt::EditRole` (or any other value-bearing role) for the
+    /// emitted range -- if it does, the listeners that filter via
+    /// this helper will fall out of sync with the underlying
+    /// data. `RefreshAllRowStyles` upholds the contract for its
+    /// own emit; future style-only emits must do the same or add
+    /// the appropriate value role to the list so listeners
+    /// refresh.
     [[nodiscard]] static bool IsStyleOnlyRoleChange(const QList<int> &roles) noexcept;
 
 signals:

--- a/app/include/log_model.hpp
+++ b/app/include/log_model.hpp
@@ -246,6 +246,19 @@ public:
         int columnIndex
     ) const noexcept;
 
+    /// Emit `dataChanged` for the theme-derived style roles
+    /// (Background, Foreground, Font) across the whole visible
+    /// table. `MainWindow::OnThemeChanged` calls this so a Light
+    /// <-> Dark flip refreshes the rendered row tints. A bare
+    /// `viewport()->update()` does not reliably invalidate the
+    /// view's per-item style cache in every Qt 6 release; emitting
+    /// `dataChanged` forces every visible delegate to re-query the
+    /// new brushes. Roles are restricted to the styled set so the
+    /// existing `dataChanged` listeners (find-cache, record-detail
+    /// pane) can filter the notification out and skip their own
+    /// per-emission work -- nothing semantic actually changed.
+    void RefreshAllRowStyles();
+
 signals:
     /// Cumulative error count, emitted when a batch carries errors.
     void errorCountChanged(qsizetype count);

--- a/app/include/main_window.hpp
+++ b/app/include/main_window.hpp
@@ -808,8 +808,20 @@ private:
     /// Uses `Qt::UniqueConnection`, so repeat calls are idempotent.
     void RebindRecordDetailSelectionTracking();
 
-    /// True iff the find dock is realised and on-screen. The
-    /// `mFindDock != nullptr` half guards against early
+    /// True iff the find dock is realised and on-screen.
+    ///
+    /// Tabified-dock semantics: when the dock is the inactive tab
+    /// of a tabified group, Qt's `QDockWidget::isVisible()`
+    /// returns `false` (the buried tab's widget really is hidden
+    /// under the tab bar). That's the desired behaviour here --
+    /// we don't want to pay for a full-table match-count recount
+    /// when the indicator label can't be seen. This relies on an
+    /// observed Qt 6 behaviour rather than an explicitly
+    /// documented contract; if a future Qt release flips it, the
+    /// `OnFindCacheInvalidated` bump would start firing for
+    /// buried tabs too -- still correct but no longer free.
+    ///
+    /// The `mFindDock != nullptr` half guards against early
     /// constructor-phase callers (signals from the proxy can fire
     /// while the dock is still being built) and against shutdown
     /// (the `QPointer` clears before the connection is torn

--- a/app/include/main_window.hpp
+++ b/app/include/main_window.hpp
@@ -1037,6 +1037,16 @@ private:
     qsizetype mStreamingLineCount = 0;
     qsizetype mStreamingErrorCount = 0;
 
+    /// High-water mark into `mModel->StreamingErrors()` consumed by
+    /// the per-file batch in `OnStreamingFinished`. Multi-file static
+    /// opens accumulate every file's errors in a single vector on
+    /// the model; this watermark lets us peel off only the errors
+    /// produced by the file that just finished so each file gets
+    /// its own labelled batch in the `ParseErrorsDock`. Reset to 0
+    /// alongside every `mParseErrorsDock->ResetSessionState()` to
+    /// stay in lockstep with the model's `mStreamingErrors.clear()`.
+    size_t mStreamingErrorsCut = 0;
+
     /// True after the first non-empty batch; gates the one-shot column
     /// auto-resize.
     bool mFirstStreamingBatchSeen = false;

--- a/app/include/main_window.hpp
+++ b/app/include/main_window.hpp
@@ -435,8 +435,9 @@ private slots:
 
     /// Refresh the status-bar parse-errors indicator. Wired to
     /// `ParseErrorsDock::countChanged`; hides the button when the
-    /// dock is empty.
-    void UpdateParseErrorsStatus(int count);
+    /// dock is empty. @p droppedCount surfaces in the tooltip so
+    /// the user can tell when the dock has truncated.
+    void UpdateParseErrorsStatus(int count, int droppedCount);
 
     /// Recount matches for the current find query and push the
     /// result back into the find bar. Hooked up to
@@ -456,6 +457,15 @@ private slots:
     /// proxy layout changes so a stale cache cannot survive a
     /// filter add / remove or a streaming append.
     void InvalidateFindMatchCache();
+
+    /// Centralised invalidation + debounced re-request. Wired to
+    /// every model / proxy signal that can change the match set
+    /// (`rowsInserted`, `rowsRemoved`, `layoutChanged`, model
+    /// resets, `dataChanged`). Doing a synchronous re-scan per
+    /// signal would melt under streaming, so the cache is dropped
+    /// eagerly and the visible find bar's debounce timer is
+    /// nudged so a single recount runs after activity settles.
+    void OnFindCacheInvalidated();
 
     void Find();
     void FindRecords(const QString &text, bool next, bool wildcards, bool regularExpressions);

--- a/app/include/main_window.hpp
+++ b/app/include/main_window.hpp
@@ -2,10 +2,12 @@
 
 #include "anchor_manager.hpp"
 #include "anchors_dock.hpp"
+#include "find_dock.hpp"
 #include "find_record_widget.hpp"
 #include "log_filter_model.hpp"
 #include "log_model.hpp"
 #include "log_table_view.hpp"
+#include "parse_errors_dock.hpp"
 #include "preferences_editor.hpp"
 #include "record_detail_dock.hpp"
 #include "record_detail_window.hpp"
@@ -431,6 +433,18 @@ private slots:
     /// mismatches are present.
     void UpdateDiagnosticsStatus();
 
+    /// Refresh the status-bar parse-errors indicator. Wired to
+    /// `ParseErrorsDock::countChanged`; hides the button when the
+    /// dock is empty.
+    void UpdateParseErrorsStatus(int count);
+
+    /// Recount matches for the current find query and push the
+    /// result back into the find bar. Hooked up to
+    /// `FindRecordWidget::MatchCountRequested`. Skips work when
+    /// the bar is hidden / the proxy model is unset / the needle
+    /// is empty.
+    void UpdateFindMatchCount(const QString &text, bool wildcards, bool regularExpressions);
+
     void Find();
     void FindRecords(const QString &text, bool next, bool wildcards, bool regularExpressions);
 
@@ -774,7 +788,26 @@ private:
     LogFilterModel *mSortFilterProxyModel;
     LogTableView *mTableView;
     LogModel *mModel;
-    FindRecordWidget *mFindRecord;
+    /// Dockable find bar. Owned via `QMainWindow` parentage.
+    /// `mFindRecord` is the `FindRecordWidget` it hosts; both
+    /// pointers stay valid for the window's lifetime.
+    FindDock *mFindDock = nullptr;
+    FindRecordWidget *mFindRecord = nullptr;
+    /// Dockable replacement for the old `QMessageBox::warning`
+    /// parse-error popups. Hidden by default; auto-raised on the
+    /// first error of a session.
+    ParseErrorsDock *mParseErrorsDock = nullptr;
+    /// Toggle action for `mFindDock`, mirrored onto the View menu.
+    /// Programmatic because the .ui has no entry; re-added on
+    /// every `RebuildViewMenu`.
+    QAction *mActionToggleFind = nullptr;
+    /// Toggle action for `mParseErrorsDock`. Same lifecycle as
+    /// `mActionToggleFind`.
+    QAction *mActionToggleParseErrors = nullptr;
+    /// Status-bar indicator that surfaces when the parse-errors
+    /// dock has entries; clicking it opens the dock. Mirrors the
+    /// pattern used by `mDiagnosticsButton`.
+    QPushButton *mParseErrorsStatusButton = nullptr;
     PreferencesEditor *mPreferencesEditor;
     /// Non-owning. Lives in `main()` (or the test fixture).
     /// `nullptr` for legacy no-args construction; theme code paths

--- a/app/include/main_window.hpp
+++ b/app/include/main_window.hpp
@@ -20,6 +20,8 @@
 // the full type comes in transitively through `log_filter_model.hpp`.
 
 #include <QAction>
+#include <QApplication>
+#include <QDockWidget>
 #include <QDragEnterEvent>
 #include <QDropEvent>
 #include <QElapsedTimer>
@@ -30,6 +32,7 @@
 #include <QMimeData>
 #include <QPointer>
 #include <QPushButton>
+#include <QSignalBlocker>
 #include <QString>
 #include <QStringList>
 #include <QTimer>
@@ -37,6 +40,7 @@
 #include <QVBoxLayout>
 
 #include <array>
+#include <functional>
 #include <memory>
 #include <optional>
 #include <string>
@@ -804,6 +808,57 @@ private:
     /// Uses `Qt::UniqueConnection`, so repeat calls are idempotent.
     void RebindRecordDetailSelectionTracking();
 
+    /// True iff the find dock is realised and on-screen. The
+    /// `mFindDock != nullptr` half guards against early
+    /// constructor-phase callers (signals from the proxy can fire
+    /// while the dock is still being built) and against shutdown
+    /// (the `QPointer` clears before the connection is torn
+    /// down). Centralised so every find-aware path goes through
+    /// the same null + visibility check.
+    [[nodiscard]] bool IsFindBarVisible() const noexcept
+    {
+        return mFindDock != nullptr && mFindDock->isVisible();
+    }
+
+    /// True iff the find dock is visible AND keyboard focus sits
+    /// inside its widget tree. Used by the parse-errors auto-raise
+    /// guard (don't yank focus from a user mid-search) and the
+    /// `Find()` smart toggle (Ctrl+F closes the bar only when
+    /// focus is already in it).
+    [[nodiscard]] bool FindBarHoldsFocus() const noexcept
+    {
+        return IsFindBarVisible() && mFindDock->isAncestorOf(QApplication::focusWidget());
+    }
+
+    /// Wire the standard dock toggle pattern: `action->toggled` opens
+    /// (`onShow` callback, defaults to `dock->show() + dock->raise()`)
+    /// or closes (`dock->close()`) the dock; `dock->visibilityChanged(true)`
+    /// re-checks the action (covers tab activations and `restoreState`);
+    /// `dock->closed` un-checks it on genuine user dismissal.
+    /// Splitting visibility into "on" via `visibilityChanged(true)` and
+    /// "off" via `closed` is what lets the menu checkmark survive tab
+    /// switches inside a tabified group -- `visibilityChanged(false)`
+    /// fires for both genuine close and tab inactivation, so listening
+    /// to it would un-check the action every time the user switched tabs.
+    ///
+    /// `onShown` runs after the visibility-change handler checks the
+    /// action and is the place to plug per-dock side effects (e.g.
+    /// `RecordDetailDock` re-pulling the table selection, `FindDock`
+    /// catching up the match count). Defaults to no-op.
+    ///
+    /// All four dock toggles in `MainWindow` (Anchors, Find,
+    /// ParseErrors, RecordDetails) used to inline this 25-line
+    /// pattern, which made it easy to drift one wiring relative to
+    /// the others; centralising fixes the contract in one spot.
+    template <typename DockT>
+    void WireDockToggle(
+        DockT *dock,
+        QAction *action,
+        void (DockT::*closedSignal)(),
+        const std::function<void()> &onShow = {},
+        const std::function<void()> &onShown = {}
+    );
+
     Ui::MainWindow *ui;
     QVBoxLayout *mLayout;
     RowOrderProxyModel *mRowOrderProxyModel;
@@ -811,14 +866,21 @@ private:
     LogTableView *mTableView;
     LogModel *mModel;
     /// Dockable find bar. Owned via `QMainWindow` parentage.
-    /// `mFindRecord` is the `FindRecordWidget` it hosts; both
-    /// pointers stay valid for the window's lifetime.
-    FindDock *mFindDock = nullptr;
-    FindRecordWidget *mFindRecord = nullptr;
+    /// `mFindRecord` is the `FindRecordWidget` it hosts. Both
+    /// are `QPointer`s so a model / proxy signal that fires
+    /// during shutdown -- after Qt has destroyed the find dock
+    /// subtree but before the connection on `MainWindow` is torn
+    /// down -- finds them already null instead of dangling. The
+    /// connections are wired with PMFs to slots on `this`, which
+    /// lives until the very end of `~MainWindow`, so the window
+    /// of vulnerability is real even if narrow.
+    QPointer<FindDock> mFindDock;
+    QPointer<FindRecordWidget> mFindRecord;
     /// Dockable replacement for the old `QMessageBox::warning`
     /// parse-error popups. Hidden by default; auto-raised on the
-    /// first error of a session.
-    ParseErrorsDock *mParseErrorsDock = nullptr;
+    /// first error of a session. `QPointer` for the same shutdown
+    /// reasoning as `mFindDock`.
+    QPointer<ParseErrorsDock> mParseErrorsDock;
     /// Toggle action for `mFindDock`, mirrored onto the View menu.
     /// Programmatic because the .ui has no entry; re-added on
     /// every `RebuildViewMenu`.
@@ -1061,3 +1123,67 @@ private:
     int mLastDroppedFilterCountForTest = 0;
 #endif
 };
+
+template <typename DockT>
+void MainWindow::WireDockToggle(
+    DockT *dock,
+    QAction *action,
+    void (DockT::*closedSignal)(),
+    const std::function<void()> &onShow,
+    const std::function<void()> &onShown
+)
+{
+    Q_ASSERT(dock != nullptr);
+    Q_ASSERT(action != nullptr);
+    // Toggle action -> show / close. Reverts the toggle when the
+    // host main window is not yet realised (early test driver
+    // call) so the action can't sit checked while the dock stays
+    // hidden.
+    connect(action, &QAction::toggled, this, [this, dock, action, onShow](bool on) {
+        if (on && !isVisible())
+        {
+            const QSignalBlocker blocker(action);
+            action->setChecked(false);
+            return;
+        }
+        if (on)
+        {
+            if (onShow)
+            {
+                onShow();
+            }
+            else
+            {
+                dock->show();
+                dock->raise();
+            }
+        }
+        else
+        {
+            // `close()` (not `hide()`) so the dock subclass'
+            // `closeEvent` fires and `closedSignal` propagates.
+            dock->close();
+        }
+    });
+    // On-edge: `visibilityChanged(true)` fires for cold reveals
+    // *and* tab activations, both of which want the action
+    // checked. Off-edge `visibilityChanged(false)` is ambiguous
+    // (tab inactivation looks the same), so we don't listen for
+    // it -- `closedSignal` handles that side.
+    connect(dock, &QDockWidget::visibilityChanged, this, [action, onShown](bool visible) {
+        if (!visible)
+        {
+            return;
+        }
+        const QSignalBlocker blocker(action);
+        action->setChecked(true);
+        if (onShown)
+        {
+            onShown();
+        }
+    });
+    connect(dock, closedSignal, this, [action]() {
+        const QSignalBlocker blocker(action);
+        action->setChecked(false);
+    });
+}

--- a/app/include/main_window.hpp
+++ b/app/include/main_window.hpp
@@ -443,7 +443,19 @@ private slots:
     /// `FindRecordWidget::MatchCountRequested`. Skips work when
     /// the bar is hidden / the proxy model is unset / the needle
     /// is empty.
+    ///
+    /// Caches the row list keyed by `(needle, wildcards, regex)`.
+    /// Subsequent calls with the same needle (e.g. after a
+    /// Next / Previous click moved the current index) skip the
+    /// full-table scan and just resolve `i` via binary search.
+    /// `InvalidateFindMatchCache` is wired to model / proxy
+    /// signals that change which rows match.
     void UpdateFindMatchCount(const QString &text, bool wildcards, bool regularExpressions);
+
+    /// Drop the cached match-row list. Wired to model resets and
+    /// proxy layout changes so a stale cache cannot survive a
+    /// filter add / remove or a streaming append.
+    void InvalidateFindMatchCache();
 
     void Find();
     void FindRecords(const QString &text, bool next, bool wildcards, bool regularExpressions);
@@ -808,6 +820,23 @@ private:
     /// dock has entries; clicking it opens the dock. Mirrors the
     /// pattern used by `mDiagnosticsButton`.
     QPushButton *mParseErrorsStatusButton = nullptr;
+
+    /// Cached match-row list for the find bar's "*i* of *N*"
+    /// indicator. Keyed by `(needle, wildcards, regex)` so a
+    /// Next / Previous click after the count was last computed
+    /// can resolve the new `i` via binary search instead of
+    /// re-running `MatchRow` over the entire proxy. `sortedRows`
+    /// is row-deduplicated (a row matching in N visible columns
+    /// counts once) so the indicator agrees with how
+    /// `FindRecords` walks the table.
+    struct FindMatchCache
+    {
+        QString needle;
+        bool wildcards = false;
+        bool regularExpressions = false;
+        std::vector<int> sortedRows;
+    };
+    std::optional<FindMatchCache> mFindMatchCache;
     PreferencesEditor *mPreferencesEditor;
     /// Non-owning. Lives in `main()` (or the test fixture).
     /// `nullptr` for legacy no-args construction; theme code paths

--- a/app/include/main_window.hpp
+++ b/app/include/main_window.hpp
@@ -437,38 +437,24 @@ private slots:
     /// mismatches are present.
     void UpdateDiagnosticsStatus();
 
-    /// Refresh the status-bar parse-errors indicator. Wired to
-    /// `ParseErrorsDock::countChanged`; hides the button when the
-    /// dock is empty. @p droppedCount surfaces in the tooltip so
-    /// the user can tell when the dock has truncated.
+    /// Refresh the status-bar parse-errors indicator. Hooked to
+    /// `ParseErrorsDock::countChanged`; hides when the dock is empty.
     void UpdateParseErrorsStatus(int count, int droppedCount);
 
     /// Recount matches for the current find query and push the
-    /// result back into the find bar. Hooked up to
-    /// `FindRecordWidget::MatchCountRequested`. Skips work when
-    /// the bar is hidden / the proxy model is unset / the needle
-    /// is empty.
-    ///
-    /// Caches the row list keyed by `(needle, wildcards, regex)`.
-    /// Subsequent calls with the same needle (e.g. after a
-    /// Next / Previous click moved the current index) skip the
-    /// full-table scan and just resolve `i` via binary search.
-    /// `InvalidateFindMatchCache` is wired to model / proxy
-    /// signals that change which rows match.
+    /// result back into the find bar. Caches the row list keyed by
+    /// `(needle, wildcards, regex)` so Next / Previous clicks reuse
+    /// the scan and just resolve the new `i` via binary search.
+    /// Skipped when the bar is hidden / proxy is unset / needle empty.
     void UpdateFindMatchCount(const QString &text, bool wildcards, bool regularExpressions);
 
     /// Drop the cached match-row list. Wired to model resets and
-    /// proxy layout changes so a stale cache cannot survive a
-    /// filter add / remove or a streaming append.
+    /// proxy layout changes so a stale cache cannot survive.
     void InvalidateFindMatchCache();
 
-    /// Centralised invalidation + debounced re-request. Wired to
-    /// every model / proxy signal that can change the match set
-    /// (`rowsInserted`, `rowsRemoved`, `layoutChanged`, model
-    /// resets, `dataChanged`). Doing a synchronous re-scan per
-    /// signal would melt under streaming, so the cache is dropped
-    /// eagerly and the visible find bar's debounce timer is
-    /// nudged so a single recount runs after activity settles.
+    /// Centralised invalidate + debounced re-request. Wired to every
+    /// model / proxy signal that can change the match set; a sync
+    /// re-scan per signal would melt under streaming.
     void OnFindCacheInvalidated();
 
     void Find();
@@ -808,60 +794,33 @@ private:
     /// Uses `Qt::UniqueConnection`, so repeat calls are idempotent.
     void RebindRecordDetailSelectionTracking();
 
-    /// True iff the find dock is realised and on-screen.
-    ///
-    /// Tabified-dock semantics: when the dock is the inactive tab
-    /// of a tabified group, Qt's `QDockWidget::isVisible()`
-    /// returns `false` (the buried tab's widget really is hidden
-    /// under the tab bar). That's the desired behaviour here --
-    /// we don't want to pay for a full-table match-count recount
-    /// when the indicator label can't be seen. This relies on an
-    /// observed Qt 6 behaviour rather than an explicitly
-    /// documented contract; if a future Qt release flips it, the
-    /// `OnFindCacheInvalidated` bump would start firing for
-    /// buried tabs too -- still correct but no longer free.
-    ///
-    /// The `mFindDock != nullptr` half guards against early
-    /// constructor-phase callers (signals from the proxy can fire
-    /// while the dock is still being built) and against shutdown
-    /// (the `QPointer` clears before the connection is torn
-    /// down). Centralised so every find-aware path goes through
-    /// the same null + visibility check.
+    /// True iff the find dock is realised and visible. Tabified-dock
+    /// semantics: the inactive tab of a tabified group reports
+    /// `isVisible() == false`, which is exactly what we want -- no
+    /// match-count recount when the indicator can't be seen. The null
+    /// check guards constructor-phase and shutdown races.
     [[nodiscard]] bool IsFindBarVisible() const noexcept
     {
         return mFindDock != nullptr && mFindDock->isVisible();
     }
 
-    /// True iff the find dock is visible AND keyboard focus sits
-    /// inside its widget tree. Used by the parse-errors auto-raise
-    /// guard (don't yank focus from a user mid-search) and the
-    /// `Find()` smart toggle (Ctrl+F closes the bar only when
-    /// focus is already in it).
+    /// True iff the find dock is visible AND holds keyboard focus.
+    /// Used by the parse-errors auto-raise guard and `Find()`'s smart
+    /// toggle (Ctrl+F closes only when focus is already in the bar).
     [[nodiscard]] bool FindBarHoldsFocus() const noexcept
     {
         return IsFindBarVisible() && mFindDock->isAncestorOf(QApplication::focusWidget());
     }
 
     /// Wire the standard dock toggle pattern: `action->toggled` opens
-    /// (`onShow` callback, defaults to `dock->show() + dock->raise()`)
-    /// or closes (`dock->close()`) the dock; `dock->visibilityChanged(true)`
-    /// re-checks the action (covers tab activations and `restoreState`);
-    /// `dock->closed` un-checks it on genuine user dismissal.
-    /// Splitting visibility into "on" via `visibilityChanged(true)` and
-    /// "off" via `closed` is what lets the menu checkmark survive tab
-    /// switches inside a tabified group -- `visibilityChanged(false)`
-    /// fires for both genuine close and tab inactivation, so listening
-    /// to it would un-check the action every time the user switched tabs.
+    /// (`onShow`, default show+raise) or closes (`close()`) the dock;
+    /// `visibilityChanged(true)` re-checks the action; `closedSignal`
+    /// un-checks it on genuine dismissal. Splitting on/off across
+    /// these two signals is what lets the menu checkmark survive
+    /// tab switches in a tabified group.
     ///
-    /// `onShown` runs after the visibility-change handler checks the
-    /// action and is the place to plug per-dock side effects (e.g.
-    /// `RecordDetailDock` re-pulling the table selection, `FindDock`
-    /// catching up the match count). Defaults to no-op.
-    ///
-    /// All four dock toggles in `MainWindow` (Anchors, Find,
-    /// ParseErrors, RecordDetails) used to inline this 25-line
-    /// pattern, which made it easy to drift one wiring relative to
-    /// the others; centralising fixes the contract in one spot.
+    /// `onShown` runs after the action is re-checked and is the hook
+    /// for per-dock catch-up work (selection refresh, match count, ...).
     template <typename DockT>
     void WireDockToggle(
         DockT *dock,
@@ -877,55 +836,36 @@ private:
     LogFilterModel *mSortFilterProxyModel;
     LogTableView *mTableView;
     LogModel *mModel;
-    /// Dockable find bar. Owned via `QMainWindow` parentage.
-    /// `mFindRecord` is the `FindRecordWidget` it hosts. Both
-    /// are `QPointer`s so a model / proxy signal that fires
-    /// during shutdown -- after Qt has destroyed the find dock
-    /// subtree but before the connection on `MainWindow` is torn
-    /// down -- finds them already null instead of dangling. The
-    /// connections are wired with PMFs to slots on `this`, which
-    /// lives until the very end of `~MainWindow`, so the window
-    /// of vulnerability is real even if narrow.
+    /// Dockable find bar (owned via `QMainWindow` parentage).
+    /// `mFindRecord` is the hosted widget. `QPointer` on both so
+    /// model / proxy signals that fire during shutdown find them
+    /// null instead of dangling.
     QPointer<FindDock> mFindDock;
     QPointer<FindRecordWidget> mFindRecord;
     /// Dockable replacement for the old `QMessageBox::warning`
     /// parse-error popups. Hidden by default; auto-raised on the
-    /// first error of a session. `QPointer` for the same shutdown
-    /// reasoning as `mFindDock`.
+    /// first error of a session.
     QPointer<ParseErrorsDock> mParseErrorsDock;
     /// Toggle action for `mFindDock`, mirrored onto the View menu.
-    /// Programmatic because the .ui has no entry; re-added on
-    /// every `RebuildViewMenu`.
+    /// Programmatic because the .ui has no entry.
     QAction *mActionToggleFind = nullptr;
-    /// Toggle action for `mParseErrorsDock`. Same lifecycle as
-    /// `mActionToggleFind`.
+    /// Toggle action for `mParseErrorsDock`.
     QAction *mActionToggleParseErrors = nullptr;
-    /// Status-bar indicator that surfaces when the parse-errors
-    /// dock has entries; clicking it opens the dock. Mirrors the
-    /// pattern used by `mDiagnosticsButton`.
+    /// Status-bar indicator that surfaces when the parse-errors dock
+    /// has entries; clicking it opens the dock.
     QPushButton *mParseErrorsStatusButton = nullptr;
 
-    /// Hard cap on rows the live "*i* of *N*" scan may collect
-    /// before short-circuiting. The scan runs synchronously on
-    /// the GUI thread; an unbounded walk over a million-row
-    /// proxy with a frequent needle ("the", " ", ...) freezes
-    /// the UI for hundreds of ms per recount. Past the cap the
-    /// indicator shows "*N*+" so the user can tell the count is
-    /// truncated; Next / Previous still work via the live
-    /// `FindRecords` path which has its own start position and
-    /// doesn't pay the full-table scan.
+    /// Hard cap on the "*i* of *N*" scan. The scan runs synchronously
+    /// on the GUI thread; an unbounded walk over a million-row proxy
+    /// with a frequent needle would freeze the UI per recount. Past
+    /// the cap the indicator shows "*N*+"; Next / Previous still work.
     static constexpr int MAX_FIND_MATCH_COUNT = 10000;
 
-    /// Cached match-row list for the find bar's "*i* of *N*"
-    /// indicator. Keyed by `(needle, wildcards, regex)` so a
-    /// Next / Previous click after the count was last computed
-    /// can resolve the new `i` via binary search instead of
-    /// re-running `MatchRow` over the entire proxy. `sortedRows`
-    /// is row-deduplicated (a row matching in N visible columns
-    /// counts once) so the indicator agrees with how
-    /// `FindRecords` walks the table. `overflowed` is set when
-    /// the scan stopped at `MAX_FIND_MATCH_COUNT` rather than
-    /// running to completion.
+    /// Cached match-row list for the "*i* of *N*" indicator. Keyed by
+    /// `(needle, wildcards, regex)` so a Next / Previous click can
+    /// resolve the new `i` via binary search instead of re-scanning.
+    /// Row-deduplicated so the indicator agrees with how `FindRecords`
+    /// walks the table. `overflowed` is set when the scan hit the cap.
     struct FindMatchCache
     {
         QString needle;
@@ -1147,10 +1087,9 @@ void MainWindow::WireDockToggle(
 {
     Q_ASSERT(dock != nullptr);
     Q_ASSERT(action != nullptr);
-    // Toggle action -> show / close. Reverts the toggle when the
-    // host main window is not yet realised (early test driver
-    // call) so the action can't sit checked while the dock stays
-    // hidden.
+    // Toggle -> show / close. Reverts the toggle when the host
+    // isn't realised (early test driver) so the action can't sit
+    // checked while the dock stays hidden.
     connect(action, &QAction::toggled, this, [this, dock, action, onShow](bool on) {
         if (on && !isVisible())
         {
@@ -1172,16 +1111,15 @@ void MainWindow::WireDockToggle(
         }
         else
         {
-            // `close()` (not `hide()`) so the dock subclass'
-            // `closeEvent` fires and `closedSignal` propagates.
+            // `close()` (not `hide()`) so `closeEvent` fires and
+            // `closedSignal` propagates.
             dock->close();
         }
     });
-    // On-edge: `visibilityChanged(true)` fires for cold reveals
-    // *and* tab activations, both of which want the action
-    // checked. Off-edge `visibilityChanged(false)` is ambiguous
-    // (tab inactivation looks the same), so we don't listen for
-    // it -- `closedSignal` handles that side.
+    // `visibilityChanged(true)` fires for cold reveals AND tab
+    // activations; both want the action checked. We don't listen
+    // to the false edge -- `closedSignal` handles that side because
+    // tab inactivation also fires `visibilityChanged(false)`.
     connect(dock, &QDockWidget::visibilityChanged, this, [action, onShown](bool visible) {
         if (!visible)
         {

--- a/app/include/main_window.hpp
+++ b/app/include/main_window.hpp
@@ -831,6 +831,17 @@ private:
     /// pattern used by `mDiagnosticsButton`.
     QPushButton *mParseErrorsStatusButton = nullptr;
 
+    /// Hard cap on rows the live "*i* of *N*" scan may collect
+    /// before short-circuiting. The scan runs synchronously on
+    /// the GUI thread; an unbounded walk over a million-row
+    /// proxy with a frequent needle ("the", " ", ...) freezes
+    /// the UI for hundreds of ms per recount. Past the cap the
+    /// indicator shows "*N*+" so the user can tell the count is
+    /// truncated; Next / Previous still work via the live
+    /// `FindRecords` path which has its own start position and
+    /// doesn't pay the full-table scan.
+    static constexpr int MAX_FIND_MATCH_COUNT = 10000;
+
     /// Cached match-row list for the find bar's "*i* of *N*"
     /// indicator. Keyed by `(needle, wildcards, regex)` so a
     /// Next / Previous click after the count was last computed
@@ -838,12 +849,15 @@ private:
     /// re-running `MatchRow` over the entire proxy. `sortedRows`
     /// is row-deduplicated (a row matching in N visible columns
     /// counts once) so the indicator agrees with how
-    /// `FindRecords` walks the table.
+    /// `FindRecords` walks the table. `overflowed` is set when
+    /// the scan stopped at `MAX_FIND_MATCH_COUNT` rather than
+    /// running to completion.
     struct FindMatchCache
     {
         QString needle;
         bool wildcards = false;
         bool regularExpressions = false;
+        bool overflowed = false;
         std::vector<int> sortedRows;
     };
     std::optional<FindMatchCache> mFindMatchCache;

--- a/app/include/parse_errors_dock.hpp
+++ b/app/include/parse_errors_dock.hpp
@@ -20,26 +20,52 @@ class QLabel;
 ///
 /// Position persists across runs via `QMainWindow::saveState()`
 /// / `restoreState()` keyed on the dock's `objectName`. Entries
-/// are session-scoped — a new file open or model reset calls
-/// `Clear()`.
+/// are session-scoped — every destructive open path in
+/// `MainWindow` calls `ClearErrors()`.
+///
+/// To keep pathological streams (millions of malformed lines)
+/// from OOM-ing the GUI, the live store is capped at
+/// `MAX_DISPLAYED_ERRORS`. Past the cap the dock evicts oldest
+/// entries and shows a sticky "and N more dropped" footer so the
+/// user knows the count is honest.
 class ParseErrorsDock : public QDockWidget
 {
     Q_OBJECT
 
 public:
+    /// Hard cap on stored entries. Beyond this the oldest are
+    /// evicted; the eviction count surfaces in the summary.
+    static constexpr int MAX_DISPLAYED_ERRORS = 1000;
+
     explicit ParseErrorsDock(QWidget *parent = nullptr);
 
     /// Append one batch of errors under @p title. No-op for an
-    /// empty @p errors. Auto-shows + raises the dock so the user
-    /// notices the new entries.
+    /// empty @p errors. The dock auto-raises only on the first
+    /// batch of a session (i.e. when the panel was previously
+    /// empty); subsequent batches update silently and rely on the
+    /// status-bar indicator to surface the new count. This avoids
+    /// stealing focus from a streaming-session user who has
+    /// already deliberately closed the dock.
     void AppendErrors(const QString &title, const std::vector<std::string> &errors);
 
     /// Drop every entry. Used when the user clicks the Clear
     /// button and from `MainWindow` on session discards.
     void ClearErrors();
 
-    /// Total number of error entries currently displayed.
-    [[nodiscard]] int Count() const noexcept;
+    /// Total number of error entries currently displayed (does
+    /// not include evicted entries; see @p DroppedCount). O(1).
+    [[nodiscard]] int Count() const noexcept
+    {
+        return mErrorCount;
+    }
+
+    /// Number of entries evicted by the `MAX_DISPLAYED_ERRORS`
+    /// cap since the last `ClearErrors()`. Reflected in the
+    /// summary header.
+    [[nodiscard]] int DroppedCount() const noexcept
+    {
+        return mDroppedCount;
+    }
 
 signals:
     /// Emitted whenever `Count()` changes. The status-bar
@@ -52,7 +78,24 @@ private:
     /// `countChanged`.
     void RefreshSummary();
 
+    /// Copy the selected error rows to the clipboard, one entry
+    /// per line. Group headers and the overflow footer are
+    /// included verbatim so the pasted block reads coherently.
+    void CopySelection() const;
+
+    /// Keep `mList` under the cap by evicting oldest entries
+    /// (and any group header that becomes orphaned). Increments
+    /// `mDroppedCount` per evicted error row.
+    void TrimToCap();
+
     QListWidget *mList = nullptr;
     QLabel *mSummary = nullptr;
     QPushButton *mClearButton = nullptr;
+
+    /// Running tally of error rows in `mList`. Maintained on
+    /// every append / evict / clear so `Count()` stays O(1) and
+    /// `RefreshSummary` doesn't walk the list.
+    int mErrorCount = 0;
+    /// Cumulative evictions since the last `ClearErrors()`.
+    int mDroppedCount = 0;
 };

--- a/app/include/parse_errors_dock.hpp
+++ b/app/include/parse_errors_dock.hpp
@@ -6,6 +6,7 @@
 #include <string>
 #include <vector>
 
+class QCloseEvent;
 class QListWidget;
 class QPushButton;
 class QLabel;
@@ -68,10 +69,31 @@ public:
     }
 
 signals:
-    /// Emitted whenever `Count()` changes. The status-bar
-    /// indicator listens here so it can hide itself when the
-    /// dock empties.
-    void countChanged(int count);
+    /// Emitted whenever the displayed-error count or the dropped
+    /// count changes. The status-bar indicator listens here so it
+    /// can hide itself when the dock empties and surface both
+    /// figures in its tooltip.
+    void countChanged(int count, int droppedCount);
+
+    /// Emitted on the first batch appended after a `ClearErrors()`
+    /// (or since construction). `MainWindow` listens so it can
+    /// decide whether to raise / show the dock, factoring in
+    /// whether the user is currently doing something the auto-raise
+    /// would interrupt (e.g. typing in the find bar). Moving the
+    /// raise decision out of the dock keeps the dock unaware of
+    /// the rest of the chrome.
+    void firstBatchArrived();
+
+    /// Emitted when the user actually dismisses the dock. Not
+    /// emitted on tab inactivation -- see `FindDock::closed` for
+    /// the same idiom and rationale.
+    void closed();
+
+protected:
+    /// Emit `closed` once the base class has accepted the close so
+    /// the View-menu checkmark can drop without false-firing on
+    /// tab switches.
+    void closeEvent(QCloseEvent *event) override;
 
 private:
     /// Refresh the header summary (e.g. "12 entries") and emit
@@ -86,7 +108,24 @@ private:
     /// Keep `mList` under the cap by evicting oldest entries
     /// (and any group header that becomes orphaned). Increments
     /// `mDroppedCount` per evicted error row.
+    ///
+    /// Does *not* manage the overflow footer -- that's
+    /// `RebuildOverflowFooter`'s job. Splitting them matters
+    /// because a single batch larger than the cap reaches
+    /// `mErrorCount == MAX_DISPLAYED_ERRORS` exactly (the
+    /// pre-trim in `AppendErrors` lops the surplus off the
+    /// *input* before items are minted), so this method has no
+    /// eviction work to do but the dock still owes the user a
+    /// footer reflecting the pre-trimmed drops.
     void TrimToCap();
+
+    /// Ensure the trailing overflow footer is present iff
+    /// `mDroppedCount > 0`, with text reflecting the current
+    /// count. Idempotent. The caller is responsible for having
+    /// removed any prior footer (`AppendErrors` does this at the
+    /// top of the function) so this method only ever *adds* a
+    /// footer; it never has to compare-and-replace.
+    void RebuildOverflowFooter();
 
     QListWidget *mList = nullptr;
     QLabel *mSummary = nullptr;

--- a/app/include/parse_errors_dock.hpp
+++ b/app/include/parse_errors_dock.hpp
@@ -11,151 +11,99 @@ class QListWidget;
 class QPushButton;
 class QLabel;
 
-/// Dockable panel that shows accumulated parse / open errors.
+/// Dockable panel that collects parse / open errors.
 ///
 /// Replaces the modal `QMessageBox::warning` that used to surface
-/// errors from `MainWindow::ShowParseErrors`. A persistent panel
-/// is better suited to streaming sessions where new errors can
-/// arrive at any moment without the user wanting to dismiss a
-/// dialog each time.
+/// errors from `MainWindow::ShowParseErrors`; a persistent panel
+/// fits streaming sessions where errors arrive continuously.
 ///
-/// Position persists across runs via `QMainWindow::saveState()`
-/// / `restoreState()` keyed on the dock's `objectName`. Entries
-/// are session-scoped — every destructive open path in
-/// `MainWindow` calls `ClearErrors()`.
-///
-/// To keep pathological streams (millions of malformed lines)
-/// from OOM-ing the GUI, the live store is capped at
-/// `MAX_DISPLAYED_ERRORS`. Past the cap the dock evicts oldest
-/// entries and shows a sticky "and N more dropped" footer so the
-/// user knows the count is honest.
+/// Position persists via `QMainWindow::saveState()` / `restoreState()`.
+/// Entries are session-scoped: every destructive open path in
+/// `MainWindow` calls `ResetSessionState()`. The live store is
+/// capped at `MAX_DISPLAYED_ERRORS`; older entries are evicted and
+/// a sticky overflow footer reports the dropped count.
 class ParseErrorsDock : public QDockWidget
 {
     Q_OBJECT
 
 public:
-    /// Hard cap on stored entries. Beyond this the oldest are
-    /// evicted; the eviction count surfaces in the summary.
+    /// Hard cap on stored entries. Older ones are evicted and the
+    /// count is surfaced in the summary.
     static constexpr int MAX_DISPLAYED_ERRORS = 1000;
 
     explicit ParseErrorsDock(QWidget *parent = nullptr);
 
-    /// Append one batch of errors under @p title. No-op for an
-    /// empty @p errors. The dock fires `firstBatchArrived` only
-    /// once per session boundary (see `ResetSessionState`);
-    /// subsequent batches update silently and rely on the
-    /// status-bar indicator. This avoids stealing focus from a
-    /// streaming-session user who has already deliberately closed
-    /// the dock or used the Clear button mid-session.
+    /// Append one batch of errors under @p title. No-op for empty
+    /// @p errors. Fires `firstBatchArrived` once per session
+    /// (cleared only by `ResetSessionState`) so a user who already
+    /// dismissed the dock isn't yanked back to it mid-session.
     void AppendErrors(const QString &title, const std::vector<std::string> &errors);
 
-    /// Drop every displayed entry. Wired to the in-dock Clear
-    /// button. Does **not** re-arm `firstBatchArrived`: a user
-    /// who clicks Clear and dismisses the dock should not have
-    /// it re-pop the next time a streaming line fails to parse.
-    /// Use `ResetSessionState()` for the destructive session
-    /// boundary path (NewSession, OpenLogStreamFromPath, ...).
+    /// Drop every displayed entry. Does NOT re-arm
+    /// `firstBatchArrived`; use `ResetSessionState` for that.
     void ClearErrors();
 
-    /// Drop every displayed entry **and** re-arm
-    /// `firstBatchArrived` so the next call to `AppendErrors`
-    /// fires it again. `MainWindow` calls this from every
-    /// destructive session boundary (NewSession,
-    /// OpenLogStreamFromPath, OpenNetworkStream,
-    /// ApplyLoadedConfiguration, append-replace) so a fresh
-    /// session can auto-raise the dock on its first error.
+    /// Drop every entry AND re-arm `firstBatchArrived`. Called
+    /// from every destructive session boundary in `MainWindow`.
     void ResetSessionState();
 
-    /// Total number of error entries currently displayed (does
-    /// not include evicted entries; see @p DroppedCount). O(1).
+    /// Total entries currently displayed (excludes evicted). O(1).
     [[nodiscard]] int Count() const noexcept
     {
         return mErrorCount;
     }
 
-    /// Number of entries evicted by the `MAX_DISPLAYED_ERRORS`
-    /// cap since the last `ClearErrors()`. Reflected in the
-    /// summary header.
+    /// Entries evicted by `MAX_DISPLAYED_ERRORS` since the last
+    /// `ClearErrors()`. Reflected in the summary header.
     [[nodiscard]] int DroppedCount() const noexcept
     {
         return mDroppedCount;
     }
 
 signals:
-    /// Emitted whenever the displayed-error count or the dropped
-    /// count changes. The status-bar indicator listens here so it
-    /// can hide itself when the dock empties and surface both
-    /// figures in its tooltip.
+    /// Emitted on every count change. The status-bar indicator listens
+    /// here to hide itself when empty and to update its tooltip.
     void countChanged(int count, int droppedCount);
 
-    /// Emitted on the first batch appended after a `ClearErrors()`
-    /// (or since construction). `MainWindow` listens so it can
-    /// decide whether to raise / show the dock, factoring in
-    /// whether the user is currently doing something the auto-raise
-    /// would interrupt (e.g. typing in the find bar). Moving the
-    /// raise decision out of the dock keeps the dock unaware of
-    /// the rest of the chrome.
+    /// First batch after construction or `ResetSessionState`.
+    /// `MainWindow` decides whether to raise the dock (it shouldn't
+    /// interrupt e.g. an in-progress find).
     void firstBatchArrived();
 
-    /// Emitted when the user actually dismisses the dock. Not
-    /// emitted on tab inactivation -- see `FindDock::closed` for
-    /// the same idiom and rationale.
+    /// Emitted on genuine user dismissal. See `FindDock::closed`
+    /// for the rationale.
     void closed();
 
 protected:
-    /// Emit `closed` once the base class has accepted the close so
-    /// the View-menu checkmark can drop without false-firing on
-    /// tab switches.
     void closeEvent(QCloseEvent *event) override;
 
 private:
-    /// Refresh the header summary (e.g. "12 entries") and emit
-    /// `countChanged`.
+    /// Refresh the header summary and emit `countChanged`.
     void RefreshSummary();
 
-    /// Copy the selected error rows to the clipboard, one entry
-    /// per line. Group headers and the overflow footer are
-    /// included verbatim so the pasted block reads coherently.
+    /// Copy selected error rows (with synthesised headers and
+    /// overflow footer) to the clipboard.
     void CopySelection() const;
 
-    /// Keep `mList` under the cap by evicting oldest entries
-    /// (and any group header that becomes orphaned). Increments
-    /// `mDroppedCount` per evicted error row.
-    ///
-    /// Does *not* manage the overflow footer -- that's
-    /// `RebuildOverflowFooter`'s job. Splitting them matters
-    /// because a single batch larger than the cap reaches
-    /// `mErrorCount == MAX_DISPLAYED_ERRORS` exactly (the
-    /// pre-trim in `AppendErrors` lops the surplus off the
-    /// *input* before items are minted), so this method has no
-    /// eviction work to do but the dock still owes the user a
-    /// footer reflecting the pre-trimmed drops.
+    /// Evict oldest entries until the count is back under the cap.
+    /// Re-mints the most recently evicted group header when its
+    /// surviving rows would otherwise be stranded.
     void TrimToCap();
 
-    /// Ensure the trailing overflow footer is present iff
-    /// `mDroppedCount > 0`, with text reflecting the current
-    /// count. Idempotent. The caller is responsible for having
-    /// removed any prior footer (`AppendErrors` does this at the
-    /// top of the function) so this method only ever *adds* a
-    /// footer; it never has to compare-and-replace.
+    /// Append the "...N more dropped" footer iff `mDroppedCount > 0`.
+    /// Caller is responsible for stripping any prior footer first.
     void RebuildOverflowFooter();
 
     QListWidget *mList = nullptr;
     QLabel *mSummary = nullptr;
     QPushButton *mClearButton = nullptr;
 
-    /// Running tally of error rows in `mList`. Maintained on
-    /// every append / evict / clear so `Count()` stays O(1) and
-    /// `RefreshSummary` doesn't walk the list.
+    /// Running tally of error rows in `mList` so `Count()` stays O(1).
     int mErrorCount = 0;
     /// Cumulative evictions since the last `ClearErrors()`.
     int mDroppedCount = 0;
-    /// `false` until the first `AppendErrors` of the session, then
-    /// `true` until `ResetSessionState` re-arms it. Decoupled from
-    /// `mErrorCount`/`mDroppedCount` so the in-dock Clear button
-    /// (which zeroes both counters) does not retrigger
-    /// `firstBatchArrived` on the next streamed parse error -- if
-    /// the user just clicked Clear they have signalled they're
-    /// not interested in being interrupted again.
+    /// First-batch latch; cleared only by `ResetSessionState`. Decoupled
+    /// from the counts so the in-dock Clear button doesn't re-arm the
+    /// auto-raise -- the user already signalled they're not interested.
     bool mHasSeenFirstBatch = false;
 };

--- a/app/include/parse_errors_dock.hpp
+++ b/app/include/parse_errors_dock.hpp
@@ -41,17 +41,30 @@ public:
     explicit ParseErrorsDock(QWidget *parent = nullptr);
 
     /// Append one batch of errors under @p title. No-op for an
-    /// empty @p errors. The dock auto-raises only on the first
-    /// batch of a session (i.e. when the panel was previously
-    /// empty); subsequent batches update silently and rely on the
-    /// status-bar indicator to surface the new count. This avoids
-    /// stealing focus from a streaming-session user who has
-    /// already deliberately closed the dock.
+    /// empty @p errors. The dock fires `firstBatchArrived` only
+    /// once per session boundary (see `ResetSessionState`);
+    /// subsequent batches update silently and rely on the
+    /// status-bar indicator. This avoids stealing focus from a
+    /// streaming-session user who has already deliberately closed
+    /// the dock or used the Clear button mid-session.
     void AppendErrors(const QString &title, const std::vector<std::string> &errors);
 
-    /// Drop every entry. Used when the user clicks the Clear
-    /// button and from `MainWindow` on session discards.
+    /// Drop every displayed entry. Wired to the in-dock Clear
+    /// button. Does **not** re-arm `firstBatchArrived`: a user
+    /// who clicks Clear and dismisses the dock should not have
+    /// it re-pop the next time a streaming line fails to parse.
+    /// Use `ResetSessionState()` for the destructive session
+    /// boundary path (NewSession, OpenLogStreamFromPath, ...).
     void ClearErrors();
+
+    /// Drop every displayed entry **and** re-arm
+    /// `firstBatchArrived` so the next call to `AppendErrors`
+    /// fires it again. `MainWindow` calls this from every
+    /// destructive session boundary (NewSession,
+    /// OpenLogStreamFromPath, OpenNetworkStream,
+    /// ApplyLoadedConfiguration, append-replace) so a fresh
+    /// session can auto-raise the dock on its first error.
+    void ResetSessionState();
 
     /// Total number of error entries currently displayed (does
     /// not include evicted entries; see @p DroppedCount). O(1).
@@ -137,4 +150,12 @@ private:
     int mErrorCount = 0;
     /// Cumulative evictions since the last `ClearErrors()`.
     int mDroppedCount = 0;
+    /// `false` until the first `AppendErrors` of the session, then
+    /// `true` until `ResetSessionState` re-arms it. Decoupled from
+    /// `mErrorCount`/`mDroppedCount` so the in-dock Clear button
+    /// (which zeroes both counters) does not retrigger
+    /// `firstBatchArrived` on the next streamed parse error -- if
+    /// the user just clicked Clear they have signalled they're
+    /// not interested in being interrupted again.
+    bool mHasSeenFirstBatch = false;
 };

--- a/app/include/parse_errors_dock.hpp
+++ b/app/include/parse_errors_dock.hpp
@@ -1,0 +1,58 @@
+#pragma once
+
+#include <QDockWidget>
+#include <QString>
+
+#include <string>
+#include <vector>
+
+class QListWidget;
+class QPushButton;
+class QLabel;
+
+/// Dockable panel that shows accumulated parse / open errors.
+///
+/// Replaces the modal `QMessageBox::warning` that used to surface
+/// errors from `MainWindow::ShowParseErrors`. A persistent panel
+/// is better suited to streaming sessions where new errors can
+/// arrive at any moment without the user wanting to dismiss a
+/// dialog each time.
+///
+/// Position persists across runs via `QMainWindow::saveState()`
+/// / `restoreState()` keyed on the dock's `objectName`. Entries
+/// are session-scoped — a new file open or model reset calls
+/// `Clear()`.
+class ParseErrorsDock : public QDockWidget
+{
+    Q_OBJECT
+
+public:
+    explicit ParseErrorsDock(QWidget *parent = nullptr);
+
+    /// Append one batch of errors under @p title. No-op for an
+    /// empty @p errors. Auto-shows + raises the dock so the user
+    /// notices the new entries.
+    void AppendErrors(const QString &title, const std::vector<std::string> &errors);
+
+    /// Drop every entry. Used when the user clicks the Clear
+    /// button and from `MainWindow` on session discards.
+    void ClearErrors();
+
+    /// Total number of error entries currently displayed.
+    [[nodiscard]] int Count() const noexcept;
+
+signals:
+    /// Emitted whenever `Count()` changes. The status-bar
+    /// indicator listens here so it can hide itself when the
+    /// dock empties.
+    void countChanged(int count);
+
+private:
+    /// Refresh the header summary (e.g. "12 entries") and emit
+    /// `countChanged`.
+    void RefreshSummary();
+
+    QListWidget *mList = nullptr;
+    QLabel *mSummary = nullptr;
+    QPushButton *mClearButton = nullptr;
+};

--- a/app/include/preferences_editor.hpp
+++ b/app/include/preferences_editor.hpp
@@ -25,20 +25,10 @@ public:
     void UpdateFields();
 
 protected:
-    /// Treat closing the window (X button, Esc, OS shortcut) as
-    /// Cancel: revert any live-previewed theme to the persisted
-    /// selection and reload the streaming/session config. Without
-    /// this, a Dark preview leaks past the dialog until the next
-    /// application restart, because `QWidget::close()` does not go
-    /// through the Cancel slot.
-    ///
-    /// Both Ok and Cancel slots set `mClosingViaButton` and call
-    /// `close()`, so this slot fires for them too. Skipping the
-    /// revert in those paths avoids an extra disk read on Ok and
-    /// a redundant theme round-trip on Cancel; the bypass is keyed
-    /// on the flag rather than just an idempotency claim because
-    /// `StreamingControl::LoadConfiguration` is not free and could
-    /// surface transient I/O errors during a perfectly normal Ok.
+    /// Treat genuine close (X / Esc / OS shortcut) as Cancel so a
+    /// live-previewed theme doesn't leak past the dialog. Ok / Cancel
+    /// slots set `mClosingViaButton` to bypass this path -- they've
+    /// already taken care of state.
     void closeEvent(QCloseEvent *event) override;
 
 signals:
@@ -83,10 +73,7 @@ private:
     /// its theme work in that case.
     ThemeControl *mTheme;
 
-    /// Set by the Ok / Cancel button slots immediately before they
-    /// call `close()`, so `closeEvent` can skip the revert path.
-    /// The X button / Alt+F4 / programmatic `close()` from
-    /// elsewhere all leave it `false`, which is the case the
-    /// revert exists for.
+    /// Set by Ok / Cancel before they call `close()` so `closeEvent`
+    /// skips the revert path. Genuine close (X / Alt+F4) leaves it false.
     bool mClosingViaButton = false;
 };

--- a/app/include/preferences_editor.hpp
+++ b/app/include/preferences_editor.hpp
@@ -31,6 +31,14 @@ protected:
     /// this, a Dark preview leaks past the dialog until the next
     /// application restart, because `QWidget::close()` does not go
     /// through the Cancel slot.
+    ///
+    /// Both Ok and Cancel slots set `mClosingViaButton` and call
+    /// `close()`, so this slot fires for them too. Skipping the
+    /// revert in those paths avoids an extra disk read on Ok and
+    /// a redundant theme round-trip on Cancel; the bypass is keyed
+    /// on the flag rather than just an idempotency claim because
+    /// `StreamingControl::LoadConfiguration` is not free and could
+    /// surface transient I/O errors during a perfectly normal Ok.
     void closeEvent(QCloseEvent *event) override;
 
 signals:
@@ -74,4 +82,11 @@ private:
     /// `nullptr` is tolerated for tests; the theme group skips
     /// its theme work in that case.
     ThemeControl *mTheme;
+
+    /// Set by the Ok / Cancel button slots immediately before they
+    /// call `close()`, so `closeEvent` can skip the revert path.
+    /// The X button / Alt+F4 / programmatic `close()` from
+    /// elsewhere all leave it `false`, which is the case the
+    /// revert exists for.
+    bool mClosingViaButton = false;
 };

--- a/app/include/preferences_editor.hpp
+++ b/app/include/preferences_editor.hpp
@@ -7,6 +7,7 @@
 #include <QTimer>
 #include <QWidget>
 
+class QCloseEvent;
 class ThemeControl;
 
 class PreferencesEditor : public QWidget
@@ -22,6 +23,15 @@ public:
     explicit PreferencesEditor(ThemeControl *theme = nullptr, QWidget *parent = nullptr);
 
     void UpdateFields();
+
+protected:
+    /// Treat closing the window (X button, Esc, OS shortcut) as
+    /// Cancel: revert any live-previewed theme to the persisted
+    /// selection and reload the streaming/session config. Without
+    /// this, a Dark preview leaks past the dialog until the next
+    /// application restart, because `QWidget::close()` does not go
+    /// through the Cancel slot.
+    void closeEvent(QCloseEvent *event) override;
 
 signals:
     /// Fired after Ok commits the new retention cap to `QSettings`.

--- a/app/include/record_detail_dock.hpp
+++ b/app/include/record_detail_dock.hpp
@@ -6,6 +6,7 @@
 
 class LogModel;
 class RecordDetailWidget;
+class QCloseEvent;
 
 /// Dockable host for a single `RecordDetailWidget`. Owned by
 /// `MainWindow`; lives next to the central table view.
@@ -63,6 +64,20 @@ signals:
     /// User clicked "Open in new window". Argument is the current
     /// source row, or -1 when no row is pinned.
     void openInNewWindowRequested(int sourceRow);
+
+    /// Emitted when the user actually dismisses the dock (X
+    /// button, system close). Not emitted on tab inactivation,
+    /// so the View-menu toggle stays accurate when the dock is
+    /// tabified with another (e.g. `AnchorsDock`).
+    void closed();
+
+protected:
+    /// Emit `closed` once the base class accepts the close.
+    /// `visibilityChanged(false)` alone is ambiguous for tabified
+    /// docks (it fires on tab switches too); this signal lets the
+    /// View-menu checkmark react only to genuine user-initiated
+    /// dismissals.
+    void closeEvent(QCloseEvent *event) override;
 
 #ifdef LOGAPP_BUILD_TESTING
 public:

--- a/app/include/record_detail_dock.hpp
+++ b/app/include/record_detail_dock.hpp
@@ -65,18 +65,12 @@ signals:
     /// source row, or -1 when no row is pinned.
     void openInNewWindowRequested(int sourceRow);
 
-    /// Emitted when the user actually dismisses the dock (X
-    /// button, system close). Not emitted on tab inactivation,
-    /// so the View-menu toggle stays accurate when the dock is
-    /// tabified with another (e.g. `AnchorsDock`).
+    /// Emitted on genuine user dismissal (X button, system close).
+    /// Distinct from `visibilityChanged(false)`, which also fires on
+    /// tab inactivation in a tabified group.
     void closed();
 
 protected:
-    /// Emit `closed` once the base class accepts the close.
-    /// `visibilityChanged(false)` alone is ambiguous for tabified
-    /// docks (it fires on tab switches too); this signal lets the
-    /// View-menu checkmark react only to genuine user-initiated
-    /// dismissals.
     void closeEvent(QCloseEvent *event) override;
 
 #ifdef LOGAPP_BUILD_TESTING

--- a/app/src/anchors_dock.cpp
+++ b/app/src/anchors_dock.cpp
@@ -6,6 +6,7 @@
 #include <QAction>
 #include <QApplication>
 #include <QBrush>
+#include <QCloseEvent>
 #include <QHBoxLayout>
 #include <QIcon>
 #include <QListWidget>
@@ -303,6 +304,15 @@ bool AnchorsDock::IsVisibleForRefresh() const noexcept
         return false;
     }
     return mPerceivedVisible;
+}
+
+void AnchorsDock::closeEvent(QCloseEvent *event)
+{
+    QDockWidget::closeEvent(event);
+    if (event->isAccepted())
+    {
+        emit closed();
+    }
 }
 
 int AnchorsDock::SourceRowForItem(const QListWidgetItem *item) const

--- a/app/src/configuration_diagnostics_dialog.cpp
+++ b/app/src/configuration_diagnostics_dialog.cpp
@@ -9,9 +9,11 @@
 #include <QBrush>
 #include <QColor>
 #include <QDialogButtonBox>
+#include <QEvent>
 #include <QHBoxLayout>
 #include <QHeaderView>
 #include <QLabel>
+#include <QPalette>
 #include <QPushButton>
 #include <QStringList>
 #include <QStyle>
@@ -25,6 +27,9 @@ namespace
 {
 constexpr int DIALOG_INITIAL_WIDTH = 720;
 constexpr int DIALOG_INITIAL_HEIGHT = 480;
+/// `QColor::lightness` is 0..255. Below this we treat the dialog as
+/// running on a dark palette and pick the dark-mode highlight colours.
+constexpr int BASE_LUMA_DARK_THRESHOLD = 128;
 constexpr int COL_HEADER = 0;
 constexpr int COL_TYPE = 1;
 constexpr int COL_AUTODETECT = 2;
@@ -270,12 +275,24 @@ void ConfigurationDiagnosticsDialog::Refresh()
 
         if (mismatched > 0)
         {
-            const QBrush highlight(QColor(255, 235, 235));
+            // Theme-aware "warning row" highlight. We pair an explicit
+            // background and foreground so legibility holds on every
+            // palette: a uniform pale pink reads as near-white on
+            // dark themes (the bug the original explicit-fg fix
+            // tried to mitigate but still left the row glaringly
+            // bright). On Dark we flip to a muted maroon bg with a
+            // light-pink fg so the row still reads as "warning" but
+            // sits inside the dark dialog instead of punching through
+            // it.
+            const bool darkMode = palette().color(QPalette::Base).lightness() < BASE_LUMA_DARK_THRESHOLD;
+            const QBrush highlightBg(darkMode ? QColor(80, 30, 30) : QColor(255, 235, 235));
+            const QBrush highlightFg(darkMode ? QColor(255, 210, 210) : QColor(60, 0, 0));
             for (int c = 0; c < mTable->columnCount(); ++c)
             {
                 if (auto *item = mTable->item(i, c); item != nullptr)
                 {
-                    item->setBackground(highlight);
+                    item->setBackground(highlightBg);
+                    item->setForeground(highlightFg);
                 }
             }
         }
@@ -317,4 +334,24 @@ int ConfigurationDiagnosticsDialog::MismatchedColumnCount(const LogModel &model)
         }
     }
     return mismatched;
+}
+
+void ConfigurationDiagnosticsDialog::changeEvent(QEvent *event)
+{
+    if (event != nullptr)
+    {
+        const QEvent::Type type = event->type();
+        if (type == QEvent::PaletteChange || type == QEvent::StyleChange ||
+            type == QEvent::ApplicationPaletteChange || type == QEvent::ThemeChange)
+        {
+            // Re-render so the warning-row brushes follow the new
+            // palette. Guarded on `mModel` because `Refresh()`
+            // dereferences it.
+            if (mModel != nullptr)
+            {
+                Refresh();
+            }
+        }
+    }
+    QDialog::changeEvent(event);
 }

--- a/app/src/configuration_diagnostics_dialog.cpp
+++ b/app/src/configuration_diagnostics_dialog.cpp
@@ -271,7 +271,7 @@ void ConfigurationDiagnosticsDialog::Refresh()
     // luminance heuristic on platforms / Qt builds that return
     // `Unknown`.
     Qt::ColorScheme scheme = Qt::ColorScheme::Unknown;
-    if (QStyleHints *hints = QGuiApplication::styleHints(); hints != nullptr)
+    if (const QStyleHints *hints = QGuiApplication::styleHints(); hints != nullptr)
     {
         scheme = hints->colorScheme();
     }

--- a/app/src/configuration_diagnostics_dialog.cpp
+++ b/app/src/configuration_diagnostics_dialog.cpp
@@ -10,6 +10,7 @@
 #include <QColor>
 #include <QDialogButtonBox>
 #include <QEvent>
+#include <QGuiApplication>
 #include <QHBoxLayout>
 #include <QHeaderView>
 #include <QLabel>
@@ -17,6 +18,7 @@
 #include <QPushButton>
 #include <QStringList>
 #include <QStyle>
+#include <QStyleHints>
 #include <QTableWidget>
 #include <QTableWidgetItem>
 #include <QVBoxLayout>
@@ -28,8 +30,32 @@ namespace
 constexpr int DIALOG_INITIAL_WIDTH = 720;
 constexpr int DIALOG_INITIAL_HEIGHT = 480;
 /// `QColor::lightness` is 0..255. Below this we treat the dialog as
-/// running on a dark palette and pick the dark-mode highlight colours.
+/// running on a dark palette. Used as a fallback when
+/// `QGuiApplication::styleHints()->colorScheme()` returns
+/// `Qt::ColorScheme::Unknown` (older Qt builds, custom platforms).
 constexpr int BASE_LUMA_DARK_THRESHOLD = 128;
+/// Opacity of the warning-row tint. Low enough that the underlying
+/// alternate-row banding still shows through, high enough that the
+/// row reads as warning at a glance.
+constexpr int WARNING_TINT_ALPHA = 64;
+/// HSV saturation for the warning row's red tint, on each theme.
+/// Dark themes need a punchier saturation because the eye dampens
+/// reds against a dark surface; light themes settle for a paler
+/// pink tint so the highlight doesn't overpower the cell text.
+constexpr int WARNING_HSV_SATURATION_DARK = 200;
+constexpr int WARNING_HSV_SATURATION_LIGHT = 110;
+/// Floor on `surface.value()` so a near-black surface (custom
+/// themes pushing the base towards `#000`) doesn't yield a
+/// nearly-invisible red.
+constexpr int WARNING_HSV_VALUE_FLOOR = 40;
+/// Foreground biasing on the warning row's text colour. On dark
+/// themes the palette `Text` is near-white; nudge red up by this
+/// amount so "warning red" reads against the tinted base. On light
+/// themes the palette `Text` is near-black; halve it (and clamp at
+/// the lower bound below) so the saturated red below stays legible.
+constexpr int WARNING_FG_RED_BIAS_DARK = 40;
+constexpr int WARNING_FG_GREEN_BLUE_DARK = 200;
+constexpr int WARNING_FG_RED_FLOOR_LIGHT = 100;
 constexpr int COL_HEADER = 0;
 constexpr int COL_TYPE = 1;
 constexpr int COL_AUTODETECT = 2;
@@ -236,6 +262,48 @@ void ConfigurationDiagnosticsDialog::Refresh()
     mTable->clearContents();
     mTable->setRowCount(static_cast<int>(columns.size()));
 
+    // Resolve the warning brushes once per `Refresh()` so every
+    // mismatched row uses identical colours and the per-row loop
+    // stays cheap. Derive from the active palette so user themes
+    // (high-contrast, custom palettes) get sane warning highlights
+    // without a separate code path. `colorScheme()` (Qt 6.5+) is
+    // the canonical "is this dark?" probe; fall back to the
+    // luminance heuristic on platforms / Qt builds that return
+    // `Unknown`.
+    Qt::ColorScheme scheme = Qt::ColorScheme::Unknown;
+    if (QStyleHints *hints = QGuiApplication::styleHints(); hints != nullptr)
+    {
+        scheme = hints->colorScheme();
+    }
+    const bool darkMode = (scheme == Qt::ColorScheme::Dark) ||
+                          (scheme == Qt::ColorScheme::Unknown &&
+                           palette().color(QPalette::Base).lightness() < BASE_LUMA_DARK_THRESHOLD);
+    // Tint the row red but anchor saturation/value to the surface
+    // so the highlight sits *inside* the dialog instead of
+    // punching through it. Alpha is kept low so alternate-row
+    // banding still reads. Foreground biases the palette `Text`
+    // colour toward red on dark themes (otherwise pure-white text
+    // on a pink-tinted dark base reads identical to a normal
+    // row); on light themes a darker saturated red gives the
+    // strongest legibility against the pale tint.
+    const QColor surface = palette().color(QPalette::Base);
+    QColor warningBg = QColor::fromHsv(
+        /*h=*/0,
+        darkMode ? WARNING_HSV_SATURATION_DARK : WARNING_HSV_SATURATION_LIGHT,
+        std::max(surface.value(), WARNING_HSV_VALUE_FLOOR)
+    );
+    warningBg.setAlpha(WARNING_TINT_ALPHA);
+    const QColor textColor = palette().color(QPalette::Text);
+    const QColor warningFg = darkMode
+        ? QColor(
+              std::min(textColor.red() + WARNING_FG_RED_BIAS_DARK, 255),
+              WARNING_FG_GREEN_BLUE_DARK,
+              WARNING_FG_GREEN_BLUE_DARK
+          )
+        : QColor(std::max(textColor.red() / 2, WARNING_FG_RED_FLOOR_LIGHT), 0, 0);
+    const QBrush highlightBg(warningBg);
+    const QBrush highlightFg(warningFg);
+
     int mismatchedColumns = 0;
     for (int i = 0; std::cmp_less(i, columns.size()); ++i)
     {
@@ -275,18 +343,9 @@ void ConfigurationDiagnosticsDialog::Refresh()
 
         if (mismatched > 0)
         {
-            // Theme-aware "warning row" highlight. We pair an explicit
-            // background and foreground so legibility holds on every
-            // palette: a uniform pale pink reads as near-white on
-            // dark themes (the bug the original explicit-fg fix
-            // tried to mitigate but still left the row glaringly
-            // bright). On Dark we flip to a muted maroon bg with a
-            // light-pink fg so the row still reads as "warning" but
-            // sits inside the dark dialog instead of punching through
-            // it.
-            const bool darkMode = palette().color(QPalette::Base).lightness() < BASE_LUMA_DARK_THRESHOLD;
-            const QBrush highlightBg(darkMode ? QColor(80, 30, 30) : QColor(255, 235, 235));
-            const QBrush highlightFg(darkMode ? QColor(255, 210, 210) : QColor(60, 0, 0));
+            // Brushes resolved once per `Refresh()` from the
+            // active palette; see the `darkMode` / `warningBg`
+            // setup above the loop.
             for (int c = 0; c < mTable->columnCount(); ++c)
             {
                 if (auto *item = mTable->item(i, c); item != nullptr)

--- a/app/src/configuration_diagnostics_dialog.cpp
+++ b/app/src/configuration_diagnostics_dialog.cpp
@@ -275,9 +275,9 @@ void ConfigurationDiagnosticsDialog::Refresh()
     {
         scheme = hints->colorScheme();
     }
-    const bool darkMode = (scheme == Qt::ColorScheme::Dark) ||
-                          (scheme == Qt::ColorScheme::Unknown &&
-                           palette().color(QPalette::Base).lightness() < BASE_LUMA_DARK_THRESHOLD);
+    const bool darkMode =
+        (scheme == Qt::ColorScheme::Dark) ||
+        (scheme == Qt::ColorScheme::Unknown && palette().color(QPalette::Base).lightness() < BASE_LUMA_DARK_THRESHOLD);
     // Tint the row red but anchor saturation/value to the surface
     // so the highlight sits *inside* the dialog instead of
     // punching through it. Alpha is kept low so alternate-row
@@ -294,13 +294,12 @@ void ConfigurationDiagnosticsDialog::Refresh()
     );
     warningBg.setAlpha(WARNING_TINT_ALPHA);
     const QColor textColor = palette().color(QPalette::Text);
-    const QColor warningFg = darkMode
-        ? QColor(
-              std::min(textColor.red() + WARNING_FG_RED_BIAS_DARK, 255),
-              WARNING_FG_GREEN_BLUE_DARK,
-              WARNING_FG_GREEN_BLUE_DARK
-          )
-        : QColor(std::max(textColor.red() / 2, WARNING_FG_RED_FLOOR_LIGHT), 0, 0);
+    const QColor warningFg = darkMode ? QColor(
+                                            std::min(textColor.red() + WARNING_FG_RED_BIAS_DARK, 255),
+                                            WARNING_FG_GREEN_BLUE_DARK,
+                                            WARNING_FG_GREEN_BLUE_DARK
+                                        )
+                                      : QColor(std::max(textColor.red() / 2, WARNING_FG_RED_FLOOR_LIGHT), 0, 0);
     const QBrush highlightBg(warningBg);
     const QBrush highlightFg(warningFg);
 
@@ -400,8 +399,8 @@ void ConfigurationDiagnosticsDialog::changeEvent(QEvent *event)
     if (event != nullptr)
     {
         const QEvent::Type type = event->type();
-        if (type == QEvent::PaletteChange || type == QEvent::StyleChange ||
-            type == QEvent::ApplicationPaletteChange || type == QEvent::ThemeChange)
+        if (type == QEvent::PaletteChange || type == QEvent::StyleChange || type == QEvent::ApplicationPaletteChange ||
+            type == QEvent::ThemeChange)
         {
             // Re-render so the warning-row brushes follow the new
             // palette. Guarded on `mModel` because `Refresh()`

--- a/app/src/configuration_diagnostics_dialog.cpp
+++ b/app/src/configuration_diagnostics_dialog.cpp
@@ -29,30 +29,16 @@ namespace
 {
 constexpr int DIALOG_INITIAL_WIDTH = 720;
 constexpr int DIALOG_INITIAL_HEIGHT = 480;
-/// `QColor::lightness` is 0..255. Below this we treat the dialog as
-/// running on a dark palette. Used as a fallback when
-/// `QGuiApplication::styleHints()->colorScheme()` returns
-/// `Qt::ColorScheme::Unknown` (older Qt builds, custom platforms).
+/// Lightness fallback for "is this dark?" when `colorScheme()` returns Unknown.
 constexpr int BASE_LUMA_DARK_THRESHOLD = 128;
-/// Opacity of the warning-row tint. Low enough that the underlying
-/// alternate-row banding still shows through, high enough that the
-/// row reads as warning at a glance.
+/// Warning-tint alpha: low enough to let alternate-row banding through.
 constexpr int WARNING_TINT_ALPHA = 64;
-/// HSV saturation for the warning row's red tint, on each theme.
-/// Dark themes need a punchier saturation because the eye dampens
-/// reds against a dark surface; light themes settle for a paler
-/// pink tint so the highlight doesn't overpower the cell text.
+/// HSV saturation for the warning tint; dark themes need a punchier red.
 constexpr int WARNING_HSV_SATURATION_DARK = 200;
 constexpr int WARNING_HSV_SATURATION_LIGHT = 110;
-/// Floor on `surface.value()` so a near-black surface (custom
-/// themes pushing the base towards `#000`) doesn't yield a
-/// nearly-invisible red.
+/// Floor on surface value so a near-black base doesn't render an invisible red.
 constexpr int WARNING_HSV_VALUE_FLOOR = 40;
-/// Foreground biasing on the warning row's text colour. On dark
-/// themes the palette `Text` is near-white; nudge red up by this
-/// amount so "warning red" reads against the tinted base. On light
-/// themes the palette `Text` is near-black; halve it (and clamp at
-/// the lower bound below) so the saturated red below stays legible.
+/// Warning-text colour biases per theme: nudge red up on dark, clamp down on light.
 constexpr int WARNING_FG_RED_BIAS_DARK = 40;
 constexpr int WARNING_FG_GREEN_BLUE_DARK = 200;
 constexpr int WARNING_FG_RED_FLOOR_LIGHT = 100;
@@ -262,14 +248,10 @@ void ConfigurationDiagnosticsDialog::Refresh()
     mTable->clearContents();
     mTable->setRowCount(static_cast<int>(columns.size()));
 
-    // Resolve the warning brushes once per `Refresh()` so every
-    // mismatched row uses identical colours and the per-row loop
-    // stays cheap. Derive from the active palette so user themes
-    // (high-contrast, custom palettes) get sane warning highlights
-    // without a separate code path. `colorScheme()` (Qt 6.5+) is
-    // the canonical "is this dark?" probe; fall back to the
-    // luminance heuristic on platforms / Qt builds that return
-    // `Unknown`.
+    // Resolve warning brushes once from the active palette so user
+    // themes get sane highlights without a separate code path.
+    // `colorScheme()` (Qt 6.5+) is the "is this dark?" probe; the
+    // luminance heuristic covers Qt builds that return Unknown.
     Qt::ColorScheme scheme = Qt::ColorScheme::Unknown;
     if (const QStyleHints *hints = QGuiApplication::styleHints(); hints != nullptr)
     {
@@ -278,14 +260,8 @@ void ConfigurationDiagnosticsDialog::Refresh()
     const bool darkMode =
         (scheme == Qt::ColorScheme::Dark) ||
         (scheme == Qt::ColorScheme::Unknown && palette().color(QPalette::Base).lightness() < BASE_LUMA_DARK_THRESHOLD);
-    // Tint the row red but anchor saturation/value to the surface
-    // so the highlight sits *inside* the dialog instead of
-    // punching through it. Alpha is kept low so alternate-row
-    // banding still reads. Foreground biases the palette `Text`
-    // colour toward red on dark themes (otherwise pure-white text
-    // on a pink-tinted dark base reads identical to a normal
-    // row); on light themes a darker saturated red gives the
-    // strongest legibility against the pale tint.
+    // Tint anchored to the surface (instead of a fixed colour) so the
+    // highlight sits inside the dialog rather than punching through it.
     const QColor surface = palette().color(QPalette::Base);
     QColor warningBg = QColor::fromHsv(
         /*h=*/0,
@@ -342,9 +318,6 @@ void ConfigurationDiagnosticsDialog::Refresh()
 
         if (mismatched > 0)
         {
-            // Brushes resolved once per `Refresh()` from the
-            // active palette; see the `darkMode` / `warningBg`
-            // setup above the loop.
             for (int c = 0; c < mTable->columnCount(); ++c)
             {
                 if (auto *item = mTable->item(i, c); item != nullptr)
@@ -402,9 +375,7 @@ void ConfigurationDiagnosticsDialog::changeEvent(QEvent *event)
         if (type == QEvent::PaletteChange || type == QEvent::StyleChange || type == QEvent::ApplicationPaletteChange ||
             type == QEvent::ThemeChange)
         {
-            // Re-render so the warning-row brushes follow the new
-            // palette. Guarded on `mModel` because `Refresh()`
-            // dereferences it.
+            // Re-render so the warning-row brushes follow the new palette.
             if (mModel != nullptr)
             {
                 Refresh();

--- a/app/src/find_dock.cpp
+++ b/app/src/find_dock.cpp
@@ -1,0 +1,27 @@
+#include "find_dock.hpp"
+
+#include "find_record_widget.hpp"
+
+FindDock::FindDock(QWidget *parent)
+    : QDockWidget(tr("Find"), parent)
+{
+    setObjectName(QStringLiteral("findDock"));
+    // Find bars belong at the top or the bottom of the editor; a
+    // vertical side dock would squeeze the search field into a
+    // useless narrow column.
+    setAllowedAreas(Qt::TopDockWidgetArea | Qt::BottomDockWidgetArea);
+    setFeatures(QDockWidget::DockWidgetClosable | QDockWidget::DockWidgetMovable | QDockWidget::DockWidgetFloatable);
+
+    mWidget = new FindRecordWidget(this);
+    setWidget(mWidget);
+}
+
+void FindDock::RevealAndFocus()
+{
+    if (!isVisible())
+    {
+        show();
+    }
+    raise();
+    mWidget->SetEditFocus();
+}

--- a/app/src/find_dock.cpp
+++ b/app/src/find_dock.cpp
@@ -2,6 +2,10 @@
 
 #include "find_record_widget.hpp"
 
+#include <QApplication>
+#include <QHideEvent>
+#include <QWidget>
+
 FindDock::FindDock(QWidget *parent)
     : QDockWidget(tr("Find"), parent)
 {
@@ -18,10 +22,38 @@ FindDock::FindDock(QWidget *parent)
 
 void FindDock::RevealAndFocus()
 {
+    // Capture the pre-reveal focus only on a real reveal: a second
+    // call while the bar is already open should not overwrite the
+    // saved target with the find edit itself.
     if (!isVisible())
     {
+        QWidget *current = QApplication::focusWidget();
+        // Don't re-stash a pointer into our own subtree -- if the
+        // bar was hidden but somehow holds focus (test path), the
+        // restore would just bounce back into the find edit.
+        if (current != nullptr && !isAncestorOf(current))
+        {
+            mFocusBeforeReveal = current;
+        }
         show();
     }
     raise();
     mWidget->SetEditFocus();
+}
+
+void FindDock::hideEvent(QHideEvent *event)
+{
+    // Snapshot + clear before forwarding so a re-entrant hide
+    // (e.g. inside a focusOut handler that triggers another
+    // close) can't double-fire the restore.
+    QWidget *target = mFocusBeforeReveal.data();
+    mFocusBeforeReveal.clear();
+    QDockWidget::hideEvent(event);
+    // Skip the restore for the construction-time `hide()` (no
+    // saved target) and for restores that race a teardown of the
+    // previously-focused widget.
+    if (target != nullptr && target->isVisible())
+    {
+        target->setFocus(Qt::OtherFocusReason);
+    }
 }

--- a/app/src/find_dock.cpp
+++ b/app/src/find_dock.cpp
@@ -23,19 +23,24 @@ FindDock::FindDock(QWidget *parent)
 
 void FindDock::RevealAndFocus()
 {
-    // Capture the pre-reveal focus only on a real reveal: a second
-    // call while the bar is already open should not overwrite the
-    // saved target with the find edit itself.
+    // Refresh `mFocusBeforeReveal` on *every* reveal whose source
+    // focus is outside our subtree. Earlier we gated this on
+    // `!isVisible()`, which meant a Ctrl+F invoked while the bar
+    // was already on-screen (but the user had clicked back into
+    // the table view) kept the stash pointing at whatever was
+    // focused on the very first reveal -- often a widget that no
+    // longer existed or no longer made sense to restore. The
+    // `isAncestorOf` guard still prevents a focus already inside
+    // the bar (the edit, the regex toggle, ...) from overwriting
+    // the saved target with itself; otherwise dismissing the bar
+    // would just bounce focus back into the bar's own widget tree.
+    QWidget *current = QApplication::focusWidget();
+    if (current != nullptr && !isAncestorOf(current))
+    {
+        mFocusBeforeReveal = current;
+    }
     if (!isVisible())
     {
-        QWidget *current = QApplication::focusWidget();
-        // Don't re-stash a pointer into our own subtree -- if the
-        // bar was hidden but somehow holds focus (test path), the
-        // restore would just bounce back into the find edit.
-        if (current != nullptr && !isAncestorOf(current))
-        {
-            mFocusBeforeReveal = current;
-        }
         show();
     }
     raise();

--- a/app/src/find_dock.cpp
+++ b/app/src/find_dock.cpp
@@ -3,6 +3,7 @@
 #include "find_record_widget.hpp"
 
 #include <QApplication>
+#include <QCloseEvent>
 #include <QHideEvent>
 #include <QWidget>
 
@@ -55,5 +56,14 @@ void FindDock::hideEvent(QHideEvent *event)
     if (target != nullptr && target->isVisible())
     {
         target->setFocus(Qt::OtherFocusReason);
+    }
+}
+
+void FindDock::closeEvent(QCloseEvent *event)
+{
+    QDockWidget::closeEvent(event);
+    if (event->isAccepted())
+    {
+        emit closed();
     }
 }

--- a/app/src/find_dock.cpp
+++ b/app/src/find_dock.cpp
@@ -4,7 +4,7 @@
 
 #include <QApplication>
 #include <QCloseEvent>
-#include <QHideEvent>
+#include <QShowEvent>
 #include <QWidget>
 
 FindDock::FindDock(QWidget *parent)
@@ -42,28 +42,35 @@ void FindDock::RevealAndFocus()
     mWidget->SetEditFocus();
 }
 
-void FindDock::hideEvent(QHideEvent *event)
+void FindDock::closeEvent(QCloseEvent *event)
 {
-    // Snapshot + clear before forwarding so a re-entrant hide
+    // Snapshot + clear before forwarding so a re-entrant close
     // (e.g. inside a focusOut handler that triggers another
     // close) can't double-fire the restore.
     QWidget *target = mFocusBeforeReveal.data();
     mFocusBeforeReveal.clear();
-    QDockWidget::hideEvent(event);
-    // Skip the restore for the construction-time `hide()` (no
-    // saved target) and for restores that race a teardown of the
-    // previously-focused widget.
+    QDockWidget::closeEvent(event);
+    if (!event->isAccepted())
+    {
+        return;
+    }
+    // Skip the restore for the construction-time hide (no saved
+    // target) and for races where the previously-focused widget
+    // was torn down while the bar was open.
     if (target != nullptr && target->isVisible())
     {
         target->setFocus(Qt::OtherFocusReason);
     }
+    emit closed();
 }
 
-void FindDock::closeEvent(QCloseEvent *event)
+void FindDock::showEvent(QShowEvent *event)
 {
-    QDockWidget::closeEvent(event);
-    if (event->isAccepted())
-    {
-        emit closed();
-    }
+    QDockWidget::showEvent(event);
+    // `revealed` fires for cold reveals *and* for tab activations
+    // inside a tabified group; both are moments when the user is
+    // about to look at the bar and any stale match count needs to
+    // catch up to model activity that happened while it was
+    // invisible.
+    emit revealed();
 }

--- a/app/src/find_dock.cpp
+++ b/app/src/find_dock.cpp
@@ -11,9 +11,8 @@ FindDock::FindDock(QWidget *parent)
     : QDockWidget(tr("Find"), parent)
 {
     setObjectName(QStringLiteral("findDock"));
-    // Find bars belong at the top or the bottom of the editor; a
-    // vertical side dock would squeeze the search field into a
-    // useless narrow column.
+    // Find bars belong on the top or bottom edge; a vertical side dock
+    // would squeeze the search field into a useless narrow column.
     setAllowedAreas(Qt::TopDockWidgetArea | Qt::BottomDockWidgetArea);
     setFeatures(QDockWidget::DockWidgetClosable | QDockWidget::DockWidgetMovable | QDockWidget::DockWidgetFloatable);
 
@@ -23,17 +22,10 @@ FindDock::FindDock(QWidget *parent)
 
 void FindDock::RevealAndFocus()
 {
-    // Refresh `mFocusBeforeReveal` on *every* reveal whose source
-    // focus is outside our subtree. Earlier we gated this on
-    // `!isVisible()`, which meant a Ctrl+F invoked while the bar
-    // was already on-screen (but the user had clicked back into
-    // the table view) kept the stash pointing at whatever was
-    // focused on the very first reveal -- often a widget that no
-    // longer existed or no longer made sense to restore. The
-    // `isAncestorOf` guard still prevents a focus already inside
-    // the bar (the edit, the regex toggle, ...) from overwriting
-    // the saved target with itself; otherwise dismissing the bar
-    // would just bounce focus back into the bar's own widget tree.
+    // Refresh the stash on every reveal whose source focus is outside
+    // our subtree, so Ctrl+F invoked while the bar is already on-screen
+    // (but focus has drifted back to the table) picks up the current
+    // target instead of a stale one from the very first reveal.
     QWidget *current = QApplication::focusWidget();
     if (current != nullptr && !isAncestorOf(current))
     {
@@ -49,9 +41,9 @@ void FindDock::RevealAndFocus()
 
 void FindDock::closeEvent(QCloseEvent *event)
 {
-    // Snapshot + clear before forwarding so a re-entrant close
-    // (e.g. inside a focusOut handler that triggers another
-    // close) can't double-fire the restore.
+    // Snapshot + clear before forwarding so a re-entrant close (e.g.
+    // a focusOut handler that triggers another close) can't double-fire
+    // the restore.
     QWidget *target = mFocusBeforeReveal.data();
     mFocusBeforeReveal.clear();
     QDockWidget::closeEvent(event);
@@ -59,9 +51,6 @@ void FindDock::closeEvent(QCloseEvent *event)
     {
         return;
     }
-    // Skip the restore for the construction-time hide (no saved
-    // target) and for races where the previously-focused widget
-    // was torn down while the bar was open.
     if (target != nullptr && target->isVisible())
     {
         target->setFocus(Qt::OtherFocusReason);
@@ -72,10 +61,5 @@ void FindDock::closeEvent(QCloseEvent *event)
 void FindDock::showEvent(QShowEvent *event)
 {
     QDockWidget::showEvent(event);
-    // `revealed` fires for cold reveals *and* for tab activations
-    // inside a tabified group; both are moments when the user is
-    // about to look at the bar and any stale match count needs to
-    // catch up to model activity that happened while it was
-    // invisible.
     emit revealed();
 }

--- a/app/src/find_record_widget.cpp
+++ b/app/src/find_record_widget.cpp
@@ -468,8 +468,7 @@ bool FindRecordWidget::eventFilter(QObject *watched, QEvent *event)
         // not enable RTTI on `QEvent`. Same idiom as the
         // `QFileOpenEvent` cast in `main.cpp`.
         auto *ke = static_cast<QKeyEvent *>(event); // NOLINT(cppcoreguidelines-pro-type-static-cast-downcast)
-        if ((ke->key() == Qt::Key_Return || ke->key() == Qt::Key_Enter) &&
-            ke->modifiers().testFlag(Qt::ShiftModifier))
+        if ((ke->key() == Qt::Key_Return || ke->key() == Qt::Key_Enter) && ke->modifiers().testFlag(Qt::ShiftModifier))
         {
             // Intercept before `QLineEdit::keyPressEvent` runs.
             // Otherwise it would emit `returnPressed` (wired to

--- a/app/src/find_record_widget.cpp
+++ b/app/src/find_record_widget.cpp
@@ -3,27 +3,19 @@
 #include <QAction>
 #include <QApplication>
 #include <QDockWidget>
-#include <QEasingCurve>
+#include <QEvent>
 #include <QHBoxLayout>
 #include <QKeyEvent>
 #include <QLabel>
 #include <QLineEdit>
-#include <QPropertyAnimation>
 #include <QShortcut>
-#include <QShowEvent>
 #include <QSizePolicy>
 #include <QStyle>
 #include <QTimer>
 #include <QToolButton>
 
-#include <algorithm>
-
 namespace
 {
-/// Slide-in / slide-out duration. Slow enough to read, fast
-/// enough not to feel sluggish; matches VS Code's find bar.
-constexpr int FIND_REVEAL_ANIMATION_MS = 120;
-
 /// Debounce window after a key press before we ask the parent to
 /// recount matches. Avoids a full-table scan on every keystroke
 /// of a long word.
@@ -121,10 +113,13 @@ FindRecordWidget::FindRecordWidget(QWidget *parent)
     connect(mButtonNext, &QToolButton::clicked, this, &FindRecordWidget::FindNext);
     connect(mButtonPrevious, &QToolButton::clicked, this, &FindRecordWidget::FindPrevious);
 
-    // Return triggers find-next; Shift+Return is wired through
-    // `keyPressEvent` because `returnPressed` does not carry
-    // modifier state.
+    // Plain Return -> find-next via `returnPressed`. Shift+Return
+    // -> find-previous is wired through `eventFilter` below;
+    // `QLineEdit::keyPressEvent` accepts Return for itself, so the
+    // event never bubbles to our `keyPressEvent`, and
+    // `returnPressed` carries no modifier state.
     connect(mEdit, &QLineEdit::returnPressed, this, &FindRecordWidget::FindNext);
+    mEdit->installEventFilter(this);
 
     // Owned single-shot timer; `start()` restarts it on each
     // keystroke so multi-keystroke edits coalesce into one
@@ -144,11 +139,10 @@ FindRecordWidget::FindRecordWidget(QWidget *parent)
 
     // Escape dismisses the bar. Scope `WidgetWithChildrenShortcut`
     // so the shortcut fires whenever this widget (or any
-    // descendant focusable) has focus. When hosted in a
-    // `QDockWidget`, close the dock so its `visibilityChanged`
-    // mirrors the toggle action and a subsequent `RevealAndFocus`
-    // properly re-shows everything. The legacy in-layout fallback
-    // (no dock parent) keeps the slide-out animation.
+    // descendant focusable) has focus. `DismissBar` closes the
+    // host `QDockWidget` so its `visibilityChanged` mirrors the
+    // toggle action and a subsequent `RevealAndFocus` properly
+    // re-shows everything.
     auto *escapeShortcut = new QShortcut(QKeySequence(Qt::Key_Escape), this);
     escapeShortcut->setContext(Qt::WidgetWithChildrenShortcut);
     connect(escapeShortcut, &QShortcut::activated, this, &FindRecordWidget::DismissBar);
@@ -181,31 +175,6 @@ void FindRecordWidget::SetMatchInfo(int current, int total)
     mMatchCountLabel->setVisible(true);
 }
 
-void FindRecordWidget::RevealAnimated()
-{
-    if (mNaturalHeight == 0)
-    {
-        // `sizeHint` is the best estimate before the first paint
-        // delivers a real geometry; tracked in `showEvent` once
-        // we know.
-        mNaturalHeight = sizeHint().height();
-    }
-    setMaximumHeight(mNaturalHeight);
-    show();
-
-    if (mAnimation && mAnimation->state() == QAbstractAnimation::Running)
-    {
-        mAnimation->stop();
-    }
-    auto *animation = new QPropertyAnimation(this, "maximumHeight", this);
-    animation->setDuration(FIND_REVEAL_ANIMATION_MS);
-    animation->setStartValue(0);
-    animation->setEndValue(mNaturalHeight);
-    animation->setEasingCurve(QEasingCurve::OutCubic);
-    animation->start(QAbstractAnimation::DeleteWhenStopped);
-    mAnimation = animation;
-}
-
 void FindRecordWidget::BumpMatchCountDebounce()
 {
     if (mEdit == nullptr || mEdit->text().isEmpty())
@@ -220,11 +189,13 @@ void FindRecordWidget::BumpMatchCountDebounce()
 
 void FindRecordWidget::DismissBar()
 {
-    // Walk up the parent chain to a `QDockWidget` host (the
-    // typical layout). Closing the dock is the only correct
-    // dismiss: hiding only the inner widget leaves the dock title
-    // bar floating over an empty body, and a later `show()` on
-    // the dock will not un-hide an explicitly-hidden child.
+    // Walk up to the host `QDockWidget` and close it. Closing the
+    // dock is the only correct dismiss: hiding only the inner
+    // widget leaves the dock title bar floating over an empty
+    // body, and a later `show()` on the dock will not un-hide an
+    // explicitly-hidden child. Walking the parent chain (instead
+    // of asserting a single hop) keeps this resilient to any
+    // future intermediate container the dock framework introduces.
     for (QWidget *p = parentWidget(); p != nullptr; p = p->parentWidget())
     {
         if (auto *dock = qobject_cast<QDockWidget *>(p))
@@ -233,40 +204,15 @@ void FindRecordWidget::DismissBar()
             return;
         }
     }
-    // No dock host (legacy in-layout call site): fall back to the
-    // slide-out animation so the bar collapses gracefully.
-    HideAnimated();
-}
-
-void FindRecordWidget::HideAnimated()
-{
-    if (!isVisible())
-    {
-        return;
-    }
-    const int from = height();
-    if (mAnimation && mAnimation->state() == QAbstractAnimation::Running)
-    {
-        mAnimation->stop();
-    }
-    auto *animation = new QPropertyAnimation(this, "maximumHeight", this);
-    animation->setDuration(FIND_REVEAL_ANIMATION_MS);
-    animation->setStartValue(from);
-    animation->setEndValue(0);
-    animation->setEasingCurve(QEasingCurve::OutCubic);
-    connect(animation, &QPropertyAnimation::finished, this, [this]() {
-        hide();
-        // Reset the cap so a subsequent `show()` (e.g. parent
-        // calls `show()` directly instead of `RevealAnimated`)
-        // does not stay collapsed.
-        setMaximumHeight(QWIDGETSIZE_MAX);
-    });
-    animation->start(QAbstractAnimation::DeleteWhenStopped);
-    mAnimation = animation;
 }
 
 void FindRecordWidget::keyPressEvent(QKeyEvent *event)
 {
+    // Shift+Return on `mEdit` is handled in `eventFilter` (the
+    // line edit accepts the event itself, so it never bubbles
+    // here). This override only catches Shift+Return / Return
+    // when focus is on the find bar's buttons or the bar widget
+    // itself -- a rare path, but keep the convention.
     if (event->key() == Qt::Key_Return || event->key() == Qt::Key_Enter)
     {
         if (event->modifiers().testFlag(Qt::ShiftModifier))
@@ -275,20 +221,33 @@ void FindRecordWidget::keyPressEvent(QKeyEvent *event)
             event->accept();
             return;
         }
-        // Plain Return is already wired through `returnPressed`
-        // on the line edit; fall through so the default still
-        // works for buttons that have focus.
+        FindNext();
+        event->accept();
+        return;
     }
     QWidget::keyPressEvent(event);
 }
 
-void FindRecordWidget::showEvent(QShowEvent *event)
+bool FindRecordWidget::eventFilter(QObject *watched, QEvent *event)
 {
-    QWidget::showEvent(event);
-    // Capture the real expanded height the first time we are
-    // realized so `RevealAnimated` has a sane target on later
-    // toggles.
-    mNaturalHeight = std::max(mNaturalHeight, sizeHint().height());
+    if (watched == mEdit && event->type() == QEvent::KeyPress)
+    {
+        // `QEvent::KeyPress` guarantees the dynamic type; Qt does
+        // not enable RTTI on `QEvent`. Same idiom as the
+        // `QFileOpenEvent` cast in `main.cpp`.
+        auto *ke = static_cast<QKeyEvent *>(event); // NOLINT(cppcoreguidelines-pro-type-static-cast-downcast)
+        if ((ke->key() == Qt::Key_Return || ke->key() == Qt::Key_Enter) &&
+            ke->modifiers().testFlag(Qt::ShiftModifier))
+        {
+            // Intercept before `QLineEdit::keyPressEvent` runs.
+            // Otherwise it would emit `returnPressed` (wired to
+            // `FindNext`) and accept the event, swallowing the
+            // shift-modified variant.
+            FindPrevious();
+            return true;
+        }
+    }
+    return QWidget::eventFilter(watched, event);
 }
 
 void FindRecordWidget::FindNext()

--- a/app/src/find_record_widget.cpp
+++ b/app/src/find_record_widget.cpp
@@ -25,72 +25,42 @@
 
 namespace
 {
-/// Debounce window after a key press before we ask the parent to
-/// recount matches. Avoids a full-table scan on every keystroke
-/// of a long word.
+/// Trailing-edge debounce after a keystroke / model bump before we
+/// recount matches. Coalesces fast typing into one scan.
 constexpr int MATCH_COUNT_DEBOUNCE_MS = 120;
 
-/// Hard cap on how long a match-count emit can be deferred. The
-/// trailing-edge debounce restarts on every keystroke / model
-/// bump, which under continuous activity (live-tail streaming,
-/// long words held down) means it would never fire and the "*i*
-/// of *N*" indicator would lag the live data by minutes. The
-/// max-age timer is armed once when the trailing debounce first
-/// starts and is *not* restarted, so it guarantees an emit
-/// within this window even when the trailing timer keeps
-/// resetting.
+/// Max age the debounced match-count emit can be deferred. The
+/// trailing timer restarts on every bump and would never fire under
+/// sustained activity (streaming, held keys), so this caps the lag.
 constexpr int MATCH_COUNT_MAX_AGE_MS = 750;
 
-/// Visual minimum so the search field doesn't collapse to nothing
-/// when the bar is squeezed.
+/// Visual minimum for the search field.
 constexpr int EDIT_MIN_WIDTH = 220;
 
-/// Floor for the find bar as a whole. Drives `setMinimumWidth` on
-/// the widget so a floating `FindDock` can't collapse below this
-/// (the line edit's own minimum protects only the inner layout,
-/// not the dock's outer frame). Sized to fit the line edit, both
-/// toggles, the count label, and both arrow buttons without
-/// truncation.
+/// Widget-level minimum so a floating `FindDock` can't be dragged
+/// narrow enough to truncate the toggles or count label.
 constexpr int WIDGET_MIN_WIDTH = 360;
 
-/// Outer margins / spacing for the find bar's horizontal layout.
-/// Matches the densities of the other docks (`anchors_dock`,
-/// `record_detail_widget`).
 constexpr int LAYOUT_OUTER_H_MARGIN = 6;
 constexpr int LAYOUT_OUTER_V_MARGIN = 4;
 constexpr int LAYOUT_SPACING = 4;
 
-/// Reserved width for the "i of N" label so the count digits
-/// don't shift the arrow buttons left/right as totals grow.
+/// Reserved width for the count label so digits don't shift the arrow
+/// buttons around as totals grow.
 constexpr int MATCH_LABEL_MIN_WIDTH = 80;
 
-/// Edge length for the painted arrow icons. Falls back to this
-/// when `QStyle::PM_SmallIconSize` returns nonsense (offscreen
-/// QPA with no style hint table).
+/// Edge length for the arrow icons when `PM_SmallIconSize` is unavailable.
 constexpr int ARROW_ICON_FALLBACK_PX = 14;
 
-/// Fraction of the icon edge to inset the triangle from each
-/// side. Tuned by eye to match the visual weight of the
-/// surrounding `.*` / `*?` toggle glyphs.
+/// Triangle inset / centre as fractions of the icon edge. Tuned by
+/// eye to match the visual weight of the `.*` / `*?` toggle glyphs.
 constexpr qreal ARROW_INSET_RATIO = 0.18;
-
-/// Centre of the icon expressed as a fraction of the edge.
 constexpr qreal ARROW_CENTRE_RATIO = 0.5;
 
-/// Build a small chevron-style arrow icon painted in @p color so
-/// the glyph follows the active palette / theme. `pointingUp =
-/// true` mints the previous-match arrow (apex at the top), false
-/// the next-match arrow (apex at the bottom). Replaces
-/// `QStyle::SP_ArrowUp` / `SP_ArrowDown`, which Qt bakes as raster
-/// black-on-transparent pixmaps that vanish on dark themes.
-///
-/// @p devicePixelRatio scales the backing pixmap so the painted
-/// triangle is sharp on HiDPI displays. Without it the pixmap is
-/// minted at logical pixel size and Qt up-scales the rasterised
-/// triangle, leaving the chevrons softer than the surrounding
-/// `.*` / `*?` text glyphs. The painter still draws in logical
-/// coordinates because we set `setDevicePixelRatio` before
-/// drawing.
+/// Paint a chevron arrow icon in @p color (so it tracks the active
+/// palette / theme). `pointingUp` selects prev (apex up) vs next
+/// (apex down). @p devicePixelRatio sizes the backing pixmap so the
+/// glyph stays sharp on HiDPI.
 [[nodiscard]] QIcon MakeArrowIcon(int sizePx, bool pointingUp, const QColor &color, qreal devicePixelRatio)
 {
     const qreal dpr = devicePixelRatio > 0.0 ? devicePixelRatio : 1.0;
@@ -145,17 +115,9 @@ FindRecordWidget::FindRecordWidget(QWidget *parent)
 
     hLayout->addWidget(mEdit, /*stretch=*/1);
 
-    // Regex / wildcard toggles. Rendered as small flat `QToolButton`s
-    // beside the line edit (not `QLineEdit::addAction` icons) because:
-    //   - we want the glyphs ".*" and "*?" visible, but
-    //     `QLineEdit::addAction` only renders the action's icon and
-    //     hides the text; and
-    //   - Qt's `QStyle::SP_*` icon catalogue has no recognisable
-    //     regex / wildcard glyph, so falling back to file-dialog
-    //     icons (as the previous version did) reads as a file-view
-    //     toggle and misleads users about what the toggle does.
-    // `setAutoRaise(true)` matches the find-next / find-prev
-    // buttons' flat look.
+    // Toggles rendered as flat `QToolButton`s with text glyphs (not
+    // `QLineEdit::addAction` icons): `addAction` hides text and the
+    // `SP_*` catalogue has no regex/wildcard icon.
     mRegexAction = new QAction(this);
     mRegexAction->setObjectName(QStringLiteral("regexToggle"));
     mRegexAction->setCheckable(true);
@@ -167,11 +129,8 @@ FindRecordWidget::FindRecordWidget(QWidget *parent)
     regexButton->setDefaultAction(mRegexAction);
     regexButton->setAutoRaise(true);
     regexButton->setToolButtonStyle(Qt::ToolButtonTextOnly);
-    // Defensive: `setDefaultAction` propagates the action's text in
-    // most styles, but a few platform styles only render text when
-    // `QToolButton` has its own. Setting it explicitly pins the
-    // glyph regardless of style; click handling continues to flow
-    // through the action.
+    // Pin the button text explicitly; a few platform styles don't
+    // propagate the action's text when the button has none of its own.
     regexButton->setText(mRegexAction->text());
     hLayout->addWidget(regexButton);
 
@@ -186,7 +145,7 @@ FindRecordWidget::FindRecordWidget(QWidget *parent)
     wildcardsButton->setDefaultAction(mWildcardsAction);
     wildcardsButton->setAutoRaise(true);
     wildcardsButton->setToolButtonStyle(Qt::ToolButtonTextOnly);
-    // Same rationale as `regexButton` above.
+    // See `regexButton` above for why we pin the text explicitly.
     wildcardsButton->setText(mWildcardsAction->text());
     hLayout->addWidget(wildcardsButton);
 
@@ -194,11 +153,8 @@ FindRecordWidget::FindRecordWidget(QWidget *parent)
     mMatchCountLabel->setObjectName(QStringLiteral("findMatchCount"));
     mMatchCountLabel->setAlignment(Qt::AlignCenter);
     mMatchCountLabel->setMinimumWidth(MATCH_LABEL_MIN_WIDTH);
-    // Always present in the layout (just empty) so the arrow
-    // buttons keep their horizontal position when the indicator
-    // toggles between "no needle" and "12 matches"; otherwise
-    // they jump left/right on every keystroke that crosses the
-    // empty boundary.
+    // Keep the label slot reserved (just blank) so the arrow buttons
+    // don't jitter when the indicator toggles between empty and populated.
     mMatchCountLabel->setText(QString());
     hLayout->addWidget(mMatchCountLabel);
 
@@ -214,89 +170,50 @@ FindRecordWidget::FindRecordWidget(QWidget *parent)
     mButtonNext->setAutoRaise(true);
     hLayout->addWidget(mButtonNext);
 
-    // Paint the arrow glyphs from the palette so they remain
-    // visible after a Light <-> Dark theme switch. The default
-    // `QStyle::SP_ArrowUp` / `SP_ArrowDown` pixmaps are baked
-    // black on Windows and vanish on a dark background; our own
-    // icons follow `QPalette::WindowText`. `changeEvent` re-runs
-    // this when the application palette / style updates.
     RefreshArrowIcons();
 
     setSizePolicy(QSizePolicy::Minimum, QSizePolicy::Preferred);
-    // Width floor so a floating `FindDock` (the dock has no
-    // minimum of its own) can't be dragged narrow enough to
-    // truncate the toggles or the count label. The line edit's
-    // `EDIT_MIN_WIDTH` covers the layout's inner shrinking, not
-    // the outer frame.
     setMinimumWidth(WIDGET_MIN_WIDTH);
-    // Focus order: line edit -> regex toggle -> wildcards toggle ->
-    // previous -> next. Each `setTabOrder(a, b)` re-inserts `b`
-    // immediately after `a` and detaches it from its prior slot --
-    // so the chain has to name *every* focusable widget, not just
-    // the endpoints, otherwise the unnamed siblings get severed
-    // from the chain and become unreachable via Tab. (Earlier
-    // versions of this widget chained only `mEdit -> previous ->
-    // next`, which made the regex/wildcards toggles keyboard-
-    // unreachable.)
+    // Focus order must name every focusable widget: each `setTabOrder`
+    // detaches `b` from its prior slot, so omitting the toggles here
+    // would make them keyboard-unreachable.
     setTabOrder(mEdit, regexButton);
     setTabOrder(regexButton, wildcardsButton);
     setTabOrder(wildcardsButton, mButtonPrevious);
     setTabOrder(mButtonPrevious, mButtonNext);
-    // No constructor `setFocus`: the host (dock or layout) is not
-    // realised yet, so the call is a no-op. Real focus is granted
-    // by `SetEditFocus` from `RevealAndFocus` / `Find`.
+    // No constructor `setFocus`: the host dock isn't realised yet.
+    // `SetEditFocus` from `RevealAndFocus` / `Find` does the real work.
 
     connect(mButtonNext, &QToolButton::clicked, this, &FindRecordWidget::FindNext);
     connect(mButtonPrevious, &QToolButton::clicked, this, &FindRecordWidget::FindPrevious);
 
-    // Plain Return -> find-next via `returnPressed`. Shift+Return
-    // -> find-previous is wired through `eventFilter` below;
-    // `QLineEdit::keyPressEvent` accepts Return for itself, so the
-    // event never bubbles to our `keyPressEvent`, and
-    // `returnPressed` carries no modifier state.
+    // Plain Return -> find-next. Shift+Return -> find-prev is wired
+    // in `eventFilter`: `returnPressed` is modifier-agnostic and
+    // `QLineEdit::keyPressEvent` accepts the event without bubbling.
     connect(mEdit, &QLineEdit::returnPressed, this, &FindRecordWidget::FindNext);
     mEdit->installEventFilter(this);
 
-    // Owned single-shot timer; `start()` restarts it on each
-    // keystroke so multi-keystroke edits coalesce into one
-    // `MatchCountRequested` emit. `QTimer::singleShot` does not
-    // coalesce because each call schedules an independent fire.
-    //
-    // `objectName` is set so tests can probe the trailing vs
-    // max-age timers individually via `findChild<QTimer*>(...)`
-    // instead of walking every timer parented to this widget and
-    // guessing which is which.
+    // `objectName`s on both timers let tests probe trailing vs max-age
+    // individually instead of guessing which `findChild<QTimer*>` is which.
     mMatchCountTimer = new QTimer(this);
     mMatchCountTimer->setObjectName(QStringLiteral("matchCountDebounceTimer"));
     mMatchCountTimer->setSingleShot(true);
     mMatchCountTimer->setInterval(MATCH_COUNT_DEBOUNCE_MS);
     connect(mMatchCountTimer, &QTimer::timeout, this, &FindRecordWidget::EmitMatchCountRequest);
 
-    // Companion max-age timer: armed alongside `mMatchCountTimer`
-    // (only when the trailing timer wasn't already running) and
-    // *never* restarted by subsequent bumps. Forces an emit after
-    // at most `MATCH_COUNT_MAX_AGE_MS`, so live-tail streaming or
-    // a held-down key can't strand the "*i* of *N*" indicator at
-    // its pre-activity value.
     mMatchCountMaxAgeTimer = new QTimer(this);
     mMatchCountMaxAgeTimer->setObjectName(QStringLiteral("matchCountMaxAgeTimer"));
     mMatchCountMaxAgeTimer->setSingleShot(true);
     mMatchCountMaxAgeTimer->setInterval(MATCH_COUNT_MAX_AGE_MS);
     connect(mMatchCountMaxAgeTimer, &QTimer::timeout, this, &FindRecordWidget::EmitMatchCountRequest);
 
-    // Text + toggle changes drive live match-count requests. We
-    // debounce via `mMatchCountTimer` so a fast typist doesn't
-    // trigger a full-table scan on every keystroke.
     connect(mEdit, &QLineEdit::textChanged, this, &FindRecordWidget::RequestMatchCountSoon);
     connect(mWildcardsAction, &QAction::toggled, this, &FindRecordWidget::RequestMatchCountSoon);
     connect(mRegexAction, &QAction::toggled, this, &FindRecordWidget::RequestMatchCountSoon);
 
-    // Regex and wildcards are mutually exclusive match modes in the
-    // backend (`LogFilterModel::Matches` treats them as alternatives,
-    // not modifiers). Mirror that in the UI so toggling one
-    // automatically untoggles the other instead of leaving the user
-    // with two enabled-looking toggles where only one actually takes
-    // effect.
+    // Regex and wildcards are mutually exclusive in the backend
+    // (`LogFilterModel::Matches`); mirror that in the UI so toggling
+    // one automatically untoggles the other.
     connect(mRegexAction, &QAction::toggled, this, [this](bool on) {
         if (on && mWildcardsAction->isChecked())
         {
@@ -312,12 +229,8 @@ FindRecordWidget::FindRecordWidget(QWidget *parent)
         }
     });
 
-    // Escape dismisses the bar. Scope `WidgetWithChildrenShortcut`
-    // so the shortcut fires whenever this widget (or any
-    // descendant focusable) has focus. `DismissBar` closes the
-    // host `QDockWidget` so its `visibilityChanged` mirrors the
-    // toggle action and a subsequent `RevealAndFocus` properly
-    // re-shows everything.
+    // Escape dismisses the bar via the host dock. Widget-scoped so
+    // the shortcut only fires when this widget (or a descendant) has focus.
     auto *escapeShortcut = new QShortcut(QKeySequence(Qt::Key_Escape), this);
     escapeShortcut->setContext(Qt::WidgetWithChildrenShortcut);
     connect(escapeShortcut, &QShortcut::activated, this, &FindRecordWidget::DismissBar);
@@ -333,18 +246,11 @@ void FindRecordWidget::SetMatchInfo(int current, int total, bool overflowed)
 {
     if (total <= 0)
     {
-        // Keep the label slot in the layout but blank, so the
-        // arrow buttons don't shift left/right as the indicator
-        // appears and disappears around each keystroke that
-        // empties or refills the search field. The reserved
-        // `MATCH_LABEL_MIN_WIDTH` continues to hold the slot
-        // open.
+        // Blank label, slot stays reserved (see `MATCH_LABEL_MIN_WIDTH`).
         mMatchCountLabel->clear();
         return;
     }
-    // Locale-grouped digits matching the rest of the GUI; the "+"
-    // suffix surfaces the parent's hit cap so a million-row log
-    // doesn't pretend the count is exactly at the cap.
+    // Locale-grouped digits; "+" suffix surfaces the parent's hit cap.
     const QLocale locale = QLocale::system();
     const QString totalText =
         locale.toString(static_cast<qlonglong>(total)) + (overflowed ? QStringLiteral("+") : QString());
@@ -355,13 +261,9 @@ void FindRecordWidget::SetMatchInfo(int current, int total, bool overflowed)
     }
     else
     {
-        // Two formatters because `%n` / `%Ln` only handles one
-        // number; we already formatted `totalText` above.
-        // `%Ln` (not `%n`) keeps digit grouping consistent with
-        // the "%1 of %2" branch above and with
-        // `ParseErrorsDock::RefreshSummary` -- otherwise a count
-        // of 10000 would render unstyled while the next-click
-        // refresh would render `1 of 10,000`.
+        // `%Ln` keeps digit grouping consistent with the "%1 of %2"
+        // branch above. Two formatters when overflowed because `%Ln`
+        // only handles one number and we already formatted `totalText`.
         text = overflowed ? tr("%1 matches").arg(totalText) : tr("%Ln matches", nullptr, total);
     }
     mMatchCountLabel->setText(text);
@@ -373,36 +275,17 @@ void FindRecordWidget::BumpMatchCountDebounce()
     {
         return;
     }
-    // Fast path: trailing timer already running AND max-age
-    // timer already running means a recount is already queued
-    // and capped. Skip the `start()` call entirely -- it's
-    // technically idempotent (`QTimer::start` resets the
-    // countdown), but the trailing-timer reset *defeats*
-    // coalescing in the streaming-burst case where this is the
-    // hottest invalidation path:
-    //
-    //   model emits dataChanged 100x/sec while live-tailing,
-    //   each emit calls OnFindCacheInvalidated, which calls
-    //   BumpMatchCountDebounce. Without this guard, every emit
-    //   restarts the trailing timer and the recount never
-    //   actually fires until streaming pauses; the max-age
-    //   timer is the only thing forcing progress. With the
-    //   guard, the *first* invalidation arms both timers and
-    //   subsequent invalidations are no-ops -- the trailing
-    //   timer expires on schedule and the recount runs.
+    // Skip the `start()` call when both timers are already armed.
+    // Restarting the trailing timer on every dataChanged during
+    // streaming would defeat coalescing and only the max-age timer
+    // would force the recount through.
     if (mMatchCountTimer->isActive() && mMatchCountMaxAgeTimer->isActive())
     {
         return;
     }
-    // Restart the trailing timer; identical mechanism to the
-    // textChanged path. A burst of model signals collapses into
-    // one final recount.
-    //
-    // Arm the max-age timer only when it isn't already running,
-    // so continuous activity can't keep pushing the deadline
-    // out -- it caps the longest possible delay between an
-    // invalidation and the visible recount.
     mMatchCountTimer->start();
+    // Max-age timer arms only on the leading edge so continuous
+    // activity can't keep pushing the deadline out.
     if (!mMatchCountMaxAgeTimer->isActive())
     {
         mMatchCountMaxAgeTimer->start();
@@ -411,13 +294,11 @@ void FindRecordWidget::BumpMatchCountDebounce()
 
 void FindRecordWidget::DismissBar()
 {
-    // Walk up to the host `QDockWidget` and close it. Closing the
-    // dock is the only correct dismiss: hiding only the inner
-    // widget leaves the dock title bar floating over an empty
-    // body, and a later `show()` on the dock will not un-hide an
-    // explicitly-hidden child. Walking the parent chain (instead
-    // of asserting a single hop) keeps this resilient to any
-    // future intermediate container the dock framework introduces.
+    // Closing the dock is the only correct dismiss: hiding just the
+    // inner widget leaves the dock framed around an empty body, and
+    // a later `show()` on the dock won't un-hide an explicitly-hidden
+    // child. Walk the parent chain in case the dock framework ever
+    // introduces an intermediate container.
     for (QWidget *p = parentWidget(); p != nullptr; p = p->parentWidget())
     {
         if (auto *dock = qobject_cast<QDockWidget *>(p))
@@ -426,24 +307,17 @@ void FindRecordWidget::DismissBar()
             return;
         }
     }
-    // No host dock -- production never hits this (the widget is
-    // always parented under `FindDock`), but a test or future
-    // embedding could. Surface a `qWarning` so the silent no-op
-    // isn't mistaken for a working Escape: the user pressed Esc
-    // and nothing happened, which is hard to debug without a
-    // breadcrumb. Doesn't fire `Q_ASSERT` because non-dock
-    // hosting is a legitimate design choice for future variants
-    // (the bar simply has no chrome to dismiss).
+    // Production never hits this (always parented under `FindDock`),
+    // but a test or future embedding could. Surface the no-op so a
+    // silent Escape isn't mistaken for a working one.
     qWarning() << "FindRecordWidget::DismissBar: no QDockWidget ancestor; Escape is a no-op in this configuration";
 }
 
 void FindRecordWidget::keyPressEvent(QKeyEvent *event)
 {
-    // Reachable only when focus is on the bar but not on `mEdit`
-    // (the toggle / arrow buttons). For `mEdit`, the line edit
-    // accepts Return for itself and the modifier-bearing variant
-    // is handled in `eventFilter`. Handling it here too keeps the
-    // VS Code / Chromium convention for the rest of the bar.
+    // Only reaches us when focus is on a toggle / arrow button. For
+    // `mEdit`, the line edit handles Return itself and `eventFilter`
+    // handles Shift+Return.
     if (event->key() == Qt::Key_Return || event->key() == Qt::Key_Enter)
     {
         if (event->modifiers().testFlag(Qt::ShiftModifier))
@@ -464,16 +338,14 @@ bool FindRecordWidget::eventFilter(QObject *watched, QEvent *event)
 {
     if (watched == mEdit && event->type() == QEvent::KeyPress)
     {
-        // `QEvent::KeyPress` guarantees the dynamic type; Qt does
-        // not enable RTTI on `QEvent`. Same idiom as the
-        // `QFileOpenEvent` cast in `main.cpp`.
+        // `QEvent::KeyPress` guarantees the dynamic type; Qt doesn't
+        // enable RTTI on `QEvent`.
         auto *ke = static_cast<QKeyEvent *>(event); // NOLINT(cppcoreguidelines-pro-type-static-cast-downcast)
         if ((ke->key() == Qt::Key_Return || ke->key() == Qt::Key_Enter) && ke->modifiers().testFlag(Qt::ShiftModifier))
         {
-            // Intercept before `QLineEdit::keyPressEvent` runs.
-            // Otherwise it would emit `returnPressed` (wired to
-            // `FindNext`) and accept the event, swallowing the
-            // shift-modified variant.
+            // Intercept before `QLineEdit::keyPressEvent`, which
+            // would otherwise emit `returnPressed` (-> FindNext)
+            // and swallow the shift-modified variant.
             FindPrevious();
             return true;
         }
@@ -503,25 +375,14 @@ void FindRecordWidget::RequestMatchCountSoon()
 {
     if (mEdit->text().isEmpty())
     {
-        // Empty needle: clear immediately without bouncing off
-        // the debounce timer, so the label can't lag a clear.
-        // Cancel any in-flight tick (trailing + max-age) so a
-        // stale needle doesn't overwrite the cleared state. No
-        // signal emitted -- the parent has nothing to recount,
-        // and a per-keystroke round-trip just to be told "still
-        // empty" is wasted work. The cache the parent holds is
-        // keyed by needle, so the next non-empty query rebuilds
-        // it anyway.
+        // Empty needle: clear immediately and cancel any in-flight
+        // tick so a stale needle can't overwrite the cleared state.
+        // No emit; the parent has nothing to recount.
         mMatchCountTimer->stop();
         mMatchCountMaxAgeTimer->stop();
         SetMatchInfo(0, 0);
         return;
     }
-    // `start()` resets the countdown if already running, so a
-    // fast typist coalesces N keystrokes into a single trailing
-    // match-count scan. The max-age timer arms once on the
-    // leading edge so it caps the longest possible delay even
-    // under sustained typing.
     mMatchCountTimer->start();
     if (!mMatchCountMaxAgeTimer->isActive())
     {
@@ -536,12 +397,9 @@ void FindRecordWidget::changeEvent(QEvent *event)
     {
         return;
     }
-    // Both events fire on a theme switch:
-    //   PaletteChange  - new colours rolled into `palette()`
-    //   StyleChange    - theme also swapped `qApp->style()`
-    // Either one is sufficient to mint stale icons, so handle
-    // both. The repaint is cheap (two 14x14 triangles) and
-    // `RefreshArrowIcons` is idempotent.
+    // Both events can fire on a theme switch (PaletteChange when
+    // colours roll into `palette()`, StyleChange when the theme
+    // also swaps `qApp->style()`); `RefreshArrowIcons` is idempotent.
     const QEvent::Type type = event->type();
     if (type == QEvent::PaletteChange || type == QEvent::StyleChange || type == QEvent::ApplicationPaletteChange)
     {
@@ -551,13 +409,9 @@ void FindRecordWidget::changeEvent(QEvent *event)
 
 bool FindRecordWidget::event(QEvent *event)
 {
-    // `DevicePixelRatioChange` fires when the window backing the
-    // widget moves between monitors with different scale factors
-    // (e.g. dragging a floating `FindDock` from a 100% laptop
-    // panel to a 200% external display). The icon pixmap was
-    // allocated at the previous DPR, so re-mint it now or Qt
-    // will up-scale a low-resolution rasterisation. The cost is
-    // two tiny pixmaps; safe to do unconditionally.
+    // Re-mint at the new DPR when the bar moves between monitors
+    // with different scale factors; otherwise Qt up-scales the
+    // pixmap allocated at the previous DPR.
     if (event != nullptr && event->type() == QEvent::DevicePixelRatioChange)
     {
         RefreshArrowIcons();
@@ -571,19 +425,11 @@ void FindRecordWidget::RefreshArrowIcons()
     {
         return;
     }
-    // Pull `WindowText` rather than `ButtonText`: the buttons are
-    // `autoRaise` toolbuttons whose backdrop matches the
-    // surrounding find-bar surface, not a raised button face, so
-    // `WindowText` is the contrast colour the user actually sees
-    // these glyphs against. Matches the colour the `.*` / `*?`
-    // toggle action glyphs render in.
+    // `WindowText` (not `ButtonText`): these are autoRaise toolbuttons
+    // whose backdrop is the find-bar surface, not a raised button face.
+    // Matches the colour of the `.*` / `*?` toggle glyphs.
     const QColor color = palette().color(QPalette::Active, QPalette::WindowText);
     const int sizePx = ArrowIconPixels(this);
-    // `devicePixelRatioF()` walks up the parent chain to the host
-    // window; on a 200% scaled monitor this returns 2.0 and the
-    // pixmap is allocated 2x in each axis so the triangle is
-    // pixel-sharp. Falls back to 1.0 when the widget is not yet
-    // realised (early constructor call before `show()`).
     const qreal dpr = devicePixelRatioF();
     mButtonPrevious->setIcon(MakeArrowIcon(sizePx, /*pointingUp=*/true, color, dpr));
     mButtonNext->setIcon(MakeArrowIcon(sizePx, /*pointingUp=*/false, color, dpr));
@@ -591,13 +437,9 @@ void FindRecordWidget::RefreshArrowIcons()
 
 void FindRecordWidget::EmitMatchCountRequest()
 {
-    // Stop the *other* timer so a max-age fire doesn't get
-    // followed 50 ms later by a redundant trailing fire (and
-    // vice versa). The re-entrancy guard catches the harder
-    // case: when both timers' `timeout` events landed in the
-    // queue on the same pass, stopping them here doesn't undo
-    // the second event that's already queued -- but the guard
-    // collapses it.
+    // Re-entrancy guard: both timers route here, and if both
+    // `timeout` events landed in the queue on the same pass, the
+    // first invocation's `stop()` calls can't undo the queued second.
     if (mEmittingMatchCountRequest)
     {
         return;

--- a/app/src/find_record_widget.cpp
+++ b/app/src/find_record_widget.cpp
@@ -36,6 +36,14 @@ constexpr int MATCH_COUNT_MAX_AGE_MS = 750;
 /// when the bar is squeezed.
 constexpr int EDIT_MIN_WIDTH = 220;
 
+/// Floor for the find bar as a whole. Drives `setMinimumWidth` on
+/// the widget so a floating `FindDock` can't collapse below this
+/// (the line edit's own minimum protects only the inner layout,
+/// not the dock's outer frame). Sized to fit the line edit, both
+/// toggles, the count label, and both arrow buttons without
+/// truncation.
+constexpr int WIDGET_MIN_WIDTH = 360;
+
 /// Outer margins / spacing for the find bar's horizontal layout.
 /// Matches the densities of the other docks (`anchors_dock`,
 /// `record_detail_widget`).
@@ -114,7 +122,12 @@ FindRecordWidget::FindRecordWidget(QWidget *parent)
     mMatchCountLabel->setObjectName(QStringLiteral("findMatchCount"));
     mMatchCountLabel->setAlignment(Qt::AlignCenter);
     mMatchCountLabel->setMinimumWidth(MATCH_LABEL_MIN_WIDTH);
-    mMatchCountLabel->setVisible(false);
+    // Always present in the layout (just empty) so the arrow
+    // buttons keep their horizontal position when the indicator
+    // toggles between "no needle" and "12 matches"; otherwise
+    // they jump left/right on every keystroke that crosses the
+    // empty boundary.
+    mMatchCountLabel->setText(QString());
     hLayout->addWidget(mMatchCountLabel);
 
     mButtonPrevious = new QToolButton(this);
@@ -132,9 +145,24 @@ FindRecordWidget::FindRecordWidget(QWidget *parent)
     hLayout->addWidget(mButtonNext);
 
     setSizePolicy(QSizePolicy::Minimum, QSizePolicy::Preferred);
-    // Focus order: line edit first; toggles + arrow buttons stay
-    // reachable via Tab once focus is in the bar.
-    setTabOrder(mEdit, mButtonPrevious);
+    // Width floor so a floating `FindDock` (the dock has no
+    // minimum of its own) can't be dragged narrow enough to
+    // truncate the toggles or the count label. The line edit's
+    // `EDIT_MIN_WIDTH` covers the layout's inner shrinking, not
+    // the outer frame.
+    setMinimumWidth(WIDGET_MIN_WIDTH);
+    // Focus order: line edit -> regex toggle -> wildcards toggle ->
+    // previous -> next. Each `setTabOrder(a, b)` re-inserts `b`
+    // immediately after `a` and detaches it from its prior slot --
+    // so the chain has to name *every* focusable widget, not just
+    // the endpoints, otherwise the unnamed siblings get severed
+    // from the chain and become unreachable via Tab. (Earlier
+    // versions of this widget chained only `mEdit -> previous ->
+    // next`, which made the regex/wildcards toggles keyboard-
+    // unreachable.)
+    setTabOrder(mEdit, regexButton);
+    setTabOrder(regexButton, wildcardsButton);
+    setTabOrder(wildcardsButton, mButtonPrevious);
     setTabOrder(mButtonPrevious, mButtonNext);
     // No constructor `setFocus`: the host (dock or layout) is not
     // realised yet, so the call is a no-op. Real focus is granted
@@ -220,8 +248,13 @@ void FindRecordWidget::SetMatchInfo(int current, int total, bool overflowed)
 {
     if (total <= 0)
     {
+        // Keep the label slot in the layout but blank, so the
+        // arrow buttons don't shift left/right as the indicator
+        // appears and disappears around each keystroke that
+        // empties or refills the search field. The reserved
+        // `MATCH_LABEL_MIN_WIDTH` continues to hold the slot
+        // open.
         mMatchCountLabel->clear();
-        mMatchCountLabel->setVisible(false);
         return;
     }
     // Locale-grouped digits matching the rest of the GUI; the "+"
@@ -237,12 +270,16 @@ void FindRecordWidget::SetMatchInfo(int current, int total, bool overflowed)
     }
     else
     {
-        // Two formatters because `%n` only handles one number;
-        // we already formatted `totalText` above.
-        text = overflowed ? tr("%1 matches").arg(totalText) : tr("%n matches", nullptr, total);
+        // Two formatters because `%n` / `%Ln` only handles one
+        // number; we already formatted `totalText` above.
+        // `%Ln` (not `%n`) keeps digit grouping consistent with
+        // the "%1 of %2" branch above and with
+        // `ParseErrorsDock::RefreshSummary` -- otherwise a count
+        // of 10000 would render unstyled while the next-click
+        // refresh would render `1 of 10,000`.
+        text = overflowed ? tr("%1 matches").arg(totalText) : tr("%Ln matches", nullptr, total);
     }
     mMatchCountLabel->setText(text);
-    mMatchCountLabel->setVisible(true);
 }
 
 void FindRecordWidget::BumpMatchCountDebounce()

--- a/app/src/find_record_widget.cpp
+++ b/app/src/find_record_widget.cpp
@@ -3,6 +3,7 @@
 #include <QAction>
 #include <QApplication>
 #include <QColor>
+#include <QDebug>
 #include <QDockWidget>
 #include <QEvent>
 #include <QHBoxLayout>
@@ -260,7 +261,13 @@ FindRecordWidget::FindRecordWidget(QWidget *parent)
     // keystroke so multi-keystroke edits coalesce into one
     // `MatchCountRequested` emit. `QTimer::singleShot` does not
     // coalesce because each call schedules an independent fire.
+    //
+    // `objectName` is set so tests can probe the trailing vs
+    // max-age timers individually via `findChild<QTimer*>(...)`
+    // instead of walking every timer parented to this widget and
+    // guessing which is which.
     mMatchCountTimer = new QTimer(this);
+    mMatchCountTimer->setObjectName(QStringLiteral("matchCountDebounceTimer"));
     mMatchCountTimer->setSingleShot(true);
     mMatchCountTimer->setInterval(MATCH_COUNT_DEBOUNCE_MS);
     connect(mMatchCountTimer, &QTimer::timeout, this, &FindRecordWidget::EmitMatchCountRequest);
@@ -272,6 +279,7 @@ FindRecordWidget::FindRecordWidget(QWidget *parent)
     // a held-down key can't strand the "*i* of *N*" indicator at
     // its pre-activity value.
     mMatchCountMaxAgeTimer = new QTimer(this);
+    mMatchCountMaxAgeTimer->setObjectName(QStringLiteral("matchCountMaxAgeTimer"));
     mMatchCountMaxAgeTimer->setSingleShot(true);
     mMatchCountMaxAgeTimer->setInterval(MATCH_COUNT_MAX_AGE_MS);
     connect(mMatchCountMaxAgeTimer, &QTimer::timeout, this, &FindRecordWidget::EmitMatchCountRequest);
@@ -418,6 +426,15 @@ void FindRecordWidget::DismissBar()
             return;
         }
     }
+    // No host dock -- production never hits this (the widget is
+    // always parented under `FindDock`), but a test or future
+    // embedding could. Surface a `qWarning` so the silent no-op
+    // isn't mistaken for a working Escape: the user pressed Esc
+    // and nothing happened, which is hard to debug without a
+    // breadcrumb. Doesn't fire `Q_ASSERT` because non-dock
+    // hosting is a legitimate design choice for future variants
+    // (the bar simply has no chrome to dismiss).
+    qWarning() << "FindRecordWidget::DismissBar: no QDockWidget ancestor; Escape is a no-op in this configuration";
 }
 
 void FindRecordWidget::keyPressEvent(QKeyEvent *event)

--- a/app/src/find_record_widget.cpp
+++ b/app/src/find_record_widget.cpp
@@ -2,6 +2,7 @@
 
 #include <QAction>
 #include <QApplication>
+#include <QDockWidget>
 #include <QEasingCurve>
 #include <QHBoxLayout>
 #include <QKeyEvent>
@@ -58,13 +59,12 @@ FindRecordWidget::FindRecordWidget(QWidget *parent)
     mEdit->setPlaceholderText(tr("Find in logs\u2026"));
     mEdit->setClearButtonEnabled(true);
     mEdit->setMinimumWidth(EDIT_MIN_WIDTH);
-    // Leading magnifying-glass affordance. The action is decorative
-    // only; clicking it focuses the field (idempotent, since the
-    // user just clicked into the field).
-    auto *searchIconAction = mEdit->addAction(
+    // Leading magnifying-glass affordance. Decorative only -- the
+    // leading-position icon in `QLineEdit` does not emit
+    // `triggered` on click, so wiring a slot is dead code.
+    mEdit->addAction(
         QApplication::style()->standardIcon(QStyle::SP_FileDialogContentsView), QLineEdit::LeadingPosition
     );
-    connect(searchIconAction, &QAction::triggered, mEdit, qOverload<>(&QWidget::setFocus));
 
     // Trailing toggle "buttons" embedded in the line edit. `addAction`
     // with `TrailingPosition` renders them as small icon buttons
@@ -114,9 +114,9 @@ FindRecordWidget::FindRecordWidget(QWidget *parent)
     // reachable via Tab once focus is in the bar.
     setTabOrder(mEdit, mButtonPrevious);
     setTabOrder(mButtonPrevious, mButtonNext);
-
-    mEdit->setFocus();
-    QTimer::singleShot(0, mEdit, qOverload<>(&QWidget::setFocus));
+    // No constructor `setFocus`: the host (dock or layout) is not
+    // realised yet, so the call is a no-op. Real focus is granted
+    // by `SetEditFocus` from `RevealAndFocus` / `Find`.
 
     connect(mButtonNext, &QToolButton::clicked, this, &FindRecordWidget::FindNext);
     connect(mButtonPrevious, &QToolButton::clicked, this, &FindRecordWidget::FindPrevious);
@@ -126,19 +126,32 @@ FindRecordWidget::FindRecordWidget(QWidget *parent)
     // modifier state.
     connect(mEdit, &QLineEdit::returnPressed, this, &FindRecordWidget::FindNext);
 
+    // Owned single-shot timer; `start()` restarts it on each
+    // keystroke so multi-keystroke edits coalesce into one
+    // `MatchCountRequested` emit. `QTimer::singleShot` does not
+    // coalesce because each call schedules an independent fire.
+    mMatchCountTimer = new QTimer(this);
+    mMatchCountTimer->setSingleShot(true);
+    mMatchCountTimer->setInterval(MATCH_COUNT_DEBOUNCE_MS);
+    connect(mMatchCountTimer, &QTimer::timeout, this, &FindRecordWidget::EmitMatchCountRequest);
+
     // Text + toggle changes drive live match-count requests. We
-    // debounce so a fast typist doesn't trigger a full-table scan
-    // on every keystroke.
+    // debounce via `mMatchCountTimer` so a fast typist doesn't
+    // trigger a full-table scan on every keystroke.
     connect(mEdit, &QLineEdit::textChanged, this, &FindRecordWidget::RequestMatchCountSoon);
     connect(mWildcardsAction, &QAction::toggled, this, &FindRecordWidget::RequestMatchCountSoon);
     connect(mRegexAction, &QAction::toggled, this, &FindRecordWidget::RequestMatchCountSoon);
 
-    // Escape hides the bar instead of an explicit "X" button.
-    // Scope `WindowShortcut` so the shortcut fires whenever this
-    // widget (or any descendant focusable) has focus.
+    // Escape dismisses the bar. Scope `WidgetWithChildrenShortcut`
+    // so the shortcut fires whenever this widget (or any
+    // descendant focusable) has focus. When hosted in a
+    // `QDockWidget`, close the dock so its `visibilityChanged`
+    // mirrors the toggle action and a subsequent `RevealAndFocus`
+    // properly re-shows everything. The legacy in-layout fallback
+    // (no dock parent) keeps the slide-out animation.
     auto *escapeShortcut = new QShortcut(QKeySequence(Qt::Key_Escape), this);
     escapeShortcut->setContext(Qt::WidgetWithChildrenShortcut);
-    connect(escapeShortcut, &QShortcut::activated, this, &FindRecordWidget::HideAnimated);
+    connect(escapeShortcut, &QShortcut::activated, this, &FindRecordWidget::DismissBar);
 }
 
 void FindRecordWidget::SetEditFocus()
@@ -191,6 +204,38 @@ void FindRecordWidget::RevealAnimated()
     animation->setEasingCurve(QEasingCurve::OutCubic);
     animation->start(QAbstractAnimation::DeleteWhenStopped);
     mAnimation = animation;
+}
+
+void FindRecordWidget::BumpMatchCountDebounce()
+{
+    if (mEdit == nullptr || mEdit->text().isEmpty())
+    {
+        return;
+    }
+    // Restart the timer; identical mechanism to the textChanged
+    // path. A burst of model signals collapses into one final
+    // recount.
+    mMatchCountTimer->start();
+}
+
+void FindRecordWidget::DismissBar()
+{
+    // Walk up the parent chain to a `QDockWidget` host (the
+    // typical layout). Closing the dock is the only correct
+    // dismiss: hiding only the inner widget leaves the dock title
+    // bar floating over an empty body, and a later `show()` on
+    // the dock will not un-hide an explicitly-hidden child.
+    for (QWidget *p = parentWidget(); p != nullptr; p = p->parentWidget())
+    {
+        if (auto *dock = qobject_cast<QDockWidget *>(p))
+        {
+            dock->close();
+            return;
+        }
+    }
+    // No dock host (legacy in-layout call site): fall back to the
+    // slide-out animation so the bar collapses gracefully.
+    HideAnimated();
 }
 
 void FindRecordWidget::HideAnimated()
@@ -270,14 +315,17 @@ void FindRecordWidget::RequestMatchCountSoon()
     {
         // Empty needle: clear immediately without bouncing off
         // the debounce timer, so the label can't lag a clear.
+        // Cancel any in-flight tick so a stale needle doesn't
+        // overwrite the cleared state.
+        mMatchCountTimer->stop();
         SetMatchInfo(0, 0);
         emit MatchCountRequested(QString(), mWildcardsAction->isChecked(), mRegexAction->isChecked());
         return;
     }
-    // Debounce so multi-keystroke edits coalesce into one count
-    // request. `singleShot` against `this` so destruction cancels
-    // the pending fire.
-    QTimer::singleShot(MATCH_COUNT_DEBOUNCE_MS, this, &FindRecordWidget::EmitMatchCountRequest);
+    // `start()` resets the countdown if already running, so a
+    // fast typist coalesces N keystrokes into a single trailing
+    // match-count scan.
+    mMatchCountTimer->start();
 }
 
 void FindRecordWidget::EmitMatchCountRequest()

--- a/app/src/find_record_widget.cpp
+++ b/app/src/find_record_widget.cpp
@@ -308,10 +308,13 @@ void FindRecordWidget::RequestMatchCountSoon()
         // Empty needle: clear immediately without bouncing off
         // the debounce timer, so the label can't lag a clear.
         // Cancel any in-flight tick so a stale needle doesn't
-        // overwrite the cleared state.
+        // overwrite the cleared state. No signal emitted -- the
+        // parent has nothing to recount, and a per-keystroke
+        // round-trip just to be told "still empty" is wasted
+        // work. The cache the parent holds is keyed by needle,
+        // so the next non-empty query rebuilds it anyway.
         mMatchCountTimer->stop();
         SetMatchInfo(0, 0);
-        emit MatchCountRequested(QString(), mWildcardsAction->isChecked(), mRegexAction->isChecked());
         return;
     }
     // `start()` resets the countdown if already running, so a

--- a/app/src/find_record_widget.cpp
+++ b/app/src/find_record_widget.cpp
@@ -419,8 +419,18 @@ void FindRecordWidget::EmitMatchCountRequest()
 {
     // Stop the *other* timer so a max-age fire doesn't get
     // followed 50 ms later by a redundant trailing fire (and
-    // vice versa).
+    // vice versa). The re-entrancy guard catches the harder
+    // case: when both timers' `timeout` events landed in the
+    // queue on the same pass, stopping them here doesn't undo
+    // the second event that's already queued -- but the guard
+    // collapses it.
+    if (mEmittingMatchCountRequest)
+    {
+        return;
+    }
+    mEmittingMatchCountRequest = true;
     mMatchCountTimer->stop();
     mMatchCountMaxAgeTimer->stop();
     emit MatchCountRequested(mEdit->text(), mWildcardsAction->isChecked(), mRegexAction->isChecked());
+    mEmittingMatchCountRequest = false;
 }

--- a/app/src/find_record_widget.cpp
+++ b/app/src/find_record_widget.cpp
@@ -8,8 +8,8 @@
 #include <QLabel>
 #include <QLineEdit>
 #include <QPropertyAnimation>
-#include <QShowEvent>
 #include <QShortcut>
+#include <QShowEvent>
 #include <QSizePolicy>
 #include <QStyle>
 #include <QTimer>

--- a/app/src/find_record_widget.cpp
+++ b/app/src/find_record_widget.cpp
@@ -51,34 +51,45 @@ FindRecordWidget::FindRecordWidget(QWidget *parent)
     mEdit->setPlaceholderText(tr("Find in logs\u2026"));
     mEdit->setClearButtonEnabled(true);
     mEdit->setMinimumWidth(EDIT_MIN_WIDTH);
-    // Leading magnifying-glass affordance. Decorative only -- the
-    // leading-position icon in `QLineEdit` does not emit
-    // `triggered` on click, so wiring a slot is dead code.
-    mEdit->addAction(
-        QApplication::style()->standardIcon(QStyle::SP_FileDialogContentsView), QLineEdit::LeadingPosition
-    );
 
-    // Trailing toggle "buttons" embedded in the line edit. `addAction`
-    // with `TrailingPosition` renders them as small icon buttons
-    // inside the field, before the clear button (Qt orders them in
-    // insertion order from the inner edge outward).
+    hLayout->addWidget(mEdit, /*stretch=*/1);
+
+    // Regex / wildcard toggles. Rendered as small flat `QToolButton`s
+    // beside the line edit (not `QLineEdit::addAction` icons) because:
+    //   - we want the glyphs ".*" and "*?" visible, but
+    //     `QLineEdit::addAction` only renders the action's icon and
+    //     hides the text; and
+    //   - Qt's `QStyle::SP_*` icon catalogue has no recognisable
+    //     regex / wildcard glyph, so falling back to file-dialog
+    //     icons (as the previous version did) reads as a file-view
+    //     toggle and misleads users about what the toggle does.
+    // `setAutoRaise(true)` matches the find-next / find-prev
+    // buttons' flat look.
     mRegexAction = new QAction(this);
     mRegexAction->setObjectName(QStringLiteral("regexToggle"));
     mRegexAction->setCheckable(true);
     mRegexAction->setText(QStringLiteral(".*"));
-    mRegexAction->setIcon(QApplication::style()->standardIcon(QStyle::SP_FileDialogDetailedView));
     mRegexAction->setToolTip(tr("Match using regular expressions"));
-    mEdit->addAction(mRegexAction, QLineEdit::TrailingPosition);
+
+    auto *regexButton = new QToolButton(this);
+    regexButton->setObjectName(QStringLiteral("regexToggleButton"));
+    regexButton->setDefaultAction(mRegexAction);
+    regexButton->setAutoRaise(true);
+    regexButton->setToolButtonStyle(Qt::ToolButtonTextOnly);
+    hLayout->addWidget(regexButton);
 
     mWildcardsAction = new QAction(this);
     mWildcardsAction->setObjectName(QStringLiteral("wildcardsToggle"));
     mWildcardsAction->setCheckable(true);
     mWildcardsAction->setText(QStringLiteral("*?"));
-    mWildcardsAction->setIcon(QApplication::style()->standardIcon(QStyle::SP_FileDialogListView));
     mWildcardsAction->setToolTip(tr("Match using wildcards (* and ?)"));
-    mEdit->addAction(mWildcardsAction, QLineEdit::TrailingPosition);
 
-    hLayout->addWidget(mEdit, /*stretch=*/1);
+    auto *wildcardsButton = new QToolButton(this);
+    wildcardsButton->setObjectName(QStringLiteral("wildcardsToggleButton"));
+    wildcardsButton->setDefaultAction(mWildcardsAction);
+    wildcardsButton->setAutoRaise(true);
+    wildcardsButton->setToolButtonStyle(Qt::ToolButtonTextOnly);
+    hLayout->addWidget(wildcardsButton);
 
     mMatchCountLabel = new QLabel(this);
     mMatchCountLabel->setObjectName(QStringLiteral("findMatchCount"));
@@ -136,6 +147,27 @@ FindRecordWidget::FindRecordWidget(QWidget *parent)
     connect(mEdit, &QLineEdit::textChanged, this, &FindRecordWidget::RequestMatchCountSoon);
     connect(mWildcardsAction, &QAction::toggled, this, &FindRecordWidget::RequestMatchCountSoon);
     connect(mRegexAction, &QAction::toggled, this, &FindRecordWidget::RequestMatchCountSoon);
+
+    // Regex and wildcards are mutually exclusive match modes in the
+    // backend (`LogFilterModel::Matches` treats them as alternatives,
+    // not modifiers). Mirror that in the UI so toggling one
+    // automatically untoggles the other instead of leaving the user
+    // with two enabled-looking toggles where only one actually takes
+    // effect.
+    connect(mRegexAction, &QAction::toggled, this, [this](bool on) {
+        if (on && mWildcardsAction->isChecked())
+        {
+            const QSignalBlocker blocker(mWildcardsAction);
+            mWildcardsAction->setChecked(false);
+        }
+    });
+    connect(mWildcardsAction, &QAction::toggled, this, [this](bool on) {
+        if (on && mRegexAction->isChecked())
+        {
+            const QSignalBlocker blocker(mRegexAction);
+            mRegexAction->setChecked(false);
+        }
+    });
 
     // Escape dismisses the bar. Scope `WidgetWithChildrenShortcut`
     // so the shortcut fires whenever this widget (or any
@@ -208,20 +240,21 @@ void FindRecordWidget::DismissBar()
 
 void FindRecordWidget::keyPressEvent(QKeyEvent *event)
 {
-    // Shift+Return on `mEdit` is handled in `eventFilter` (the
-    // line edit accepts the event itself, so it never bubbles
-    // here). This override only catches Shift+Return / Return
-    // when focus is on the find bar's buttons or the bar widget
-    // itself -- a rare path, but keep the convention.
+    // Reachable only when focus is on the bar but not on `mEdit`
+    // (the toggle / arrow buttons). For `mEdit`, the line edit
+    // accepts Return for itself and the modifier-bearing variant
+    // is handled in `eventFilter`. Handling it here too keeps the
+    // VS Code / Chromium convention for the rest of the bar.
     if (event->key() == Qt::Key_Return || event->key() == Qt::Key_Enter)
     {
         if (event->modifiers().testFlag(Qt::ShiftModifier))
         {
             FindPrevious();
-            event->accept();
-            return;
         }
-        FindNext();
+        else
+        {
+            FindNext();
+        }
         event->accept();
         return;
     }

--- a/app/src/find_record_widget.cpp
+++ b/app/src/find_record_widget.cpp
@@ -1,38 +1,144 @@
 #include "find_record_widget.hpp"
 
-#include <QCheckBox>
+#include <QAction>
+#include <QApplication>
+#include <QEasingCurve>
 #include <QHBoxLayout>
+#include <QKeyEvent>
+#include <QLabel>
 #include <QLineEdit>
-#include <QPushButton>
+#include <QPropertyAnimation>
+#include <QShowEvent>
+#include <QShortcut>
+#include <QSizePolicy>
+#include <QStyle>
 #include <QTimer>
+#include <QToolButton>
+
+#include <algorithm>
+
+namespace
+{
+/// Slide-in / slide-out duration. Slow enough to read, fast
+/// enough not to feel sluggish; matches VS Code's find bar.
+constexpr int FIND_REVEAL_ANIMATION_MS = 120;
+
+/// Debounce window after a key press before we ask the parent to
+/// recount matches. Avoids a full-table scan on every keystroke
+/// of a long word.
+constexpr int MATCH_COUNT_DEBOUNCE_MS = 120;
+
+/// Visual minimum so the search field doesn't collapse to nothing
+/// when the bar is squeezed.
+constexpr int EDIT_MIN_WIDTH = 220;
+
+/// Outer margins / spacing for the find bar's horizontal layout.
+/// Matches the densities of the other docks (`anchors_dock`,
+/// `record_detail_widget`).
+constexpr int LAYOUT_OUTER_H_MARGIN = 6;
+constexpr int LAYOUT_OUTER_V_MARGIN = 4;
+constexpr int LAYOUT_SPACING = 4;
+
+/// Reserved width for the "i of N" label so the count digits
+/// don't shift the arrow buttons left/right as totals grow.
+constexpr int MATCH_LABEL_MIN_WIDTH = 80;
+} // namespace
 
 FindRecordWidget::FindRecordWidget(QWidget *parent)
     : QWidget{parent}
 {
     auto *hLayout = new QHBoxLayout(this);
+    hLayout->setContentsMargins(
+        LAYOUT_OUTER_H_MARGIN, LAYOUT_OUTER_V_MARGIN, LAYOUT_OUTER_H_MARGIN, LAYOUT_OUTER_V_MARGIN
+    );
+    hLayout->setSpacing(LAYOUT_SPACING);
 
     mEdit = new QLineEdit(this);
-    hLayout->addWidget(mEdit);
-    mCheckBoxWildcards = new QCheckBox("Wildcards", this);
-    hLayout->addWidget(mCheckBoxWildcards);
-    mCheckBoxRegularExpressions = new QCheckBox("Regular Expressions", this);
-    hLayout->addWidget(mCheckBoxRegularExpressions);
-    mButtonNext = new QPushButton("Next", this);
-    hLayout->addWidget(mButtonNext);
-    mButtonPrevious = new QPushButton("Previous", this);
+    mEdit->setObjectName(QStringLiteral("findEdit"));
+    mEdit->setPlaceholderText(tr("Find in logs\u2026"));
+    mEdit->setClearButtonEnabled(true);
+    mEdit->setMinimumWidth(EDIT_MIN_WIDTH);
+    // Leading magnifying-glass affordance. The action is decorative
+    // only; clicking it focuses the field (idempotent, since the
+    // user just clicked into the field).
+    auto *searchIconAction = mEdit->addAction(
+        QApplication::style()->standardIcon(QStyle::SP_FileDialogContentsView), QLineEdit::LeadingPosition
+    );
+    connect(searchIconAction, &QAction::triggered, mEdit, qOverload<>(&QWidget::setFocus));
+
+    // Trailing toggle "buttons" embedded in the line edit. `addAction`
+    // with `TrailingPosition` renders them as small icon buttons
+    // inside the field, before the clear button (Qt orders them in
+    // insertion order from the inner edge outward).
+    mRegexAction = new QAction(this);
+    mRegexAction->setObjectName(QStringLiteral("regexToggle"));
+    mRegexAction->setCheckable(true);
+    mRegexAction->setText(QStringLiteral(".*"));
+    mRegexAction->setIcon(QApplication::style()->standardIcon(QStyle::SP_FileDialogDetailedView));
+    mRegexAction->setToolTip(tr("Match using regular expressions"));
+    mEdit->addAction(mRegexAction, QLineEdit::TrailingPosition);
+
+    mWildcardsAction = new QAction(this);
+    mWildcardsAction->setObjectName(QStringLiteral("wildcardsToggle"));
+    mWildcardsAction->setCheckable(true);
+    mWildcardsAction->setText(QStringLiteral("*?"));
+    mWildcardsAction->setIcon(QApplication::style()->standardIcon(QStyle::SP_FileDialogListView));
+    mWildcardsAction->setToolTip(tr("Match using wildcards (* and ?)"));
+    mEdit->addAction(mWildcardsAction, QLineEdit::TrailingPosition);
+
+    hLayout->addWidget(mEdit, /*stretch=*/1);
+
+    mMatchCountLabel = new QLabel(this);
+    mMatchCountLabel->setObjectName(QStringLiteral("findMatchCount"));
+    mMatchCountLabel->setAlignment(Qt::AlignCenter);
+    mMatchCountLabel->setMinimumWidth(MATCH_LABEL_MIN_WIDTH);
+    mMatchCountLabel->setVisible(false);
+    hLayout->addWidget(mMatchCountLabel);
+
+    mButtonPrevious = new QToolButton(this);
+    mButtonPrevious->setObjectName(QStringLiteral("findPrevious"));
+    mButtonPrevious->setIcon(QApplication::style()->standardIcon(QStyle::SP_ArrowUp));
+    mButtonPrevious->setToolTip(tr("Previous match (Shift+Enter)"));
+    mButtonPrevious->setAutoRaise(true);
     hLayout->addWidget(mButtonPrevious);
-    mButtonClose = new QToolButton(this);
-    mButtonClose->setText("X");
-    hLayout->addWidget(mButtonClose);
 
-    this->setSizePolicy(QSizePolicy::Minimum, QSizePolicy::Preferred);
+    mButtonNext = new QToolButton(this);
+    mButtonNext->setObjectName(QStringLiteral("findNext"));
+    mButtonNext->setIcon(QApplication::style()->standardIcon(QStyle::SP_ArrowDown));
+    mButtonNext->setToolTip(tr("Next match (Enter)"));
+    mButtonNext->setAutoRaise(true);
+    hLayout->addWidget(mButtonNext);
+
+    setSizePolicy(QSizePolicy::Minimum, QSizePolicy::Preferred);
+    // Focus order: line edit first; toggles + arrow buttons stay
+    // reachable via Tab once focus is in the bar.
+    setTabOrder(mEdit, mButtonPrevious);
+    setTabOrder(mButtonPrevious, mButtonNext);
+
     mEdit->setFocus();
+    QTimer::singleShot(0, mEdit, qOverload<>(&QWidget::setFocus));
 
-    QTimer::singleShot(0, mEdit, SLOT(setFocus()));
+    connect(mButtonNext, &QToolButton::clicked, this, &FindRecordWidget::FindNext);
+    connect(mButtonPrevious, &QToolButton::clicked, this, &FindRecordWidget::FindPrevious);
 
-    connect(mButtonNext, &QPushButton::clicked, this, &FindRecordWidget::FindNext);
-    connect(mButtonPrevious, &QPushButton::clicked, this, &FindRecordWidget::FindPrevious);
-    connect(mButtonClose, &QPushButton::clicked, this, &FindRecordWidget::hide);
+    // Return triggers find-next; Shift+Return is wired through
+    // `keyPressEvent` because `returnPressed` does not carry
+    // modifier state.
+    connect(mEdit, &QLineEdit::returnPressed, this, &FindRecordWidget::FindNext);
+
+    // Text + toggle changes drive live match-count requests. We
+    // debounce so a fast typist doesn't trigger a full-table scan
+    // on every keystroke.
+    connect(mEdit, &QLineEdit::textChanged, this, &FindRecordWidget::RequestMatchCountSoon);
+    connect(mWildcardsAction, &QAction::toggled, this, &FindRecordWidget::RequestMatchCountSoon);
+    connect(mRegexAction, &QAction::toggled, this, &FindRecordWidget::RequestMatchCountSoon);
+
+    // Escape hides the bar instead of an explicit "X" button.
+    // Scope `WindowShortcut` so the shortcut fires whenever this
+    // widget (or any descendant focusable) has focus.
+    auto *escapeShortcut = new QShortcut(QKeySequence(Qt::Key_Escape), this);
+    escapeShortcut->setContext(Qt::WidgetWithChildrenShortcut);
+    connect(escapeShortcut, &QShortcut::activated, this, &FindRecordWidget::HideAnimated);
 }
 
 void FindRecordWidget::SetEditFocus()
@@ -41,10 +147,103 @@ void FindRecordWidget::SetEditFocus()
     mEdit->selectAll();
 }
 
-void FindRecordWidget::closeEvent(QCloseEvent *event)
+void FindRecordWidget::SetMatchInfo(int current, int total)
 {
-    emit Closed();
-    QWidget::closeEvent(event);
+    if (total <= 0)
+    {
+        mMatchCountLabel->clear();
+        mMatchCountLabel->setVisible(false);
+        return;
+    }
+    QString text;
+    if (current > 0)
+    {
+        text = tr("%1 of %2").arg(current).arg(total);
+    }
+    else
+    {
+        text = tr("%n matches", nullptr, total);
+    }
+    mMatchCountLabel->setText(text);
+    mMatchCountLabel->setVisible(true);
+}
+
+void FindRecordWidget::RevealAnimated()
+{
+    if (mNaturalHeight == 0)
+    {
+        // `sizeHint` is the best estimate before the first paint
+        // delivers a real geometry; tracked in `showEvent` once
+        // we know.
+        mNaturalHeight = sizeHint().height();
+    }
+    setMaximumHeight(mNaturalHeight);
+    show();
+
+    if (mAnimation && mAnimation->state() == QAbstractAnimation::Running)
+    {
+        mAnimation->stop();
+    }
+    auto *animation = new QPropertyAnimation(this, "maximumHeight", this);
+    animation->setDuration(FIND_REVEAL_ANIMATION_MS);
+    animation->setStartValue(0);
+    animation->setEndValue(mNaturalHeight);
+    animation->setEasingCurve(QEasingCurve::OutCubic);
+    animation->start(QAbstractAnimation::DeleteWhenStopped);
+    mAnimation = animation;
+}
+
+void FindRecordWidget::HideAnimated()
+{
+    if (!isVisible())
+    {
+        return;
+    }
+    const int from = height();
+    if (mAnimation && mAnimation->state() == QAbstractAnimation::Running)
+    {
+        mAnimation->stop();
+    }
+    auto *animation = new QPropertyAnimation(this, "maximumHeight", this);
+    animation->setDuration(FIND_REVEAL_ANIMATION_MS);
+    animation->setStartValue(from);
+    animation->setEndValue(0);
+    animation->setEasingCurve(QEasingCurve::OutCubic);
+    connect(animation, &QPropertyAnimation::finished, this, [this]() {
+        hide();
+        // Reset the cap so a subsequent `show()` (e.g. parent
+        // calls `show()` directly instead of `RevealAnimated`)
+        // does not stay collapsed.
+        setMaximumHeight(QWIDGETSIZE_MAX);
+    });
+    animation->start(QAbstractAnimation::DeleteWhenStopped);
+    mAnimation = animation;
+}
+
+void FindRecordWidget::keyPressEvent(QKeyEvent *event)
+{
+    if (event->key() == Qt::Key_Return || event->key() == Qt::Key_Enter)
+    {
+        if (event->modifiers().testFlag(Qt::ShiftModifier))
+        {
+            FindPrevious();
+            event->accept();
+            return;
+        }
+        // Plain Return is already wired through `returnPressed`
+        // on the line edit; fall through so the default still
+        // works for buttons that have focus.
+    }
+    QWidget::keyPressEvent(event);
+}
+
+void FindRecordWidget::showEvent(QShowEvent *event)
+{
+    QWidget::showEvent(event);
+    // Capture the real expanded height the first time we are
+    // realized so `RevealAnimated` has a sane target on later
+    // toggles.
+    mNaturalHeight = std::max(mNaturalHeight, sizeHint().height());
 }
 
 void FindRecordWidget::FindNext()
@@ -53,7 +252,7 @@ void FindRecordWidget::FindNext()
     {
         return;
     }
-    emit FindRecords(mEdit->text(), true, mCheckBoxWildcards->isChecked(), mCheckBoxRegularExpressions->isChecked());
+    emit FindRecords(mEdit->text(), true, mWildcardsAction->isChecked(), mRegexAction->isChecked());
 }
 
 void FindRecordWidget::FindPrevious()
@@ -62,5 +261,26 @@ void FindRecordWidget::FindPrevious()
     {
         return;
     }
-    emit FindRecords(mEdit->text(), false, mCheckBoxWildcards->isChecked(), mCheckBoxRegularExpressions->isChecked());
+    emit FindRecords(mEdit->text(), false, mWildcardsAction->isChecked(), mRegexAction->isChecked());
+}
+
+void FindRecordWidget::RequestMatchCountSoon()
+{
+    if (mEdit->text().isEmpty())
+    {
+        // Empty needle: clear immediately without bouncing off
+        // the debounce timer, so the label can't lag a clear.
+        SetMatchInfo(0, 0);
+        emit MatchCountRequested(QString(), mWildcardsAction->isChecked(), mRegexAction->isChecked());
+        return;
+    }
+    // Debounce so multi-keystroke edits coalesce into one count
+    // request. `singleShot` against `this` so destruction cancels
+    // the pending fire.
+    QTimer::singleShot(MATCH_COUNT_DEBOUNCE_MS, this, &FindRecordWidget::EmitMatchCountRequest);
+}
+
+void FindRecordWidget::EmitMatchCountRequest()
+{
+    emit MatchCountRequested(mEdit->text(), mWildcardsAction->isChecked(), mRegexAction->isChecked());
 }

--- a/app/src/find_record_widget.cpp
+++ b/app/src/find_record_widget.cpp
@@ -21,6 +21,17 @@ namespace
 /// of a long word.
 constexpr int MATCH_COUNT_DEBOUNCE_MS = 120;
 
+/// Hard cap on how long a match-count emit can be deferred. The
+/// trailing-edge debounce restarts on every keystroke / model
+/// bump, which under continuous activity (live-tail streaming,
+/// long words held down) means it would never fire and the "*i*
+/// of *N*" indicator would lag the live data by minutes. The
+/// max-age timer is armed once when the trailing debounce first
+/// starts and is *not* restarted, so it guarantees an emit
+/// within this window even when the trailing timer keeps
+/// resetting.
+constexpr int MATCH_COUNT_MAX_AGE_MS = 750;
+
 /// Visual minimum so the search field doesn't collapse to nothing
 /// when the bar is squeezed.
 constexpr int EDIT_MIN_WIDTH = 220;
@@ -76,6 +87,12 @@ FindRecordWidget::FindRecordWidget(QWidget *parent)
     regexButton->setDefaultAction(mRegexAction);
     regexButton->setAutoRaise(true);
     regexButton->setToolButtonStyle(Qt::ToolButtonTextOnly);
+    // Defensive: `setDefaultAction` propagates the action's text in
+    // most styles, but a few platform styles only render text when
+    // `QToolButton` has its own. Setting it explicitly pins the
+    // glyph regardless of style; click handling continues to flow
+    // through the action.
+    regexButton->setText(mRegexAction->text());
     hLayout->addWidget(regexButton);
 
     mWildcardsAction = new QAction(this);
@@ -89,6 +106,8 @@ FindRecordWidget::FindRecordWidget(QWidget *parent)
     wildcardsButton->setDefaultAction(mWildcardsAction);
     wildcardsButton->setAutoRaise(true);
     wildcardsButton->setToolButtonStyle(Qt::ToolButtonTextOnly);
+    // Same rationale as `regexButton` above.
+    wildcardsButton->setText(mWildcardsAction->text());
     hLayout->addWidget(wildcardsButton);
 
     mMatchCountLabel = new QLabel(this);
@@ -141,6 +160,17 @@ FindRecordWidget::FindRecordWidget(QWidget *parent)
     mMatchCountTimer->setInterval(MATCH_COUNT_DEBOUNCE_MS);
     connect(mMatchCountTimer, &QTimer::timeout, this, &FindRecordWidget::EmitMatchCountRequest);
 
+    // Companion max-age timer: armed alongside `mMatchCountTimer`
+    // (only when the trailing timer wasn't already running) and
+    // *never* restarted by subsequent bumps. Forces an emit after
+    // at most `MATCH_COUNT_MAX_AGE_MS`, so live-tail streaming or
+    // a held-down key can't strand the "*i* of *N*" indicator at
+    // its pre-activity value.
+    mMatchCountMaxAgeTimer = new QTimer(this);
+    mMatchCountMaxAgeTimer->setSingleShot(true);
+    mMatchCountMaxAgeTimer->setInterval(MATCH_COUNT_MAX_AGE_MS);
+    connect(mMatchCountMaxAgeTimer, &QTimer::timeout, this, &FindRecordWidget::EmitMatchCountRequest);
+
     // Text + toggle changes drive live match-count requests. We
     // debounce via `mMatchCountTimer` so a fast typist doesn't
     // trigger a full-table scan on every keystroke.
@@ -186,7 +216,7 @@ void FindRecordWidget::SetEditFocus()
     mEdit->selectAll();
 }
 
-void FindRecordWidget::SetMatchInfo(int current, int total)
+void FindRecordWidget::SetMatchInfo(int current, int total, bool overflowed)
 {
     if (total <= 0)
     {
@@ -194,14 +224,22 @@ void FindRecordWidget::SetMatchInfo(int current, int total)
         mMatchCountLabel->setVisible(false);
         return;
     }
+    // Locale-grouped digits matching the rest of the GUI; the "+"
+    // suffix surfaces the parent's hit cap so a million-row log
+    // doesn't pretend the count is exactly at the cap.
+    const QLocale locale = QLocale::system();
+    const QString totalText =
+        locale.toString(static_cast<qlonglong>(total)) + (overflowed ? QStringLiteral("+") : QString());
     QString text;
     if (current > 0)
     {
-        text = tr("%1 of %2").arg(current).arg(total);
+        text = tr("%1 of %2").arg(locale.toString(static_cast<qlonglong>(current)), totalText);
     }
     else
     {
-        text = tr("%n matches", nullptr, total);
+        // Two formatters because `%n` only handles one number;
+        // we already formatted `totalText` above.
+        text = overflowed ? tr("%1 matches").arg(totalText) : tr("%n matches", nullptr, total);
     }
     mMatchCountLabel->setText(text);
     mMatchCountLabel->setVisible(true);
@@ -213,10 +251,19 @@ void FindRecordWidget::BumpMatchCountDebounce()
     {
         return;
     }
-    // Restart the timer; identical mechanism to the textChanged
-    // path. A burst of model signals collapses into one final
-    // recount.
+    // Restart the trailing timer; identical mechanism to the
+    // textChanged path. A burst of model signals collapses into
+    // one final recount.
+    //
+    // Arm the max-age timer only when it isn't already running,
+    // so continuous activity can't keep pushing the deadline
+    // out -- it caps the longest possible delay between an
+    // invalidation and the visible recount.
     mMatchCountTimer->start();
+    if (!mMatchCountMaxAgeTimer->isActive())
+    {
+        mMatchCountMaxAgeTimer->start();
+    }
 }
 
 void FindRecordWidget::DismissBar()
@@ -307,23 +354,36 @@ void FindRecordWidget::RequestMatchCountSoon()
     {
         // Empty needle: clear immediately without bouncing off
         // the debounce timer, so the label can't lag a clear.
-        // Cancel any in-flight tick so a stale needle doesn't
-        // overwrite the cleared state. No signal emitted -- the
-        // parent has nothing to recount, and a per-keystroke
-        // round-trip just to be told "still empty" is wasted
-        // work. The cache the parent holds is keyed by needle,
-        // so the next non-empty query rebuilds it anyway.
+        // Cancel any in-flight tick (trailing + max-age) so a
+        // stale needle doesn't overwrite the cleared state. No
+        // signal emitted -- the parent has nothing to recount,
+        // and a per-keystroke round-trip just to be told "still
+        // empty" is wasted work. The cache the parent holds is
+        // keyed by needle, so the next non-empty query rebuilds
+        // it anyway.
         mMatchCountTimer->stop();
+        mMatchCountMaxAgeTimer->stop();
         SetMatchInfo(0, 0);
         return;
     }
     // `start()` resets the countdown if already running, so a
     // fast typist coalesces N keystrokes into a single trailing
-    // match-count scan.
+    // match-count scan. The max-age timer arms once on the
+    // leading edge so it caps the longest possible delay even
+    // under sustained typing.
     mMatchCountTimer->start();
+    if (!mMatchCountMaxAgeTimer->isActive())
+    {
+        mMatchCountMaxAgeTimer->start();
+    }
 }
 
 void FindRecordWidget::EmitMatchCountRequest()
 {
+    // Stop the *other* timer so a max-age fire doesn't get
+    // followed 50 ms later by a redundant trailing fire (and
+    // vice versa).
+    mMatchCountTimer->stop();
+    mMatchCountMaxAgeTimer->stop();
     emit MatchCountRequested(mEdit->text(), mWildcardsAction->isChecked(), mRegexAction->isChecked());
 }

--- a/app/src/find_record_widget.cpp
+++ b/app/src/find_record_widget.cpp
@@ -82,9 +82,19 @@ constexpr qreal ARROW_CENTRE_RATIO = 0.5;
 /// the next-match arrow (apex at the bottom). Replaces
 /// `QStyle::SP_ArrowUp` / `SP_ArrowDown`, which Qt bakes as raster
 /// black-on-transparent pixmaps that vanish on dark themes.
-[[nodiscard]] QIcon MakeArrowIcon(int sizePx, bool pointingUp, const QColor &color)
+///
+/// @p devicePixelRatio scales the backing pixmap so the painted
+/// triangle is sharp on HiDPI displays. Without it the pixmap is
+/// minted at logical pixel size and Qt up-scales the rasterised
+/// triangle, leaving the chevrons softer than the surrounding
+/// `.*` / `*?` text glyphs. The painter still draws in logical
+/// coordinates because we set `setDevicePixelRatio` before
+/// drawing.
+[[nodiscard]] QIcon MakeArrowIcon(int sizePx, bool pointingUp, const QColor &color, qreal devicePixelRatio)
 {
-    QPixmap pix(sizePx, sizePx);
+    const qreal dpr = devicePixelRatio > 0.0 ? devicePixelRatio : 1.0;
+    QPixmap pix(QSize(sizePx, sizePx) * dpr);
+    pix.setDevicePixelRatio(dpr);
     pix.fill(Qt::transparent);
     QPainter painter(&pix);
     painter.setRenderHint(QPainter::Antialiasing, true);
@@ -355,6 +365,27 @@ void FindRecordWidget::BumpMatchCountDebounce()
     {
         return;
     }
+    // Fast path: trailing timer already running AND max-age
+    // timer already running means a recount is already queued
+    // and capped. Skip the `start()` call entirely -- it's
+    // technically idempotent (`QTimer::start` resets the
+    // countdown), but the trailing-timer reset *defeats*
+    // coalescing in the streaming-burst case where this is the
+    // hottest invalidation path:
+    //
+    //   model emits dataChanged 100x/sec while live-tailing,
+    //   each emit calls OnFindCacheInvalidated, which calls
+    //   BumpMatchCountDebounce. Without this guard, every emit
+    //   restarts the trailing timer and the recount never
+    //   actually fires until streaming pauses; the max-age
+    //   timer is the only thing forcing progress. With the
+    //   guard, the *first* invalidation arms both timers and
+    //   subsequent invalidations are no-ops -- the trailing
+    //   timer expires on schedule and the recount runs.
+    if (mMatchCountTimer->isActive() && mMatchCountMaxAgeTimer->isActive())
+    {
+        return;
+    }
     // Restart the trailing timer; identical mechanism to the
     // textChanged path. A burst of model signals collapses into
     // one final recount.
@@ -502,6 +533,22 @@ void FindRecordWidget::changeEvent(QEvent *event)
     }
 }
 
+bool FindRecordWidget::event(QEvent *event)
+{
+    // `DevicePixelRatioChange` fires when the window backing the
+    // widget moves between monitors with different scale factors
+    // (e.g. dragging a floating `FindDock` from a 100% laptop
+    // panel to a 200% external display). The icon pixmap was
+    // allocated at the previous DPR, so re-mint it now or Qt
+    // will up-scale a low-resolution rasterisation. The cost is
+    // two tiny pixmaps; safe to do unconditionally.
+    if (event != nullptr && event->type() == QEvent::DevicePixelRatioChange)
+    {
+        RefreshArrowIcons();
+    }
+    return QWidget::event(event);
+}
+
 void FindRecordWidget::RefreshArrowIcons()
 {
     if (mButtonPrevious == nullptr || mButtonNext == nullptr)
@@ -516,8 +563,14 @@ void FindRecordWidget::RefreshArrowIcons()
     // toggle action glyphs render in.
     const QColor color = palette().color(QPalette::Active, QPalette::WindowText);
     const int sizePx = ArrowIconPixels(this);
-    mButtonPrevious->setIcon(MakeArrowIcon(sizePx, /*pointingUp=*/true, color));
-    mButtonNext->setIcon(MakeArrowIcon(sizePx, /*pointingUp=*/false, color));
+    // `devicePixelRatioF()` walks up the parent chain to the host
+    // window; on a 200% scaled monitor this returns 2.0 and the
+    // pixmap is allocated 2x in each axis so the triangle is
+    // pixel-sharp. Falls back to 1.0 when the widget is not yet
+    // realised (early constructor call before `show()`).
+    const qreal dpr = devicePixelRatioF();
+    mButtonPrevious->setIcon(MakeArrowIcon(sizePx, /*pointingUp=*/true, color, dpr));
+    mButtonNext->setIcon(MakeArrowIcon(sizePx, /*pointingUp=*/false, color, dpr));
 }
 
 void FindRecordWidget::EmitMatchCountRequest()

--- a/app/src/find_record_widget.cpp
+++ b/app/src/find_record_widget.cpp
@@ -2,12 +2,20 @@
 
 #include <QAction>
 #include <QApplication>
+#include <QColor>
 #include <QDockWidget>
 #include <QEvent>
 #include <QHBoxLayout>
+#include <QIcon>
 #include <QKeyEvent>
 #include <QLabel>
 #include <QLineEdit>
+#include <QPainter>
+#include <QPainterPath>
+#include <QPalette>
+#include <QPen>
+#include <QPixmap>
+#include <QPointF>
 #include <QShortcut>
 #include <QSizePolicy>
 #include <QStyle>
@@ -54,6 +62,59 @@ constexpr int LAYOUT_SPACING = 4;
 /// Reserved width for the "i of N" label so the count digits
 /// don't shift the arrow buttons left/right as totals grow.
 constexpr int MATCH_LABEL_MIN_WIDTH = 80;
+
+/// Edge length for the painted arrow icons. Falls back to this
+/// when `QStyle::PM_SmallIconSize` returns nonsense (offscreen
+/// QPA with no style hint table).
+constexpr int ARROW_ICON_FALLBACK_PX = 14;
+
+/// Fraction of the icon edge to inset the triangle from each
+/// side. Tuned by eye to match the visual weight of the
+/// surrounding `.*` / `*?` toggle glyphs.
+constexpr qreal ARROW_INSET_RATIO = 0.18;
+
+/// Centre of the icon expressed as a fraction of the edge.
+constexpr qreal ARROW_CENTRE_RATIO = 0.5;
+
+/// Build a small chevron-style arrow icon painted in @p color so
+/// the glyph follows the active palette / theme. `pointingUp =
+/// true` mints the previous-match arrow (apex at the top), false
+/// the next-match arrow (apex at the bottom). Replaces
+/// `QStyle::SP_ArrowUp` / `SP_ArrowDown`, which Qt bakes as raster
+/// black-on-transparent pixmaps that vanish on dark themes.
+[[nodiscard]] QIcon MakeArrowIcon(int sizePx, bool pointingUp, const QColor &color)
+{
+    QPixmap pix(sizePx, sizePx);
+    pix.fill(Qt::transparent);
+    QPainter painter(&pix);
+    painter.setRenderHint(QPainter::Antialiasing, true);
+    const qreal inset = sizePx * ARROW_INSET_RATIO;
+    const qreal apex = pointingUp ? inset : sizePx - inset;
+    const qreal base = pointingUp ? sizePx - inset : inset;
+    QPainterPath triangle;
+    triangle.moveTo(QPointF(sizePx * ARROW_CENTRE_RATIO, apex));
+    triangle.lineTo(QPointF(inset, base));
+    triangle.lineTo(QPointF(sizePx - inset, base));
+    triangle.closeSubpath();
+    painter.setPen(Qt::NoPen);
+    painter.setBrush(color);
+    painter.drawPath(triangle);
+    painter.end();
+    return QIcon{pix};
+}
+
+[[nodiscard]] int ArrowIconPixels(const QWidget *widget)
+{
+    if (const QStyle *style = (widget != nullptr) ? widget->style() : QApplication::style(); style != nullptr)
+    {
+        const int metric = style->pixelMetric(QStyle::PM_SmallIconSize, nullptr, widget);
+        if (metric > 0)
+        {
+            return metric;
+        }
+    }
+    return ARROW_ICON_FALLBACK_PX;
+}
 } // namespace
 
 FindRecordWidget::FindRecordWidget(QWidget *parent)
@@ -132,17 +193,23 @@ FindRecordWidget::FindRecordWidget(QWidget *parent)
 
     mButtonPrevious = new QToolButton(this);
     mButtonPrevious->setObjectName(QStringLiteral("findPrevious"));
-    mButtonPrevious->setIcon(QApplication::style()->standardIcon(QStyle::SP_ArrowUp));
     mButtonPrevious->setToolTip(tr("Previous match (Shift+Enter)"));
     mButtonPrevious->setAutoRaise(true);
     hLayout->addWidget(mButtonPrevious);
 
     mButtonNext = new QToolButton(this);
     mButtonNext->setObjectName(QStringLiteral("findNext"));
-    mButtonNext->setIcon(QApplication::style()->standardIcon(QStyle::SP_ArrowDown));
     mButtonNext->setToolTip(tr("Next match (Enter)"));
     mButtonNext->setAutoRaise(true);
     hLayout->addWidget(mButtonNext);
+
+    // Paint the arrow glyphs from the palette so they remain
+    // visible after a Light <-> Dark theme switch. The default
+    // `QStyle::SP_ArrowUp` / `SP_ArrowDown` pixmaps are baked
+    // black on Windows and vanish on a dark background; our own
+    // icons follow `QPalette::WindowText`. `changeEvent` re-runs
+    // this when the application palette / style updates.
+    RefreshArrowIcons();
 
     setSizePolicy(QSizePolicy::Minimum, QSizePolicy::Preferred);
     // Width floor so a floating `FindDock` (the dock has no
@@ -413,6 +480,44 @@ void FindRecordWidget::RequestMatchCountSoon()
     {
         mMatchCountMaxAgeTimer->start();
     }
+}
+
+void FindRecordWidget::changeEvent(QEvent *event)
+{
+    QWidget::changeEvent(event);
+    if (event == nullptr)
+    {
+        return;
+    }
+    // Both events fire on a theme switch:
+    //   PaletteChange  - new colours rolled into `palette()`
+    //   StyleChange    - theme also swapped `qApp->style()`
+    // Either one is sufficient to mint stale icons, so handle
+    // both. The repaint is cheap (two 14x14 triangles) and
+    // `RefreshArrowIcons` is idempotent.
+    const QEvent::Type type = event->type();
+    if (type == QEvent::PaletteChange || type == QEvent::StyleChange || type == QEvent::ApplicationPaletteChange)
+    {
+        RefreshArrowIcons();
+    }
+}
+
+void FindRecordWidget::RefreshArrowIcons()
+{
+    if (mButtonPrevious == nullptr || mButtonNext == nullptr)
+    {
+        return;
+    }
+    // Pull `WindowText` rather than `ButtonText`: the buttons are
+    // `autoRaise` toolbuttons whose backdrop matches the
+    // surrounding find-bar surface, not a raised button face, so
+    // `WindowText` is the contrast colour the user actually sees
+    // these glyphs against. Matches the colour the `.*` / `*?`
+    // toggle action glyphs render in.
+    const QColor color = palette().color(QPalette::Active, QPalette::WindowText);
+    const int sizePx = ArrowIconPixels(this);
+    mButtonPrevious->setIcon(MakeArrowIcon(sizePx, /*pointingUp=*/true, color));
+    mButtonNext->setIcon(MakeArrowIcon(sizePx, /*pointingUp=*/false, color));
 }
 
 void FindRecordWidget::EmitMatchCountRequest()

--- a/app/src/log_filter_model.cpp
+++ b/app/src/log_filter_model.cpp
@@ -1232,24 +1232,14 @@ Qt::MatchFlags LogFilterModel::ComposeFindFlags(bool wildcards, bool regularExpr
 
 bool LogFilterModel::Matches(const QVariant &data, const QVariant &value, Qt::MatchFlags flags)
 {
-    // `Qt::MatchExactly == 0`, so `flags.testFlag(Qt::MatchExactly)`
-    // returns true only when `flags` is exactly 0 -- every caller in
-    // this codebase OR-s in `MatchWrap | MatchRecursive`, so the
-    // direct-equality branch was historically dead code. Mask the
-    // match-type field (see the QString overload below for the
-    // disjoint-bit rationale) and short-circuit MatchExactly on the
-    // QVariant equality, which is cheaper than stringifying twice and
-    // preserves typed comparisons (numeric, timestamp, enum id).
+    // Mask the match-type field (see QString overload below for the
+    // disjoint-bit rationale). Short-circuit MatchExactly on the
+    // QVariant compare -- cheaper than stringifying and preserves
+    // typed comparisons.
     //
-    // Caveat: because `MatchExactly == 0`, *any* `flags` value with
-    // no match-type bit set (e.g. `MatchWrap | MatchRecursive` on
-    // its own) silently routes through the exact-equality branch.
-    // No in-tree caller currently passes a flag set with no type
-    // bit -- `LogFilterModel::ComposeFindFlags` always picks one
-    // of Contains / Wildcard / Regex -- but a future caller mis-composing flags
-    // would otherwise get the wrong match silently. The Q_ASSERT
-    // below blows up loudly in debug; release builds still default
-    // to MatchExactly to preserve Qt's documented semantics.
+    // `MatchExactly == 0`, so flags with no match-type bit silently
+    // route here. The assert catches mis-composed flags in debug;
+    // release defaults to MatchExactly per Qt's documented semantics.
     constexpr int MATCH_TYPE_MASK = 0x000F;
     const int matchType = static_cast<int>(flags) & MATCH_TYPE_MASK;
     Q_ASSERT_X(
@@ -1268,19 +1258,12 @@ bool LogFilterModel::Matches(const QVariant &data, const QVariant &value, Qt::Ma
 
 bool LogFilterModel::Matches(const QString &text, const QString &needle, Qt::MatchFlags flags)
 {
-    // `Qt::MatchFlag`'s match-type values are *not* disjoint bit
-    // flags: `MatchWildcard = 5` overlaps `MatchContains = 1` and
+    // `Qt::MatchFlag`'s match-type values are NOT disjoint bits:
+    // `MatchWildcard = 5` overlaps `MatchContains = 1` and
     // `MatchRegularExpression = 4`; `MatchEndsWith = 3` overlaps
-    // `MatchContains = 1` and `MatchStartsWith = 2`. A naive
-    // `testFlag` ladder therefore picks the *first* check whose
-    // bit subset is present, which is silently the *least*
-    // specific match -- so `MatchWildcard` would fall into the
-    // `MatchContains` branch and the wildcard search would run
-    // as a plain substring scan with the literal `*` / `?`. Mask
-    // the match-type field and compare for exact equality so the
-    // semantics line up with how Qt's own item-view searches
-    // interpret these constants. The QVariant overload above uses
-    // the same mask so the two stay in lock-step.
+    // `MatchContains | MatchStartsWith`. A `testFlag` ladder would
+    // silently pick the least specific match. Mask and compare for
+    // equality so the semantics match Qt's own item-view searches.
     constexpr int MATCH_TYPE_MASK = 0x000F;
     const int matchType = static_cast<int>(flags) & MATCH_TYPE_MASK;
     switch (matchType)
@@ -1304,13 +1287,9 @@ bool LogFilterModel::Matches(const QString &text, const QString &needle, Qt::Mat
         return regex.match(text).hasMatch();
     }
     default:
-        // `Qt::MatchFixedString` (value 8) lands here and is
-        // deliberately *not* implemented -- no in-tree caller
-        // needs it, and the find bar exposes contains/regex/
-        // wildcard explicitly. A future contributor adding it
-        // should slot a case label in above; today the default
-        // is "no match" so a typo'd flag set fails closed
-        // instead of silently behaving like contains.
+        // `Qt::MatchFixedString` (8) is deliberately not implemented;
+        // no in-tree caller needs it. Fail closed rather than silently
+        // behaving like contains.
         return false;
     }
 }

--- a/app/src/log_filter_model.cpp
+++ b/app/src/log_filter_model.cpp
@@ -1214,7 +1214,17 @@ QList<QModelIndex> LogFilterModel::MatchRow(
 
 bool LogFilterModel::Matches(const QVariant &data, const QVariant &value, Qt::MatchFlags flags)
 {
-    if (flags.testFlag(Qt::MatchExactly))
+    // `Qt::MatchExactly == 0`, so `flags.testFlag(Qt::MatchExactly)`
+    // returns true only when `flags` is exactly 0 -- every caller in
+    // this codebase OR-s in `MatchWrap | MatchRecursive`, so the
+    // direct-equality branch was historically dead code. Mask the
+    // match-type field (see the QString overload below for the
+    // disjoint-bit rationale) and short-circuit MatchExactly on the
+    // QVariant equality, which is cheaper than stringifying twice and
+    // preserves typed comparisons (numeric, timestamp, enum id).
+    constexpr int MATCH_TYPE_MASK = 0x000F;
+    const int matchType = static_cast<int>(flags) & MATCH_TYPE_MASK;
+    if (matchType == Qt::MatchExactly)
     {
         return data == value;
     }
@@ -1234,7 +1244,8 @@ bool LogFilterModel::Matches(const QString &text, const QString &needle, Qt::Mat
     // as a plain substring scan with the literal `*` / `?`. Mask
     // the match-type field and compare for exact equality so the
     // semantics line up with how Qt's own item-view searches
-    // interpret these constants.
+    // interpret these constants. The QVariant overload above uses
+    // the same mask so the two stay in lock-step.
     constexpr int MATCH_TYPE_MASK = 0x000F;
     const int matchType = static_cast<int>(flags) & MATCH_TYPE_MASK;
     switch (matchType)

--- a/app/src/log_filter_model.cpp
+++ b/app/src/log_filter_model.cpp
@@ -1212,6 +1212,24 @@ QList<QModelIndex> LogFilterModel::MatchRow(
     return result;
 }
 
+Qt::MatchFlags LogFilterModel::ComposeFindFlags(bool wildcards, bool regularExpressions)
+{
+    Qt::MatchFlags flags = Qt::MatchWrap | Qt::MatchRecursive;
+    if (regularExpressions)
+    {
+        flags |= Qt::MatchRegularExpression;
+    }
+    else if (wildcards)
+    {
+        flags |= Qt::MatchWildcard;
+    }
+    else
+    {
+        flags |= Qt::MatchContains;
+    }
+    return flags;
+}
+
 bool LogFilterModel::Matches(const QVariant &data, const QVariant &value, Qt::MatchFlags flags)
 {
     // `Qt::MatchExactly == 0`, so `flags.testFlag(Qt::MatchExactly)`
@@ -1225,15 +1243,22 @@ bool LogFilterModel::Matches(const QVariant &data, const QVariant &value, Qt::Ma
     //
     // Caveat: because `MatchExactly == 0`, *any* `flags` value with
     // no match-type bit set (e.g. `MatchWrap | MatchRecursive` on
-    // its own) now silently routes through the exact-equality
-    // branch. Previously the testFlag ladder rejected that case
-    // outright. No in-tree caller currently passes a flag set with
-    // no type bit -- `ComposeFindFlags` always picks one of
-    // Contains / Wildcard / Regex -- but a future caller should be
-    // aware that the type field defaults to `MatchExactly`, not
-    // "no-match".
+    // its own) silently routes through the exact-equality branch.
+    // No in-tree caller currently passes a flag set with no type
+    // bit -- `LogFilterModel::ComposeFindFlags` always picks one
+    // of Contains / Wildcard / Regex -- but a future caller mis-composing flags
+    // would otherwise get the wrong match silently. The Q_ASSERT
+    // below blows up loudly in debug; release builds still default
+    // to MatchExactly to preserve Qt's documented semantics.
     constexpr int MATCH_TYPE_MASK = 0x000F;
     const int matchType = static_cast<int>(flags) & MATCH_TYPE_MASK;
+    Q_ASSERT_X(
+        matchType != Qt::MatchExactly || flags == Qt::MatchExactly,
+        "LogFilterModel::Matches",
+        "no match-type bit set (Contains/Wildcard/Regex/StartsWith/EndsWith) -- "
+        "flags has Wrap/Recursive but no type, which silently routes through MatchExactly. "
+        "Use LogFilterModel::ComposeFindFlags or pick a type explicitly."
+    );
     if (matchType == Qt::MatchExactly)
     {
         return data == value;

--- a/app/src/log_filter_model.cpp
+++ b/app/src/log_filter_model.cpp
@@ -1223,31 +1223,41 @@ bool LogFilterModel::Matches(const QVariant &data, const QVariant &value, Qt::Ma
 
 bool LogFilterModel::Matches(const QString &text, const QString &needle, Qt::MatchFlags flags)
 {
-    if (flags.testFlag(Qt::MatchExactly))
+    // `Qt::MatchFlag`'s match-type values are *not* disjoint bit
+    // flags: `MatchWildcard = 5` overlaps `MatchContains = 1` and
+    // `MatchRegularExpression = 4`; `MatchEndsWith = 3` overlaps
+    // `MatchContains = 1` and `MatchStartsWith = 2`. A naive
+    // `testFlag` ladder therefore picks the *first* check whose
+    // bit subset is present, which is silently the *least*
+    // specific match -- so `MatchWildcard` would fall into the
+    // `MatchContains` branch and the wildcard search would run
+    // as a plain substring scan with the literal `*` / `?`. Mask
+    // the match-type field and compare for exact equality so the
+    // semantics line up with how Qt's own item-view searches
+    // interpret these constants.
+    constexpr int MATCH_TYPE_MASK = 0x000F;
+    const int matchType = static_cast<int>(flags) & MATCH_TYPE_MASK;
+    switch (matchType)
     {
+    case Qt::MatchExactly:
         return text == needle;
-    }
-    if (flags.testFlag(Qt::MatchStartsWith))
-    {
+    case Qt::MatchStartsWith:
         return text.startsWith(needle);
-    }
-    if (flags.testFlag(Qt::MatchEndsWith))
-    {
+    case Qt::MatchEndsWith:
         return text.endsWith(needle);
-    }
-    if (flags.testFlag(Qt::MatchContains))
-    {
+    case Qt::MatchContains:
         return text.contains(needle);
-    }
-    if (flags.testFlag(Qt::MatchRegularExpression))
+    case Qt::MatchRegularExpression:
     {
         const QRegularExpression regex(needle);
         return regex.match(text).hasMatch();
     }
-    if (flags.testFlag(Qt::MatchWildcard))
+    case Qt::MatchWildcard:
     {
         const QRegularExpression regex(QRegularExpression::wildcardToRegularExpression(needle));
         return regex.match(text).hasMatch();
     }
-    return false;
+    default:
+        return false;
+    }
 }

--- a/app/src/log_filter_model.cpp
+++ b/app/src/log_filter_model.cpp
@@ -1222,6 +1222,16 @@ bool LogFilterModel::Matches(const QVariant &data, const QVariant &value, Qt::Ma
     // disjoint-bit rationale) and short-circuit MatchExactly on the
     // QVariant equality, which is cheaper than stringifying twice and
     // preserves typed comparisons (numeric, timestamp, enum id).
+    //
+    // Caveat: because `MatchExactly == 0`, *any* `flags` value with
+    // no match-type bit set (e.g. `MatchWrap | MatchRecursive` on
+    // its own) now silently routes through the exact-equality
+    // branch. Previously the testFlag ladder rejected that case
+    // outright. No in-tree caller currently passes a flag set with
+    // no type bit -- `ComposeFindFlags` always picks one of
+    // Contains / Wildcard / Regex -- but a future caller should be
+    // aware that the type field defaults to `MatchExactly`, not
+    // "no-match".
     constexpr int MATCH_TYPE_MASK = 0x000F;
     const int matchType = static_cast<int>(flags) & MATCH_TYPE_MASK;
     if (matchType == Qt::MatchExactly)
@@ -1269,6 +1279,13 @@ bool LogFilterModel::Matches(const QString &text, const QString &needle, Qt::Mat
         return regex.match(text).hasMatch();
     }
     default:
+        // `Qt::MatchFixedString` (value 8) lands here and is
+        // deliberately *not* implemented -- no in-tree caller
+        // needs it, and the find bar exposes contains/regex/
+        // wildcard explicitly. A future contributor adding it
+        // should slot a case label in above; today the default
+        // is "no match" so a typo'd flag set fails closed
+        // instead of silently behaving like contains.
         return false;
     }
 }

--- a/app/src/log_model.cpp
+++ b/app/src/log_model.cpp
@@ -1270,10 +1270,8 @@ void LogModel::RefreshAllRowStyles()
     {
         return;
     }
-    // FontRole rides along: themes can bold/italicise per level
-    // (`Theme::levelTypes[level].bold/italic`), so a flip can
-    // change font weight on rows whose level matches a re-styled
-    // entry. Including the role here is cheaper than two emits.
+    // FontRole rides along: themes can bold/italicise per level, so
+    // a flip can change font weight on level-styled rows.
     emit dataChanged(index(0, 0), index(rows - 1, cols - 1), {Qt::BackgroundRole, Qt::ForegroundRole, Qt::FontRole});
 }
 
@@ -1281,14 +1279,9 @@ bool LogModel::IsStyleOnlyRoleChange(const QList<int> &roles) noexcept
 {
     if (roles.isEmpty())
     {
-        // Qt's "I don't know what changed" sentinel; conservative
-        // listeners must refresh.
+        // Qt's "I don't know what changed" sentinel; refresh conservatively.
         return false;
     }
-    // Hand-rolled set membership (3-4 entries on the hot path) is
-    // cheaper than building a `QSet`. Roles match those emitted
-    // by `RefreshAllRowStyles` plus `DecorationRole` (covers
-    // future icon-only changes) so the common case short-circuits.
     return std::ranges::all_of(roles, [](int role) {
         return role == Qt::BackgroundRole || role == Qt::ForegroundRole || role == Qt::FontRole ||
                role == Qt::DecorationRole;

--- a/app/src/log_model.cpp
+++ b/app/src/log_model.cpp
@@ -1262,6 +1262,23 @@ void LogModel::RefreshAllAnchorRows()
     emit dataChanged(index(0, 0), index(rows - 1, cols - 1), {Qt::BackgroundRole, Qt::ForegroundRole});
 }
 
+void LogModel::RefreshAllRowStyles()
+{
+    const int rows = rowCount();
+    const int cols = columnCount();
+    if (rows <= 0 || cols <= 0)
+    {
+        return;
+    }
+    // FontRole rides along: themes can bold/italicise per level
+    // (`Theme::levelTypes[level].bold/italic`), so a flip can
+    // change font weight on rows whose level matches a re-styled
+    // entry. Including the role here is cheaper than two emits.
+    emit dataChanged(
+        index(0, 0), index(rows - 1, cols - 1), {Qt::BackgroundRole, Qt::ForegroundRole, Qt::FontRole}
+    );
+}
+
 void LogModel::DropAnchorsForEvictionPrefix(int dropCount)
 {
     if (mAnchors == nullptr || dropCount <= 0 || mAnchors->Empty())

--- a/app/src/log_model.cpp
+++ b/app/src/log_model.cpp
@@ -1279,6 +1279,24 @@ void LogModel::RefreshAllRowStyles()
     );
 }
 
+bool LogModel::IsStyleOnlyRoleChange(const QList<int> &roles) noexcept
+{
+    if (roles.isEmpty())
+    {
+        // Qt's "I don't know what changed" sentinel; conservative
+        // listeners must refresh.
+        return false;
+    }
+    // Hand-rolled set membership (3-4 entries on the hot path) is
+    // cheaper than building a `QSet`. Roles match those emitted
+    // by `RefreshAllRowStyles` plus `DecorationRole` (covers
+    // future icon-only changes) so the common case short-circuits.
+    return std::ranges::all_of(roles, [](int role) {
+        return role == Qt::BackgroundRole || role == Qt::ForegroundRole || role == Qt::FontRole ||
+               role == Qt::DecorationRole;
+    });
+}
+
 void LogModel::DropAnchorsForEvictionPrefix(int dropCount)
 {
     if (mAnchors == nullptr || dropCount <= 0 || mAnchors->Empty())

--- a/app/src/log_model.cpp
+++ b/app/src/log_model.cpp
@@ -1274,9 +1274,7 @@ void LogModel::RefreshAllRowStyles()
     // (`Theme::levelTypes[level].bold/italic`), so a flip can
     // change font weight on rows whose level matches a re-styled
     // entry. Including the role here is cheaper than two emits.
-    emit dataChanged(
-        index(0, 0), index(rows - 1, cols - 1), {Qt::BackgroundRole, Qt::ForegroundRole, Qt::FontRole}
-    );
+    emit dataChanged(index(0, 0), index(rows - 1, cols - 1), {Qt::BackgroundRole, Qt::ForegroundRole, Qt::FontRole});
 }
 
 bool LogModel::IsStyleOnlyRoleChange(const QList<int> &roles) noexcept

--- a/app/src/main_window.cpp
+++ b/app/src/main_window.cpp
@@ -3701,28 +3701,50 @@ void MainWindow::UpdateFindMatchCount(const QString &text, bool wildcards, bool 
             return;
         }
         const QVariant value = QVariant::fromValue(text);
+        // Cap the scan at `MAX_FIND_MATCH_COUNT + 1`: one extra
+        // hit lets us distinguish "exactly at the cap" from "ran
+        // off the end". Bigger needles on huge tables (1 M+ rows,
+        // common needle like " ") used to block the GUI for
+        // hundreds of ms; the cap keeps the recount bounded
+        // regardless of input size.
         const QModelIndexList matches = mSortFilterProxyModel->MatchRow(
-            start, Qt::DisplayRole, value, LogFilterModel::UNLIMITED_HITS, flags, true, 0
+            start, Qt::DisplayRole, value, MAX_FIND_MATCH_COUNT + 1, flags, true, 0
         );
-        // `MatchRow` returns at most one entry per row (it
-        // `break`s on the first matching column) and walks rows
-        // in ascending order from `start` (row 0), so the result
-        // is already row-deduplicated and sorted -- exactly what
-        // the binary-search lookup below needs. Asserting the
-        // invariant in debug builds keeps us honest if MatchRow's
-        // contract ever changes.
+        const bool overflowed = matches.size() > MAX_FIND_MATCH_COUNT;
+        // `MatchRow` is documented to return at most one entry
+        // per row (it `break`s on the first matching column) and
+        // to walk rows ascending from `start` (row 0). That
+        // *should* leave us with sorted, deduplicated rows --
+        // but a future contributor could change either invariant
+        // and the binary-search path below would silently
+        // misreport. Sort + unique defensively so a contract
+        // drift can't corrupt the indicator. Keep the asserts so
+        // debug builds still catch the regression at the source.
         std::vector<int> rows;
-        rows.reserve(matches.size());
+        rows.reserve(static_cast<size_t>(matches.size()));
         for (const QModelIndex &m : matches)
         {
             rows.push_back(m.row());
         }
         Q_ASSERT(std::ranges::is_sorted(rows));
         Q_ASSERT(std::ranges::adjacent_find(rows) == rows.end());
+        if (!std::ranges::is_sorted(rows))
+        {
+            std::ranges::sort(rows);
+        }
+        rows.erase(std::ranges::unique(rows).begin(), rows.end());
+        if (overflowed)
+        {
+            // We requested cap+1 hits to detect overflow; trim
+            // the surplus before storing so `sortedRows.size()`
+            // matches the cap exactly.
+            rows.resize(static_cast<size_t>(MAX_FIND_MATCH_COUNT));
+        }
         mFindMatchCache = FindMatchCache{
             .needle = text,
             .wildcards = wildcards,
             .regularExpressions = regularExpressions,
+            .overflowed = overflowed,
             .sortedRows = std::move(rows),
         };
     }
@@ -3743,7 +3765,7 @@ void MainWindow::UpdateFindMatchCount(const QString &text, bool wildcards, bool 
             }
         }
     }
-    mFindRecord->SetMatchInfo(currentOneBased, total);
+    mFindRecord->SetMatchInfo(currentOneBased, total, mFindMatchCache->overflowed);
 }
 
 void MainWindow::InvalidateFindMatchCache()
@@ -3932,11 +3954,18 @@ void MainWindow::Find()
         return;
     }
     // Smart toggle (VS Code / Chrome convention):
-    //   - bar hidden          -> open + focus the search field.
-    //   - bar visible but not focused -> focus the search field.
-    //   - bar visible AND focused     -> close (so Ctrl+F twice
-    //                                    dismisses it, no need
-    //                                    to chase Esc).
+    //   - bar hidden / tab-buried        -> reveal + focus the
+    //                                       search field.
+    //   - bar visible, focus outside it  -> just focus the field
+    //                                       (no close).
+    //   - bar visible, focus *inside* it -> close it, so a
+    //                                       second Ctrl+F is the
+    //                                       dismiss verb (no
+    //                                       need to chase Esc).
+    // The `isAncestorOf` check on the focused widget is what
+    // distinguishes the second case from the third: a bare
+    // `isVisible` check would close the bar when the user
+    // pressed Ctrl+F from the table view.
     if (mFindDock->isVisible() && mFindDock->isAncestorOf(QApplication::focusWidget()))
     {
         mFindDock->close();
@@ -5699,6 +5728,14 @@ void MainWindow::SetColumnVisible(int logicalIndex, bool visible)
     {
         mTableView->sortByColumn(-1, Qt::AscendingOrder);
     }
+    // `LogFilterModel::MatchRow` skips columns where
+    // `LogConfiguration::columns[i].visible == false`, but column
+    // visibility flips don't emit any of the model / proxy signals
+    // that `OnFindCacheInvalidated` is wired to (rowsInserted,
+    // layoutChanged, dataChanged, ...). Invalidate explicitly so
+    // the find bar's "*i* of *N*" indicator can't strand a stale
+    // count that includes hits in now-hidden columns.
+    OnFindCacheInvalidated();
 }
 
 void MainWindow::ApplyColumnVisibility()
@@ -5714,6 +5751,13 @@ void MainWindow::ApplyColumnVisibility()
     {
         header->setSectionHidden(static_cast<int>(i), !columns[i].visible);
     }
+    // Visibility may have changed without any model / proxy signal
+    // firing -- this method is also called from header-recovery
+    // paths and configuration loads. Drop the find cache for the
+    // same reason `SetColumnVisible` does: `MatchRow` honours
+    // `Column::visible` and a stale cache would lie about the
+    // count.
+    OnFindCacheInvalidated();
 }
 
 void MainWindow::RebuildViewMenu()

--- a/app/src/main_window.cpp
+++ b/app/src/main_window.cpp
@@ -4775,15 +4775,50 @@ void MainWindow::AddLogFilter(const QString &id, const loglib::LogConfiguration:
 
 void MainWindow::OnThemeChanged()
 {
+    // Force Qt's QSS engine to re-resolve palette references on
+    // the table view. Once `ApplyTableStyleSheet` has installed a
+    // body QSS rule (the monospace `QTableView::item` font, added
+    // in the GUI-polish phase 1) the view enters QSS-managed item
+    // painting, and `QStyleSheetStyle` caches palette-derived
+    // colours at polish time. Our "skip unchanged writes"
+    // optimisation in `ApplyTableStyleSheet` then makes the next
+    // call a no-op (rule text unchanged) so the cached resolution
+    // never refreshes -- the user sees rows whose level brush
+    // doesn't change (Info / Trace) stuck on the previous theme's
+    // palette, while rows whose `data(BackgroundRole)` returns a
+    // different brush (Error / Warn / anchor-coloured) repaint
+    // correctly via the `RefreshAllRowStyles` notification below.
+    // Clearing our cached "last applied" tracker before
+    // `ApplyTableStyleSheet` forces the polish cascade to run on
+    // every theme switch, which is the cheap-but-correct fix.
+    // Theme switches are rare; the polish cost doesn't matter.
+    mLastBodyStyleSheet = QString{};
+    mLastHeaderStyleSheet = QString{};
     ApplyTableStyleSheet();
     ApplyThemedWindowIcon();
 
-    // Repaint just the viewport — Qt re-queries `data()` for visible cells.
-    // Avoids the proxy-chain walk that a full `dataChanged` would force.
-    // (`ApplyTableStyleSheet` above already re-resolved the monospace rule.)
+    // Tell the view to re-query the new theme brushes. Necessary
+    // for cells whose `data(BackgroundRole)` returns a different
+    // brush between themes -- the `setStyleSheet` polish above
+    // covers the palette-default cells, but the explicit-brush
+    // cells need a model-level `dataChanged` to invalidate the
+    // view's per-item style cache.
+    if (mModel != nullptr)
+    {
+        mModel->RefreshAllRowStyles();
+    }
     if (mTableView != nullptr)
     {
+        // Headers don't go through `data()`, so the `dataChanged`
+        // emit above doesn't reach them. The header QSS is now
+        // guaranteed re-applied by the tracker reset above, but
+        // an explicit repaint flushes any backing-store fragments
+        // left behind by a modal dialog (Preferences) that was
+        // overlapping the table when the user picked the new
+        // theme.
         mTableView->viewport()->update();
+        mTableView->horizontalHeader()->update();
+        mTableView->verticalHeader()->update();
     }
 
     // These widgets cache palette-derived state (e.g. brushes

--- a/app/src/main_window.cpp
+++ b/app/src/main_window.cpp
@@ -647,10 +647,80 @@ MainWindow::MainWindow(ThemeControl *theme, SessionHistoryManager *historyManage
         }
     });
 
-    mFindRecord = new FindRecordWidget(this);
+    // Find bar lives in a dockable host so users can float it,
+    // dock it bottom (IDE convention) or top, and the layout
+    // round-trips through `saveState` / `restoreState`. The
+    // hosted `FindRecordWidget` keeps the same slots so existing
+    // wiring (see `FindRecords` below) is unchanged.
+    mFindDock = new FindDock(this);
+    addDockWidget(Qt::BottomDockWidgetArea, mFindDock);
+    mFindDock->hide();
+    mFindRecord = mFindDock->Widget();
     connect(mFindRecord, &FindRecordWidget::FindRecords, this, &MainWindow::FindRecords);
-    mLayout->addWidget(mFindRecord);
-    mFindRecord->hide();
+    connect(
+        mFindRecord, &FindRecordWidget::MatchCountRequested, this,
+        [this](const QString &text, bool wildcards, bool regularExpressions) {
+            UpdateFindMatchCount(text, wildcards, regularExpressions);
+        }
+    );
+
+    mActionToggleFind = new QAction(tr("Find"), this);
+    mActionToggleFind->setObjectName(QStringLiteral("actionToggleFind"));
+    mActionToggleFind->setCheckable(true);
+    addAction(mActionToggleFind);
+    connect(mActionToggleFind, &QAction::toggled, this, [this](bool on) {
+        if (on && !isVisible())
+        {
+            // Host not realised (early toggle from a test driver).
+            // Revert so the action can't sit checked while the
+            // dock stays hidden.
+            const QSignalBlocker blocker(mActionToggleFind);
+            mActionToggleFind->setChecked(false);
+            return;
+        }
+        if (on)
+        {
+            mFindDock->RevealAndFocus();
+        }
+        else
+        {
+            mFindDock->hide();
+        }
+    });
+    connect(mFindDock, &QDockWidget::visibilityChanged, this, [this](bool visible) {
+        const QSignalBlocker blocker(mActionToggleFind);
+        mActionToggleFind->setChecked(visible);
+    });
+
+    // Parse-errors dock replaces the old `QMessageBox::warning`
+    // popups for streaming / open errors. Hidden until the first
+    // error of a session; `ShowParseErrors` auto-raises.
+    mParseErrorsDock = new ParseErrorsDock(this);
+    addDockWidget(Qt::BottomDockWidgetArea, mParseErrorsDock);
+    mParseErrorsDock->hide();
+
+    mActionToggleParseErrors = new QAction(tr("Parse Errors"), this);
+    mActionToggleParseErrors->setObjectName(QStringLiteral("actionToggleParseErrors"));
+    mActionToggleParseErrors->setCheckable(true);
+    addAction(mActionToggleParseErrors);
+    connect(mActionToggleParseErrors, &QAction::toggled, this, [this](bool on) {
+        if (on && !isVisible())
+        {
+            const QSignalBlocker blocker(mActionToggleParseErrors);
+            mActionToggleParseErrors->setChecked(false);
+            return;
+        }
+        mParseErrorsDock->setVisible(on);
+        if (on)
+        {
+            mParseErrorsDock->raise();
+        }
+    });
+    connect(mParseErrorsDock, &QDockWidget::visibilityChanged, this, [this](bool visible) {
+        const QSignalBlocker blocker(mActionToggleParseErrors);
+        mActionToggleParseErrors->setChecked(visible);
+    });
+    connect(mParseErrorsDock, &ParseErrorsDock::countChanged, this, &MainWindow::UpdateParseErrorsStatus);
 
     // Record-detail dock: hidden by default; the View menu's Ctrl+I
     // toggle and row double-click both surface it.
@@ -794,6 +864,29 @@ MainWindow::MainWindow(ThemeControl *theme, SessionHistoryManager *historyManage
     statusBar()->addPermanentWidget(mDiagnosticsButton);
     connect(mDiagnosticsButton, &QPushButton::clicked, this, &MainWindow::ShowConfigurationDiagnostics);
     connect(mModel, &LogModel::columnHealthChanged, this, &MainWindow::UpdateDiagnosticsStatus);
+
+    // Status-bar indicator for the parse-errors dock. Same UX as
+    // `mDiagnosticsButton`: a permanent widget that hides itself
+    // when the dock is empty and opens / raises the dock on
+    // click.
+    mParseErrorsStatusButton = new QPushButton(this);
+    mParseErrorsStatusButton->setObjectName(QStringLiteral("parseErrorsStatusButton"));
+    mParseErrorsStatusButton->setIcon(QApplication::style()->standardIcon(QStyle::SP_MessageBoxCritical));
+    mParseErrorsStatusButton->setFlat(true);
+    mParseErrorsStatusButton->setCursor(Qt::PointingHandCursor);
+    mParseErrorsStatusButton->hide();
+    statusBar()->addPermanentWidget(mParseErrorsStatusButton);
+    connect(mParseErrorsStatusButton, &QPushButton::clicked, this, [this]() {
+        if (mParseErrorsDock == nullptr)
+        {
+            return;
+        }
+        if (!mParseErrorsDock->isVisible())
+        {
+            mParseErrorsDock->show();
+        }
+        mParseErrorsDock->raise();
+    });
 
     connect(mModel, &LogModel::lineCountChanged, this, [this](qsizetype count) {
         mStreamingLineCount = count;
@@ -2755,20 +2848,15 @@ void MainWindow::ShowParseErrors(const QString &title, const std::vector<std::st
     {
         return;
     }
-
-    constexpr size_t MAX_ERRORS_SHOWN = 20;
-    QString message;
-    const size_t shown = std::min(errors.size(), MAX_ERRORS_SHOWN);
-    for (size_t i = 0; i < shown; ++i)
+    if (mParseErrorsDock == nullptr)
     {
-        message += QString::fromStdString(errors[i]) + QLatin1Char('\n');
+        // Defensive fallback. Should never hit in production
+        // (the dock is built in the constructor before any open
+        // path can run), but keep the prior behaviour for tests
+        // that bypass the GUI shell.
+        return;
     }
-    if (errors.size() > MAX_ERRORS_SHOWN)
-    {
-        message += QString("... and %1 more error(s).").arg(errors.size() - MAX_ERRORS_SHOWN);
-    }
-
-    QMessageBox::warning(this, title, message);
+    mParseErrorsDock->AppendErrors(title, errors);
 }
 
 void MainWindow::ShowDroppedFiltersDialog(int droppedCount, const QString &message)
@@ -3329,6 +3417,79 @@ void MainWindow::UpdateDiagnosticsStatus()
     mDiagnosticsButton->show();
 }
 
+void MainWindow::UpdateParseErrorsStatus(int count)
+{
+    if (mParseErrorsStatusButton == nullptr)
+    {
+        return;
+    }
+    if (count <= 0)
+    {
+        mParseErrorsStatusButton->hide();
+        mParseErrorsStatusButton->setText(QString());
+        mParseErrorsStatusButton->setToolTip(QString());
+        return;
+    }
+    const QString text = tr("%n parse error(s)", nullptr, count);
+    mParseErrorsStatusButton->setText(text);
+    mParseErrorsStatusButton->setToolTip(
+        tr("%1 parse error(s) recorded in this session. Click to open the Parse Errors panel.").arg(count)
+    );
+    mParseErrorsStatusButton->show();
+}
+
+void MainWindow::UpdateFindMatchCount(const QString &text, bool wildcards, bool regularExpressions)
+{
+    if (mFindRecord == nullptr || mSortFilterProxyModel == nullptr)
+    {
+        return;
+    }
+    if (text.isEmpty())
+    {
+        mFindRecord->SetMatchInfo(0, 0);
+        return;
+    }
+    Qt::MatchFlags flags = Qt::MatchContains | Qt::MatchWrap | Qt::MatchRecursive;
+    if (wildcards)
+    {
+        flags |= Qt::MatchWildcard;
+    }
+    if (regularExpressions)
+    {
+        flags |= Qt::MatchRegularExpression;
+    }
+    const QModelIndex start = mSortFilterProxyModel->index(0, 0);
+    if (!start.isValid())
+    {
+        mFindRecord->SetMatchInfo(0, 0);
+        return;
+    }
+    const QVariant value = QVariant::fromValue(text);
+    const QModelIndexList matches =
+        mSortFilterProxyModel->MatchRow(start, Qt::DisplayRole, value, LogFilterModel::UNLIMITED_HITS, flags, true, 0);
+    const int total = static_cast<int>(matches.size());
+
+    int currentOneBased = 0;
+    if (total > 0)
+    {
+        // Locate the current selection within the match list so
+        // the bar can render "i of N" instead of just "N matches".
+        const QModelIndex currentIdx = mTableView != nullptr ? mTableView->currentIndex() : QModelIndex();
+        if (currentIdx.isValid())
+        {
+            for (int i = 0; i < matches.size(); ++i)
+            {
+                if (matches[i].row() == currentIdx.row())
+                {
+                    currentOneBased = i + 1;
+                    break;
+                }
+            }
+        }
+    }
+    mFindRecord->SetMatchInfo(currentOneBased, total);
+}
+
 bool MainWindow::DoLoadConfiguration(const QString &path)
 {
     // Parse into a temporary first so a parse failure cannot
@@ -3490,9 +3651,11 @@ void MainWindow::RebuildFiltersFromConfiguration()
 
 void MainWindow::Find()
 {
-    mFindRecord->show();
-    mFindRecord->setFocus();
-    mFindRecord->SetEditFocus();
+    if (mFindDock == nullptr)
+    {
+        return;
+    }
+    mFindDock->RevealAndFocus();
 }
 
 void MainWindow::SelectSourceRow(int sourceRow)
@@ -3676,6 +3839,15 @@ void MainWindow::FindRecords(const QString &text, bool next, bool wildcards, boo
         mTableView->scrollTo(matches[0]);
         mTableView->selectionModel()->select(matches[0], QItemSelectionModel::Select | QItemSelectionModel::Rows);
         mTableView->selectionModel()->setCurrentIndex(matches[0], QItemSelectionModel::NoUpdate);
+    }
+
+    // Refresh the find bar's "i of N" indicator now that the
+    // current index has moved. Gated on the bar actually being
+    // visible so a programmatic `FindRecords` call from a test
+    // path does not pay for the full-table count scan.
+    if (mFindDock != nullptr && mFindDock->isVisible())
+    {
+        UpdateFindMatchCount(text, wildcards, regularExpressions);
     }
 }
 
@@ -5268,6 +5440,20 @@ void MainWindow::RebuildViewMenu()
     if (mActionToggleAnchors != nullptr)
     {
         viewMenu->addAction(mActionToggleAnchors);
+    }
+
+    // Find dock toggle. Same programmatic-action pattern as
+    // `mActionToggleAnchors`: re-added on every menu rebuild so
+    // the View menu always lists every dockable surface.
+    if (mActionToggleFind != nullptr)
+    {
+        viewMenu->addAction(mActionToggleFind);
+    }
+
+    // Parse-errors dock toggle.
+    if (mActionToggleParseErrors != nullptr)
+    {
+        viewMenu->addAction(mActionToggleParseErrors);
     }
 
     const auto &columns = mModel->Configuration().columns;

--- a/app/src/main_window.cpp
+++ b/app/src/main_window.cpp
@@ -473,46 +473,10 @@ MainWindow::MainWindow(ThemeControl *theme, SessionHistoryManager *historyManage
     mActionToggleAnchors->setCheckable(true);
     mActionToggleAnchors->setShortcut(QKeySequence(Qt::CTRL | Qt::Key_K));
     addAction(mActionToggleAnchors);
-    connect(mActionToggleAnchors, &QAction::toggled, this, [this](bool on) {
-        if (on && !isVisible())
-        {
-            // Host not realised (early Ctrl+K). Revert so the
-            // action can't sit checked while the dock stays hidden.
-            const QSignalBlocker blocker(mActionToggleAnchors);
-            mActionToggleAnchors->setChecked(false);
-            return;
-        }
-        if (on)
-        {
-            mAnchorsDock->show();
-            mAnchorsDock->raise();
-        }
-        else
-        {
-            // `close()` so the dock's `closeEvent` fires and the
-            // `closed` signal reaches the menu sync handler; raw
-            // `setVisible(false)` would bypass that path.
-            mAnchorsDock->close();
-        }
-    });
-    // Show-side only: `visibilityChanged(false)` fires on tab
-    // inactivation in tabified groups (Anchors is tabified with
-    // Record Details below), which would falsely un-check the
-    // menu entry every time the user switched tabs. The
-    // `AnchorsDock::closed` signal handles user-initiated
-    // dismissal cleanly.
-    connect(mAnchorsDock, &QDockWidget::visibilityChanged, this, [this](bool visible) {
-        if (!visible)
-        {
-            return;
-        }
-        const QSignalBlocker blocker(mActionToggleAnchors);
-        mActionToggleAnchors->setChecked(true);
-    });
-    connect(mAnchorsDock, &AnchorsDock::closed, this, [this]() {
-        const QSignalBlocker blocker(mActionToggleAnchors);
-        mActionToggleAnchors->setChecked(false);
-    });
+    // Standard dock toggle pattern (show/raise on activate,
+    // close() on deactivate, action checkmark synced via the
+    // `closed` signal so tab switches don't false-fire).
+    WireDockToggle(mAnchorsDock, mActionToggleAnchors, &AnchorsDock::closed);
     // `modelReset` clears the header's hidden flags, but
     // `Column::visible` survives. Re-apply on every reset so load /
     // re-stream / teardown all stay consistent with the saved config.
@@ -709,19 +673,18 @@ MainWindow::MainWindow(ThemeControl *theme, SessionHistoryManager *historyManage
     connect(mSortFilterProxyModel, &QAbstractItemModel::columnsMoved, this, &MainWindow::OnFindCacheInvalidated);
     // `dataChanged` covers in-place cell updates that don't shift
     // the row set (enum dictionary growth, column renames). It
-    // also fires for theme repaints (`{BackgroundRole,
-    // ForegroundRole}` only) which can't affect display-role
-    // matching, so filter those out -- otherwise every level /
-    // theme change during streaming wakes the debounce timer for
-    // no work. An empty `roles` list is Qt's "I don't know what
-    // changed" sentinel; treat it as conservatively dirty.
+    // also fires for theme repaints (Background/Foreground/Font)
+    // which can't affect display-role matching, so filter those
+    // out via `LogModel::IsStyleOnlyRoleChange` -- otherwise
+    // every theme switch wakes the debounce timer for no work.
+    // An empty `roles` list (Qt's "I don't know what changed"
+    // sentinel) refreshes conservatively.
     connect(
         mSortFilterProxyModel,
         &QAbstractItemModel::dataChanged,
         this,
         [this](const QModelIndex & /*topLeft*/, const QModelIndex & /*bottomRight*/, const QList<int> &roles) {
-            if (!roles.isEmpty() && !roles.contains(Qt::DisplayRole) &&
-                !roles.contains(static_cast<int>(LogModelItemDataRole::SortRole)))
+            if (LogModel::IsStyleOnlyRoleChange(roles))
             {
                 return;
             }
@@ -734,51 +697,16 @@ MainWindow::MainWindow(ThemeControl *theme, SessionHistoryManager *historyManage
     mActionToggleFind->setCheckable(true);
     mActionToggleFind->setToolTip(tr("Show or hide the find bar. Ctrl+F focuses it; Ctrl+F again or Esc closes it."));
     addAction(mActionToggleFind);
-    connect(mActionToggleFind, &QAction::toggled, this, [this](bool on) {
-        if (on && !isVisible())
-        {
-            // Host not realised (early toggle from a test driver).
-            // Revert so the action can't sit checked while the
-            // dock stays hidden.
-            const QSignalBlocker blocker(mActionToggleFind);
-            mActionToggleFind->setChecked(false);
-            return;
-        }
-        if (on)
-        {
-            mFindDock->RevealAndFocus();
-        }
-        else
-        {
-            // `close()` (not bare `hide()`) so the dock subclass'
-            // `closeEvent` fires and `closed` propagates. Without
-            // it the matched show/hide-edge handlers above would
-            // become asymmetric: show via `closeEvent` accept,
-            // hide via raw `hide()` -> no signal -> menu state OK
-            // only because the toggle already set itself.
-            // Keeping the symmetry simplifies reasoning.
-            mFindDock->close();
-        }
-    });
-    // `QDockWidget::visibilityChanged(false)` fires on tab
-    // inactivation too, not just user dismissal, so binding the
-    // checkmark blindly to it would un-check the menu entry every
-    // time the user switched tabs in the tabified bottom group.
-    // Drive the off-state from the `closed` signal (genuine user
-    // close) and only mirror the on-state from `visibilityChanged`
-    // (the show direction is unambiguous).
-    connect(mFindDock, &QDockWidget::visibilityChanged, this, [this](bool visible) {
-        if (!visible)
-        {
-            return;
-        }
-        const QSignalBlocker blocker(mActionToggleFind);
-        mActionToggleFind->setChecked(true);
-    });
-    connect(mFindDock, &FindDock::closed, this, [this]() {
-        const QSignalBlocker blocker(mActionToggleFind);
-        mActionToggleFind->setChecked(false);
-    });
+    // Find bar uses the standard dock toggle pattern but with a
+    // custom show callback: `RevealAndFocus()` raises the dock
+    // *and* moves keyboard focus into the search field, so the
+    // toggle behaves like every IDE find bar.
+    WireDockToggle(
+        mFindDock.data(),
+        mActionToggleFind,
+        &FindDock::closed,
+        /*onShow=*/[this]() { mFindDock->RevealAndFocus(); }
+    );
     // Catch up the match count after a reveal -- the cache may
     // have been invalidated by streaming / filter activity while
     // the bar was hidden or buried under a sibling tab, in which
@@ -822,38 +750,7 @@ MainWindow::MainWindow(ThemeControl *theme, SessionHistoryManager *historyManage
     mActionToggleParseErrors->setCheckable(true);
     mActionToggleParseErrors->setToolTip(tr("Show or hide the Parse Errors panel."));
     addAction(mActionToggleParseErrors);
-    connect(mActionToggleParseErrors, &QAction::toggled, this, [this](bool on) {
-        if (on && !isVisible())
-        {
-            const QSignalBlocker blocker(mActionToggleParseErrors);
-            mActionToggleParseErrors->setChecked(false);
-            return;
-        }
-        if (on)
-        {
-            mParseErrorsDock->show();
-            mParseErrorsDock->raise();
-        }
-        else
-        {
-            mParseErrorsDock->close();
-        }
-    });
-    // Same tab-switch protection as `mFindDock` above: `closed`
-    // is the trustworthy off-edge; `visibilityChanged(true)`
-    // covers the on-edge.
-    connect(mParseErrorsDock, &QDockWidget::visibilityChanged, this, [this](bool visible) {
-        if (!visible)
-        {
-            return;
-        }
-        const QSignalBlocker blocker(mActionToggleParseErrors);
-        mActionToggleParseErrors->setChecked(true);
-    });
-    connect(mParseErrorsDock, &ParseErrorsDock::closed, this, [this]() {
-        const QSignalBlocker blocker(mActionToggleParseErrors);
-        mActionToggleParseErrors->setChecked(false);
-    });
+    WireDockToggle(mParseErrorsDock.data(), mActionToggleParseErrors, &ParseErrorsDock::closed);
     connect(mParseErrorsDock, &ParseErrorsDock::countChanged, this, &MainWindow::UpdateParseErrorsStatus);
     // First batch of a session: surface the panel, unless the user
     // is actively interacting with another bottom-area dock (the
@@ -864,8 +761,7 @@ MainWindow::MainWindow(ThemeControl *theme, SessionHistoryManager *historyManage
         {
             return;
         }
-        if (mFindDock != nullptr && mFindDock->isVisible() &&
-            mFindDock->isAncestorOf(QApplication::focusWidget()))
+        if (FindBarHoldsFocus())
         {
             // Find bar holds focus; status-bar indicator alone is
             // enough notice. Auto-raise on the *next* session's
@@ -896,45 +792,17 @@ MainWindow::MainWindow(ThemeControl *theme, SessionHistoryManager *historyManage
     // is associated with a widget; add it here so `Ctrl+I` is live
     // from a cold launch, before the View menu is ever opened.
     addAction(ui->actionToggleRecordDetails);
-    connect(ui->actionToggleRecordDetails, &QAction::toggled, this, [this](bool on) {
-        // Gate hidden->visible on a realised host window (see
-        // `ShowRecordDetailsForProxyIndex`). Revert the check so a
-        // hidden dock can't be paired with a checked toggle.
-        if (on && !isVisible())
-        {
-            const QSignalBlocker blocker(ui->actionToggleRecordDetails);
-            ui->actionToggleRecordDetails->setChecked(false);
-            return;
-        }
-        if (on)
-        {
-            mRecordDetailDock->show();
-            mRecordDetailDock->raise();
-        }
-        else
-        {
-            mRecordDetailDock->close();
-        }
-    });
-    // Mirror dock visibility back onto the menu entry. Show-side
-    // is driven by `visibilityChanged(true)` (also fires on tab
-    // activation, which is the right time to re-pin the selection).
-    // Off-edge listens to `RecordDetailDock::closed` so tab
-    // inactivation in the (Anchors + Record Details) tab group
-    // doesn't drop the menu checkmark.
-    connect(mRecordDetailDock, &QDockWidget::visibilityChanged, this, [this](bool visible) {
-        if (!visible)
-        {
-            return;
-        }
-        const QSignalBlocker blocker(ui->actionToggleRecordDetails);
-        ui->actionToggleRecordDetails->setChecked(true);
-        UpdateRecordDetailsFromSelection();
-    });
-    connect(mRecordDetailDock, &RecordDetailDock::closed, this, [this]() {
-        const QSignalBlocker blocker(ui->actionToggleRecordDetails);
-        ui->actionToggleRecordDetails->setChecked(false);
-    });
+    // Standard dock toggle; on every visibility-change-true edge
+    // (cold reveal *and* tab activation) re-pull the table
+    // selection so the dock body reflects whatever row is
+    // currently focused.
+    WireDockToggle(
+        mRecordDetailDock,
+        ui->actionToggleRecordDetails,
+        &RecordDetailDock::closed,
+        /*onShow=*/{},
+        /*onShown=*/[this]() { UpdateRecordDetailsFromSelection(); }
+    );
     connect(mRecordDetailDock, &RecordDetailDock::openInNewWindowRequested, this, &MainWindow::OpenRecordDetailWindow);
 
     connect(mTableView, &QAbstractItemView::doubleClicked, this, &MainWindow::ShowRecordDetailsForProxyIndex);
@@ -1047,7 +915,13 @@ MainWindow::MainWindow(ThemeControl *theme, SessionHistoryManager *historyManage
     // click.
     mParseErrorsStatusButton = new QPushButton(this);
     mParseErrorsStatusButton->setObjectName(QStringLiteral("parseErrorsStatusButton"));
-    mParseErrorsStatusButton->setIcon(QApplication::style()->standardIcon(QStyle::SP_MessageBoxCritical));
+    // Warning (not Critical) to match the per-row icon in the
+    // dock and the actual semantic: these are recoverable
+    // line-level parse failures, not application-level fatals.
+    // `SP_MessageBoxCritical` previously made the status bar
+    // look like the app crashed every time a single log line
+    // failed to deserialise.
+    mParseErrorsStatusButton->setIcon(QApplication::style()->standardIcon(QStyle::SP_MessageBoxWarning));
     mParseErrorsStatusButton->setFlat(true);
     mParseErrorsStatusButton->setCursor(Qt::PointingHandCursor);
     mParseErrorsStatusButton->hide();
@@ -1789,11 +1663,14 @@ void MainWindow::NewSession()
         mAnchors->ClearAll();
     }
 
-    // Parse errors are also session-scoped: a fresh session must
-    // not show diagnostics inherited from the discarded one.
+    // Parse errors are session-scoped: a fresh session must not
+    // show diagnostics inherited from the discarded one. Use
+    // `ResetSessionState` (not `ClearErrors`) so the next batch
+    // can auto-raise the dock -- this is a destructive boundary,
+    // not a user-initiated clear.
     if (mParseErrorsDock != nullptr)
     {
-        mParseErrorsDock->ClearErrors();
+        mParseErrorsDock->ResetSessionState();
     }
 
     mCurrentSource.reset();
@@ -2023,10 +1900,12 @@ void MainWindow::StartStreamingOpenQueue(QStringList files, OpenMode mode)
         {
             mAnchors->ClearAll();
         }
-        // Parse errors are also session-scoped; preserved on append.
+        // Parse errors are also session-scoped; preserved on
+        // append. `ResetSessionState` re-arms the auto-raise so
+        // the new session's first parse error can pop the dock.
         if (mParseErrorsDock != nullptr)
         {
-            mParseErrorsDock->ClearErrors();
+            mParseErrorsDock->ResetSessionState();
         }
         mCurrentSource.reset();
         mSessionMode = SessionMode::Idle;
@@ -2346,10 +2225,11 @@ void MainWindow::OpenLogStreamFromPath(const QString &file)
     {
         mAnchors->ClearAll();
     }
-    // Parse errors are session-scoped.
+    // Parse errors are session-scoped; `ResetSessionState`
+    // re-arms the auto-raise for the new live-tail session.
     if (mParseErrorsDock != nullptr)
     {
-        mParseErrorsDock->ClearErrors();
+        mParseErrorsDock->ResetSessionState();
     }
     // Live-tail is transient and not auto-saved; leaving the prior
     // static session's uuid pinned would let closeEvent's
@@ -2470,10 +2350,11 @@ void MainWindow::OpenNetworkStream()
     {
         mAnchors->ClearAll();
     }
-    // Parse errors are session-scoped.
+    // Parse errors are session-scoped; `ResetSessionState`
+    // re-arms the auto-raise for the new network-stream session.
     if (mParseErrorsDock != nullptr)
     {
-        mParseErrorsDock->ClearErrors();
+        mParseErrorsDock->ResetSessionState();
     }
     DetachAutoSaveUuid();
 
@@ -3489,33 +3370,6 @@ namespace
     return sourceIndex.row();
 }
 
-/// Build the `Qt::MatchFlags` for a find query. The match-type
-/// values in `Qt::MatchFlag` are *alternatives*, not bit-mask
-/// modifiers (`LogFilterModel::Matches` masks the type field and
-/// dispatches with a switch), so OR-ing `MatchContains` alongside
-/// `MatchWildcard` / `MatchRegularExpression` silently demotes
-/// the search to plain substring -- the regex / wildcard toggles
-/// would look enabled but match like they're off. The two find
-/// call sites (`MainWindow::FindRecords` and the cache rebuild in
-/// `UpdateFindMatchCount`) share this helper so a future refactor
-/// can't desync them.
-[[nodiscard]] Qt::MatchFlags ComposeFindFlags(bool wildcards, bool regularExpressions)
-{
-    Qt::MatchFlags flags = Qt::MatchWrap | Qt::MatchRecursive;
-    if (regularExpressions)
-    {
-        flags |= Qt::MatchRegularExpression;
-    }
-    else if (wildcards)
-    {
-        flags |= Qt::MatchWildcard;
-    }
-    else
-    {
-        flags |= Qt::MatchContains;
-    }
-    return flags;
-}
 } // namespace
 
 void MainWindow::ShowRecordDetailsForProxyIndex(const QModelIndex &proxyIndex)
@@ -3720,7 +3574,7 @@ void MainWindow::UpdateFindMatchCount(const QString &text, bool wildcards, bool 
     // the asymmetric outlier. We still drop the cache below for
     // an empty needle so a later reveal doesn't show a stale "i
     // of N" against the wrong needle.
-    if (mFindDock == nullptr || !mFindDock->isVisible())
+    if (!IsFindBarVisible())
     {
         return;
     }
@@ -3745,7 +3599,7 @@ void MainWindow::UpdateFindMatchCount(const QString &text, bool wildcards, bool 
                           mFindMatchCache->regularExpressions == regularExpressions;
     if (!cacheHit)
     {
-        const Qt::MatchFlags flags = ComposeFindFlags(wildcards, regularExpressions);
+        const Qt::MatchFlags flags = LogFilterModel::ComposeFindFlags(wildcards, regularExpressions);
         const QModelIndex start = mSortFilterProxyModel->index(0, 0);
         if (!start.isValid())
         {
@@ -3793,9 +3647,23 @@ void MainWindow::UpdateFindMatchCount(const QString &text, bool wildcards, bool 
         Q_ASSERT(sortedAsExpected);
         if (!sortedAsExpected)
         {
+            // Release builds compile the `Q_ASSERT` out, so emit
+            // a `qWarning` here too -- a future `MatchRow`
+            // refactor that breaks the ascending-rows contract
+            // would otherwise silently get patched over by the
+            // defensive sort and never surface the regression in
+            // a release build (CI / shipped binary).
+            qWarning() << "MainWindow::UpdateFindMatchCount: MatchRow returned unsorted rows; "
+                          "sorting defensively. This is a contract violation worth investigating.";
             std::ranges::sort(rows);
         }
-        Q_ASSERT(std::ranges::adjacent_find(rows) == rows.end());
+        const bool dedupedAsExpected = std::ranges::adjacent_find(rows) == rows.end();
+        Q_ASSERT(dedupedAsExpected);
+        if (!dedupedAsExpected)
+        {
+            qWarning() << "MainWindow::UpdateFindMatchCount: MatchRow returned duplicate rows; "
+                          "deduplicating defensively. This is a contract violation worth investigating.";
+        }
         rows.erase(std::ranges::unique(rows).begin(), rows.end());
         if (overflowed)
         {
@@ -3840,7 +3708,7 @@ void MainWindow::InvalidateFindMatchCache()
 void MainWindow::OnFindCacheInvalidated()
 {
     InvalidateFindMatchCache();
-    if (mFindRecord != nullptr && mFindDock != nullptr && mFindDock->isVisible())
+    if (mFindRecord != nullptr && IsFindBarVisible())
     {
         mFindRecord->BumpMatchCountDebounce();
     }
@@ -3885,9 +3753,12 @@ bool MainWindow::ApplyLoadedConfiguration(loglib::LogConfiguration parsed)
         mModel->Reset();
         // Parse errors are session-scoped: a config load is a
         // destructive session boundary just like `NewSession`.
+        // `ResetSessionState` re-arms the auto-raise so the
+        // newly-loaded configuration's first parse error can pop
+        // the dock.
         if (mParseErrorsDock != nullptr)
         {
-            mParseErrorsDock->ClearErrors();
+            mParseErrorsDock->ResetSessionState();
         }
         mModel->ConfigurationManager().SetConfiguration(std::move(parsed));
         // `SetConfiguration` does not emit a model signal; the
@@ -4030,7 +3901,7 @@ void MainWindow::Find()
     // distinguishes the second case from the third: a bare
     // `isVisible` check would close the bar when the user
     // pressed Ctrl+F from the table view.
-    if (mFindDock->isVisible() && mFindDock->isAncestorOf(QApplication::focusWidget()))
+    if (FindBarHoldsFocus())
     {
         mFindDock->close();
         return;
@@ -4197,9 +4068,9 @@ void MainWindow::FindRecords(const QString &text, bool next, bool wildcards, boo
     // OR-ing `MatchContains` with one of the others therefore silently
     // demotes the search to plain substring matching, so the regex /
     // wildcard toggles look enabled but match like they're off.
-    // `ComposeFindFlags` is the single source of truth shared with
-    // `UpdateFindMatchCount`.
-    const Qt::MatchFlags flags = ComposeFindFlags(wildcards, regularExpressions);
+    // `LogFilterModel::ComposeFindFlags` is the single source of
+    // truth shared with `UpdateFindMatchCount`.
+    const Qt::MatchFlags flags = LogFilterModel::ComposeFindFlags(wildcards, regularExpressions);
     int skipFirstN = 0;
     if (mTableView->selectionModel()->isRowSelected(searchStartIndex.row()))
     {
@@ -4228,7 +4099,7 @@ void MainWindow::FindRecords(const QString &text, bool next, bool wildcards, boo
     // bar being visible so a programmatic `FindRecords` call from
     // a test path doesn't pay even for the cache rebuild on the
     // first hit.
-    if (mFindDock != nullptr && mFindDock->isVisible())
+    if (IsFindBarVisible())
     {
         UpdateFindMatchCount(text, wildcards, regularExpressions);
     }

--- a/app/src/main_window.cpp
+++ b/app/src/main_window.cpp
@@ -607,6 +607,11 @@ MainWindow::MainWindow(ThemeControl *theme, SessionHistoryManager *historyManage
     connect(ui->actionExit, &QAction::triggered, this, [] { QApplication::closeAllWindows(); });
 
     connect(ui->actionCopy, &QAction::triggered, mTableView, &LogTableView::CopySelectedRowsToClipboard);
+    // `MainWindow::Find` is a smart toggle: open + focus, focus
+    // if open-but-unfocused, or close if open + focused. Tooltip
+    // reflects that so the menu / toolbar surface doesn't claim
+    // an "always reveal" behaviour.
+    ui->actionFind->setToolTip(tr("Find in logs. Press again to close."));
     connect(ui->actionFind, &QAction::triggered, this, &MainWindow::Find);
 
     connect(ui->actionAddFilter, &QAction::triggered, this, [this]() { AddFilter(QUuid::createUuid().toString()); });
@@ -684,11 +689,24 @@ MainWindow::MainWindow(ThemeControl *theme, SessionHistoryManager *historyManage
     connect(mSortFilterProxyModel, &QAbstractItemModel::rowsRemoved, this, refreshFindCount);
     connect(mSortFilterProxyModel, &QAbstractItemModel::layoutChanged, this, refreshFindCount);
     connect(mSortFilterProxyModel, &QAbstractItemModel::modelReset, this, refreshFindCount);
+    // `dataChanged` covers in-place cell updates that don't shift
+    // the row set: enum dictionary growth re-formats existing
+    // cells, and a column rename is published this way too. Both
+    // can flip whether a row matches the current needle, so the
+    // cached match list has to invalidate. Wired on the proxy
+    // (not the source) so Qt's row-mapping is already applied
+    // by the time the slot runs.
+    connect(
+        mSortFilterProxyModel,
+        &QAbstractItemModel::dataChanged,
+        this,
+        [refreshFindCount](const QModelIndex &, const QModelIndex &, const QList<int> &) { refreshFindCount(); }
+    );
 
     mActionToggleFind = new QAction(tr("Find Bar"), this);
     mActionToggleFind->setObjectName(QStringLiteral("actionToggleFind"));
     mActionToggleFind->setCheckable(true);
-    mActionToggleFind->setToolTip(tr("Show or hide the find bar (Ctrl+F to focus)."));
+    mActionToggleFind->setToolTip(tr("Show or hide the find bar. Ctrl+F focuses it; Ctrl+F again or Esc closes it."));
     addAction(mActionToggleFind);
     connect(mActionToggleFind, &QAction::toggled, this, [this](bool on) {
         if (on && !isVisible())
@@ -3490,10 +3508,13 @@ void MainWindow::UpdateParseErrorsStatus(int count)
         mParseErrorsStatusButton->setToolTip(QString());
         return;
     }
-    const QString text = tr("%n parse error(s)", nullptr, count);
-    mParseErrorsStatusButton->setText(text);
+    // `%Ln` -> locale-grouped digits (1,234 / 1.234) matching the
+    // streaming-status text. Plain `%n` would print "1234" and
+    // jitter the button width as counts grew across a streaming
+    // session.
+    mParseErrorsStatusButton->setText(tr("%Ln parse error(s)", nullptr, count));
     mParseErrorsStatusButton->setToolTip(
-        tr("%1 parse error(s) recorded in this session. Click to open the Parse Errors panel.").arg(count)
+        tr("%Ln parse error(s) recorded in this session. Click to open the Parse Errors panel.", nullptr, count)
     );
     mParseErrorsStatusButton->show();
 }
@@ -3540,19 +3561,21 @@ void MainWindow::UpdateFindMatchCount(const QString &text, bool wildcards, bool 
         const QModelIndexList matches = mSortFilterProxyModel->MatchRow(
             start, Qt::DisplayRole, value, LogFilterModel::UNLIMITED_HITS, flags, true, 0
         );
-        // Dedupe to row level: a row matching in N visible
-        // columns yields N entries from `MatchRow`, but the user
-        // navigates and counts in row order. Sorting + uniquing
-        // also unlocks the binary-search lookup below.
+        // `MatchRow` returns at most one entry per row (it
+        // `break`s on the first matching column) and walks rows
+        // in ascending order from `start` (row 0), so the result
+        // is already row-deduplicated and sorted -- exactly what
+        // the binary-search lookup below needs. Asserting the
+        // invariant in debug builds keeps us honest if MatchRow's
+        // contract ever changes.
         std::vector<int> rows;
         rows.reserve(matches.size());
         for (const QModelIndex &m : matches)
         {
             rows.push_back(m.row());
         }
-        std::ranges::sort(rows);
-        const auto last = std::ranges::unique(rows);
-        rows.erase(last.begin(), last.end());
+        Q_ASSERT(std::ranges::is_sorted(rows));
+        Q_ASSERT(std::ranges::adjacent_find(rows) == rows.end());
         mFindMatchCache = FindMatchCache{
             .needle = text,
             .wildcards = wildcards,
@@ -3754,6 +3777,17 @@ void MainWindow::Find()
 {
     if (mFindDock == nullptr)
     {
+        return;
+    }
+    // Smart toggle (VS Code / Chrome convention):
+    //   - bar hidden          -> open + focus the search field.
+    //   - bar visible but not focused -> focus the search field.
+    //   - bar visible AND focused     -> close (so Ctrl+F twice
+    //                                    dismisses it, no need
+    //                                    to chase Esc).
+    if (mFindDock->isVisible() && mFindDock->isAncestorOf(QApplication::focusWidget()))
+    {
+        mFindDock->close();
         return;
     }
     mFindDock->RevealAndFocus();

--- a/app/src/main_window.cpp
+++ b/app/src/main_window.cpp
@@ -658,7 +658,9 @@ MainWindow::MainWindow(ThemeControl *theme, SessionHistoryManager *historyManage
     mFindRecord = mFindDock->Widget();
     connect(mFindRecord, &FindRecordWidget::FindRecords, this, &MainWindow::FindRecords);
     connect(
-        mFindRecord, &FindRecordWidget::MatchCountRequested, this,
+        mFindRecord,
+        &FindRecordWidget::MatchCountRequested,
+        this,
         [this](const QString &text, bool wildcards, bool regularExpressions) {
             UpdateFindMatchCount(text, wildcards, regularExpressions);
         }

--- a/app/src/main_window.cpp
+++ b/app/src/main_window.cpp
@@ -473,9 +473,6 @@ MainWindow::MainWindow(ThemeControl *theme, SessionHistoryManager *historyManage
     mActionToggleAnchors->setCheckable(true);
     mActionToggleAnchors->setShortcut(QKeySequence(Qt::CTRL | Qt::Key_K));
     addAction(mActionToggleAnchors);
-    // Standard dock toggle pattern (show/raise on activate,
-    // close() on deactivate, action checkmark synced via the
-    // `closed` signal so tab switches don't false-fire).
     WireDockToggle(mAnchorsDock, mActionToggleAnchors, &AnchorsDock::closed);
     // `modelReset` clears the header's hidden flags, but
     // `Column::visible` survives. Re-apply on every reset so load /
@@ -592,10 +589,7 @@ MainWindow::MainWindow(ThemeControl *theme, SessionHistoryManager *historyManage
     connect(ui->actionExit, &QAction::triggered, this, [] { QApplication::closeAllWindows(); });
 
     connect(ui->actionCopy, &QAction::triggered, mTableView, &LogTableView::CopySelectedRowsToClipboard);
-    // `MainWindow::Find` is a smart toggle: open + focus, focus
-    // if open-but-unfocused, or close if open + focused. Tooltip
-    // reflects that so the menu / toolbar surface doesn't claim
-    // an "always reveal" behaviour.
+    // Tooltip reflects `Find`'s smart toggle behaviour.
     ui->actionFind->setToolTip(tr("Find in logs. Press again to close."));
     connect(ui->actionFind, &QAction::triggered, this, &MainWindow::Find);
 
@@ -637,11 +631,10 @@ MainWindow::MainWindow(ThemeControl *theme, SessionHistoryManager *historyManage
         }
     });
 
-    // Find bar lives in a dockable host so users can float it,
-    // dock it bottom (IDE convention) or top, and the layout
-    // round-trips through `saveState` / `restoreState`. The
-    // hosted `FindRecordWidget` keeps the same slots so existing
-    // wiring (see `FindRecords` below) is unchanged.
+    // Find bar lives in a dockable host so the user can float / dock
+    // it and the layout round-trips through `saveState`. The hosted
+    // `FindRecordWidget` keeps the same slots, so existing wiring
+    // (see `FindRecords` below) is unchanged.
     mFindDock = new FindDock(this);
     addDockWidget(Qt::BottomDockWidgetArea, mFindDock);
     mFindDock->hide();
@@ -649,21 +642,11 @@ MainWindow::MainWindow(ThemeControl *theme, SessionHistoryManager *historyManage
     connect(mFindRecord, &FindRecordWidget::FindRecords, this, &MainWindow::FindRecords);
     connect(mFindRecord, &FindRecordWidget::MatchCountRequested, this, &MainWindow::UpdateFindMatchCount);
 
-    // Any signal that mutates the proxy's row set invalidates the
-    // find bar's cached match list. `OnFindCacheInvalidated`
-    // drops the cache (cheap) and -- when the bar is visible --
-    // bumps the debounce timer so a single recount runs once the
-    // activity settles.
-    //
-    // `modelReset` is hooked on the proxy only: the source-side
-    // reset chains through the proxy and emits a second time, so
-    // listening to both would fire `OnFindCacheInvalidated` twice
-    // per reset. Same logic for `rowsInserted/Removed` and
-    // `layoutChanged`.
-    //
-    // Column structure changes can flip which columns participate
-    // in the search even when no row text actually changed, so the
-    // column-mutating signals invalidate too.
+    // Every signal that can change the match set invalidates the
+    // find bar's match cache. Hooked on the proxy only -- the
+    // source-side signals chain through and would otherwise
+    // double-fire. Column changes invalidate too because
+    // `MatchRow` honours `Column::visible`.
     connect(mSortFilterProxyModel, &QAbstractItemModel::rowsInserted, this, &MainWindow::OnFindCacheInvalidated);
     connect(mSortFilterProxyModel, &QAbstractItemModel::rowsRemoved, this, &MainWindow::OnFindCacheInvalidated);
     connect(mSortFilterProxyModel, &QAbstractItemModel::layoutChanged, this, &MainWindow::OnFindCacheInvalidated);
@@ -671,14 +654,9 @@ MainWindow::MainWindow(ThemeControl *theme, SessionHistoryManager *historyManage
     connect(mSortFilterProxyModel, &QAbstractItemModel::columnsInserted, this, &MainWindow::OnFindCacheInvalidated);
     connect(mSortFilterProxyModel, &QAbstractItemModel::columnsRemoved, this, &MainWindow::OnFindCacheInvalidated);
     connect(mSortFilterProxyModel, &QAbstractItemModel::columnsMoved, this, &MainWindow::OnFindCacheInvalidated);
-    // `dataChanged` covers in-place cell updates that don't shift
-    // the row set (enum dictionary growth, column renames). It
-    // also fires for theme repaints (Background/Foreground/Font)
-    // which can't affect display-role matching, so filter those
-    // out via `LogModel::IsStyleOnlyRoleChange` -- otherwise
-    // every theme switch wakes the debounce timer for no work.
-    // An empty `roles` list (Qt's "I don't know what changed"
-    // sentinel) refreshes conservatively.
+    // `dataChanged` covers in-place cell updates. Filter out style-only
+    // emits via `IsStyleOnlyRoleChange` so theme repaints don't wake
+    // the debounce timer for nothing.
     connect(
         mSortFilterProxyModel,
         &QAbstractItemModel::dataChanged,
@@ -697,31 +675,19 @@ MainWindow::MainWindow(ThemeControl *theme, SessionHistoryManager *historyManage
     mActionToggleFind->setCheckable(true);
     mActionToggleFind->setToolTip(tr("Show or hide the find bar. Ctrl+F focuses it; Ctrl+F again or Esc closes it."));
     addAction(mActionToggleFind);
-    // Find bar uses the standard dock toggle pattern but with a
-    // custom show callback: `RevealAndFocus()` raises the dock
-    // *and* moves keyboard focus into the search field, so the
-    // toggle behaves like every IDE find bar.
+    // Custom show callback: `RevealAndFocus` also moves keyboard focus
+    // into the search field so the toggle behaves like every IDE find bar.
     WireDockToggle(
         mFindDock.data(),
         mActionToggleFind,
         &FindDock::closed,
         /*onShow=*/[this]() { mFindDock->RevealAndFocus(); }
     );
-    // Catch up the match count after a reveal -- the cache may
-    // have been invalidated by streaming / filter activity while
-    // the bar was hidden or buried under a sibling tab, in which
-    // case the label was last updated against a stale dataset.
-    // `BumpMatchCountDebounce` no-ops on an empty needle, so the
-    // common case (re-show, no prior search) costs nothing.
-    //
-    // We deliberately do *not* gate this on `mFindMatchCache`
-    // existing: a populated cache only saves the full-table scan,
-    // not the binary-search for the new `i` (the current selection
-    // may have moved while the bar was hidden, so the indicator
-    // can be stale on `i` even when the row list is still
-    // correct). Cache-hit recounts in `UpdateFindMatchCount` are
-    // cheap by design, so the worst case here is a binary search
-    // on `revealed`, which is fine.
+    // Catch up the match count after a reveal: the cache may have
+    // been invalidated while the bar was hidden / buried, and the
+    // current selection may have moved (so `i` can be stale even
+    // when the row list is still correct). The cache-hit recount is
+    // cheap; `BumpMatchCountDebounce` no-ops on an empty needle.
     connect(mFindDock, &FindDock::revealed, this, [this]() {
         if (mFindRecord != nullptr)
         {
@@ -730,19 +696,13 @@ MainWindow::MainWindow(ThemeControl *theme, SessionHistoryManager *historyManage
     });
 
     // Parse-errors dock replaces the old `QMessageBox::warning`
-    // popups for streaming / open errors. Hidden until the first
-    // error of a session; `ShowParseErrors` auto-raises only on
-    // the first batch (subsequent batches use the status-bar
-    // indicator).
+    // popups. Hidden until the first error of a session.
     mParseErrorsDock = new ParseErrorsDock(this);
     addDockWidget(Qt::BottomDockWidgetArea, mParseErrorsDock);
     mParseErrorsDock->hide();
 
-    // Default layout: tabify the two bottom docks so they share
-    // the same horizontal strip rather than stacking vertically
-    // and eating ~30% of the editor height when both are open.
-    // Manual drag-to-tabify still works after this; restoreState
-    // overrides on subsequent launches.
+    // Tabify the two bottom docks by default so they share the same
+    // horizontal strip; `restoreState` overrides on later launches.
     tabifyDockWidget(mFindDock, mParseErrorsDock);
 
     mActionToggleParseErrors = new QAction(tr("Parse Errors"), this);
@@ -752,10 +712,9 @@ MainWindow::MainWindow(ThemeControl *theme, SessionHistoryManager *historyManage
     addAction(mActionToggleParseErrors);
     WireDockToggle(mParseErrorsDock.data(), mActionToggleParseErrors, &ParseErrorsDock::closed);
     connect(mParseErrorsDock, &ParseErrorsDock::countChanged, this, &MainWindow::UpdateParseErrorsStatus);
-    // First batch of a session: surface the panel, unless the user
-    // is actively interacting with another bottom-area dock (the
-    // find bar in particular). Raising over an in-progress search
-    // would yank the user's focus and reset their query mid-type.
+    // Auto-raise on the first batch of a session, unless the find
+    // bar holds focus -- raising would yank focus mid-search. The
+    // status-bar indicator is enough notice in that case.
     connect(mParseErrorsDock, &ParseErrorsDock::firstBatchArrived, this, [this]() {
         if (mParseErrorsDock == nullptr)
         {
@@ -763,9 +722,6 @@ MainWindow::MainWindow(ThemeControl *theme, SessionHistoryManager *historyManage
         }
         if (FindBarHoldsFocus())
         {
-            // Find bar holds focus; status-bar indicator alone is
-            // enough notice. Auto-raise on the *next* session's
-            // first batch instead.
             return;
         }
         if (!mParseErrorsDock->isVisible())
@@ -781,10 +737,8 @@ MainWindow::MainWindow(ThemeControl *theme, SessionHistoryManager *historyManage
     addDockWidget(Qt::RightDockWidgetArea, mRecordDetailDock);
     mRecordDetailDock->hide();
 
-    // Tab the two right-side docks (Anchors + Record Details) so
-    // they share the same panel by default. `restoreState` (run
-    // at the end of the constructor) overrides on subsequent
-    // launches if the user moved them.
+    // Tabify the two right-side docks by default; `restoreState`
+    // (later in the constructor) overrides if the user moved them.
     tabifyDockWidget(mAnchorsDock, mRecordDetailDock);
     // `actionToggleRecordDetails` is declared in `main_window.ui` but
     // not placed in any `<addaction>`, so uic doesn't add it to any
@@ -792,10 +746,9 @@ MainWindow::MainWindow(ThemeControl *theme, SessionHistoryManager *historyManage
     // is associated with a widget; add it here so `Ctrl+I` is live
     // from a cold launch, before the View menu is ever opened.
     addAction(ui->actionToggleRecordDetails);
-    // Standard dock toggle; on every visibility-change-true edge
-    // (cold reveal *and* tab activation) re-pull the table
-    // selection so the dock body reflects whatever row is
-    // currently focused.
+    // On every visibility-true edge (reveal AND tab activation)
+    // re-pull the table selection so the dock body reflects the
+    // currently-focused row.
     WireDockToggle(
         mRecordDetailDock,
         ui->actionToggleRecordDetails,
@@ -910,17 +863,11 @@ MainWindow::MainWindow(ThemeControl *theme, SessionHistoryManager *historyManage
     connect(mModel, &LogModel::columnHealthChanged, this, &MainWindow::UpdateDiagnosticsStatus);
 
     // Status-bar indicator for the parse-errors dock. Same UX as
-    // `mDiagnosticsButton`: a permanent widget that hides itself
-    // when the dock is empty and opens / raises the dock on
-    // click.
+    // `mDiagnosticsButton`: hides when empty, opens the dock on click.
     mParseErrorsStatusButton = new QPushButton(this);
     mParseErrorsStatusButton->setObjectName(QStringLiteral("parseErrorsStatusButton"));
-    // Warning (not Critical) to match the per-row icon in the
-    // dock and the actual semantic: these are recoverable
-    // line-level parse failures, not application-level fatals.
-    // `SP_MessageBoxCritical` previously made the status bar
-    // look like the app crashed every time a single log line
-    // failed to deserialise.
+    // Warning (not Critical): these are recoverable line-level
+    // failures, not application-level fatals.
     mParseErrorsStatusButton->setIcon(QApplication::style()->standardIcon(QStyle::SP_MessageBoxWarning));
     mParseErrorsStatusButton->setFlat(true);
     mParseErrorsStatusButton->setCursor(Qt::PointingHandCursor);
@@ -1663,11 +1610,8 @@ void MainWindow::NewSession()
         mAnchors->ClearAll();
     }
 
-    // Parse errors are session-scoped: a fresh session must not
-    // show diagnostics inherited from the discarded one. Use
-    // `ResetSessionState` (not `ClearErrors`) so the next batch
-    // can auto-raise the dock -- this is a destructive boundary,
-    // not a user-initiated clear.
+    // Parse errors are session-scoped. `ResetSessionState` re-arms
+    // the auto-raise for the new session.
     if (mParseErrorsDock != nullptr)
     {
         mParseErrorsDock->ResetSessionState();
@@ -1900,9 +1844,7 @@ void MainWindow::StartStreamingOpenQueue(QStringList files, OpenMode mode)
         {
             mAnchors->ClearAll();
         }
-        // Parse errors are also session-scoped; preserved on
-        // append. `ResetSessionState` re-arms the auto-raise so
-        // the new session's first parse error can pop the dock.
+        // Session-scoped; `ResetSessionState` re-arms the auto-raise.
         if (mParseErrorsDock != nullptr)
         {
             mParseErrorsDock->ResetSessionState();
@@ -2225,8 +2167,7 @@ void MainWindow::OpenLogStreamFromPath(const QString &file)
     {
         mAnchors->ClearAll();
     }
-    // Parse errors are session-scoped; `ResetSessionState`
-    // re-arms the auto-raise for the new live-tail session.
+    // Session-scoped; `ResetSessionState` re-arms the auto-raise.
     if (mParseErrorsDock != nullptr)
     {
         mParseErrorsDock->ResetSessionState();
@@ -2350,8 +2291,7 @@ void MainWindow::OpenNetworkStream()
     {
         mAnchors->ClearAll();
     }
-    // Parse errors are session-scoped; `ResetSessionState`
-    // re-arms the auto-raise for the new network-stream session.
+    // Session-scoped; `ResetSessionState` re-arms the auto-raise.
     if (mParseErrorsDock != nullptr)
     {
         mParseErrorsDock->ResetSessionState();
@@ -2929,15 +2869,10 @@ void MainWindow::ShowParseErrors(const QString &title, const std::vector<std::st
     }
     if (mParseErrorsDock == nullptr)
     {
-        // Defensive fallback. Should never hit in production --
-        // the dock is built in the constructor before any open
-        // path can run -- but a test fixture that pokes
-        // `ShowParseErrors` on a stripped-down window would
-        // otherwise lose the diagnostic silently. Surface to the
-        // log so failures are noticed instead of swallowed; this
-        // is closer in spirit to the prior `QMessageBox::warning`
-        // (which a real user could not have missed) than the
-        // earlier silent return.
+        // Should never hit in production (the dock is built in the
+        // constructor before any open path runs). Surface so a test
+        // fixture poking `ShowParseErrors` on a stripped-down window
+        // doesn't lose the diagnostic silently.
         qWarning() << "ShowParseErrors: parse-errors dock is unavailable; dropping" << errors.size() << "error(s) under"
                    << title;
         return;
@@ -3517,27 +3452,19 @@ void MainWindow::UpdateParseErrorsStatus(int count, int droppedCount)
         mParseErrorsStatusButton->setToolTip(QString());
         return;
     }
-    // `%Ln` -> locale-grouped digits (1,234 / 1.234) matching the
-    // streaming-status text. Plain `%n` would print "1234" and
-    // jitter the button width as counts grew across a streaming
-    // session.
+    // `%Ln` -> locale-grouped digits matching the streaming-status
+    // text (no width jitter as counts grow).
     const int displayedTotal = count + droppedCount;
     if (droppedCount > 0)
     {
-        // Surface the dropped-count on the button label itself
-        // (not just the tooltip) so the user can tell at a glance
-        // that the dock has truncated. Without this the button
-        // reports "12,345 parse errors" but clicking it opens a
-        // dock that reads "11,345 errors; 1,000 earlier dropped"
-        // -- the discrepancy reads as a bug.
+        // Surface the dropped-count on the label itself; otherwise
+        // the button says "12,345 parse errors" but the dock reads
+        // "11,345 errors; 1,000 earlier dropped" -- looks like a bug.
         const QLocale locale = QLocale::system();
         mParseErrorsStatusButton->setText(tr("%1 parse error(s) (+%2 dropped)")
                                               .arg(locale.toString(static_cast<qlonglong>(count)))
                                               .arg(locale.toString(static_cast<qlonglong>(droppedCount))));
-        // Two independent counts -> can't use a single `%Ln`
-        // plural; format both via QLocale so the tooltip matches
-        // the dock summary ("12,345 errors; 1,000 earlier
-        // dropped").
+        // Two independent counts -> can't use a single `%Ln` plural.
         mParseErrorsStatusButton->setToolTip(
             tr("%1 parse error(s) in this session "
                "(%2 visible, %3 earlier dropped). Click to open the Parse Errors panel.")
@@ -3562,36 +3489,26 @@ void MainWindow::UpdateFindMatchCount(const QString &text, bool wildcards, bool 
     {
         return;
     }
-    // Skip the full-table scan when the bar is hidden -- a
-    // debounce timer armed while the bar was visible can fire
-    // after the user dismissed the dock, and `FindRecords` calls
-    // us back after a Next / Previous click for the indicator
-    // refresh (which is also pointless when the indicator isn't
-    // on screen). `OnFindCacheInvalidated` and `FindRecords`
-    // already gate their own paths the same way; this slot was
-    // the asymmetric outlier. We still drop the cache below for
-    // an empty needle so a later reveal doesn't show a stale "i
-    // of N" against the wrong needle.
+    // Skip the full-table scan when the bar isn't visible; a debounce
+    // timer armed before the dismissal can fire after the fact, and
+    // refreshing an off-screen indicator is pointless.
     if (!IsFindBarVisible())
     {
         return;
     }
     if (text.isEmpty())
     {
-        // `FindRecordWidget::RequestMatchCountSoon` already
-        // suppresses the signal for an empty needle, so the only
-        // way we land here is a programmatic call (e.g. the
-        // post-`FindRecords` refresh after a Clear). Keep the
-        // label clear in case the cache was previously populated.
+        // Only reachable via a programmatic call (the widget
+        // suppresses the signal on empty text). Keep the label
+        // clear in case the cache was previously populated.
         InvalidateFindMatchCache();
         mFindRecord->SetMatchInfo(0, 0);
         return;
     }
 
-    // Rebuild the cache only when the needle / flags actually
-    // changed. A Next / Previous click reports the same needle,
-    // so the second call skips the full-table scan and just
-    // updates `i` via the binary-search below.
+    // Rebuild only when the needle / flags actually changed. A
+    // Next / Previous click reports the same needle, so the second
+    // call just resolves the new `i` via binary search below.
     const bool cacheHit = mFindMatchCache.has_value() && mFindMatchCache->needle == text &&
                           mFindMatchCache->wildcards == wildcards &&
                           mFindMatchCache->regularExpressions == regularExpressions;
@@ -3606,50 +3523,30 @@ void MainWindow::UpdateFindMatchCount(const QString &text, bool wildcards, bool 
             return;
         }
         const QVariant value = QVariant::fromValue(text);
-        // Cap the scan at `MAX_FIND_MATCH_COUNT + 1`: one extra
-        // hit lets us distinguish "exactly at the cap" from "ran
-        // off the end". Bigger needles on huge tables (1 M+ rows,
-        // common needle like " ") used to block the GUI for
-        // hundreds of ms; the cap keeps the recount bounded
-        // regardless of input size.
+        // Cap + 1: the extra hit lets us distinguish "exactly at the
+        // cap" from "ran off the end". Keeps the GUI bounded on huge
+        // tables with a common needle.
         const QModelIndexList matches =
             mSortFilterProxyModel->MatchRow(start, Qt::DisplayRole, value, MAX_FIND_MATCH_COUNT + 1, flags, true, 0);
         const bool overflowed = matches.size() > MAX_FIND_MATCH_COUNT;
-        // `MatchRow` is documented to return at most one entry
-        // per row (it `break`s on the first matching column) and
-        // to walk rows ascending from `start` (row 0). That
-        // *should* leave us with sorted, deduplicated rows --
-        // but a future contributor could change either invariant
-        // and the binary-search path below would silently
-        // misreport. Sort + unique defensively so a contract
-        // drift can't corrupt the indicator. Keep the asserts so
-        // debug builds still catch the regression at the source.
+        // `MatchRow` is contracted to return one entry per row in
+        // ascending order. Sort + unique defensively so a future
+        // contract drift can't silently corrupt the binary search;
+        // asserts catch the regression at the source in debug builds.
         std::vector<int> rows;
         rows.reserve(static_cast<size_t>(matches.size()));
         for (const QModelIndex &m : matches)
         {
             rows.push_back(m.row());
         }
-        // The sort assertion has to come before the adjacent_find
-        // assertion: `adjacent_find` only spots adjacent dupes,
-        // so on an unsorted vector with non-adjacent duplicates
-        // it would silently pass and let the dedup contract drift
-        // unnoticed. Order: assert sorted, defensively sort if
-        // not, then assert dedup, then defensively unique.
-        //
-        // Hoist `is_sorted` into a local so the `Q_ASSERT` and the
-        // fallback `if` share one walk in debug builds (in release,
-        // `Q_ASSERT` compiles out and only the `if` runs once).
+        // Sort check must precede dedup check: `adjacent_find` only
+        // spots adjacent dupes, so unsorted input with non-adjacent
+        // duplicates would slip through. `qWarning` mirrors the
+        // assert because release builds compile it out.
         const bool sortedAsExpected = std::ranges::is_sorted(rows);
         Q_ASSERT(sortedAsExpected);
         if (!sortedAsExpected)
         {
-            // Release builds compile the `Q_ASSERT` out, so emit
-            // a `qWarning` here too -- a future `MatchRow`
-            // refactor that breaks the ascending-rows contract
-            // would otherwise silently get patched over by the
-            // defensive sort and never surface the regression in
-            // a release build (CI / shipped binary).
             qWarning() << "MainWindow::UpdateFindMatchCount: MatchRow returned unsorted rows; "
                           "sorting defensively. This is a contract violation worth investigating.";
             std::ranges::sort(rows);
@@ -3662,15 +3559,9 @@ void MainWindow::UpdateFindMatchCount(const QString &text, bool wildcards, bool 
                           "deduplicating defensively. This is a contract violation worth investigating.";
         }
         rows.erase(std::ranges::unique(rows).begin(), rows.end());
-        // Guard on `>` (not just `if (overflowed)`): the defensive
-        // dedup above can drop entries, so a `matches.size() ==
-        // cap + 1` result could end up with `rows.size() < cap`
-        // after de-duplication. An unconditional `resize(cap)`
-        // would then *grow* the vector with default-constructed
-        // zero ints -- those zeros look like spurious matches at
-        // proxy row 0 to both the total count and the
-        // `std::lower_bound` below. Trim only when we genuinely
-        // have surplus rows to discard.
+        // Trim only when there's surplus -- the dedup above can drop
+        // entries below the cap, and a blind `resize(cap)` would then
+        // grow the vector with zeros that look like matches at row 0.
         if (rows.size() > static_cast<size_t>(MAX_FIND_MATCH_COUNT))
         {
             rows.resize(static_cast<size_t>(MAX_FIND_MATCH_COUNT));
@@ -3754,11 +3645,7 @@ bool MainWindow::ApplyLoadedConfiguration(loglib::LogConfiguration parsed)
         const SessionSwitchScope switchGuard(*this);
 
         mModel->Reset();
-        // Parse errors are session-scoped: a config load is a
-        // destructive session boundary just like `NewSession`.
-        // `ResetSessionState` re-arms the auto-raise so the
-        // newly-loaded configuration's first parse error can pop
-        // the dock.
+        // Config load is a session boundary; re-arm the auto-raise.
         if (mParseErrorsDock != nullptr)
         {
             mParseErrorsDock->ResetSessionState();
@@ -3892,18 +3779,10 @@ void MainWindow::Find()
         return;
     }
     // Smart toggle (VS Code / Chrome convention):
-    //   - bar hidden / tab-buried        -> reveal + focus the
-    //                                       search field.
-    //   - bar visible, focus outside it  -> just focus the field
-    //                                       (no close).
-    //   - bar visible, focus *inside* it -> close it, so a
-    //                                       second Ctrl+F is the
-    //                                       dismiss verb (no
-    //                                       need to chase Esc).
-    // The `isAncestorOf` check on the focused widget is what
-    // distinguishes the second case from the third: a bare
-    // `isVisible` check would close the bar when the user
-    // pressed Ctrl+F from the table view.
+    //   - hidden / tab-buried        -> reveal + focus
+    //   - visible, focus outside     -> focus the field (no close)
+    //   - visible, focus inside      -> close (Ctrl+F is also the
+    //                                   dismiss verb -- no chasing Esc)
     if (FindBarHoldsFocus())
     {
         mFindDock->close();
@@ -4065,14 +3944,10 @@ void MainWindow::FindRecords(const QString &text, bool next, bool wildcards, boo
     {
         searchStartIndex = mTableView->currentIndex();
     }
-    // `MatchContains` / `MatchWildcard` / `MatchRegularExpression` are
-    // *alternatives*, not additions: `LogFilterModel::Matches` checks
-    // them in declaration order and short-circuits on the first hit.
-    // OR-ing `MatchContains` with one of the others therefore silently
-    // demotes the search to plain substring matching, so the regex /
-    // wildcard toggles look enabled but match like they're off.
-    // `LogFilterModel::ComposeFindFlags` is the single source of
-    // truth shared with `UpdateFindMatchCount`.
+    // Match-type flags are alternatives, not additions; OR-ing
+    // contains with regex / wildcard silently demotes the search.
+    // `ComposeFindFlags` is the single source of truth shared with
+    // `UpdateFindMatchCount`.
     const Qt::MatchFlags flags = LogFilterModel::ComposeFindFlags(wildcards, regularExpressions);
     int skipFirstN = 0;
     if (mTableView->selectionModel()->isRowSelected(searchStartIndex.row()))
@@ -4095,13 +3970,9 @@ void MainWindow::FindRecords(const QString &text, bool next, bool wildcards, boo
         mTableView->selectionModel()->setCurrentIndex(matches[0], QItemSelectionModel::NoUpdate);
     }
 
-    // Refresh the find bar's "i of N" indicator now that the
-    // current index has moved. With the match-row cache in place,
-    // the same `(text, flags)` is a cache hit and resolves the new
-    // `i` via binary search -- no full-table scan. Gated on the
-    // bar being visible so a programmatic `FindRecords` call from
-    // a test path doesn't pay even for the cache rebuild on the
-    // first hit.
+    // Refresh the "i of N" indicator now that the current index moved.
+    // Cache-hit resolves the new `i` via binary search; gated on
+    // visibility so a programmatic call from tests pays nothing.
     if (IsFindBarVisible())
     {
         UpdateFindMatchCount(text, wildcards, regularExpressions);
@@ -4649,47 +4520,27 @@ void MainWindow::AddLogFilter(const QString &id, const loglib::LogConfiguration:
 
 void MainWindow::OnThemeChanged()
 {
-    // Force Qt's QSS engine to re-resolve palette references on
-    // the table view. Once `ApplyTableStyleSheet` has installed a
-    // body QSS rule (the monospace `QTableView::item` font, added
-    // in the GUI-polish phase 1) the view enters QSS-managed item
-    // painting, and `QStyleSheetStyle` caches palette-derived
-    // colours at polish time. Our "skip unchanged writes"
-    // optimisation in `ApplyTableStyleSheet` then makes the next
-    // call a no-op (rule text unchanged) so the cached resolution
-    // never refreshes -- the user sees rows whose level brush
-    // doesn't change (Info / Trace) stuck on the previous theme's
-    // palette, while rows whose `data(BackgroundRole)` returns a
-    // different brush (Error / Warn / anchor-coloured) repaint
-    // correctly via the `RefreshAllRowStyles` notification below.
-    // Clearing our cached "last applied" tracker before
-    // `ApplyTableStyleSheet` forces the polish cascade to run on
-    // every theme switch, which is the cheap-but-correct fix.
-    // Theme switches are rare; the polish cost doesn't matter.
+    // Clear the "last applied" tracker so `ApplyTableStyleSheet` re-runs
+    // the polish cascade. `QStyleSheetStyle` caches palette-derived
+    // colours at polish time, and our "skip unchanged writes" guard
+    // would otherwise leave the cache frozen on the old theme.
     mLastBodyStyleSheet = QString{};
     mLastHeaderStyleSheet = QString{};
     ApplyTableStyleSheet();
     ApplyThemedWindowIcon();
 
-    // Tell the view to re-query the new theme brushes. Necessary
-    // for cells whose `data(BackgroundRole)` returns a different
-    // brush between themes -- the `setStyleSheet` polish above
-    // covers the palette-default cells, but the explicit-brush
-    // cells need a model-level `dataChanged` to invalidate the
-    // view's per-item style cache.
+    // Re-query brushes for cells whose `data(BackgroundRole)` returns
+    // an explicit colour (Error / Warn / anchor); the QSS polish above
+    // only covers palette-default cells.
     if (mModel != nullptr)
     {
         mModel->RefreshAllRowStyles();
     }
     if (mTableView != nullptr)
     {
-        // Headers don't go through `data()`, so the `dataChanged`
-        // emit above doesn't reach them. The header QSS is now
-        // guaranteed re-applied by the tracker reset above, but
-        // an explicit repaint flushes any backing-store fragments
-        // left behind by a modal dialog (Preferences) that was
-        // overlapping the table when the user picked the new
-        // theme.
+        // Headers don't go through `data()`, so the emit above doesn't
+        // reach them. Repaint also flushes any backing-store fragments
+        // left by a modal dialog (e.g. Preferences) that was overlapping.
         mTableView->viewport()->update();
         mTableView->horizontalHeader()->update();
         mTableView->verticalHeader()->update();
@@ -5691,13 +5542,10 @@ void MainWindow::SetColumnVisible(int logicalIndex, bool visible)
     {
         mTableView->sortByColumn(-1, Qt::AscendingOrder);
     }
-    // `LogFilterModel::MatchRow` skips columns where
-    // `LogConfiguration::columns[i].visible == false`, but column
-    // visibility flips don't emit any of the model / proxy signals
-    // that `OnFindCacheInvalidated` is wired to (rowsInserted,
-    // layoutChanged, dataChanged, ...). Invalidate explicitly so
-    // the find bar's "*i* of *N*" indicator can't strand a stale
-    // count that includes hits in now-hidden columns.
+    // `MatchRow` honours `Column::visible`, but visibility flips
+    // don't emit any of the signals `OnFindCacheInvalidated` listens
+    // to. Invalidate explicitly so the indicator can't strand a
+    // count that still includes hits from hidden columns.
     OnFindCacheInvalidated();
 }
 
@@ -5714,12 +5562,9 @@ void MainWindow::ApplyColumnVisibility()
     {
         header->setSectionHidden(static_cast<int>(i), !columns[i].visible);
     }
-    // Visibility may have changed without any model / proxy signal
-    // firing -- this method is also called from header-recovery
-    // paths and configuration loads. Drop the find cache for the
-    // same reason `SetColumnVisible` does: `MatchRow` honours
-    // `Column::visible` and a stale cache would lie about the
-    // count.
+    // Visibility may have changed without a signal -- this is also
+    // called from header-recovery and configuration-load paths. Drop
+    // the find cache for the same reason as `SetColumnVisible`.
     OnFindCacheInvalidated();
 }
 
@@ -5749,15 +5594,12 @@ void MainWindow::RebuildViewMenu()
         viewMenu->addAction(mActionToggleAnchors);
     }
 
-    // Find dock toggle. Same programmatic-action pattern as
-    // `mActionToggleAnchors`: re-added on every menu rebuild so
-    // the View menu always lists every dockable surface.
+    // Find + parse-errors dock toggles, re-added on every rebuild
+    // (same pattern as `mActionToggleAnchors`).
     if (mActionToggleFind != nullptr)
     {
         viewMenu->addAction(mActionToggleFind);
     }
-
-    // Parse-errors dock toggle.
     if (mActionToggleParseErrors != nullptr)
     {
         viewMenu->addAction(mActionToggleParseErrors);

--- a/app/src/main_window.cpp
+++ b/app/src/main_window.cpp
@@ -1920,7 +1920,7 @@ void MainWindow::OnStreamingFinished(StreamingResult result)
         const size_t cut = std::min(mStreamingErrorsCut, allErrors.size());
         if (cut < allErrors.size())
         {
-            std::vector<std::string> thisFileErrors(
+            const std::vector<std::string> thisFileErrors(
                 allErrors.begin() + static_cast<std::ptrdiff_t>(cut), allErrors.end()
             );
             const QString title = mStreamingFileName.isEmpty()

--- a/app/src/main_window.cpp
+++ b/app/src/main_window.cpp
@@ -1611,11 +1611,14 @@ void MainWindow::NewSession()
     }
 
     // Parse errors are session-scoped. `ResetSessionState` re-arms
-    // the auto-raise for the new session.
+    // the auto-raise for the new session. The per-file watermark
+    // mirrors the dock reset so the next session's first batch
+    // starts at index 0.
     if (mParseErrorsDock != nullptr)
     {
         mParseErrorsDock->ResetSessionState();
     }
+    mStreamingErrorsCut = 0;
 
     mCurrentSource.reset();
     mSessionMode = SessionMode::Idle;
@@ -1845,10 +1848,12 @@ void MainWindow::StartStreamingOpenQueue(QStringList files, OpenMode mode)
             mAnchors->ClearAll();
         }
         // Session-scoped; `ResetSessionState` re-arms the auto-raise.
+        // Watermark resets in lockstep with the dock + model error vector.
         if (mParseErrorsDock != nullptr)
         {
             mParseErrorsDock->ResetSessionState();
         }
+        mStreamingErrorsCut = 0;
         mCurrentSource.reset();
         mSessionMode = SessionMode::Idle;
         mLastTerminalSessionMode = SessionMode::Idle;
@@ -1895,6 +1900,36 @@ void MainWindow::OnStreamingFinished(StreamingResult result)
 
     // Clear the `Source unavailable` latch.
     mSourceWaiting = false;
+
+    // Per-file batch under a header that names the file (or stream)
+    // that just finished. Fires *before* the chaining check so the
+    // intermediate file's errors don't get folded into the last
+    // file's batch in a multi-file static open. `mStreamingFileName`
+    // is still set to the just-finished source here -- the chaining
+    // path below will overwrite it for the next file.
+    //
+    // Open-failure entries in `mPendingOpenErrors` are intentionally
+    // *not* folded in here: they aren't tied to any one streamed file
+    // and would be misleading under a file-named header. They're
+    // surfaced under their own batch at the bottom of this function.
+    if (result == StreamingResult::Success)
+    {
+        const auto &allErrors = mModel->StreamingErrors();
+        // `std::min` guards against a model reset that landed between
+        // our last slice and now (would leave the watermark past end).
+        const size_t cut = std::min(mStreamingErrorsCut, allErrors.size());
+        if (cut < allErrors.size())
+        {
+            std::vector<std::string> thisFileErrors(
+                allErrors.begin() + static_cast<std::ptrdiff_t>(cut), allErrors.end()
+            );
+            const QString title = mStreamingFileName.isEmpty()
+                                      ? tr("Error Parsing Logs")
+                                      : tr("Error Parsing Logs \u2014 %1").arg(mStreamingFileName);
+            ShowParseErrors(title, thisFileErrors);
+        }
+        mStreamingErrorsCut = allErrors.size();
+    }
 
     // Multi-file static open: Success advances the queue. Keep
     // `mSessionMode == Static` across `StreamNextPendingFile` so
@@ -1946,22 +1981,17 @@ void MainWindow::OnStreamingFinished(StreamingResult result)
     // settled. Drives the header warning glyph and the status-bar
     // mismatch summary via `columnHealthChanged`.
     mModel->RefreshColumnHealth();
-    // Only Success produces a post-parse error summary.
-    if (result == StreamingResult::Success)
+    // Per-file parse-error batches were already surfaced at the top
+    // of this function (one per file in the chain). What remains is
+    // any open-failure residue from the multi-file queue -- those
+    // entries are tied to files that never streamed, so they get
+    // their own dedicated batch instead of being mislabeled under
+    // a streamed-file header.
+    if (result == StreamingResult::Success && !mPendingOpenErrors.empty())
     {
-        std::vector<std::string> errors = mModel->StreamingErrors();
-        errors.insert(
-            errors.end(),
-            std::make_move_iterator(mPendingOpenErrors.begin()),
-            std::make_move_iterator(mPendingOpenErrors.end())
-        );
-        mPendingOpenErrors.clear();
-        ShowParseErrors(tr("Error Parsing Logs"), errors);
+        ShowParseErrors(tr("Error Opening File"), mPendingOpenErrors);
     }
-    else
-    {
-        mPendingOpenErrors.clear();
-    }
+    mPendingOpenErrors.clear();
     mStreamingFileName.clear();
     // Keep `mCurrentSource` on Success / Cancelled (rows are
     // still present, descriptor still describes them); drop it
@@ -2168,10 +2198,12 @@ void MainWindow::OpenLogStreamFromPath(const QString &file)
         mAnchors->ClearAll();
     }
     // Session-scoped; `ResetSessionState` re-arms the auto-raise.
+    // Watermark resets in lockstep with the dock + model error vector.
     if (mParseErrorsDock != nullptr)
     {
         mParseErrorsDock->ResetSessionState();
     }
+    mStreamingErrorsCut = 0;
     // Live-tail is transient and not auto-saved; leaving the prior
     // static session's uuid pinned would let closeEvent's
     // `RemoveOpenWindowUuid` drop that session from the multi-
@@ -2292,10 +2324,12 @@ void MainWindow::OpenNetworkStream()
         mAnchors->ClearAll();
     }
     // Session-scoped; `ResetSessionState` re-arms the auto-raise.
+    // Watermark resets in lockstep with the dock + model error vector.
     if (mParseErrorsDock != nullptr)
     {
         mParseErrorsDock->ResetSessionState();
     }
+    mStreamingErrorsCut = 0;
     DetachAutoSaveUuid();
 
     mStreamingFileName = QString::fromStdString(displayName);
@@ -3645,11 +3679,13 @@ bool MainWindow::ApplyLoadedConfiguration(loglib::LogConfiguration parsed)
         const SessionSwitchScope switchGuard(*this);
 
         mModel->Reset();
-        // Config load is a session boundary; re-arm the auto-raise.
+        // Config load is a session boundary; re-arm the auto-raise
+        // and reset the per-file slice watermark.
         if (mParseErrorsDock != nullptr)
         {
             mParseErrorsDock->ResetSessionState();
         }
+        mStreamingErrorsCut = 0;
         mModel->ConfigurationManager().SetConfiguration(std::move(parsed));
         // `SetConfiguration` does not emit a model signal; the
         // reset re-initialises the header section count and the

--- a/app/src/main_window.cpp
+++ b/app/src/main_window.cpp
@@ -3665,11 +3665,17 @@ void MainWindow::UpdateFindMatchCount(const QString &text, bool wildcards, bool 
                           "deduplicating defensively. This is a contract violation worth investigating.";
         }
         rows.erase(std::ranges::unique(rows).begin(), rows.end());
-        if (overflowed)
+        // Guard on `>` (not just `if (overflowed)`): the defensive
+        // dedup above can drop entries, so a `matches.size() ==
+        // cap + 1` result could end up with `rows.size() < cap`
+        // after de-duplication. An unconditional `resize(cap)`
+        // would then *grow* the vector with default-constructed
+        // zero ints -- those zeros look like spurious matches at
+        // proxy row 0 to both the total count and the
+        // `std::lower_bound` below. Trim only when we genuinely
+        // have surplus rows to discard.
+        if (rows.size() > static_cast<size_t>(MAX_FIND_MATCH_COUNT))
         {
-            // We requested cap+1 hits to detect overflow; trim
-            // the surplus before storing so `sortedRows.size()`
-            // matches the cap exactly.
             rows.resize(static_cast<size_t>(MAX_FIND_MATCH_COUNT));
         }
         mFindMatchCache = FindMatchCache{

--- a/app/src/main_window.cpp
+++ b/app/src/main_window.cpp
@@ -3531,11 +3531,9 @@ void MainWindow::UpdateParseErrorsStatus(int count, int droppedCount)
         // dock that reads "11,345 errors; 1,000 earlier dropped"
         // -- the discrepancy reads as a bug.
         const QLocale locale = QLocale::system();
-        mParseErrorsStatusButton->setText(
-            tr("%1 parse error(s) (+%2 dropped)")
-                .arg(locale.toString(static_cast<qlonglong>(count)))
-                .arg(locale.toString(static_cast<qlonglong>(droppedCount)))
-        );
+        mParseErrorsStatusButton->setText(tr("%1 parse error(s) (+%2 dropped)")
+                                              .arg(locale.toString(static_cast<qlonglong>(count)))
+                                              .arg(locale.toString(static_cast<qlonglong>(droppedCount))));
         // Two independent counts -> can't use a single `%Ln`
         // plural; format both via QLocale so the tooltip matches
         // the dock summary ("12,345 errors; 1,000 earlier
@@ -3614,9 +3612,8 @@ void MainWindow::UpdateFindMatchCount(const QString &text, bool wildcards, bool 
         // common needle like " ") used to block the GUI for
         // hundreds of ms; the cap keeps the recount bounded
         // regardless of input size.
-        const QModelIndexList matches = mSortFilterProxyModel->MatchRow(
-            start, Qt::DisplayRole, value, MAX_FIND_MATCH_COUNT + 1, flags, true, 0
-        );
+        const QModelIndexList matches =
+            mSortFilterProxyModel->MatchRow(start, Qt::DisplayRole, value, MAX_FIND_MATCH_COUNT + 1, flags, true, 0);
         const bool overflowed = matches.size() > MAX_FIND_MATCH_COUNT;
         // `MatchRow` is documented to return at most one entry
         // per row (it `break`s on the first matching column) and

--- a/app/src/main_window.cpp
+++ b/app/src/main_window.cpp
@@ -785,6 +785,15 @@ MainWindow::MainWindow(ThemeControl *theme, SessionHistoryManager *historyManage
     // case the label was last updated against a stale dataset.
     // `BumpMatchCountDebounce` no-ops on an empty needle, so the
     // common case (re-show, no prior search) costs nothing.
+    //
+    // We deliberately do *not* gate this on `mFindMatchCache`
+    // existing: a populated cache only saves the full-table scan,
+    // not the binary-search for the new `i` (the current selection
+    // may have moved while the bar was hidden, so the indicator
+    // can be stale on `i` even when the row list is still
+    // correct). Cache-hit recounts in `UpdateFindMatchCount` are
+    // cheap by design, so the worst case here is a binary search
+    // on `revealed`, which is fine.
     connect(mFindDock, &FindDock::revealed, this, [this]() {
         if (mFindRecord != nullptr)
         {
@@ -3039,10 +3048,17 @@ void MainWindow::ShowParseErrors(const QString &title, const std::vector<std::st
     }
     if (mParseErrorsDock == nullptr)
     {
-        // Defensive fallback. Should never hit in production
-        // (the dock is built in the constructor before any open
-        // path can run), but keep the prior behaviour for tests
-        // that bypass the GUI shell.
+        // Defensive fallback. Should never hit in production --
+        // the dock is built in the constructor before any open
+        // path can run -- but a test fixture that pokes
+        // `ShowParseErrors` on a stripped-down window would
+        // otherwise lose the diagnostic silently. Surface to the
+        // log so failures are noticed instead of swallowed; this
+        // is closer in spirit to the prior `QMessageBox::warning`
+        // (which a real user could not have missed) than the
+        // earlier silent return.
+        qWarning() << "ShowParseErrors: parse-errors dock is unavailable; dropping" << errors.size() << "error(s) under"
+                   << title;
         return;
     }
     mParseErrorsDock->AppendErrors(title, errors);
@@ -3472,6 +3488,34 @@ namespace
     }
     return sourceIndex.row();
 }
+
+/// Build the `Qt::MatchFlags` for a find query. The match-type
+/// values in `Qt::MatchFlag` are *alternatives*, not bit-mask
+/// modifiers (`LogFilterModel::Matches` masks the type field and
+/// dispatches with a switch), so OR-ing `MatchContains` alongside
+/// `MatchWildcard` / `MatchRegularExpression` silently demotes
+/// the search to plain substring -- the regex / wildcard toggles
+/// would look enabled but match like they're off. The two find
+/// call sites (`MainWindow::FindRecords` and the cache rebuild in
+/// `UpdateFindMatchCount`) share this helper so a future refactor
+/// can't desync them.
+[[nodiscard]] Qt::MatchFlags ComposeFindFlags(bool wildcards, bool regularExpressions)
+{
+    Qt::MatchFlags flags = Qt::MatchWrap | Qt::MatchRecursive;
+    if (regularExpressions)
+    {
+        flags |= Qt::MatchRegularExpression;
+    }
+    else if (wildcards)
+    {
+        flags |= Qt::MatchWildcard;
+    }
+    else
+    {
+        flags |= Qt::MatchContains;
+    }
+    return flags;
+}
 } // namespace
 
 void MainWindow::ShowRecordDetailsForProxyIndex(const QModelIndex &proxyIndex)
@@ -3676,23 +3720,7 @@ void MainWindow::UpdateFindMatchCount(const QString &text, bool wildcards, bool 
                           mFindMatchCache->regularExpressions == regularExpressions;
     if (!cacheHit)
     {
-        // Same exclusivity discipline as `FindRecords`: contains /
-        // wildcard / regex are mutually exclusive match modes in
-        // `LogFilterModel::Matches`; mixing them silently downgrades
-        // to contains.
-        Qt::MatchFlags flags = Qt::MatchWrap | Qt::MatchRecursive;
-        if (regularExpressions)
-        {
-            flags |= Qt::MatchRegularExpression;
-        }
-        else if (wildcards)
-        {
-            flags |= Qt::MatchWildcard;
-        }
-        else
-        {
-            flags |= Qt::MatchContains;
-        }
+        const Qt::MatchFlags flags = ComposeFindFlags(wildcards, regularExpressions);
         const QModelIndex start = mSortFilterProxyModel->index(0, 0);
         if (!start.isValid())
         {
@@ -3726,12 +3754,18 @@ void MainWindow::UpdateFindMatchCount(const QString &text, bool wildcards, bool 
         {
             rows.push_back(m.row());
         }
+        // The sort assertion has to come before the adjacent_find
+        // assertion: `adjacent_find` only spots adjacent dupes,
+        // so on an unsorted vector with non-adjacent duplicates
+        // it would silently pass and let the dedup contract drift
+        // unnoticed. Order: assert sorted, defensively sort if
+        // not, then assert dedup, then defensively unique.
         Q_ASSERT(std::ranges::is_sorted(rows));
-        Q_ASSERT(std::ranges::adjacent_find(rows) == rows.end());
         if (!std::ranges::is_sorted(rows))
         {
             std::ranges::sort(rows);
         }
+        Q_ASSERT(std::ranges::adjacent_find(rows) == rows.end());
         rows.erase(std::ranges::unique(rows).begin(), rows.end());
         if (overflowed)
         {
@@ -4133,19 +4167,9 @@ void MainWindow::FindRecords(const QString &text, bool next, bool wildcards, boo
     // OR-ing `MatchContains` with one of the others therefore silently
     // demotes the search to plain substring matching, so the regex /
     // wildcard toggles look enabled but match like they're off.
-    Qt::MatchFlags flags = Qt::MatchWrap | Qt::MatchRecursive;
-    if (regularExpressions)
-    {
-        flags |= Qt::MatchRegularExpression;
-    }
-    else if (wildcards)
-    {
-        flags |= Qt::MatchWildcard;
-    }
-    else
-    {
-        flags |= Qt::MatchContains;
-    }
+    // `ComposeFindFlags` is the single source of truth shared with
+    // `UpdateFindMatchCount`.
+    const Qt::MatchFlags flags = ComposeFindFlags(wildcards, regularExpressions);
     int skipFirstN = 0;
     if (mTableView->selectionModel()->isRowSelected(searchStartIndex.row()))
     {

--- a/app/src/main_window.cpp
+++ b/app/src/main_window.cpp
@@ -3668,14 +3668,24 @@ void MainWindow::UpdateParseErrorsStatus(int count, int droppedCount)
     // jitter the button width as counts grew across a streaming
     // session.
     const int displayedTotal = count + droppedCount;
-    mParseErrorsStatusButton->setText(tr("%Ln parse error(s)", nullptr, displayedTotal));
     if (droppedCount > 0)
     {
+        // Surface the dropped-count on the button label itself
+        // (not just the tooltip) so the user can tell at a glance
+        // that the dock has truncated. Without this the button
+        // reports "12,345 parse errors" but clicking it opens a
+        // dock that reads "11,345 errors; 1,000 earlier dropped"
+        // -- the discrepancy reads as a bug.
+        const QLocale locale = QLocale::system();
+        mParseErrorsStatusButton->setText(
+            tr("%1 parse error(s) (+%2 dropped)")
+                .arg(locale.toString(static_cast<qlonglong>(count)))
+                .arg(locale.toString(static_cast<qlonglong>(droppedCount)))
+        );
         // Two independent counts -> can't use a single `%Ln`
         // plural; format both via QLocale so the tooltip matches
         // the dock summary ("12,345 errors; 1,000 earlier
         // dropped").
-        const QLocale locale = QLocale::system();
         mParseErrorsStatusButton->setToolTip(
             tr("%1 parse error(s) in this session "
                "(%2 visible, %3 earlier dropped). Click to open the Parse Errors panel.")
@@ -3686,6 +3696,7 @@ void MainWindow::UpdateParseErrorsStatus(int count, int droppedCount)
     }
     else
     {
+        mParseErrorsStatusButton->setText(tr("%Ln parse error(s)", nullptr, displayedTotal));
         mParseErrorsStatusButton->setToolTip(
             tr("%Ln parse error(s) in this session. Click to open the Parse Errors panel.", nullptr, count)
         );
@@ -3696,6 +3707,20 @@ void MainWindow::UpdateParseErrorsStatus(int count, int droppedCount)
 void MainWindow::UpdateFindMatchCount(const QString &text, bool wildcards, bool regularExpressions)
 {
     if (mFindRecord == nullptr || mSortFilterProxyModel == nullptr)
+    {
+        return;
+    }
+    // Skip the full-table scan when the bar is hidden -- a
+    // debounce timer armed while the bar was visible can fire
+    // after the user dismissed the dock, and `FindRecords` calls
+    // us back after a Next / Previous click for the indicator
+    // refresh (which is also pointless when the indicator isn't
+    // on screen). `OnFindCacheInvalidated` and `FindRecords`
+    // already gate their own paths the same way; this slot was
+    // the asymmetric outlier. We still drop the cache below for
+    // an empty needle so a later reveal doesn't show a stale "i
+    // of N" against the wrong needle.
+    if (mFindDock == nullptr || !mFindDock->isVisible())
     {
         return;
     }
@@ -3760,8 +3785,13 @@ void MainWindow::UpdateFindMatchCount(const QString &text, bool wildcards, bool 
         // it would silently pass and let the dedup contract drift
         // unnoticed. Order: assert sorted, defensively sort if
         // not, then assert dedup, then defensively unique.
-        Q_ASSERT(std::ranges::is_sorted(rows));
-        if (!std::ranges::is_sorted(rows))
+        //
+        // Hoist `is_sorted` into a local so the `Q_ASSERT` and the
+        // fallback `if` share one walk in debug builds (in release,
+        // `Q_ASSERT` compiles out and only the `if` runs once).
+        const bool sortedAsExpected = std::ranges::is_sorted(rows);
+        Q_ASSERT(sortedAsExpected);
+        if (!sortedAsExpected)
         {
             std::ranges::sort(rows);
         }

--- a/app/src/main_window.cpp
+++ b/app/src/main_window.cpp
@@ -666,9 +666,29 @@ MainWindow::MainWindow(ThemeControl *theme, SessionHistoryManager *historyManage
         }
     );
 
-    mActionToggleFind = new QAction(tr("Find"), this);
+    // Any signal that mutates the proxy's row set invalidates the
+    // find bar's cached match list. We always drop the cache
+    // (cheap) and -- when the bar is visible -- bump its debounce
+    // timer so a single recount runs once activity settles. Doing
+    // a synchronous recount per signal would melt under streaming
+    // (one batch arrives every ~250 ms; each scan is O(rows)).
+    auto refreshFindCount = [this]() {
+        InvalidateFindMatchCache();
+        if (mFindRecord != nullptr && mFindDock != nullptr && mFindDock->isVisible())
+        {
+            mFindRecord->BumpMatchCountDebounce();
+        }
+    };
+    connect(mModel, &QAbstractItemModel::modelReset, this, refreshFindCount);
+    connect(mSortFilterProxyModel, &QAbstractItemModel::rowsInserted, this, refreshFindCount);
+    connect(mSortFilterProxyModel, &QAbstractItemModel::rowsRemoved, this, refreshFindCount);
+    connect(mSortFilterProxyModel, &QAbstractItemModel::layoutChanged, this, refreshFindCount);
+    connect(mSortFilterProxyModel, &QAbstractItemModel::modelReset, this, refreshFindCount);
+
+    mActionToggleFind = new QAction(tr("Find Bar"), this);
     mActionToggleFind->setObjectName(QStringLiteral("actionToggleFind"));
     mActionToggleFind->setCheckable(true);
+    mActionToggleFind->setToolTip(tr("Show or hide the find bar (Ctrl+F to focus)."));
     addAction(mActionToggleFind);
     connect(mActionToggleFind, &QAction::toggled, this, [this](bool on) {
         if (on && !isVisible())
@@ -696,14 +716,24 @@ MainWindow::MainWindow(ThemeControl *theme, SessionHistoryManager *historyManage
 
     // Parse-errors dock replaces the old `QMessageBox::warning`
     // popups for streaming / open errors. Hidden until the first
-    // error of a session; `ShowParseErrors` auto-raises.
+    // error of a session; `ShowParseErrors` auto-raises only on
+    // the first batch (subsequent batches use the status-bar
+    // indicator).
     mParseErrorsDock = new ParseErrorsDock(this);
     addDockWidget(Qt::BottomDockWidgetArea, mParseErrorsDock);
     mParseErrorsDock->hide();
 
+    // Default layout: tabify the two bottom docks so they share
+    // the same horizontal strip rather than stacking vertically
+    // and eating ~30% of the editor height when both are open.
+    // Manual drag-to-tabify still works after this; restoreState
+    // overrides on subsequent launches.
+    tabifyDockWidget(mFindDock, mParseErrorsDock);
+
     mActionToggleParseErrors = new QAction(tr("Parse Errors"), this);
     mActionToggleParseErrors->setObjectName(QStringLiteral("actionToggleParseErrors"));
     mActionToggleParseErrors->setCheckable(true);
+    mActionToggleParseErrors->setToolTip(tr("Show or hide the Parse Errors panel."));
     addAction(mActionToggleParseErrors);
     connect(mActionToggleParseErrors, &QAction::toggled, this, [this](bool on) {
         if (on && !isVisible())
@@ -729,6 +759,12 @@ MainWindow::MainWindow(ThemeControl *theme, SessionHistoryManager *historyManage
     mRecordDetailDock = new RecordDetailDock(mModel, this);
     addDockWidget(Qt::RightDockWidgetArea, mRecordDetailDock);
     mRecordDetailDock->hide();
+
+    // Tab the two right-side docks (Anchors + Record Details) so
+    // they share the same panel by default. `restoreState` (run
+    // at the end of the constructor) overrides on subsequent
+    // launches if the user moved them.
+    tabifyDockWidget(mAnchorsDock, mRecordDetailDock);
     // `actionToggleRecordDetails` is declared in `main_window.ui` but
     // not placed in any `<addaction>`, so uic doesn't add it to any
     // widget's `actions()`. A QAction's shortcut only fires once it
@@ -1615,6 +1651,13 @@ void MainWindow::NewSession()
         mAnchors->ClearAll();
     }
 
+    // Parse errors are also session-scoped: a fresh session must
+    // not show diagnostics inherited from the discarded one.
+    if (mParseErrorsDock != nullptr)
+    {
+        mParseErrorsDock->ClearErrors();
+    }
+
     mCurrentSource.reset();
     mSessionMode = SessionMode::Idle;
     mLastTerminalSessionMode = SessionMode::Idle;
@@ -1841,6 +1884,11 @@ void MainWindow::StartStreamingOpenQueue(QStringList files, OpenMode mode)
         if (mAnchors != nullptr)
         {
             mAnchors->ClearAll();
+        }
+        // Parse errors are also session-scoped; preserved on append.
+        if (mParseErrorsDock != nullptr)
+        {
+            mParseErrorsDock->ClearErrors();
         }
         mCurrentSource.reset();
         mSessionMode = SessionMode::Idle;
@@ -2160,6 +2208,11 @@ void MainWindow::OpenLogStreamFromPath(const QString &file)
     {
         mAnchors->ClearAll();
     }
+    // Parse errors are session-scoped.
+    if (mParseErrorsDock != nullptr)
+    {
+        mParseErrorsDock->ClearErrors();
+    }
     // Live-tail is transient and not auto-saved; leaving the prior
     // static session's uuid pinned would let closeEvent's
     // `RemoveOpenWindowUuid` drop that session from the multi-
@@ -2278,6 +2331,11 @@ void MainWindow::OpenNetworkStream()
     if (mAnchors != nullptr)
     {
         mAnchors->ClearAll();
+    }
+    // Parse errors are session-scoped.
+    if (mParseErrorsDock != nullptr)
+    {
+        mParseErrorsDock->ClearErrors();
     }
     DetachAutoSaveUuid();
 
@@ -3448,48 +3506,83 @@ void MainWindow::UpdateFindMatchCount(const QString &text, bool wildcards, bool 
     }
     if (text.isEmpty())
     {
+        InvalidateFindMatchCache();
         mFindRecord->SetMatchInfo(0, 0);
         return;
     }
-    Qt::MatchFlags flags = Qt::MatchContains | Qt::MatchWrap | Qt::MatchRecursive;
-    if (wildcards)
-    {
-        flags |= Qt::MatchWildcard;
-    }
-    if (regularExpressions)
-    {
-        flags |= Qt::MatchRegularExpression;
-    }
-    const QModelIndex start = mSortFilterProxyModel->index(0, 0);
-    if (!start.isValid())
-    {
-        mFindRecord->SetMatchInfo(0, 0);
-        return;
-    }
-    const QVariant value = QVariant::fromValue(text);
-    const QModelIndexList matches =
-        mSortFilterProxyModel->MatchRow(start, Qt::DisplayRole, value, LogFilterModel::UNLIMITED_HITS, flags, true, 0);
-    const int total = static_cast<int>(matches.size());
 
-    int currentOneBased = 0;
-    if (total > 0)
+    // Rebuild the cache only when the needle / flags actually
+    // changed. A Next / Previous click reports the same needle,
+    // so the second call skips the full-table scan and just
+    // updates `i` via the binary-search below.
+    const bool cacheHit = mFindMatchCache.has_value() && mFindMatchCache->needle == text &&
+                          mFindMatchCache->wildcards == wildcards &&
+                          mFindMatchCache->regularExpressions == regularExpressions;
+    if (!cacheHit)
     {
-        // Locate the current selection within the match list so
-        // the bar can render "i of N" instead of just "N matches".
-        const QModelIndex currentIdx = mTableView != nullptr ? mTableView->currentIndex() : QModelIndex();
+        Qt::MatchFlags flags = Qt::MatchContains | Qt::MatchWrap | Qt::MatchRecursive;
+        if (wildcards)
+        {
+            flags |= Qt::MatchWildcard;
+        }
+        if (regularExpressions)
+        {
+            flags |= Qt::MatchRegularExpression;
+        }
+        const QModelIndex start = mSortFilterProxyModel->index(0, 0);
+        if (!start.isValid())
+        {
+            InvalidateFindMatchCache();
+            mFindRecord->SetMatchInfo(0, 0);
+            return;
+        }
+        const QVariant value = QVariant::fromValue(text);
+        const QModelIndexList matches = mSortFilterProxyModel->MatchRow(
+            start, Qt::DisplayRole, value, LogFilterModel::UNLIMITED_HITS, flags, true, 0
+        );
+        // Dedupe to row level: a row matching in N visible
+        // columns yields N entries from `MatchRow`, but the user
+        // navigates and counts in row order. Sorting + uniquing
+        // also unlocks the binary-search lookup below.
+        std::vector<int> rows;
+        rows.reserve(matches.size());
+        for (const QModelIndex &m : matches)
+        {
+            rows.push_back(m.row());
+        }
+        std::ranges::sort(rows);
+        const auto last = std::ranges::unique(rows);
+        rows.erase(last.begin(), last.end());
+        mFindMatchCache = FindMatchCache{
+            .needle = text,
+            .wildcards = wildcards,
+            .regularExpressions = regularExpressions,
+            .sortedRows = std::move(rows),
+        };
+    }
+
+    const int total = static_cast<int>(mFindMatchCache->sortedRows.size());
+    int currentOneBased = 0;
+    if (total > 0 && mTableView != nullptr)
+    {
+        const QModelIndex currentIdx = mTableView->currentIndex();
         if (currentIdx.isValid())
         {
-            for (int i = 0; i < matches.size(); ++i)
+            const auto begin = mFindMatchCache->sortedRows.begin();
+            const auto end = mFindMatchCache->sortedRows.end();
+            const auto it = std::lower_bound(begin, end, currentIdx.row());
+            if (it != end && *it == currentIdx.row())
             {
-                if (matches[i].row() == currentIdx.row())
-                {
-                    currentOneBased = i + 1;
-                    break;
-                }
+                currentOneBased = static_cast<int>(it - begin) + 1;
             }
         }
     }
     mFindRecord->SetMatchInfo(currentOneBased, total);
+}
+
+void MainWindow::InvalidateFindMatchCache()
+{
+    mFindMatchCache.reset();
 }
 
 bool MainWindow::DoLoadConfiguration(const QString &path)
@@ -3529,6 +3622,12 @@ bool MainWindow::ApplyLoadedConfiguration(loglib::LogConfiguration parsed)
         const SessionSwitchScope switchGuard(*this);
 
         mModel->Reset();
+        // Parse errors are session-scoped: a config load is a
+        // destructive session boundary just like `NewSession`.
+        if (mParseErrorsDock != nullptr)
+        {
+            mParseErrorsDock->ClearErrors();
+        }
         mModel->ConfigurationManager().SetConfiguration(std::move(parsed));
         // `SetConfiguration` does not emit a model signal; the
         // reset re-initialises the header section count and the
@@ -3844,9 +3943,12 @@ void MainWindow::FindRecords(const QString &text, bool next, bool wildcards, boo
     }
 
     // Refresh the find bar's "i of N" indicator now that the
-    // current index has moved. Gated on the bar actually being
-    // visible so a programmatic `FindRecords` call from a test
-    // path does not pay for the full-table count scan.
+    // current index has moved. With the match-row cache in place,
+    // the same `(text, flags)` is a cache hit and resolves the new
+    // `i` via binary search -- no full-table scan. Gated on the
+    // bar being visible so a programmatic `FindRecords` call from
+    // a test path doesn't pay even for the cache rebuild on the
+    // first hit.
     if (mFindDock != nullptr && mFindDock->isVisible())
     {
         UpdateFindMatchCount(text, wildcards, regularExpressions);

--- a/app/src/main_window.cpp
+++ b/app/src/main_window.cpp
@@ -689,16 +689,45 @@ MainWindow::MainWindow(ThemeControl *theme, SessionHistoryManager *historyManage
     // find bar's cached match list. `OnFindCacheInvalidated`
     // drops the cache (cheap) and -- when the bar is visible --
     // bumps the debounce timer so a single recount runs once the
-    // activity settles. `dataChanged` covers in-place cell
-    // updates that don't shift the row set (enum dictionary
-    // growth, column renames); both can still flip whether a row
-    // matches the current needle.
-    connect(mModel, &QAbstractItemModel::modelReset, this, &MainWindow::OnFindCacheInvalidated);
+    // activity settles.
+    //
+    // `modelReset` is hooked on the proxy only: the source-side
+    // reset chains through the proxy and emits a second time, so
+    // listening to both would fire `OnFindCacheInvalidated` twice
+    // per reset. Same logic for `rowsInserted/Removed` and
+    // `layoutChanged`.
+    //
+    // Column structure changes can flip which columns participate
+    // in the search even when no row text actually changed, so the
+    // column-mutating signals invalidate too.
     connect(mSortFilterProxyModel, &QAbstractItemModel::rowsInserted, this, &MainWindow::OnFindCacheInvalidated);
     connect(mSortFilterProxyModel, &QAbstractItemModel::rowsRemoved, this, &MainWindow::OnFindCacheInvalidated);
     connect(mSortFilterProxyModel, &QAbstractItemModel::layoutChanged, this, &MainWindow::OnFindCacheInvalidated);
     connect(mSortFilterProxyModel, &QAbstractItemModel::modelReset, this, &MainWindow::OnFindCacheInvalidated);
-    connect(mSortFilterProxyModel, &QAbstractItemModel::dataChanged, this, &MainWindow::OnFindCacheInvalidated);
+    connect(mSortFilterProxyModel, &QAbstractItemModel::columnsInserted, this, &MainWindow::OnFindCacheInvalidated);
+    connect(mSortFilterProxyModel, &QAbstractItemModel::columnsRemoved, this, &MainWindow::OnFindCacheInvalidated);
+    connect(mSortFilterProxyModel, &QAbstractItemModel::columnsMoved, this, &MainWindow::OnFindCacheInvalidated);
+    // `dataChanged` covers in-place cell updates that don't shift
+    // the row set (enum dictionary growth, column renames). It
+    // also fires for theme repaints (`{BackgroundRole,
+    // ForegroundRole}` only) which can't affect display-role
+    // matching, so filter those out -- otherwise every level /
+    // theme change during streaming wakes the debounce timer for
+    // no work. An empty `roles` list is Qt's "I don't know what
+    // changed" sentinel; treat it as conservatively dirty.
+    connect(
+        mSortFilterProxyModel,
+        &QAbstractItemModel::dataChanged,
+        this,
+        [this](const QModelIndex & /*topLeft*/, const QModelIndex & /*bottomRight*/, const QList<int> &roles) {
+            if (!roles.isEmpty() && !roles.contains(Qt::DisplayRole) &&
+                !roles.contains(static_cast<int>(LogModelItemDataRole::SortRole)))
+            {
+                return;
+            }
+            OnFindCacheInvalidated();
+        }
+    );
 
     mActionToggleFind = new QAction(tr("Find Bar"), this);
     mActionToggleFind->setObjectName(QStringLiteral("actionToggleFind"));
@@ -749,6 +778,18 @@ MainWindow::MainWindow(ThemeControl *theme, SessionHistoryManager *historyManage
     connect(mFindDock, &FindDock::closed, this, [this]() {
         const QSignalBlocker blocker(mActionToggleFind);
         mActionToggleFind->setChecked(false);
+    });
+    // Catch up the match count after a reveal -- the cache may
+    // have been invalidated by streaming / filter activity while
+    // the bar was hidden or buried under a sibling tab, in which
+    // case the label was last updated against a stale dataset.
+    // `BumpMatchCountDebounce` no-ops on an empty needle, so the
+    // common case (re-show, no prior search) costs nothing.
+    connect(mFindDock, &FindDock::revealed, this, [this]() {
+        if (mFindRecord != nullptr)
+        {
+            mFindRecord->BumpMatchCountDebounce();
+        }
     });
 
     // Parse-errors dock replaces the old `QMessageBox::warning`
@@ -3616,6 +3657,11 @@ void MainWindow::UpdateFindMatchCount(const QString &text, bool wildcards, bool 
     }
     if (text.isEmpty())
     {
+        // `FindRecordWidget::RequestMatchCountSoon` already
+        // suppresses the signal for an empty needle, so the only
+        // way we land here is a programmatic call (e.g. the
+        // post-`FindRecords` refresh after a Clear). Keep the
+        // label clear in case the cache was previously populated.
         InvalidateFindMatchCache();
         mFindRecord->SetMatchInfo(0, 0);
         return;

--- a/app/src/main_window.cpp
+++ b/app/src/main_window.cpp
@@ -482,15 +482,36 @@ MainWindow::MainWindow(ThemeControl *theme, SessionHistoryManager *historyManage
             mActionToggleAnchors->setChecked(false);
             return;
         }
-        mAnchorsDock->setVisible(on);
         if (on)
         {
+            mAnchorsDock->show();
             mAnchorsDock->raise();
         }
+        else
+        {
+            // `close()` so the dock's `closeEvent` fires and the
+            // `closed` signal reaches the menu sync handler; raw
+            // `setVisible(false)` would bypass that path.
+            mAnchorsDock->close();
+        }
     });
+    // Show-side only: `visibilityChanged(false)` fires on tab
+    // inactivation in tabified groups (Anchors is tabified with
+    // Record Details below), which would falsely un-check the
+    // menu entry every time the user switched tabs. The
+    // `AnchorsDock::closed` signal handles user-initiated
+    // dismissal cleanly.
     connect(mAnchorsDock, &QDockWidget::visibilityChanged, this, [this](bool visible) {
+        if (!visible)
+        {
+            return;
+        }
         const QSignalBlocker blocker(mActionToggleAnchors);
-        mActionToggleAnchors->setChecked(visible);
+        mActionToggleAnchors->setChecked(true);
+    });
+    connect(mAnchorsDock, &AnchorsDock::closed, this, [this]() {
+        const QSignalBlocker blocker(mActionToggleAnchors);
+        mActionToggleAnchors->setChecked(false);
     });
     // `modelReset` clears the header's hidden flags, but
     // `Column::visible` survives. Re-apply on every reset so load /
@@ -662,46 +683,22 @@ MainWindow::MainWindow(ThemeControl *theme, SessionHistoryManager *historyManage
     mFindDock->hide();
     mFindRecord = mFindDock->Widget();
     connect(mFindRecord, &FindRecordWidget::FindRecords, this, &MainWindow::FindRecords);
-    connect(
-        mFindRecord,
-        &FindRecordWidget::MatchCountRequested,
-        this,
-        [this](const QString &text, bool wildcards, bool regularExpressions) {
-            UpdateFindMatchCount(text, wildcards, regularExpressions);
-        }
-    );
+    connect(mFindRecord, &FindRecordWidget::MatchCountRequested, this, &MainWindow::UpdateFindMatchCount);
 
     // Any signal that mutates the proxy's row set invalidates the
-    // find bar's cached match list. We always drop the cache
-    // (cheap) and -- when the bar is visible -- bump its debounce
-    // timer so a single recount runs once activity settles. Doing
-    // a synchronous recount per signal would melt under streaming
-    // (one batch arrives every ~250 ms; each scan is O(rows)).
-    auto refreshFindCount = [this]() {
-        InvalidateFindMatchCache();
-        if (mFindRecord != nullptr && mFindDock != nullptr && mFindDock->isVisible())
-        {
-            mFindRecord->BumpMatchCountDebounce();
-        }
-    };
-    connect(mModel, &QAbstractItemModel::modelReset, this, refreshFindCount);
-    connect(mSortFilterProxyModel, &QAbstractItemModel::rowsInserted, this, refreshFindCount);
-    connect(mSortFilterProxyModel, &QAbstractItemModel::rowsRemoved, this, refreshFindCount);
-    connect(mSortFilterProxyModel, &QAbstractItemModel::layoutChanged, this, refreshFindCount);
-    connect(mSortFilterProxyModel, &QAbstractItemModel::modelReset, this, refreshFindCount);
-    // `dataChanged` covers in-place cell updates that don't shift
-    // the row set: enum dictionary growth re-formats existing
-    // cells, and a column rename is published this way too. Both
-    // can flip whether a row matches the current needle, so the
-    // cached match list has to invalidate. Wired on the proxy
-    // (not the source) so Qt's row-mapping is already applied
-    // by the time the slot runs.
-    connect(
-        mSortFilterProxyModel,
-        &QAbstractItemModel::dataChanged,
-        this,
-        [refreshFindCount](const QModelIndex &, const QModelIndex &, const QList<int> &) { refreshFindCount(); }
-    );
+    // find bar's cached match list. `OnFindCacheInvalidated`
+    // drops the cache (cheap) and -- when the bar is visible --
+    // bumps the debounce timer so a single recount runs once the
+    // activity settles. `dataChanged` covers in-place cell
+    // updates that don't shift the row set (enum dictionary
+    // growth, column renames); both can still flip whether a row
+    // matches the current needle.
+    connect(mModel, &QAbstractItemModel::modelReset, this, &MainWindow::OnFindCacheInvalidated);
+    connect(mSortFilterProxyModel, &QAbstractItemModel::rowsInserted, this, &MainWindow::OnFindCacheInvalidated);
+    connect(mSortFilterProxyModel, &QAbstractItemModel::rowsRemoved, this, &MainWindow::OnFindCacheInvalidated);
+    connect(mSortFilterProxyModel, &QAbstractItemModel::layoutChanged, this, &MainWindow::OnFindCacheInvalidated);
+    connect(mSortFilterProxyModel, &QAbstractItemModel::modelReset, this, &MainWindow::OnFindCacheInvalidated);
+    connect(mSortFilterProxyModel, &QAbstractItemModel::dataChanged, this, &MainWindow::OnFindCacheInvalidated);
 
     mActionToggleFind = new QAction(tr("Find Bar"), this);
     mActionToggleFind->setObjectName(QStringLiteral("actionToggleFind"));
@@ -724,12 +721,34 @@ MainWindow::MainWindow(ThemeControl *theme, SessionHistoryManager *historyManage
         }
         else
         {
-            mFindDock->hide();
+            // `close()` (not bare `hide()`) so the dock subclass'
+            // `closeEvent` fires and `closed` propagates. Without
+            // it the matched show/hide-edge handlers above would
+            // become asymmetric: show via `closeEvent` accept,
+            // hide via raw `hide()` -> no signal -> menu state OK
+            // only because the toggle already set itself.
+            // Keeping the symmetry simplifies reasoning.
+            mFindDock->close();
         }
     });
+    // `QDockWidget::visibilityChanged(false)` fires on tab
+    // inactivation too, not just user dismissal, so binding the
+    // checkmark blindly to it would un-check the menu entry every
+    // time the user switched tabs in the tabified bottom group.
+    // Drive the off-state from the `closed` signal (genuine user
+    // close) and only mirror the on-state from `visibilityChanged`
+    // (the show direction is unambiguous).
     connect(mFindDock, &QDockWidget::visibilityChanged, this, [this](bool visible) {
+        if (!visible)
+        {
+            return;
+        }
         const QSignalBlocker blocker(mActionToggleFind);
-        mActionToggleFind->setChecked(visible);
+        mActionToggleFind->setChecked(true);
+    });
+    connect(mFindDock, &FindDock::closed, this, [this]() {
+        const QSignalBlocker blocker(mActionToggleFind);
+        mActionToggleFind->setChecked(false);
     });
 
     // Parse-errors dock replaces the old `QMessageBox::warning`
@@ -760,17 +779,55 @@ MainWindow::MainWindow(ThemeControl *theme, SessionHistoryManager *historyManage
             mActionToggleParseErrors->setChecked(false);
             return;
         }
-        mParseErrorsDock->setVisible(on);
         if (on)
         {
+            mParseErrorsDock->show();
             mParseErrorsDock->raise();
         }
+        else
+        {
+            mParseErrorsDock->close();
+        }
     });
+    // Same tab-switch protection as `mFindDock` above: `closed`
+    // is the trustworthy off-edge; `visibilityChanged(true)`
+    // covers the on-edge.
     connect(mParseErrorsDock, &QDockWidget::visibilityChanged, this, [this](bool visible) {
+        if (!visible)
+        {
+            return;
+        }
         const QSignalBlocker blocker(mActionToggleParseErrors);
-        mActionToggleParseErrors->setChecked(visible);
+        mActionToggleParseErrors->setChecked(true);
+    });
+    connect(mParseErrorsDock, &ParseErrorsDock::closed, this, [this]() {
+        const QSignalBlocker blocker(mActionToggleParseErrors);
+        mActionToggleParseErrors->setChecked(false);
     });
     connect(mParseErrorsDock, &ParseErrorsDock::countChanged, this, &MainWindow::UpdateParseErrorsStatus);
+    // First batch of a session: surface the panel, unless the user
+    // is actively interacting with another bottom-area dock (the
+    // find bar in particular). Raising over an in-progress search
+    // would yank the user's focus and reset their query mid-type.
+    connect(mParseErrorsDock, &ParseErrorsDock::firstBatchArrived, this, [this]() {
+        if (mParseErrorsDock == nullptr)
+        {
+            return;
+        }
+        if (mFindDock != nullptr && mFindDock->isVisible() &&
+            mFindDock->isAncestorOf(QApplication::focusWidget()))
+        {
+            // Find bar holds focus; status-bar indicator alone is
+            // enough notice. Auto-raise on the *next* session's
+            // first batch instead.
+            return;
+        }
+        if (!mParseErrorsDock->isVisible())
+        {
+            mParseErrorsDock->show();
+        }
+        mParseErrorsDock->raise();
+    });
 
     // Record-detail dock: hidden by default; the View menu's Ctrl+I
     // toggle and row double-click both surface it.
@@ -799,21 +856,34 @@ MainWindow::MainWindow(ThemeControl *theme, SessionHistoryManager *historyManage
             ui->actionToggleRecordDetails->setChecked(false);
             return;
         }
-        mRecordDetailDock->setVisible(on);
         if (on)
         {
+            mRecordDetailDock->show();
             mRecordDetailDock->raise();
         }
-    });
-    // Mirror dock visibility back onto the menu entry so the title-bar
-    // X also un-checks it. `QSignalBlocker` breaks the toggled loop.
-    connect(mRecordDetailDock, &QDockWidget::visibilityChanged, this, [this](bool visible) {
-        const QSignalBlocker blocker(ui->actionToggleRecordDetails);
-        ui->actionToggleRecordDetails->setChecked(visible);
-        if (visible)
+        else
         {
-            UpdateRecordDetailsFromSelection();
+            mRecordDetailDock->close();
         }
+    });
+    // Mirror dock visibility back onto the menu entry. Show-side
+    // is driven by `visibilityChanged(true)` (also fires on tab
+    // activation, which is the right time to re-pin the selection).
+    // Off-edge listens to `RecordDetailDock::closed` so tab
+    // inactivation in the (Anchors + Record Details) tab group
+    // doesn't drop the menu checkmark.
+    connect(mRecordDetailDock, &QDockWidget::visibilityChanged, this, [this](bool visible) {
+        if (!visible)
+        {
+            return;
+        }
+        const QSignalBlocker blocker(ui->actionToggleRecordDetails);
+        ui->actionToggleRecordDetails->setChecked(true);
+        UpdateRecordDetailsFromSelection();
+    });
+    connect(mRecordDetailDock, &RecordDetailDock::closed, this, [this]() {
+        const QSignalBlocker blocker(ui->actionToggleRecordDetails);
+        ui->actionToggleRecordDetails->setChecked(false);
     });
     connect(mRecordDetailDock, &RecordDetailDock::openInNewWindowRequested, this, &MainWindow::OpenRecordDetailWindow);
 
@@ -2015,7 +2085,7 @@ void MainWindow::OnStreamingFinished(StreamingResult result)
             std::make_move_iterator(mPendingOpenErrors.end())
         );
         mPendingOpenErrors.clear();
-        ShowParseErrors("Error Parsing Logs", errors);
+        ShowParseErrors(tr("Error Parsing Logs"), errors);
     }
     else
     {
@@ -2148,7 +2218,7 @@ void MainWindow::StreamNextPendingFile()
     // otherwise the `streamingFinished` summary folds them in.
     if (!IsSessionActive() && !mPendingOpenErrors.empty())
     {
-        ShowParseErrors("Error Opening File", mPendingOpenErrors);
+        ShowParseErrors(tr("Error Opening File"), mPendingOpenErrors);
         mPendingOpenErrors.clear();
     }
 }
@@ -2185,7 +2255,7 @@ void MainWindow::OpenLogStreamFromPath(const QString &file)
     catch (const std::exception &e)
     {
         ShowParseErrors(
-            "Error Opening Log Stream",
+            tr("Error Opening Log Stream"),
             {std::string("Failed to open '") + file.toStdString() + "' for streaming: " + e.what()}
         );
         return;
@@ -2320,7 +2390,7 @@ void MainWindow::OpenNetworkStream()
     catch (const std::exception &e)
     {
         ShowParseErrors(
-            "Error Opening Network Stream",
+            tr("Error Opening Network Stream"),
             {std::string("Failed to start network listener on ") + cfg.bindAddress.toStdString() + ":" +
              std::to_string(cfg.port) + ": " + e.what()}
         );
@@ -3495,13 +3565,13 @@ void MainWindow::UpdateDiagnosticsStatus()
     mDiagnosticsButton->show();
 }
 
-void MainWindow::UpdateParseErrorsStatus(int count)
+void MainWindow::UpdateParseErrorsStatus(int count, int droppedCount)
 {
     if (mParseErrorsStatusButton == nullptr)
     {
         return;
     }
-    if (count <= 0)
+    if (count <= 0 && droppedCount <= 0)
     {
         mParseErrorsStatusButton->hide();
         mParseErrorsStatusButton->setText(QString());
@@ -3512,10 +3582,29 @@ void MainWindow::UpdateParseErrorsStatus(int count)
     // streaming-status text. Plain `%n` would print "1234" and
     // jitter the button width as counts grew across a streaming
     // session.
-    mParseErrorsStatusButton->setText(tr("%Ln parse error(s)", nullptr, count));
-    mParseErrorsStatusButton->setToolTip(
-        tr("%Ln parse error(s) recorded in this session. Click to open the Parse Errors panel.", nullptr, count)
-    );
+    const int displayedTotal = count + droppedCount;
+    mParseErrorsStatusButton->setText(tr("%Ln parse error(s)", nullptr, displayedTotal));
+    if (droppedCount > 0)
+    {
+        // Two independent counts -> can't use a single `%Ln`
+        // plural; format both via QLocale so the tooltip matches
+        // the dock summary ("12,345 errors; 1,000 earlier
+        // dropped").
+        const QLocale locale = QLocale::system();
+        mParseErrorsStatusButton->setToolTip(
+            tr("%1 parse error(s) in this session "
+               "(%2 visible, %3 earlier dropped). Click to open the Parse Errors panel.")
+                .arg(locale.toString(static_cast<qlonglong>(displayedTotal)))
+                .arg(locale.toString(static_cast<qlonglong>(count)))
+                .arg(locale.toString(static_cast<qlonglong>(droppedCount)))
+        );
+    }
+    else
+    {
+        mParseErrorsStatusButton->setToolTip(
+            tr("%Ln parse error(s) in this session. Click to open the Parse Errors panel.", nullptr, count)
+        );
+    }
     mParseErrorsStatusButton->show();
 }
 
@@ -3541,14 +3630,22 @@ void MainWindow::UpdateFindMatchCount(const QString &text, bool wildcards, bool 
                           mFindMatchCache->regularExpressions == regularExpressions;
     if (!cacheHit)
     {
-        Qt::MatchFlags flags = Qt::MatchContains | Qt::MatchWrap | Qt::MatchRecursive;
-        if (wildcards)
-        {
-            flags |= Qt::MatchWildcard;
-        }
+        // Same exclusivity discipline as `FindRecords`: contains /
+        // wildcard / regex are mutually exclusive match modes in
+        // `LogFilterModel::Matches`; mixing them silently downgrades
+        // to contains.
+        Qt::MatchFlags flags = Qt::MatchWrap | Qt::MatchRecursive;
         if (regularExpressions)
         {
             flags |= Qt::MatchRegularExpression;
+        }
+        else if (wildcards)
+        {
+            flags |= Qt::MatchWildcard;
+        }
+        else
+        {
+            flags |= Qt::MatchContains;
         }
         const QModelIndex start = mSortFilterProxyModel->index(0, 0);
         if (!start.isValid())
@@ -3606,6 +3703,15 @@ void MainWindow::UpdateFindMatchCount(const QString &text, bool wildcards, bool 
 void MainWindow::InvalidateFindMatchCache()
 {
     mFindMatchCache.reset();
+}
+
+void MainWindow::OnFindCacheInvalidated()
+{
+    InvalidateFindMatchCache();
+    if (mFindRecord != nullptr && mFindDock != nullptr && mFindDock->isVisible())
+    {
+        mFindRecord->BumpMatchCountDebounce();
+    }
 }
 
 bool MainWindow::DoLoadConfiguration(const QString &path)
@@ -3946,14 +4052,24 @@ void MainWindow::FindRecords(const QString &text, bool next, bool wildcards, boo
     {
         searchStartIndex = mTableView->currentIndex();
     }
-    Qt::MatchFlags flags = Qt::MatchContains | Qt::MatchWrap | Qt::MatchRecursive;
-    if (wildcards)
-    {
-        flags |= Qt::MatchWildcard;
-    }
+    // `MatchContains` / `MatchWildcard` / `MatchRegularExpression` are
+    // *alternatives*, not additions: `LogFilterModel::Matches` checks
+    // them in declaration order and short-circuits on the first hit.
+    // OR-ing `MatchContains` with one of the others therefore silently
+    // demotes the search to plain substring matching, so the regex /
+    // wildcard toggles look enabled but match like they're off.
+    Qt::MatchFlags flags = Qt::MatchWrap | Qt::MatchRecursive;
     if (regularExpressions)
     {
         flags |= Qt::MatchRegularExpression;
+    }
+    else if (wildcards)
+    {
+        flags |= Qt::MatchWildcard;
+    }
+    else
+    {
+        flags |= Qt::MatchContains;
     }
     int skipFirstN = 0;
     if (mTableView->selectionModel()->isRowSelected(searchStartIndex.row()))

--- a/app/src/parse_errors_dock.cpp
+++ b/app/src/parse_errors_dock.cpp
@@ -159,7 +159,7 @@ void ParseErrorsDock::AppendErrors(const QString &title, const std::vector<std::
     // the list.
     if (const int last = mList->count() - 1; last >= 0)
     {
-        QListWidgetItem *tail = mList->item(last);
+        const QListWidgetItem *tail = mList->item(last);
         if (tail != nullptr && tail->data(OVERFLOW_FOOTER_ROLE).toBool())
         {
             delete mList->takeItem(last);
@@ -296,7 +296,7 @@ void ParseErrorsDock::TrimToCap()
     bool haveEvictedHeader = false;
     while (mList->count() > 0 && mErrorCount > MAX_DISPLAYED_ERRORS)
     {
-        QListWidgetItem *item = mList->takeItem(0);
+        const QListWidgetItem *item = mList->takeItem(0);
         if (item == nullptr)
         {
             continue;
@@ -328,7 +328,7 @@ void ParseErrorsDock::TrimToCap()
     // the *next* batch's header sitting below them.
     if (haveEvictedHeader && mList->count() > 0)
     {
-        QListWidgetItem *first = mList->item(0);
+        const QListWidgetItem *first = mList->item(0);
         if (first != nullptr && first->flags().testFlag(Qt::ItemIsSelectable))
         {
             auto *replacement = new QListWidgetItem(lastEvictedHeaderText);
@@ -350,13 +350,13 @@ void ParseErrorsDock::TrimToCap()
     // its header survive after the eviction-then-reinsert dance.
     while (mList->count() > 0)
     {
-        QListWidgetItem *first = mList->item(0);
+        const QListWidgetItem *first = mList->item(0);
         if (first == nullptr || first->flags().testFlag(Qt::ItemIsSelectable))
         {
             break;
         }
         // First item is a header. Look at its successor.
-        QListWidgetItem *second = mList->count() > 1 ? mList->item(1) : nullptr;
+        const QListWidgetItem *second = mList->count() > 1 ? mList->item(1) : nullptr;
         const bool isOrphan = second == nullptr || !second->flags().testFlag(Qt::ItemIsSelectable);
         if (!isOrphan)
         {
@@ -412,12 +412,12 @@ void ParseErrorsDock::CopySelection() const
     // self-contained text rather than orphaned messages.
     QStringList lines;
     const int count = mList->count();
-    QListWidgetItem *currentHeader = nullptr;
+    const QListWidgetItem *currentHeader = nullptr;
     bool currentHeaderEmitted = false;
     bool sawAnyError = false;
     for (int i = 0; i < count; ++i)
     {
-        QListWidgetItem *item = mList->item(i);
+        const QListWidgetItem *item = mList->item(i);
         if (item == nullptr)
         {
             continue;
@@ -454,7 +454,7 @@ void ParseErrorsDock::CopySelection() const
         // header summary.
         for (int i = count - 1; i >= 0; --i)
         {
-            QListWidgetItem *item = mList->item(i);
+            const QListWidgetItem *item = mList->item(i);
             if (item != nullptr && item->data(OVERFLOW_FOOTER_ROLE).toBool())
             {
                 lines.append(item->text());

--- a/app/src/parse_errors_dock.cpp
+++ b/app/src/parse_errors_dock.cpp
@@ -13,6 +13,7 @@
 #include <QListWidgetItem>
 #include <QLocale>
 #include <QPushButton>
+#include <QScrollBar>
 #include <QShortcut>
 #include <QStringList>
 #include <QStyle>
@@ -36,6 +37,15 @@ constexpr int LAYOUT_SPACING = 4;
 /// footer item so `TrimToCap` can replace it in place instead of
 /// minting a new one each batch.
 constexpr int OVERFLOW_FOOTER_ROLE = Qt::UserRole + 1;
+
+/// Pixel slack on the vertical scrollbar's `max - value` reading
+/// below which we treat the user as "still at the tail". Anything
+/// inside this band auto-follows new batches; anything outside it
+/// preserves the user's scroll position so they can read earlier
+/// errors without being yanked back to the end on every append.
+/// Sized to absorb a row or two of rounding from
+/// `verticalScrollBar()`'s integer reporting.
+constexpr int AUTO_FOLLOW_TAIL_SLACK_PX = 4;
 } // namespace
 
 ParseErrorsDock::ParseErrorsDock(QWidget *parent)
@@ -116,6 +126,16 @@ void ParseErrorsDock::AppendErrors(const QString &title, const std::vector<std::
     // pop back open every batch.
     const bool firstBatchOfSession = mErrorCount == 0 && mDroppedCount == 0;
 
+    // Snapshot the user's scroll position *before* mutating the
+    // list. If they were already pinned at the tail (auto-follow
+    // case, also the initial empty-list case), we'll re-pin after
+    // the append; if they had scrolled up to read earlier errors,
+    // we leave the viewport alone so the new batch doesn't yank
+    // them out of context. Mirrors the chat / log convention.
+    const QScrollBar *vBar = mList->verticalScrollBar();
+    const bool wasAtTail =
+        vBar == nullptr || (vBar->maximum() - vBar->value()) <= AUTO_FOLLOW_TAIL_SLACK_PX;
+
     // The trailing overflow footer (if any) must move to the
     // bottom after the new entries land. It is always the last
     // item by construction (`TrimToCap` appends it after every
@@ -174,7 +194,15 @@ void ParseErrorsDock::AppendErrors(const QString &title, const std::vector<std::
     // `mDroppedCount` regardless of which path got us there.
     RebuildOverflowFooter();
 
-    mList->scrollToBottom();
+    // Re-pin to the tail only when the user was already there.
+    // Otherwise the new batch lands silently and the user keeps
+    // reading whatever earlier rows they had scrolled up to. The
+    // status-bar indicator already surfaces the running count so
+    // they can tell something arrived without being interrupted.
+    if (wasAtTail)
+    {
+        mList->scrollToBottom();
+    }
     RefreshSummary();
     if (firstBatchOfSession)
     {

--- a/app/src/parse_errors_dock.cpp
+++ b/app/src/parse_errors_dock.cpp
@@ -22,29 +22,19 @@
 
 namespace
 {
-/// Minimum width that still renders a typical "Error Parsing
-/// Logs: <one-line message>" entry without the horizontal
-/// scrollbar getting in the way. The dock is meant for the bottom
-/// edge by default; keep it narrow enough for that.
+/// Minimum dock width that fits a typical "Error Parsing Logs:
+/// <message>" entry without a horizontal scrollbar.
 constexpr int DOCK_MIN_WIDTH = 320;
 
-/// Outer margins / spacing matching the find bar densities.
 constexpr int OUTER_MARGIN = 6;
 constexpr int HEADER_SPACING = 6;
 constexpr int LAYOUT_SPACING = 4;
 
-/// `Qt::UserRole` flag set on the trailing "+N more dropped"
-/// footer item so `TrimToCap` can replace it in place instead of
-/// minting a new one each batch.
+/// Flag on the trailing overflow footer item so we can identify it.
 constexpr int OVERFLOW_FOOTER_ROLE = Qt::UserRole + 1;
 
-/// Pixel slack on the vertical scrollbar's `max - value` reading
-/// below which we treat the user as "still at the tail". Anything
-/// inside this band auto-follows new batches; anything outside it
-/// preserves the user's scroll position so they can read earlier
-/// errors without being yanked back to the end on every append.
-/// Sized to absorb a row or two of rounding from
-/// `verticalScrollBar()`'s integer reporting.
+/// Slack on the scrollbar's `max - value`; inside this band we treat
+/// the user as "still at the tail" and auto-follow new batches.
 constexpr int AUTO_FOLLOW_TAIL_SLACK_PX = 4;
 } // namespace
 
@@ -80,29 +70,23 @@ ParseErrorsDock::ParseErrorsDock(QWidget *parent)
 
     mList = new QListWidget(body);
     mList->setObjectName(QStringLiteral("parseErrorsList"));
-    // Read-only: parse errors are diagnostic data, not something
-    // the user edits. Selectable so they can copy individual
-    // lines via Ctrl+C.
+    // Read-only diagnostic data; selectable so Ctrl+C can copy entries.
     mList->setSelectionMode(QAbstractItemView::ExtendedSelection);
     mList->setUniformItemSizes(false);
     mList->setTextElideMode(Qt::ElideMiddle);
     mList->setAlternatingRowColors(true);
     layout->addWidget(mList, /*stretch=*/1);
 
-    // Minimum on the content widget, not the dock: setting it on
-    // the dock propagates a 320 px floor onto the entire
-    // QMainWindow even while the dock itself is hidden.
+    // Minimum on the content widget, not the dock: setting it on the
+    // dock propagates the floor onto the entire QMainWindow even
+    // while the dock is hidden.
     body->setMinimumWidth(DOCK_MIN_WIDTH);
     setWidget(body);
 
     connect(mClearButton, &QPushButton::clicked, this, &ParseErrorsDock::ClearErrors);
 
-    // Ctrl+C copies the selected error rows. Parented on `body`
-    // (not `mList`) with `WidgetWithChildrenShortcut` so the
-    // shortcut still fires when the user has clicked the Clear
-    // button (which moves focus off the list but leaves the
-    // selection intact). Window-level Copy is preserved because
-    // the scope still excludes the rest of `MainWindow`.
+    // Ctrl+C on `body` (not `mList`) so the shortcut still fires
+    // after the user clicks Clear (which moves focus off the list).
     auto *copyShortcut = new QShortcut(QKeySequence::Copy, body);
     copyShortcut->setContext(Qt::WidgetWithChildrenShortcut);
     connect(copyShortcut, &QShortcut::activated, this, &ParseErrorsDock::CopySelection);
@@ -117,14 +101,9 @@ void ParseErrorsDock::AppendErrors(const QString &title, const std::vector<std::
         return;
     }
 
-    // Fall back to a non-empty group label when the caller passed
-    // an empty title. An empty `title` would otherwise render as
-    // a blank bold list row that looks like a missing translation
-    // or a corrupt entry. Every in-tree caller wraps the title in
-    // `tr(...)`, so this guard is purely defensive against a
-    // future caller that forgets -- the `qWarning` makes the
-    // omission visible instead of silently rendering a
-    // mystery-blank row.
+    // Guard against an empty title rendering as a blank bold row that
+    // looks like a missing translation. All in-tree callers pass
+    // `tr(...)`; the warning surfaces a future caller that forgets.
     QString effectiveTitle = title;
     if (effectiveTitle.isEmpty())
     {
@@ -134,29 +113,16 @@ void ParseErrorsDock::AppendErrors(const QString &title, const std::vector<std::
 
     const QIcon warningIcon = QApplication::style()->standardIcon(QStyle::SP_MessageBoxWarning);
 
-    // Decide whether this batch should fire `firstBatchArrived`
-    // (which `MainWindow` translates into auto-raising the dock).
-    // The flag flips on the first batch *per session* and is
-    // cleared only by `ResetSessionState` -- the in-dock Clear
-    // button leaves it set, so a user who clicked Clear and
-    // dismissed the dock is not yanked back to it the next time a
-    // streaming line fails to parse.
     const bool firstBatchOfSession = !mHasSeenFirstBatch;
 
-    // Snapshot the user's scroll position *before* mutating the
-    // list. If they were already pinned at the tail (auto-follow
-    // case, also the initial empty-list case), we'll re-pin after
-    // the append; if they had scrolled up to read earlier errors,
-    // we leave the viewport alone so the new batch doesn't yank
-    // them out of context. Mirrors the chat / log convention.
+    // Snapshot scroll position so we only re-pin to the tail if the
+    // user was already there. Otherwise the new batch lands silently
+    // and the user keeps reading whatever rows they scrolled up to.
     const QScrollBar *vBar = mList->verticalScrollBar();
     const bool wasAtTail = vBar == nullptr || (vBar->maximum() - vBar->value()) <= AUTO_FOLLOW_TAIL_SLACK_PX;
 
-    // The trailing overflow footer (if any) must move to the
-    // bottom after the new entries land. It is always the last
-    // item by construction (`TrimToCap` appends it after every
-    // trim), so we only need to inspect the tail rather than walk
-    // the list.
+    // Strip the existing overflow footer so the new entries land
+    // before it; we'll rebuild it at the tail below.
     if (const int last = mList->count() - 1; last >= 0)
     {
         const QListWidgetItem *tail = mList->item(last);
@@ -166,14 +132,9 @@ void ParseErrorsDock::AppendErrors(const QString &title, const std::vector<std::
         }
     }
 
-    // Pre-trim a pathologically large batch before constructing
-    // list items. If we instead let `TrimToCap` walk the list
-    // from the top, it would evict prior batches *and* the new
-    // batch's own group header before reaching the rows that
-    // outgrew the cap, leaving the surviving rows visually
-    // headerless. Skipping the leading slice up front keeps the
-    // header pinned to the rows it labels and avoids minting
-    // QListWidgetItem objects we'll only delete a moment later.
+    // Pre-trim a pathologically large batch so we don't mint items
+    // we'd immediately delete -- and so the batch's own header isn't
+    // evicted along with the surplus rows below it.
     size_t errorsBegin = 0;
     if (errors.size() > static_cast<size_t>(MAX_DISPLAYED_ERRORS))
     {
@@ -181,10 +142,7 @@ void ParseErrorsDock::AppendErrors(const QString &title, const std::vector<std::
         mDroppedCount += static_cast<int>(errorsBegin);
     }
 
-    // Group header so consecutive batches stay visually grouped
-    // even after the user scrolls into them. The header is
-    // disabled (non-selectable in keyboard nav) so arrow keys
-    // step over it.
+    // Group header (disabled so arrow keys step over it).
     auto *headerItem = new QListWidgetItem(effectiveTitle);
     QFont headerFont = headerItem->font();
     headerFont.setBold(true);
@@ -202,19 +160,11 @@ void ParseErrorsDock::AppendErrors(const QString &title, const std::vector<std::
     }
 
     TrimToCap();
-    // Footer rebuild is intentionally separate from `TrimToCap`:
-    // a single batch sized exactly at the cap pre-trims (bumping
-    // `mDroppedCount`) without ever pushing `mErrorCount` past
-    // `MAX_DISPLAYED_ERRORS`, so `TrimToCap` has no eviction work
-    // and would skip its tail block. The footer must reflect
-    // `mDroppedCount` regardless of which path got us there.
+    // Rebuild the footer here (not inside `TrimToCap`) because a batch
+    // sized exactly at the cap pre-trims (bumping `mDroppedCount`)
+    // without ever pushing `TrimToCap` past its no-op guard.
     RebuildOverflowFooter();
 
-    // Re-pin to the tail only when the user was already there.
-    // Otherwise the new batch lands silently and the user keeps
-    // reading whatever earlier rows they had scrolled up to. The
-    // status-bar indicator already surfaces the running count so
-    // they can tell something arrived without being interrupted.
     if (wasAtTail)
     {
         mList->scrollToBottom();
@@ -222,15 +172,9 @@ void ParseErrorsDock::AppendErrors(const QString &title, const std::vector<std::
     RefreshSummary();
     if (firstBatchOfSession)
     {
-        // Latch the flag before emitting so a re-entrant
-        // `AppendErrors` from a slot connected to
-        // `firstBatchArrived` (defensive — none today) cannot
-        // double-fire it.
+        // Latch before emitting to guard against a re-entrant
+        // `AppendErrors` from a connected slot.
         mHasSeenFirstBatch = true;
-        // Let `MainWindow` decide whether to actually raise the
-        // dock -- the dock itself does not know about the rest of
-        // the GUI chrome and shouldn't yank focus off the find
-        // bar (or any future tabified neighbour).
         emit firstBatchArrived();
     }
 }
@@ -244,20 +188,17 @@ void ParseErrorsDock::ClearErrors()
     mList->clear();
     mErrorCount = 0;
     mDroppedCount = 0;
-    // `mHasSeenFirstBatch` deliberately *not* reset: the user
-    // already chose to dismiss this session's errors; popping the
-    // dock back open on the next streaming hiccup would be the
-    // bug we are guarding against. `ResetSessionState` is the
-    // canonical path to re-arm the auto-raise.
+    // `mHasSeenFirstBatch` deliberately NOT reset: re-arming the
+    // auto-raise after a user-initiated Clear is the bug we're
+    // guarding against. Use `ResetSessionState` for that.
     RefreshSummary();
 }
 
 void ParseErrorsDock::ResetSessionState()
 {
-    // Same surface as ClearErrors plus the auto-raise re-arm.
-    // Skip the work entirely if we are already in the pristine
-    // post-construction state to avoid a spurious `countChanged`
-    // emit on every session boundary in idle apps.
+    // Skip the work in the pristine post-construction state to avoid
+    // a spurious `countChanged` emit on every session boundary in
+    // idle apps.
     if (mList->count() == 0 && mErrorCount == 0 && mDroppedCount == 0 && !mHasSeenFirstBatch)
     {
         return;
@@ -284,13 +225,11 @@ void ParseErrorsDock::TrimToCap()
     {
         return;
     }
-    // Walk from the top, evicting entries until we are back under
-    // the cap. Group headers (`ItemIsEnabled` only) don't count
-    // toward `mErrorCount`; they ride along when evicting from
-    // their batch. Remember the text + font of the most recently
-    // evicted header so that, if its batch survives in part, we
-    // can re-mint a label for the orphaned rows below -- otherwise
-    // they'd float headerless above the next batch's title.
+    // Walk from the top and evict until back under the cap. Group
+    // headers don't count toward `mErrorCount` and ride along. We
+    // stash the most recently evicted header so a partially-evicted
+    // batch's survivors don't end up stranded below the next batch's
+    // title.
     QString lastEvictedHeaderText;
     QFont lastEvictedHeaderFont;
     bool haveEvictedHeader = false;
@@ -309,9 +248,6 @@ void ParseErrorsDock::TrimToCap()
         else if (!item->data(OVERFLOW_FOOTER_ROLE).toBool())
         {
             // Group header. Stash for possible re-insertion below.
-            // (The overflow footer is removed by `AppendErrors`
-            // before this method runs, so we shouldn't actually
-            // see one here -- but guard anyway.)
             lastEvictedHeaderText = item->text();
             lastEvictedHeaderFont = item->font();
             haveEvictedHeader = true;
@@ -319,13 +255,10 @@ void ParseErrorsDock::TrimToCap()
         delete item;
     }
 
-    // Re-mint the most recently evicted header if its first
-    // surviving row is now stranded at the top of the list (i.e.
-    // a selectable row with no preceding header). Without this,
-    // partial-batch eviction would leave error rows above the
-    // next batch's title with no label of their own -- the user
-    // would see a wall of errors that look like they belong to
-    // the *next* batch's header sitting below them.
+    // Re-mint the evicted header if its first surviving row is now
+    // stranded at the top with no preceding header (otherwise the
+    // user would see a wall of errors that look like they belong to
+    // the next batch's header below them).
     if (haveEvictedHeader && mList->count() > 0)
     {
         const QListWidgetItem *first = mList->item(0);
@@ -333,21 +266,13 @@ void ParseErrorsDock::TrimToCap()
         {
             auto *replacement = new QListWidgetItem(lastEvictedHeaderText);
             replacement->setFont(lastEvictedHeaderFont);
-            // Disable + non-selectable to match the header style
-            // minted in `AppendErrors`. Arrow-key nav steps over
-            // it; Ctrl+A skips it.
             replacement->setFlags(Qt::ItemIsEnabled);
             mList->insertItem(0, replacement);
         }
     }
 
-    // Compact orphan headers at the front: a header followed
-    // immediately by another header (or by nothing) lost its
-    // entire batch and should go. A header followed by an error
-    // row stays put -- it still labels surviving entries. This
-    // also catches the (unusual) case where the re-mint above
-    // produced a redundant pair, e.g. the evicted batch had only
-    // its header survive after the eviction-then-reinsert dance.
+    // Compact orphan headers at the front: a header followed by
+    // another header (or by nothing) lost its entire batch.
     while (mList->count() > 0)
     {
         const QListWidgetItem *first = mList->item(0);
@@ -372,18 +297,9 @@ void ParseErrorsDock::RebuildOverflowFooter()
     {
         return;
     }
-    // Pin the contract: caller (`AppendErrors`) is responsible
-    // for stripping any prior footer before we run, so this
-    // method only ever *appends* a fresh footer. A future
-    // refactor that calls `RebuildOverflowFooter` from a path
-    // that doesn't strip the tail would silently grow a stack
-    // of duplicate footers; the assert blows up loudly in debug.
+    // Caller must strip any prior footer first; assert catches a
+    // future refactor that would otherwise stack duplicates.
     Q_ASSERT(mList->count() == 0 || !mList->item(mList->count() - 1)->data(OVERFLOW_FOOTER_ROLE).toBool());
-    // Single overflow footer at the tail. `AppendErrors` strips
-    // any prior footer at the top of the call, so this method
-    // only ever appends -- never compares-and-replaces. `%Ln`
-    // matches the locale-grouped digits used in the summary
-    // header (no jitter when counts cross 1k / 1M).
     auto *footer = new QListWidgetItem(tr("(\u2026 %Ln earlier error(s) dropped)", nullptr, mDroppedCount));
     QFont footerFont = footer->font();
     footerFont.setItalic(true);
@@ -404,12 +320,11 @@ void ParseErrorsDock::CopySelection() const
         return;
     }
 
-    // Group headers and the overflow footer have `Qt::ItemIsEnabled`
-    // only (no `ItemIsSelectable`), so the user can never select
-    // them directly. Walk the list once and synthesise the header
-    // above the first selected row in each group plus the overflow
-    // footer at the bottom, so the pasted block reads as
-    // self-contained text rather than orphaned messages.
+    // Walk the list once and synthesise the header above the first
+    // selected row in each group, plus the overflow footer at the
+    // bottom, so the pasted block reads as self-contained text.
+    // Headers / footer are non-selectable, so the user never selects
+    // them directly.
     QStringList lines;
     const int count = mList->count();
     const QListWidgetItem *currentHeader = nullptr;
@@ -425,9 +340,8 @@ void ParseErrorsDock::CopySelection() const
         const bool isSelectable = item->flags().testFlag(Qt::ItemIsSelectable);
         if (!isSelectable)
         {
-            // Either a group header or the overflow footer; neither
-            // is user-selectable. Headers reset the per-group
-            // tracking; the footer is handled after the main loop.
+            // Either a group header (reset per-group tracking) or
+            // the overflow footer (handled after the loop).
             if (!item->data(OVERFLOW_FOOTER_ROLE).toBool())
             {
                 currentHeader = item;
@@ -449,9 +363,8 @@ void ParseErrorsDock::CopySelection() const
     }
     if (sawAnyError)
     {
-        // Append the overflow footer (if any) so the dropped count
-        // travels with the copied excerpt. Mirrors the dock's own
-        // header summary.
+        // Append the overflow footer so the dropped count travels
+        // with the copied excerpt.
         for (int i = count - 1; i >= 0; --i)
         {
             const QListWidgetItem *item = mList->item(i);
@@ -477,10 +390,8 @@ void ParseErrorsDock::RefreshSummary()
     }
     else if (mDroppedCount > 0)
     {
-        // Two independent counts -> can't use a single `%Ln`
-        // plural form; format both via QLocale so digit grouping
-        // matches the rest of the GUI ("12,345 errors; 1,000
-        // earlier dropped").
+        // Two independent counts -> can't use a single `%Ln` plural;
+        // format both via QLocale for matching digit grouping.
         const QLocale locale = QLocale::system();
         mSummary->setText(tr("%1 error(s); %2 earlier dropped.")
                               .arg(locale.toString(static_cast<qlonglong>(mErrorCount)))

--- a/app/src/parse_errors_dock.cpp
+++ b/app/src/parse_errors_dock.cpp
@@ -87,12 +87,13 @@ ParseErrorsDock::ParseErrorsDock(QWidget *parent)
 
     connect(mClearButton, &QPushButton::clicked, this, &ParseErrorsDock::ClearErrors);
 
-    // Ctrl+C copies the selected error rows. Scoped to the list
-    // so it doesn't shadow window-level Copy when focus is
-    // elsewhere. Without this, `setSelectionMode(ExtendedSelection)`
-    // would let the user select rows that they couldn't actually
-    // copy.
-    auto *copyShortcut = new QShortcut(QKeySequence::Copy, mList);
+    // Ctrl+C copies the selected error rows. Parented on `body`
+    // (not `mList`) with `WidgetWithChildrenShortcut` so the
+    // shortcut still fires when the user has clicked the Clear
+    // button (which moves focus off the list but leaves the
+    // selection intact). Window-level Copy is preserved because
+    // the scope still excludes the rest of `MainWindow`.
+    auto *copyShortcut = new QShortcut(QKeySequence::Copy, body);
     copyShortcut->setContext(Qt::WidgetWithChildrenShortcut);
     connect(copyShortcut, &QShortcut::activated, this, &ParseErrorsDock::CopySelection);
 

--- a/app/src/parse_errors_dock.cpp
+++ b/app/src/parse_errors_dock.cpp
@@ -10,6 +10,7 @@
 #include <QLabel>
 #include <QListWidget>
 #include <QListWidgetItem>
+#include <QLocale>
 #include <QPushButton>
 #include <QShortcut>
 #include <QStringList>
@@ -123,6 +124,21 @@ void ParseErrorsDock::AppendErrors(const QString &title, const std::vector<std::
         }
     }
 
+    // Pre-trim a pathologically large batch before constructing
+    // list items. If we instead let `TrimToCap` walk the list
+    // from the top, it would evict prior batches *and* the new
+    // batch's own group header before reaching the rows that
+    // outgrew the cap, leaving the surviving rows visually
+    // headerless. Skipping the leading slice up front keeps the
+    // header pinned to the rows it labels and avoids minting
+    // QListWidgetItem objects we'll only delete a moment later.
+    size_t errorsBegin = 0;
+    if (errors.size() > static_cast<size_t>(MAX_DISPLAYED_ERRORS))
+    {
+        errorsBegin = errors.size() - static_cast<size_t>(MAX_DISPLAYED_ERRORS);
+        mDroppedCount += static_cast<int>(errorsBegin);
+    }
+
     // Group header so consecutive batches stay visually grouped
     // even after the user scrolls into them. The header is
     // disabled (non-selectable in keyboard nav) so arrow keys
@@ -134,10 +150,10 @@ void ParseErrorsDock::AppendErrors(const QString &title, const std::vector<std::
     headerItem->setFlags(Qt::ItemIsEnabled);
     mList->addItem(headerItem);
 
-    for (const std::string &error : errors)
+    for (size_t i = errorsBegin; i < errors.size(); ++i)
     {
-        auto *item = new QListWidgetItem(warningIcon, QString::fromStdString(error));
-        item->setToolTip(QString::fromStdString(error));
+        auto *item = new QListWidgetItem(warningIcon, QString::fromStdString(errors[i]));
+        item->setToolTip(QString::fromStdString(errors[i]));
         item->setFlags(Qt::ItemIsSelectable | Qt::ItemIsEnabled);
         mList->addItem(item);
         ++mErrorCount;
@@ -224,8 +240,10 @@ void ParseErrorsDock::TrimToCap()
     {
         // Single overflow footer at the tail; re-minted on each
         // call (we removed the prior one in `AppendErrors` before
-        // adding the new batch) so the count stays current.
-        auto *footer = new QListWidgetItem(tr("(\u2026 %n earlier error(s) dropped)", nullptr, mDroppedCount));
+        // adding the new batch) so the count stays current. `%Ln`
+        // matches the locale-grouped digits used in the summary
+        // header above (no jitter when counts cross 1k / 1M).
+        auto *footer = new QListWidgetItem(tr("(\u2026 %Ln earlier error(s) dropped)", nullptr, mDroppedCount));
         QFont footerFont = footer->font();
         footerFont.setItalic(true);
         footer->setFont(footerFont);
@@ -269,11 +287,18 @@ void ParseErrorsDock::RefreshSummary()
     }
     else if (mDroppedCount > 0)
     {
-        mSummary->setText(tr("%1 error(s); %2 earlier dropped.").arg(mErrorCount).arg(mDroppedCount));
+        // Two independent counts -> can't use a single `%Ln`
+        // plural form; format both via QLocale so digit grouping
+        // matches the rest of the GUI ("12,345 errors; 1,000
+        // earlier dropped").
+        const QLocale locale = QLocale::system();
+        mSummary->setText(tr("%1 error(s); %2 earlier dropped.")
+                              .arg(locale.toString(static_cast<qlonglong>(mErrorCount)))
+                              .arg(locale.toString(static_cast<qlonglong>(mDroppedCount))));
     }
     else
     {
-        mSummary->setText(tr("%n error(s).", nullptr, mErrorCount));
+        mSummary->setText(tr("%Ln error(s).", nullptr, mErrorCount));
     }
     mClearButton->setEnabled(mErrorCount > 0 || mDroppedCount > 0);
     emit countChanged(mErrorCount);

--- a/app/src/parse_errors_dock.cpp
+++ b/app/src/parse_errors_dock.cpp
@@ -119,12 +119,14 @@ void ParseErrorsDock::AppendErrors(const QString &title, const std::vector<std::
 
     const QIcon warningIcon = QApplication::style()->standardIcon(QStyle::SP_MessageBoxWarning);
 
-    // Auto-raise only on the first batch of a session (i.e. when
-    // the dock was previously empty). Subsequent batches update
-    // silently and rely on the status-bar indicator -- a streaming
-    // user who has explicitly closed the dock should not have it
-    // pop back open every batch.
-    const bool firstBatchOfSession = mErrorCount == 0 && mDroppedCount == 0;
+    // Decide whether this batch should fire `firstBatchArrived`
+    // (which `MainWindow` translates into auto-raising the dock).
+    // The flag flips on the first batch *per session* and is
+    // cleared only by `ResetSessionState` -- the in-dock Clear
+    // button leaves it set, so a user who clicked Clear and
+    // dismissed the dock is not yanked back to it the next time a
+    // streaming line fails to parse.
+    const bool firstBatchOfSession = !mHasSeenFirstBatch;
 
     // Snapshot the user's scroll position *before* mutating the
     // list. If they were already pinned at the tail (auto-follow
@@ -206,6 +208,11 @@ void ParseErrorsDock::AppendErrors(const QString &title, const std::vector<std::
     RefreshSummary();
     if (firstBatchOfSession)
     {
+        // Latch the flag before emitting so a re-entrant
+        // `AppendErrors` from a slot connected to
+        // `firstBatchArrived` (defensive — none today) cannot
+        // double-fire it.
+        mHasSeenFirstBatch = true;
         // Let `MainWindow` decide whether to actually raise the
         // dock -- the dock itself does not know about the rest of
         // the GUI chrome and shouldn't yank focus off the find
@@ -223,6 +230,28 @@ void ParseErrorsDock::ClearErrors()
     mList->clear();
     mErrorCount = 0;
     mDroppedCount = 0;
+    // `mHasSeenFirstBatch` deliberately *not* reset: the user
+    // already chose to dismiss this session's errors; popping the
+    // dock back open on the next streaming hiccup would be the
+    // bug we are guarding against. `ResetSessionState` is the
+    // canonical path to re-arm the auto-raise.
+    RefreshSummary();
+}
+
+void ParseErrorsDock::ResetSessionState()
+{
+    // Same surface as ClearErrors plus the auto-raise re-arm.
+    // Skip the work entirely if we are already in the pristine
+    // post-construction state to avoid a spurious `countChanged`
+    // emit on every session boundary in idle apps.
+    if (mList->count() == 0 && mErrorCount == 0 && mDroppedCount == 0 && !mHasSeenFirstBatch)
+    {
+        return;
+    }
+    mList->clear();
+    mErrorCount = 0;
+    mDroppedCount = 0;
+    mHasSeenFirstBatch = false;
     RefreshSummary();
 }
 
@@ -329,6 +358,15 @@ void ParseErrorsDock::RebuildOverflowFooter()
     {
         return;
     }
+    // Pin the contract: caller (`AppendErrors`) is responsible
+    // for stripping any prior footer before we run, so this
+    // method only ever *appends* a fresh footer. A future
+    // refactor that calls `RebuildOverflowFooter` from a path
+    // that doesn't strip the tail would silently grow a stack
+    // of duplicate footers; the assert blows up loudly in debug.
+    Q_ASSERT(
+        mList->count() == 0 || !mList->item(mList->count() - 1)->data(OVERFLOW_FOOTER_ROLE).toBool()
+    );
     // Single overflow footer at the tail. `AppendErrors` strips
     // any prior footer at the top of the call, so this method
     // only ever appends -- never compares-and-replaces. `%Ln`

--- a/app/src/parse_errors_dock.cpp
+++ b/app/src/parse_errors_dock.cpp
@@ -150,8 +150,7 @@ void ParseErrorsDock::AppendErrors(const QString &title, const std::vector<std::
     // we leave the viewport alone so the new batch doesn't yank
     // them out of context. Mirrors the chat / log convention.
     const QScrollBar *vBar = mList->verticalScrollBar();
-    const bool wasAtTail =
-        vBar == nullptr || (vBar->maximum() - vBar->value()) <= AUTO_FOLLOW_TAIL_SLACK_PX;
+    const bool wasAtTail = vBar == nullptr || (vBar->maximum() - vBar->value()) <= AUTO_FOLLOW_TAIL_SLACK_PX;
 
     // The trailing overflow footer (if any) must move to the
     // bottom after the new entries land. It is always the last
@@ -379,9 +378,7 @@ void ParseErrorsDock::RebuildOverflowFooter()
     // refactor that calls `RebuildOverflowFooter` from a path
     // that doesn't strip the tail would silently grow a stack
     // of duplicate footers; the assert blows up loudly in debug.
-    Q_ASSERT(
-        mList->count() == 0 || !mList->item(mList->count() - 1)->data(OVERFLOW_FOOTER_ROLE).toBool()
-    );
+    Q_ASSERT(mList->count() == 0 || !mList->item(mList->count() - 1)->data(OVERFLOW_FOOTER_ROLE).toBool());
     // Single overflow footer at the tail. `AppendErrors` strips
     // any prior footer at the top of the call, so this method
     // only ever appends -- never compares-and-replaces. `%Ln`

--- a/app/src/parse_errors_dock.cpp
+++ b/app/src/parse_errors_dock.cpp
@@ -2,12 +2,17 @@
 
 #include <QApplication>
 #include <QBrush>
+#include <QClipboard>
 #include <QFont>
+#include <QGuiApplication>
 #include <QHBoxLayout>
+#include <QKeySequence>
 #include <QLabel>
 #include <QListWidget>
 #include <QListWidgetItem>
 #include <QPushButton>
+#include <QShortcut>
+#include <QStringList>
 #include <QStyle>
 #include <QVBoxLayout>
 #include <QWidget>
@@ -24,6 +29,11 @@ constexpr int DOCK_MIN_WIDTH = 320;
 constexpr int OUTER_MARGIN = 6;
 constexpr int HEADER_SPACING = 6;
 constexpr int LAYOUT_SPACING = 4;
+
+/// `Qt::UserRole` flag set on the trailing "+N more dropped"
+/// footer item so `TrimToCap` can replace it in place instead of
+/// minting a new one each batch.
+constexpr int OVERFLOW_FOOTER_ROLE = Qt::UserRole + 1;
 } // namespace
 
 ParseErrorsDock::ParseErrorsDock(QWidget *parent)
@@ -60,7 +70,7 @@ ParseErrorsDock::ParseErrorsDock(QWidget *parent)
     mList->setObjectName(QStringLiteral("parseErrorsList"));
     // Read-only: parse errors are diagnostic data, not something
     // the user edits. Selectable so they can copy individual
-    // lines.
+    // lines via Ctrl+C.
     mList->setSelectionMode(QAbstractItemView::ExtendedSelection);
     mList->setUniformItemSizes(false);
     mList->setTextElideMode(Qt::ElideMiddle);
@@ -71,6 +81,16 @@ ParseErrorsDock::ParseErrorsDock(QWidget *parent)
     setMinimumWidth(DOCK_MIN_WIDTH);
 
     connect(mClearButton, &QPushButton::clicked, this, &ParseErrorsDock::ClearErrors);
+
+    // Ctrl+C copies the selected error rows. Scoped to the list
+    // so it doesn't shadow window-level Copy when focus is
+    // elsewhere. Without this, `setSelectionMode(ExtendedSelection)`
+    // would let the user select rows that they couldn't actually
+    // copy.
+    auto *copyShortcut = new QShortcut(QKeySequence::Copy, mList);
+    copyShortcut->setContext(Qt::WidgetWithChildrenShortcut);
+    connect(copyShortcut, &QShortcut::activated, this, &ParseErrorsDock::CopySelection);
+
     RefreshSummary();
 }
 
@@ -82,6 +102,26 @@ void ParseErrorsDock::AppendErrors(const QString &title, const std::vector<std::
     }
 
     const QIcon warningIcon = QApplication::style()->standardIcon(QStyle::SP_MessageBoxWarning);
+
+    // Auto-raise only on the first batch of a session (i.e. when
+    // the dock was previously empty). Subsequent batches update
+    // silently and rely on the status-bar indicator -- a streaming
+    // user who has explicitly closed the dock should not have it
+    // pop back open every batch.
+    const bool firstBatchOfSession = mErrorCount == 0 && mDroppedCount == 0;
+
+    // The trailing overflow footer (if any) must move to the
+    // bottom after the new entries land. Drop it before the
+    // append so we can re-mint it once cap-trimming settles.
+    for (int i = mList->count() - 1; i >= 0; --i)
+    {
+        QListWidgetItem *item = mList->item(i);
+        if (item != nullptr && item->data(OVERFLOW_FOOTER_ROLE).toBool())
+        {
+            delete mList->takeItem(i);
+            break;
+        }
+    }
 
     // Group header so consecutive batches stay visually grouped
     // even after the user scrolls into them. The header is
@@ -100,68 +140,141 @@ void ParseErrorsDock::AppendErrors(const QString &title, const std::vector<std::
         item->setToolTip(QString::fromStdString(error));
         item->setFlags(Qt::ItemIsSelectable | Qt::ItemIsEnabled);
         mList->addItem(item);
+        ++mErrorCount;
     }
 
-    // Surface the new entries: scroll to the latest, then
-    // show + raise the dock so a hidden / tabified one comes to
-    // the front.
+    TrimToCap();
+
     mList->scrollToBottom();
-    if (!isVisible())
+    if (firstBatchOfSession)
     {
-        show();
+        if (!isVisible())
+        {
+            show();
+        }
+        raise();
     }
-    raise();
 
     RefreshSummary();
 }
 
 void ParseErrorsDock::ClearErrors()
 {
-    if (mList->count() == 0)
+    if (mList->count() == 0 && mErrorCount == 0 && mDroppedCount == 0)
     {
         return;
     }
     mList->clear();
+    mErrorCount = 0;
+    mDroppedCount = 0;
     RefreshSummary();
 }
 
-int ParseErrorsDock::Count() const noexcept
+void ParseErrorsDock::TrimToCap()
 {
-    if (mList == nullptr)
+    if (mErrorCount <= MAX_DISPLAYED_ERRORS)
     {
-        return 0;
+        return;
     }
-    // The list interleaves group-header items with error rows;
-    // only error rows count toward the user-visible total.
-    int count = 0;
-    for (int i = 0; i < mList->count(); ++i)
+    // Walk from the top, evicting entries until we are back under
+    // the cap. Group headers (`ItemIsEnabled` only) don't count
+    // toward `mErrorCount`; they ride along when evicting from
+    // their batch, but we never strand a header above its
+    // surviving rows -- after the loop we sweep front-side
+    // headers only when they are immediately followed by another
+    // header (orphan), preserving any header that still has rows
+    // beneath it.
+    while (mList->count() > 0 && mErrorCount > MAX_DISPLAYED_ERRORS)
     {
-        const QListWidgetItem *item = mList->item(i);
+        QListWidgetItem *item = mList->takeItem(0);
         if (item == nullptr)
         {
             continue;
         }
-        // Group headers are flagged `ItemIsEnabled` only; error
-        // rows are also `ItemIsSelectable`.
         if (item->flags().testFlag(Qt::ItemIsSelectable))
         {
-            ++count;
+            --mErrorCount;
+            ++mDroppedCount;
+        }
+        delete item;
+    }
+
+    // Compact orphan headers at the front: a header followed
+    // immediately by another header (or by nothing) lost its
+    // entire batch and should go. A header followed by an error
+    // row stays put -- it still labels surviving entries.
+    while (mList->count() > 0)
+    {
+        QListWidgetItem *first = mList->item(0);
+        if (first == nullptr || first->flags().testFlag(Qt::ItemIsSelectable))
+        {
+            break;
+        }
+        // First item is a header. Look at its successor.
+        QListWidgetItem *second = mList->count() > 1 ? mList->item(1) : nullptr;
+        const bool isOrphan = second == nullptr || !second->flags().testFlag(Qt::ItemIsSelectable);
+        if (!isOrphan)
+        {
+            break;
+        }
+        delete mList->takeItem(0);
+    }
+
+    if (mDroppedCount > 0)
+    {
+        // Single overflow footer at the tail; re-minted on each
+        // call (we removed the prior one in `AppendErrors` before
+        // adding the new batch) so the count stays current.
+        auto *footer = new QListWidgetItem(tr("(\u2026 %n earlier error(s) dropped)", nullptr, mDroppedCount));
+        QFont footerFont = footer->font();
+        footerFont.setItalic(true);
+        footer->setFont(footerFont);
+        footer->setFlags(Qt::ItemIsEnabled);
+        footer->setData(OVERFLOW_FOOTER_ROLE, true);
+        mList->addItem(footer);
+    }
+}
+
+void ParseErrorsDock::CopySelection() const
+{
+    if (mList == nullptr)
+    {
+        return;
+    }
+    const QList<QListWidgetItem *> selected = mList->selectedItems();
+    if (selected.isEmpty())
+    {
+        return;
+    }
+    // Preserve list order; `selectedItems` returns selection
+    // order which can confuse readers expecting top-to-bottom.
+    QStringList lines;
+    lines.reserve(selected.size());
+    for (int i = 0; i < mList->count(); ++i)
+    {
+        QListWidgetItem *item = mList->item(i);
+        if (item != nullptr && item->isSelected())
+        {
+            lines.append(item->text());
         }
     }
-    return count;
+    QGuiApplication::clipboard()->setText(lines.join(QChar::fromLatin1('\n')));
 }
 
 void ParseErrorsDock::RefreshSummary()
 {
-    const int count = Count();
-    if (count == 0)
+    if (mErrorCount == 0)
     {
         mSummary->setText(tr("No parse errors."));
     }
+    else if (mDroppedCount > 0)
+    {
+        mSummary->setText(tr("%1 error(s); %2 earlier dropped.").arg(mErrorCount).arg(mDroppedCount));
+    }
     else
     {
-        mSummary->setText(tr("%n error(s).", nullptr, count));
+        mSummary->setText(tr("%n error(s).", nullptr, mErrorCount));
     }
-    mClearButton->setEnabled(count > 0);
-    emit countChanged(count);
+    mClearButton->setEnabled(mErrorCount > 0 || mDroppedCount > 0);
+    emit countChanged(mErrorCount);
 }

--- a/app/src/parse_errors_dock.cpp
+++ b/app/src/parse_errors_dock.cpp
@@ -3,6 +3,7 @@
 #include <QApplication>
 #include <QBrush>
 #include <QClipboard>
+#include <QCloseEvent>
 #include <QFont>
 #include <QGuiApplication>
 #include <QHBoxLayout>
@@ -78,8 +79,11 @@ ParseErrorsDock::ParseErrorsDock(QWidget *parent)
     mList->setAlternatingRowColors(true);
     layout->addWidget(mList, /*stretch=*/1);
 
+    // Minimum on the content widget, not the dock: setting it on
+    // the dock propagates a 320 px floor onto the entire
+    // QMainWindow even while the dock itself is hidden.
+    body->setMinimumWidth(DOCK_MIN_WIDTH);
     setWidget(body);
-    setMinimumWidth(DOCK_MIN_WIDTH);
 
     connect(mClearButton, &QPushButton::clicked, this, &ParseErrorsDock::ClearErrors);
 
@@ -112,15 +116,16 @@ void ParseErrorsDock::AppendErrors(const QString &title, const std::vector<std::
     const bool firstBatchOfSession = mErrorCount == 0 && mDroppedCount == 0;
 
     // The trailing overflow footer (if any) must move to the
-    // bottom after the new entries land. Drop it before the
-    // append so we can re-mint it once cap-trimming settles.
-    for (int i = mList->count() - 1; i >= 0; --i)
+    // bottom after the new entries land. It is always the last
+    // item by construction (`TrimToCap` appends it after every
+    // trim), so we only need to inspect the tail rather than walk
+    // the list.
+    if (const int last = mList->count() - 1; last >= 0)
     {
-        QListWidgetItem *item = mList->item(i);
-        if (item != nullptr && item->data(OVERFLOW_FOOTER_ROLE).toBool())
+        QListWidgetItem *tail = mList->item(last);
+        if (tail != nullptr && tail->data(OVERFLOW_FOOTER_ROLE).toBool())
         {
-            delete mList->takeItem(i);
-            break;
+            delete mList->takeItem(last);
         }
     }
 
@@ -160,18 +165,24 @@ void ParseErrorsDock::AppendErrors(const QString &title, const std::vector<std::
     }
 
     TrimToCap();
+    // Footer rebuild is intentionally separate from `TrimToCap`:
+    // a single batch sized exactly at the cap pre-trims (bumping
+    // `mDroppedCount`) without ever pushing `mErrorCount` past
+    // `MAX_DISPLAYED_ERRORS`, so `TrimToCap` has no eviction work
+    // and would skip its tail block. The footer must reflect
+    // `mDroppedCount` regardless of which path got us there.
+    RebuildOverflowFooter();
 
     mList->scrollToBottom();
+    RefreshSummary();
     if (firstBatchOfSession)
     {
-        if (!isVisible())
-        {
-            show();
-        }
-        raise();
+        // Let `MainWindow` decide whether to actually raise the
+        // dock -- the dock itself does not know about the rest of
+        // the GUI chrome and shouldn't yank focus off the find
+        // bar (or any future tabified neighbour).
+        emit firstBatchArrived();
     }
-
-    RefreshSummary();
 }
 
 void ParseErrorsDock::ClearErrors()
@@ -184,6 +195,15 @@ void ParseErrorsDock::ClearErrors()
     mErrorCount = 0;
     mDroppedCount = 0;
     RefreshSummary();
+}
+
+void ParseErrorsDock::closeEvent(QCloseEvent *event)
+{
+    QDockWidget::closeEvent(event);
+    if (event->isAccepted())
+    {
+        emit closed();
+    }
 }
 
 void ParseErrorsDock::TrimToCap()
@@ -235,22 +255,26 @@ void ParseErrorsDock::TrimToCap()
         }
         delete mList->takeItem(0);
     }
+}
 
-    if (mDroppedCount > 0)
+void ParseErrorsDock::RebuildOverflowFooter()
+{
+    if (mDroppedCount <= 0)
     {
-        // Single overflow footer at the tail; re-minted on each
-        // call (we removed the prior one in `AppendErrors` before
-        // adding the new batch) so the count stays current. `%Ln`
-        // matches the locale-grouped digits used in the summary
-        // header above (no jitter when counts cross 1k / 1M).
-        auto *footer = new QListWidgetItem(tr("(\u2026 %Ln earlier error(s) dropped)", nullptr, mDroppedCount));
-        QFont footerFont = footer->font();
-        footerFont.setItalic(true);
-        footer->setFont(footerFont);
-        footer->setFlags(Qt::ItemIsEnabled);
-        footer->setData(OVERFLOW_FOOTER_ROLE, true);
-        mList->addItem(footer);
+        return;
     }
+    // Single overflow footer at the tail. `AppendErrors` strips
+    // any prior footer at the top of the call, so this method
+    // only ever appends -- never compares-and-replaces. `%Ln`
+    // matches the locale-grouped digits used in the summary
+    // header (no jitter when counts cross 1k / 1M).
+    auto *footer = new QListWidgetItem(tr("(\u2026 %Ln earlier error(s) dropped)", nullptr, mDroppedCount));
+    QFont footerFont = footer->font();
+    footerFont.setItalic(true);
+    footer->setFont(footerFont);
+    footer->setFlags(Qt::ItemIsEnabled);
+    footer->setData(OVERFLOW_FOOTER_ROLE, true);
+    mList->addItem(footer);
 }
 
 void ParseErrorsDock::CopySelection() const
@@ -259,22 +283,72 @@ void ParseErrorsDock::CopySelection() const
     {
         return;
     }
-    const QList<QListWidgetItem *> selected = mList->selectedItems();
-    if (selected.isEmpty())
+    if (mList->selectedItems().isEmpty())
     {
         return;
     }
-    // Preserve list order; `selectedItems` returns selection
-    // order which can confuse readers expecting top-to-bottom.
+
+    // Group headers and the overflow footer have `Qt::ItemIsEnabled`
+    // only (no `ItemIsSelectable`), so the user can never select
+    // them directly. Walk the list once and synthesise the header
+    // above the first selected row in each group plus the overflow
+    // footer at the bottom, so the pasted block reads as
+    // self-contained text rather than orphaned messages.
     QStringList lines;
-    lines.reserve(selected.size());
-    for (int i = 0; i < mList->count(); ++i)
+    const int count = mList->count();
+    QListWidgetItem *currentHeader = nullptr;
+    bool currentHeaderEmitted = false;
+    bool sawAnyError = false;
+    for (int i = 0; i < count; ++i)
     {
         QListWidgetItem *item = mList->item(i);
-        if (item != nullptr && item->isSelected())
+        if (item == nullptr)
         {
-            lines.append(item->text());
+            continue;
         }
+        const bool isSelectable = item->flags().testFlag(Qt::ItemIsSelectable);
+        if (!isSelectable)
+        {
+            // Either a group header or the overflow footer; neither
+            // is user-selectable. Headers reset the per-group
+            // tracking; the footer is handled after the main loop.
+            if (!item->data(OVERFLOW_FOOTER_ROLE).toBool())
+            {
+                currentHeader = item;
+                currentHeaderEmitted = false;
+            }
+            continue;
+        }
+        if (!item->isSelected())
+        {
+            continue;
+        }
+        if (currentHeader != nullptr && !currentHeaderEmitted)
+        {
+            lines.append(currentHeader->text());
+            currentHeaderEmitted = true;
+        }
+        lines.append(item->text());
+        sawAnyError = true;
+    }
+    if (sawAnyError)
+    {
+        // Append the overflow footer (if any) so the dropped count
+        // travels with the copied excerpt. Mirrors the dock's own
+        // header summary.
+        for (int i = count - 1; i >= 0; --i)
+        {
+            QListWidgetItem *item = mList->item(i);
+            if (item != nullptr && item->data(OVERFLOW_FOOTER_ROLE).toBool())
+            {
+                lines.append(item->text());
+                break;
+            }
+        }
+    }
+    if (lines.isEmpty())
+    {
+        return;
     }
     QGuiApplication::clipboard()->setText(lines.join(QChar::fromLatin1('\n')));
 }
@@ -301,5 +375,5 @@ void ParseErrorsDock::RefreshSummary()
         mSummary->setText(tr("%Ln error(s).", nullptr, mErrorCount));
     }
     mClearButton->setEnabled(mErrorCount > 0 || mDroppedCount > 0);
-    emit countChanged(mErrorCount);
+    emit countChanged(mErrorCount, mDroppedCount);
 }

--- a/app/src/parse_errors_dock.cpp
+++ b/app/src/parse_errors_dock.cpp
@@ -215,11 +215,13 @@ void ParseErrorsDock::TrimToCap()
     // Walk from the top, evicting entries until we are back under
     // the cap. Group headers (`ItemIsEnabled` only) don't count
     // toward `mErrorCount`; they ride along when evicting from
-    // their batch, but we never strand a header above its
-    // surviving rows -- after the loop we sweep front-side
-    // headers only when they are immediately followed by another
-    // header (orphan), preserving any header that still has rows
-    // beneath it.
+    // their batch. Remember the text + font of the most recently
+    // evicted header so that, if its batch survives in part, we
+    // can re-mint a label for the orphaned rows below -- otherwise
+    // they'd float headerless above the next batch's title.
+    QString lastEvictedHeaderText;
+    QFont lastEvictedHeaderFont;
+    bool haveEvictedHeader = false;
     while (mList->count() > 0 && mErrorCount > MAX_DISPLAYED_ERRORS)
     {
         QListWidgetItem *item = mList->takeItem(0);
@@ -232,13 +234,48 @@ void ParseErrorsDock::TrimToCap()
             --mErrorCount;
             ++mDroppedCount;
         }
+        else if (!item->data(OVERFLOW_FOOTER_ROLE).toBool())
+        {
+            // Group header. Stash for possible re-insertion below.
+            // (The overflow footer is removed by `AppendErrors`
+            // before this method runs, so we shouldn't actually
+            // see one here -- but guard anyway.)
+            lastEvictedHeaderText = item->text();
+            lastEvictedHeaderFont = item->font();
+            haveEvictedHeader = true;
+        }
         delete item;
+    }
+
+    // Re-mint the most recently evicted header if its first
+    // surviving row is now stranded at the top of the list (i.e.
+    // a selectable row with no preceding header). Without this,
+    // partial-batch eviction would leave error rows above the
+    // next batch's title with no label of their own -- the user
+    // would see a wall of errors that look like they belong to
+    // the *next* batch's header sitting below them.
+    if (haveEvictedHeader && mList->count() > 0)
+    {
+        QListWidgetItem *first = mList->item(0);
+        if (first != nullptr && first->flags().testFlag(Qt::ItemIsSelectable))
+        {
+            auto *replacement = new QListWidgetItem(lastEvictedHeaderText);
+            replacement->setFont(lastEvictedHeaderFont);
+            // Disable + non-selectable to match the header style
+            // minted in `AppendErrors`. Arrow-key nav steps over
+            // it; Ctrl+A skips it.
+            replacement->setFlags(Qt::ItemIsEnabled);
+            mList->insertItem(0, replacement);
+        }
     }
 
     // Compact orphan headers at the front: a header followed
     // immediately by another header (or by nothing) lost its
     // entire batch and should go. A header followed by an error
-    // row stays put -- it still labels surviving entries.
+    // row stays put -- it still labels surviving entries. This
+    // also catches the (unusual) case where the re-mint above
+    // produced a redundant pair, e.g. the evicted batch had only
+    // its header survive after the eviction-then-reinsert dance.
     while (mList->count() > 0)
     {
         QListWidgetItem *first = mList->item(0);

--- a/app/src/parse_errors_dock.cpp
+++ b/app/src/parse_errors_dock.cpp
@@ -1,0 +1,167 @@
+#include "parse_errors_dock.hpp"
+
+#include <QApplication>
+#include <QBrush>
+#include <QFont>
+#include <QHBoxLayout>
+#include <QLabel>
+#include <QListWidget>
+#include <QListWidgetItem>
+#include <QPushButton>
+#include <QStyle>
+#include <QVBoxLayout>
+#include <QWidget>
+
+namespace
+{
+/// Minimum width that still renders a typical "Error Parsing
+/// Logs: <one-line message>" entry without the horizontal
+/// scrollbar getting in the way. The dock is meant for the bottom
+/// edge by default; keep it narrow enough for that.
+constexpr int DOCK_MIN_WIDTH = 320;
+
+/// Outer margins / spacing matching the find bar densities.
+constexpr int OUTER_MARGIN = 6;
+constexpr int HEADER_SPACING = 6;
+constexpr int LAYOUT_SPACING = 4;
+} // namespace
+
+ParseErrorsDock::ParseErrorsDock(QWidget *parent)
+    : QDockWidget(tr("Parse Errors"), parent)
+{
+    setObjectName(QStringLiteral("parseErrorsDock"));
+    setAllowedAreas(Qt::AllDockWidgetAreas);
+    setFeatures(QDockWidget::DockWidgetClosable | QDockWidget::DockWidgetMovable | QDockWidget::DockWidgetFloatable);
+
+    auto *body = new QWidget(this);
+    auto *layout = new QVBoxLayout(body);
+    layout->setContentsMargins(OUTER_MARGIN, OUTER_MARGIN, OUTER_MARGIN, OUTER_MARGIN);
+    layout->setSpacing(LAYOUT_SPACING);
+
+    auto *header = new QHBoxLayout();
+    header->setContentsMargins(0, 0, 0, 0);
+    header->setSpacing(HEADER_SPACING);
+
+    mSummary = new QLabel(body);
+    mSummary->setObjectName(QStringLiteral("parseErrorsSummary"));
+    mSummary->setTextInteractionFlags(Qt::TextSelectableByMouse);
+    header->addWidget(mSummary, /*stretch=*/1);
+
+    mClearButton = new QPushButton(tr("Clear"), body);
+    mClearButton->setObjectName(QStringLiteral("parseErrorsClear"));
+    mClearButton->setFlat(true);
+    mClearButton->setCursor(Qt::PointingHandCursor);
+    mClearButton->setEnabled(false);
+    header->addWidget(mClearButton);
+
+    layout->addLayout(header);
+
+    mList = new QListWidget(body);
+    mList->setObjectName(QStringLiteral("parseErrorsList"));
+    // Read-only: parse errors are diagnostic data, not something
+    // the user edits. Selectable so they can copy individual
+    // lines.
+    mList->setSelectionMode(QAbstractItemView::ExtendedSelection);
+    mList->setUniformItemSizes(false);
+    mList->setTextElideMode(Qt::ElideMiddle);
+    mList->setAlternatingRowColors(true);
+    layout->addWidget(mList, /*stretch=*/1);
+
+    setWidget(body);
+    setMinimumWidth(DOCK_MIN_WIDTH);
+
+    connect(mClearButton, &QPushButton::clicked, this, &ParseErrorsDock::ClearErrors);
+    RefreshSummary();
+}
+
+void ParseErrorsDock::AppendErrors(const QString &title, const std::vector<std::string> &errors)
+{
+    if (errors.empty())
+    {
+        return;
+    }
+
+    const QIcon warningIcon = QApplication::style()->standardIcon(QStyle::SP_MessageBoxWarning);
+
+    // Group header so consecutive batches stay visually grouped
+    // even after the user scrolls into them. The header is
+    // disabled (non-selectable in keyboard nav) so arrow keys
+    // step over it.
+    auto *headerItem = new QListWidgetItem(title);
+    QFont headerFont = headerItem->font();
+    headerFont.setBold(true);
+    headerItem->setFont(headerFont);
+    headerItem->setFlags(Qt::ItemIsEnabled);
+    mList->addItem(headerItem);
+
+    for (const std::string &error : errors)
+    {
+        auto *item = new QListWidgetItem(warningIcon, QString::fromStdString(error));
+        item->setToolTip(QString::fromStdString(error));
+        item->setFlags(Qt::ItemIsSelectable | Qt::ItemIsEnabled);
+        mList->addItem(item);
+    }
+
+    // Surface the new entries: scroll to the latest, then
+    // show + raise the dock so a hidden / tabified one comes to
+    // the front.
+    mList->scrollToBottom();
+    if (!isVisible())
+    {
+        show();
+    }
+    raise();
+
+    RefreshSummary();
+}
+
+void ParseErrorsDock::ClearErrors()
+{
+    if (mList->count() == 0)
+    {
+        return;
+    }
+    mList->clear();
+    RefreshSummary();
+}
+
+int ParseErrorsDock::Count() const noexcept
+{
+    if (mList == nullptr)
+    {
+        return 0;
+    }
+    // The list interleaves group-header items with error rows;
+    // only error rows count toward the user-visible total.
+    int count = 0;
+    for (int i = 0; i < mList->count(); ++i)
+    {
+        const QListWidgetItem *item = mList->item(i);
+        if (item == nullptr)
+        {
+            continue;
+        }
+        // Group headers are flagged `ItemIsEnabled` only; error
+        // rows are also `ItemIsSelectable`.
+        if (item->flags().testFlag(Qt::ItemIsSelectable))
+        {
+            ++count;
+        }
+    }
+    return count;
+}
+
+void ParseErrorsDock::RefreshSummary()
+{
+    const int count = Count();
+    if (count == 0)
+    {
+        mSummary->setText(tr("No parse errors."));
+    }
+    else
+    {
+        mSummary->setText(tr("%n error(s).", nullptr, count));
+    }
+    mClearButton->setEnabled(count > 0);
+    emit countChanged(count);
+}

--- a/app/src/parse_errors_dock.cpp
+++ b/app/src/parse_errors_dock.cpp
@@ -117,6 +117,21 @@ void ParseErrorsDock::AppendErrors(const QString &title, const std::vector<std::
         return;
     }
 
+    // Fall back to a non-empty group label when the caller passed
+    // an empty title. An empty `title` would otherwise render as
+    // a blank bold list row that looks like a missing translation
+    // or a corrupt entry. Every in-tree caller wraps the title in
+    // `tr(...)`, so this guard is purely defensive against a
+    // future caller that forgets -- the `qWarning` makes the
+    // omission visible instead of silently rendering a
+    // mystery-blank row.
+    QString effectiveTitle = title;
+    if (effectiveTitle.isEmpty())
+    {
+        qWarning() << "ParseErrorsDock::AppendErrors: empty title; using fallback label";
+        effectiveTitle = tr("Errors");
+    }
+
     const QIcon warningIcon = QApplication::style()->standardIcon(QStyle::SP_MessageBoxWarning);
 
     // Decide whether this batch should fire `firstBatchArrived`
@@ -171,7 +186,7 @@ void ParseErrorsDock::AppendErrors(const QString &title, const std::vector<std::
     // even after the user scrolls into them. The header is
     // disabled (non-selectable in keyboard nav) so arrow keys
     // step over it.
-    auto *headerItem = new QListWidgetItem(title);
+    auto *headerItem = new QListWidgetItem(effectiveTitle);
     QFont headerFont = headerItem->font();
     headerFont.setBold(true);
     headerItem->setFont(headerFont);

--- a/app/src/preferences_editor.cpp
+++ b/app/src/preferences_editor.cpp
@@ -255,11 +255,7 @@ PreferencesEditor::PreferencesEditor(ThemeControl *theme, QWidget *parent)
     auto *cancelButton = new QPushButton("Cancel", this);
 
     connect(okButton, &QPushButton::clicked, this, [this]() {
-        // Mark the close as button-initiated so `closeEvent` skips
-        // the revert: Ok has already persisted the new state, and
-        // re-applying `PersistedSelection()` plus a fresh
-        // `StreamingControl::LoadConfiguration()` would just hit
-        // disk again to no effect.
+        // Bypass `closeEvent`'s revert: Ok already persisted state.
         mClosingViaButton = true;
         // Theme selection is already live; Ok just persists it.
         if (mTheme != nullptr)
@@ -301,12 +297,9 @@ PreferencesEditor::PreferencesEditor(ThemeControl *theme, QWidget *parent)
         {
             mTheme->SetActiveSelection(mTheme->PersistedSelection());
         }
-        // Revert the spinbox-edited values to the persisted ones; no
-        // emit needed because the on-disk values are unchanged.
+        // Revert spinbox-edited values to persisted; on-disk unchanged.
         StreamingControl::LoadConfiguration();
-        // Cancel has already done the revert; mark the close as
-        // button-initiated so `closeEvent` doesn't redo the same
-        // disk read.
+        // Bypass `closeEvent`'s revert: Cancel already reverted.
         mClosingViaButton = true;
         close();
     });
@@ -416,22 +409,16 @@ void PreferencesEditor::ShowThemeStatus(const QString &message)
 
 void PreferencesEditor::closeEvent(QCloseEvent *event)
 {
-    // Bypass the revert when Ok/Cancel routed us here -- they
-    // have already taken care of the persisted state, and
-    // re-running `StreamingControl::LoadConfiguration()` would
-    // just hit disk again (and could surface a transient I/O
-    // error during a perfectly normal Ok). Reset the flag so a
-    // re-shown dialog falls back to the genuine-close path.
     if (mClosingViaButton)
     {
+        // Ok / Cancel already took care of persisted state. Reset
+        // the flag so a re-shown dialog falls back to genuine close.
         mClosingViaButton = false;
         QWidget::closeEvent(event);
         return;
     }
-    // Genuine close (X, Alt+F4, programmatic `close()` from
-    // anywhere else): treat as Cancel. Revert any live-previewed
-    // theme and reload the streaming/session config from disk so
-    // a Dark preview doesn't leak past the dialog.
+    // Genuine close (X / Alt+F4 / programmatic `close()`): treat
+    // as Cancel so a live-previewed theme doesn't leak past the dialog.
     if (mTheme != nullptr)
     {
         mTheme->SetActiveSelection(mTheme->PersistedSelection());

--- a/app/src/preferences_editor.cpp
+++ b/app/src/preferences_editor.cpp
@@ -7,6 +7,7 @@
 #include <loglib/theme.hpp>
 
 #include <QApplication>
+#include <QCloseEvent>
 #include <QDebug>
 #include <QFile>
 #include <QGroupBox>
@@ -401,4 +402,23 @@ void PreferencesEditor::ShowThemeStatus(const QString &message)
         return;
     }
     mThemeStatusClearTimer->start(THEME_STATUS_CLEAR_MS);
+}
+
+void PreferencesEditor::closeEvent(QCloseEvent *event)
+{
+    // Treat the window-close paths (X, Alt+F4, Esc on platforms that
+    // map it to close, programmatic `close()` from anywhere other
+    // than Ok/Cancel) as Cancel: revert any live-previewed theme
+    // and reload the streaming/session config from disk. The Ok and
+    // Cancel handlers both ultimately invoke `close()`, so this slot
+    // also runs in those paths -- but the revert is idempotent there
+    // because `Ok` has already persisted the new selection (making
+    // `PersistedSelection()` match the current state) and `Cancel`
+    // has already reverted before calling `close()`.
+    if (mTheme != nullptr)
+    {
+        mTheme->SetActiveSelection(mTheme->PersistedSelection());
+    }
+    StreamingControl::LoadConfiguration();
+    QWidget::closeEvent(event);
 }

--- a/app/src/preferences_editor.cpp
+++ b/app/src/preferences_editor.cpp
@@ -255,6 +255,12 @@ PreferencesEditor::PreferencesEditor(ThemeControl *theme, QWidget *parent)
     auto *cancelButton = new QPushButton("Cancel", this);
 
     connect(okButton, &QPushButton::clicked, this, [this]() {
+        // Mark the close as button-initiated so `closeEvent` skips
+        // the revert: Ok has already persisted the new state, and
+        // re-applying `PersistedSelection()` plus a fresh
+        // `StreamingControl::LoadConfiguration()` would just hit
+        // disk again to no effect.
+        mClosingViaButton = true;
         // Theme selection is already live; Ok just persists it.
         if (mTheme != nullptr)
         {
@@ -298,6 +304,10 @@ PreferencesEditor::PreferencesEditor(ThemeControl *theme, QWidget *parent)
         // Revert the spinbox-edited values to the persisted ones; no
         // emit needed because the on-disk values are unchanged.
         StreamingControl::LoadConfiguration();
+        // Cancel has already done the revert; mark the close as
+        // button-initiated so `closeEvent` doesn't redo the same
+        // disk read.
+        mClosingViaButton = true;
         close();
     });
 
@@ -406,15 +416,22 @@ void PreferencesEditor::ShowThemeStatus(const QString &message)
 
 void PreferencesEditor::closeEvent(QCloseEvent *event)
 {
-    // Treat the window-close paths (X, Alt+F4, Esc on platforms that
-    // map it to close, programmatic `close()` from anywhere other
-    // than Ok/Cancel) as Cancel: revert any live-previewed theme
-    // and reload the streaming/session config from disk. The Ok and
-    // Cancel handlers both ultimately invoke `close()`, so this slot
-    // also runs in those paths -- but the revert is idempotent there
-    // because `Ok` has already persisted the new selection (making
-    // `PersistedSelection()` match the current state) and `Cancel`
-    // has already reverted before calling `close()`.
+    // Bypass the revert when Ok/Cancel routed us here -- they
+    // have already taken care of the persisted state, and
+    // re-running `StreamingControl::LoadConfiguration()` would
+    // just hit disk again (and could surface a transient I/O
+    // error during a perfectly normal Ok). Reset the flag so a
+    // re-shown dialog falls back to the genuine-close path.
+    if (mClosingViaButton)
+    {
+        mClosingViaButton = false;
+        QWidget::closeEvent(event);
+        return;
+    }
+    // Genuine close (X, Alt+F4, programmatic `close()` from
+    // anywhere else): treat as Cancel. Revert any live-previewed
+    // theme and reload the streaming/session config from disk so
+    // a Dark preview doesn't leak past the dialog.
     if (mTheme != nullptr)
     {
         mTheme->SetActiveSelection(mTheme->PersistedSelection());

--- a/app/src/record_detail_dock.cpp
+++ b/app/src/record_detail_dock.cpp
@@ -85,12 +85,23 @@ RecordDetailDock::RecordDetailDock(LogModel *model, QWidget *parent)
             mModel,
             &QAbstractItemModel::dataChanged,
             this,
-            [this](const QModelIndex &topLeft, const QModelIndex &bottomRight, const QList<int> & /*roles*/) {
+            [this](const QModelIndex &topLeft, const QModelIndex &bottomRight, const QList<int> &roles) {
                 if (!mCurrentSourceIndex.isValid())
                 {
                     return;
                 }
                 if (!IsVisibleForRefresh())
+                {
+                    return;
+                }
+                // Skip style-only emits (theme switch repaints fire
+                // `dataChanged` covering Background / Foreground /
+                // Font only). The pane renders Display / Edit-role
+                // text, so a re-tint doesn't change what we show.
+                // An empty `roles` list is Qt's "I don't know what
+                // changed" sentinel; treat it conservatively as a
+                // value edit and refresh.
+                if (!roles.isEmpty() && !roles.contains(Qt::DisplayRole) && !roles.contains(Qt::EditRole))
                 {
                     return;
                 }

--- a/app/src/record_detail_dock.cpp
+++ b/app/src/record_detail_dock.cpp
@@ -98,10 +98,15 @@ RecordDetailDock::RecordDetailDock(LogModel *model, QWidget *parent)
                 // `dataChanged` covering Background / Foreground /
                 // Font only). The pane renders Display / Edit-role
                 // text, so a re-tint doesn't change what we show.
-                // An empty `roles` list is Qt's "I don't know what
-                // changed" sentinel; treat it conservatively as a
-                // value edit and refresh.
-                if (!roles.isEmpty() && !roles.contains(Qt::DisplayRole) && !roles.contains(Qt::EditRole))
+                // Filter out the theme-refresh notifications via
+                // `LogModel::IsStyleOnlyRoleChange` -- the dock
+                // body only shows display-role text, so a
+                // Background/Foreground/Font flip can't change
+                // anything visible. Empty `roles` list is Qt's
+                // "I don't know what changed" sentinel; the
+                // helper reports `false` so we conservatively
+                // refresh.
+                if (LogModel::IsStyleOnlyRoleChange(roles))
                 {
                     return;
                 }

--- a/app/src/record_detail_dock.cpp
+++ b/app/src/record_detail_dock.cpp
@@ -94,18 +94,9 @@ RecordDetailDock::RecordDetailDock(LogModel *model, QWidget *parent)
                 {
                     return;
                 }
-                // Skip style-only emits (theme switch repaints fire
-                // `dataChanged` covering Background / Foreground /
-                // Font only). The pane renders Display / Edit-role
-                // text, so a re-tint doesn't change what we show.
-                // Filter out the theme-refresh notifications via
-                // `LogModel::IsStyleOnlyRoleChange` -- the dock
-                // body only shows display-role text, so a
-                // Background/Foreground/Font flip can't change
-                // anything visible. Empty `roles` list is Qt's
-                // "I don't know what changed" sentinel; the
-                // helper reports `false` so we conservatively
-                // refresh.
+                // Skip style-only emits (theme-switch repaints): the
+                // pane renders display-role text, so Background /
+                // Foreground / Font flips don't change what we show.
                 if (LogModel::IsStyleOnlyRoleChange(roles))
                 {
                     return;

--- a/app/src/record_detail_dock.cpp
+++ b/app/src/record_detail_dock.cpp
@@ -4,6 +4,7 @@
 #include "record_detail_widget.hpp"
 
 #include <QAbstractItemModel>
+#include <QCloseEvent>
 #include <QList>
 #include <QModelIndex>
 #include <QObject>
@@ -196,4 +197,13 @@ void RecordDetailDock::OnOpenInNewWindowRequested()
     // Read the row through the persistent index so eviction shifts
     // are reflected and the snapshot points at the actual record.
     emit openInNewWindowRequested(CurrentSourceRow());
+}
+
+void RecordDetailDock::closeEvent(QCloseEvent *event)
+{
+    QDockWidget::closeEvent(event);
+    if (event->isAccepted())
+    {
+        emit closed();
+    }
 }

--- a/test/app/fixtures/fixtures.qrc
+++ b/test/app/fixtures/fixtures.qrc
@@ -11,5 +11,6 @@
         <file>mixed_columns.jsonl</file>
         <file>invalid_lines.jsonl</file>
         <file>mixed_tz_and_order.jsonl</file>
+        <file>parse_errors_panel.jsonl</file>
     </qresource>
 </RCC>

--- a/test/app/fixtures/parse_errors_panel.jsonl
+++ b/test/app/fixtures/parse_errors_panel.jsonl
@@ -1,0 +1,14 @@
+{"id":1,"msg":"first valid record"}
+this line is not JSON at all
+{"id":2,"msg":"second valid record"}
+{"id":3,"msg":"unterminated string
+[1,2,3]
+"a bare JSON string"
+42
+true
+null
+{"id":4,"msg":"third valid record"}
+{trailing,comma:bad}
+{"id":5,"msg":"fourth valid record"}
+{"id":6,"msg":"missing colon" "extra":"x"}
+{"id":7,"msg":"fifth valid record"}

--- a/test/app/src/main_window_test.cpp
+++ b/test/app/src/main_window_test.cpp
@@ -4278,23 +4278,14 @@ private slots:
         QVERIFY(qvariant_cast<QFont>(fatalFont).bold());
     }
 
-    // Regression: switching themes while the main log table is
-    // visible must repaint the rows in the new colours. The model
-    // already exposes the new theme brush via `data()` (verified
-    // by `TestLogModelDataReturnsThemeBackground`), but the view
-    // needs to be told to re-query. The user-visible symptom of
-    // failure here is "I switched themes and the table still has
-    // the old level colours until I scroll / resize / refresh".
-    // We pin both halves: the model returns a new brush, *and*
-    // the view receives a `dataChanged` notification that covers
-    // the styled roles over the visible rows.
+    // Regression: a theme switch must repaint the visible rows.
+    // Symptom of failure: rows keep the old level colours until
+    // the user scrolls or resizes the table.
     void TestThemeSwitchRefreshesLogTableRows()
     {
         QVERIFY(mTheme != nullptr);
 
-        // Stream a tiny multi-level fixture so we have an Error row
-        // styled by the theme (the default themes paint Error with
-        // a distinct background).
+        // Tiny multi-level fixture to get a themed Error row.
         const QStringList lines{
             QStringLiteral(R"({"level": "info"})"),
             QStringLiteral(R"({"level": "error"})"),
@@ -4310,8 +4301,7 @@ private slots:
         const int levelCol = ColumnByHeader(*run.model, QStringLiteral("level"));
         QVERIFY2(levelCol >= 0, "level column must exist after streaming");
 
-        // Find the Error row by display value rather than fixed
-        // index, so a future fixture reorder doesn't break us.
+        // Locate the Error row by display value (robust to reorders).
         int errorRow = -1;
         for (int r = 0; r < run.model->rowCount(); ++r)
         {
@@ -4328,10 +4318,8 @@ private slots:
         QVERIFY2(lightErrorBg.isValid(), "Light theme must style the Error row background");
         const auto lightBrush = qvariant_cast<QBrush>(lightErrorBg);
 
-        // Now flip to Dark. `SetActiveSelection` -> `ApplyTheme`
-        // rebuilds the cache and emits `themeChanged`. The model
-        // shares the `ThemeControl` instance, so the next `data()`
-        // call must see the new brush.
+        // Flip to Dark; `ThemeControl` rebuilds its cache so the
+        // next `data()` call sees the new brush.
         mTheme->SetActiveSelection(QStringLiteral("Dark"));
         QCoreApplication::processEvents();
 
@@ -4345,29 +4333,21 @@ private slots:
                            .arg(lightBrush.color().name(), darkBrush.color().name()))
         );
 
-        // Sanity-check the inverse direction too: a flip back to
-        // Light returns the original brush.
+        // Inverse: Light -> Dark -> Light returns the original brush.
         mTheme->SetActiveSelection(QStringLiteral("Light"));
         QCoreApplication::processEvents();
         const auto lightBrushAgain = qvariant_cast<QBrush>(run.model->data(errorIndex, Qt::BackgroundRole));
         QCOMPARE(lightBrushAgain.color(), lightBrush.color());
     }
 
-    // Regression: against the `MainWindow`'s real table view +
-    // proxy chain, a theme switch must emit `dataChanged` on the
-    // styled roles so the view re-queries the new theme brushes.
-    // Calling only `viewport()->update()` schedules a paint but
-    // does not invalidate the view's internal item-style cache in
-    // every Qt 6 release; the user-visible bug is rows that keep
-    // the old level tint until they scroll. We pin the model-side
-    // notification.
+    // Regression: a theme switch must emit `dataChanged` on the
+    // styled roles so the view drops its per-item style cache.
+    // `viewport()->update()` alone doesn't reliably invalidate it.
     void TestThemeSwitchEmitsDataChangedOnLogTable()
     {
         QVERIFY(mTheme != nullptr);
-        // Stream a small fixture into the live `MainWindow` so its
-        // `LogModel` (not a side-car instance from `RunStreaming`)
-        // is the one we observe -- the production wiring is what
-        // we want to pin.
+        // Stream into the live `MainWindow` to observe the
+        // production-wired `LogModel`.
         const QStringList lines{
             QStringLiteral(R"({"level": "info"})"),
             QStringLiteral(R"({"level": "error"})"),
@@ -4376,8 +4356,7 @@ private slots:
         const TempJsonFile fixture(lines);
         mTheme->SetActiveSelection(QStringLiteral("Light"));
         mWindow->OpenFilesForTest({fixture.Path()}, MainWindow::OpenMode::Replace);
-        // Pump until the streaming finishes -- `streamingFinished`
-        // is queued, so a single `processEvents` isn't enough.
+        // Pump until `streamingFinished` arrives (queued connection).
         auto *model = mWindow->findChild<LogModel *>();
         QVERIFY2(model != nullptr, "MainWindow must own a LogModel");
         QSignalSpy finishedSpy(model, &LogModel::streamingFinished);
@@ -4392,18 +4371,15 @@ private slots:
         mTheme->SetActiveSelection(QStringLiteral("Dark"));
         QCoreApplication::processEvents();
 
-        // Look for a `dataChanged` emission that covers at least
-        // one of the styled roles. Other notifications (e.g.
-        // anchor-related) can ride along; we only care that *some*
-        // styled-role notification arrived.
+        // At least one `dataChanged` must cover a styled role.
+        // Other (e.g. anchor-related) notifications can ride along.
         bool foundStyledNotification = false;
         for (int i = 0; i < spy.count(); ++i)
         {
             const QList<QVariant> &args = spy.at(i);
             QVERIFY2(args.size() >= 3, "dataChanged must carry topLeft, bottomRight, roles");
             const auto roles = args.at(2).value<QList<int>>();
-            // An empty roles list is "all roles changed" in Qt's
-            // contract -- counts as styled too.
+            // Empty roles = "all roles changed" in Qt; counts as styled.
             if (roles.isEmpty() || roles.contains(Qt::BackgroundRole) || roles.contains(Qt::ForegroundRole) ||
                 roles.contains(Qt::FontRole))
             {
@@ -4418,26 +4394,16 @@ private slots:
         );
     }
 
-    // Regression: switching themes must re-apply the table view's
-    // stylesheet so `QStyleSheetStyle` drops its palette-resolved
-    // item cache. Without this, rows whose `data(BackgroundRole)`
-    // returns an invalid `QVariant` (Info / Trace levels that no
-    // theme styles) keep the previous theme's palette default,
-    // producing the user-visible "some rows repainted, some did
-    // not" symptom in dark mode. The polish has to happen even
-    // when the rule TEXT is unchanged -- the previous skip-on-
-    // identical-rule optimisation was the regression vector
-    // introduced when `ApplyTableStyleSheet` started emitting a
-    // monospace font rule (GUI-polish phase 1). We pin the
-    // observable: clearing the body stylesheet externally and
-    // then switching themes must repopulate it.
+    // Regression: a theme switch must re-apply the table view's
+    // stylesheet so `QStyleSheetStyle` drops its palette cache.
+    // Otherwise rows with no explicit Background brush (Info /
+    // Trace) keep the previous theme's default, even when the
+    // rule text is unchanged.
     void TestThemeSwitchRepolishesTableStylesheet()
     {
         QVERIFY(mTheme != nullptr);
 
-        // Prime the table view's stylesheet via the normal
-        // application path: open a fixture so streaming + initial
-        // `ApplyTableStyleSheet` run.
+        // Prime the stylesheet via the normal app path.
         const QStringList lines{
             QStringLiteral(R"({"level": "info"})"),
             QStringLiteral(R"({"level": "error"})"),
@@ -4460,18 +4426,13 @@ private slots:
             !initialStyleSheet.isEmpty(), "After a normal load the body stylesheet must include the monospace cell rule"
         );
 
-        // Externally clear the stylesheet. This mirrors the state
-        // Qt is in after the "skip unchanged write" optimisation
-        // bypasses `setStyleSheet`: the cached `mLastBodyStyleSheet`
-        // claims the rule is applied but the widget actually has
-        // a stale (or in this synthetic case, empty) stylesheet.
-        // The polish-on-theme-switch fix has to re-apply the rule
-        // regardless of what we cached.
+        // Mirror the post-optimisation state where
+        // `mLastBodyStyleSheet` claims the rule is applied but the
+        // widget's stylesheet is stale. Fix must re-apply anyway.
         tableView->setStyleSheet(QString{});
         QCOMPARE(tableView->styleSheet(), QString{});
 
-        // Switch theme. `OnThemeChanged` resets the tracker and
-        // forces `ApplyTableStyleSheet` to re-write the rule.
+        // `OnThemeChanged` resets the tracker and forces a re-write.
         mTheme->SetActiveSelection(QStringLiteral("Dark"));
         QCoreApplication::processEvents();
 
@@ -4481,9 +4442,7 @@ private slots:
                                       "`QStyleSheetStyle` re-resolves the new palette; got: '%1'")
                            .arg(tableView->styleSheet()))
         );
-        // And the re-applied rule must match what `ApplyTableStyleSheet`
-        // would build (i.e. the monospace cell rule, not some
-        // accidental empty fallback).
+        // Re-applied stylesheet must still carry the monospace rule.
         QVERIFY2(
             tableView->styleSheet().contains(QStringLiteral("QTableView::item")),
             qPrintable(QStringLiteral("Re-applied stylesheet must carry the monospace cell rule; got: '%1'")
@@ -8031,14 +7990,9 @@ private slots:
         // NOLINTNEXTLINE(clang-analyzer-core.CallAndMessage): prior QVERIFY aborts on null.
         QVERIFY2(mismatchedItem->text().toInt() > 0, "Dialog must report a non-zero mismatch count for `msg`");
 
-        // Regression: the mismatched row must pin *both* halves of
-        // the contrast pair (pink background + dark foreground).
-        // Setting only the background leaves the foreground on the
-        // palette default, which is near-white on a dark theme and
-        // renders the row's text invisible (see issue: "Column with
-        // an issue text is not visible in dark theme"). The exact
-        // colours are an implementation detail; what we pin is "the
-        // foreground is dark enough to read against pale pink".
+        // Regression: the mismatched row must pin both halves of the
+        // contrast pair; bg alone leaves fg on the palette default,
+        // which is near-white on a dark theme (row text invisible).
         for (int c = 0; c < table->columnCount(); ++c)
         {
             const QTableWidgetItem *item = table->item(matchedRowIndex, c);
@@ -8057,8 +8011,7 @@ private slots:
                                .arg(c))
             );
             // ITU-R BT.601 luma: foreground must be visibly darker
-            // than the highlight background, otherwise we're back to
-            // the original bug.
+            // than the background, or we're back to the original bug.
             const QColor fgColor = fg.color();
             const QColor bgColor = bg.color();
             constexpr double R_LUMA = 0.299;
@@ -8083,12 +8036,9 @@ private slots:
 
     // Regression: the mismatched-row highlight must adapt to the
     // active palette. The original fix pinned a pale-pink bg + dark
-    // fg, which read as a glaringly bright "white" row on Dark
-    // themes (see issue: "The row with invalid data is white in
-    // dark mode"). Verify that flipping the theme to Dark hands the
-    // dialog a *darker* highlight bg + *lighter* fg, while keeping
-    // the same high contrast (luma gap) the light-mode highlight
-    // already satisfies.
+    // fg which read as a glaringly bright row in Dark themes.
+    // Flipping to Dark must hand the dialog a darker bg + lighter
+    // fg while keeping the same luma gap.
     void TestDiagnosticsDialogHighlightAdaptsToDarkTheme()
     {
         QVERIFY(mTheme != nullptr);
@@ -8098,16 +8048,14 @@ private slots:
         const int msgCol = ColumnByHeader(*model, QStringLiteral("msg"));
         QVERIFY2(msgCol >= 0, "msg column must exist after streaming");
 
-        // Force `msg` into a mismatching state so the dialog has a
-        // warning row to paint.
+        // Force `msg` into a mismatch so the dialog paints a warning row.
         model->ConfigurationManager().SetColumnAutoDetect(static_cast<size_t>(msgCol), false);
         model->ConfigurationManager().SetColumnType(
             static_cast<size_t>(msgCol), loglib::LogConfiguration::Type::Integer
         );
         model->RefreshColumnHealth();
 
-        // Build the dialog under the Light palette and snapshot the
-        // brushes for the `msg` row.
+        // Snapshot the Light-theme brushes for the `msg` row.
         mTheme->SetActiveSelection(QStringLiteral("Light"));
         QCoreApplication::processEvents();
 
@@ -8136,11 +8084,8 @@ private slots:
         const QColor lightBg = lightItem->background().color();
         const QColor lightFg = lightItem->foreground().color();
 
-        // Flip to Dark. `SetActiveSelection` -> `ApplyTheme` swaps
-        // `QApplication::setPalette`, which fires
-        // `QEvent::ApplicationPaletteChange` on the dialog; the
-        // override re-runs `Refresh()` so the brushes pick up the
-        // dark-mode palette branch.
+        // Flip to Dark. The palette change fires `ApplicationPaletteChange`
+        // on the dialog; the override re-runs `Refresh()`.
         mTheme->SetActiveSelection(QStringLiteral("Dark"));
         QCoreApplication::processEvents();
 
@@ -8168,8 +8113,8 @@ private slots:
         constexpr double B_LUMA = 0.114;
         auto luma = [](const QColor &c) { return (R_LUMA * c.red()) + (G_LUMA * c.green()) + (B_LUMA * c.blue()); };
 
-        // Dark mode must use a *dark* highlight bg (otherwise the
-        // row punches through the dialog as a near-white slab).
+        // Dark-mode highlight bg must actually be dark; otherwise the
+        // row punches through the dialog as a near-white slab.
         constexpr double DARK_BG_MAX_LUMA = 110.0;
         QVERIFY2(
             luma(darkBg) <= DARK_BG_MAX_LUMA,
@@ -8178,8 +8123,8 @@ private slots:
                            .arg(luma(darkBg)))
         );
 
-        // Dark mode reverses the contrast pair: fg must be *lighter*
-        // than bg, by the same gap the light-mode highlight uses.
+        // Dark mode reverses the pair: fg must be lighter than bg,
+        // by the same gap as the light-mode highlight.
         constexpr double MIN_LUMA_GAP = 80.0;
         QVERIFY2(
             luma(darkFg) - luma(darkBg) >= MIN_LUMA_GAP,
@@ -8197,19 +8142,14 @@ private slots:
     }
 
     // Regression: closing the Preferences window via the X button
-    // (or any path that goes through `QWidget::close` without first
-    // running the Cancel slot) must revert a live-previewed theme
-    // back to the persisted selection. Without the `closeEvent`
-    // override, the Dark preview leaked past the dialog until the
-    // application restart (see issue: "when I change the theme and
-    // close the configuration window, the original theme is not
-    // restored").
+    // must revert a live-previewed theme to the persisted selection.
+    // Without the `closeEvent` override the Dark preview leaked
+    // past the dialog until the next app restart.
     void TestPreferencesEditorCloseEventRevertsThemePreview()
     {
         QVERIFY(mTheme != nullptr);
 
-        // Persist a known baseline (`Light`) so the close-event
-        // revert has a deterministic target.
+        // Persist a known baseline so the revert has a deterministic target.
         mTheme->SetActiveSelection(QStringLiteral("Light"));
         mTheme->SaveConfiguration();
         QCOMPARE(mTheme->PersistedSelection(), QStringLiteral("Light"));
@@ -8217,20 +8157,16 @@ private slots:
 
         PreferencesEditor editor(mTheme.data());
 
-        // Simulate the user previewing Dark via the combobox. We
-        // bypass the widget's `activated` signal and go straight to
-        // the underlying control to keep the test independent of
-        // QComboBox event quirks under offscreen-QPA.
+        // Preview Dark directly via `ThemeControl` to stay independent
+        // of QComboBox event quirks under offscreen-QPA.
         mTheme->SetActiveSelection(QStringLiteral("Dark"));
         QCoreApplication::processEvents();
         QCOMPARE(mTheme->ActiveSelection(), QStringLiteral("Dark"));
-        // Persisted selection is unchanged -- only Ok writes that.
+        // Persisted unchanged -- only Ok writes that.
         QCOMPARE(mTheme->PersistedSelection(), QStringLiteral("Light"));
 
-        // Close the window via the same path the X button takes
-        // (programmatic `close()` -> `closeEvent`). Cancel and Ok
-        // also funnel through here but they run their own logic
-        // first; what we pin is the bare path.
+        // Same path the X button takes (programmatic `close()` ->
+        // `closeEvent` without first running Cancel).
         editor.close();
         QCoreApplication::processEvents();
 
@@ -9682,17 +9618,9 @@ private slots:
         model->EndStreaming(false);
     }
 
-    // Regression: `FindRecords` and `UpdateFindMatchCount` previously
-    // OR-ed `Qt::MatchContains` with the (optional) `MatchWildcard` /
-    // `MatchRegularExpression` flags. `LogFilterModel::Matches`
-    // short-circuits on `MatchContains`, so the regex / wildcard
-    // toggles were silently no-ops -- the bar said "regex on" but
-    // the search ran as plain substring.
-    //
-    // Driver: stream lines whose substring would match plainly but
-    // whose regex / wildcard pattern must reject some of them. Then
-    // assert that find with the right flag lands on a matching row
-    // and that find without the flag still finds the broader set.
+    // Regression: `FindRecords` used to OR `MatchContains` with the
+    // regex / wildcard flags. `Matches` short-circuits on contains,
+    // so the toggles were silently no-ops.
     void TestFindUsesRegexFlagAndIgnoresContainsShadow()
     {
         const QStringList lines{
@@ -9727,20 +9655,16 @@ private slots:
         auto *filterModel = mWindow->FilterModel();
         QVERIFY2(filterModel != nullptr, "MainWindow must own a LogFilterModel");
 
-        // Anchor selection at row 0 so `FindRecords` walks forward
-        // from row 1 and lands on the first row whose digits match.
+        // Anchor at row 0 so `FindRecords` walks forward from row 1.
         tableView->selectionModel()->setCurrentIndex(
             filterModel->index(0, 0), QItemSelectionModel::ClearAndSelect | QItemSelectionModel::Rows
         );
 
-        // Regex needle `abc-\d+` matches rows 0 and 3 ("abc-123",
-        // "abc-456") but rejects row 1 ("abc-xyz") and row 2
-        // ("zzz-123"). With the old contains-wins bug this would
-        // have matched all four (substring "abc-\d+" is in none of
-        // them, so it would have *failed* the find entirely and
-        // left the selection at row 0). The fix routes purely
-        // through `MatchRegularExpression`, so we expect a hit at
-        // row 3 (skipping the selected start row 0).
+        // Regex `abc-\d+` matches rows 0 and 3 but rejects 1 and 2.
+        // The old contains-wins bug would have found nothing
+        // (substring `abc-\d+` is in none of them) and left the
+        // selection at row 0. The fix routes through regex, so we
+        // expect a hit at row 3.
         QVERIFY2(
             QMetaObject::invokeMethod(
                 mWindow,
@@ -9764,29 +9688,14 @@ private slots:
             qPrintable(QStringLiteral("regex find landed on unexpected row text: %1").arg(cell))
         );
 
-        // Wildcard branch: drive the proxy's `MatchRow` directly
-        // with `MatchWildcard` and confirm the wildcard semantics
-        // bind, independently of `FindRecords`'s start-index and
-        // skip-first-N bookkeeping.
-        //
-        // `*xyz*` (anchored to `\A.*xyz.*\z`) must match only the
-        // "abc-xyz" row. The old shadow-by-contains bug would have
-        // returned zero matches (no cell contains a literal `*`),
-        // so testing match-count alone discriminates the two
-        // implementations cleanly.
-        // Drive `MatchRow` directly with `MatchWildcard`. The
-        // bug used to lurk in two layers:
-        //   1. `MainWindow` OR-ed `MatchContains` into the flags
-        //      alongside `MatchWildcard`; and
-        //   2. `Qt::MatchFlag` values are *not* disjoint bit
-        //      flags -- `MatchWildcard = 5` already has the
-        //      `MatchContains = 1` bit set, so the old testFlag
-        //      ladder in `LogFilterModel::Matches` would short
-        //      circuit into `text.contains(needle)` even when
-        //      callers passed `MatchWildcard` alone.
-        // `*xyz*` against a literal substring of `*xyz*` matches
-        // no row, so a hit here proves the wildcard branch took
-        // effect rather than the contains branch.
+        // Wildcard branch: drive `MatchRow` directly with
+        // `MatchWildcard`, independent of `FindRecords` bookkeeping.
+        // `*xyz*` against a literal substring of `*xyz*` matches no
+        // row, so a hit here proves the wildcard branch took effect
+        // rather than the (substring) contains branch. `MatchFlag`
+        // values are not disjoint -- `MatchWildcard=5` has the
+        // `MatchContains=1` bit set, so the old testFlag ladder would
+        // demote to contains even when callers passed wildcard alone.
         const QModelIndex wildcardStart = filterModel->index(0, 0);
         QVERIFY(wildcardStart.isValid());
         const QModelIndexList wildcardHits = filterModel->MatchRow(
@@ -9805,10 +9714,8 @@ private slots:
             qPrintable(QStringLiteral("wildcard hit landed on a non-xyz row: %1").arg(wildcardCell))
         );
 
-        // And once more via the public `FindRecords` slot to
-        // pin that `MainWindow`'s flag composition is also right.
-        // Anchor selection at row 0 so wrap-around forward search
-        // lands on the only matching row (row 1, `abc-xyz`).
+        // Once more via the public `FindRecords` slot to pin that
+        // `MainWindow`'s flag composition is also right.
         tableView->selectionModel()->setCurrentIndex(
             filterModel->index(0, 0), QItemSelectionModel::ClearAndSelect | QItemSelectionModel::Rows
         );
@@ -9829,9 +9736,8 @@ private slots:
         QVERIFY2(selected.isValid(), "FindRecords with wildcards must advance to a match");
         QCOMPARE(filterModel->index(selected.row(), 0).data(Qt::DisplayRole).toString(), QStringLiteral("abc-xyz"));
 
-        // Contains needle `abc`: should reach every "abc-..." row;
-        // unchanged behaviour from before the fix, but pin it so a
-        // future refactor of the flag composition can't silently
+        // Contains needle `abc`: should reach every "abc-..." row.
+        // Pin it so a future flag-composition refactor can't silently
         // demote contains too.
         tableView->selectionModel()->setCurrentIndex(
             filterModel->index(2, 0), QItemSelectionModel::ClearAndSelect | QItemSelectionModel::Rows
@@ -9859,10 +9765,9 @@ private slots:
         model->EndStreaming(false);
     }
 
-    // Toggling the regex action in the find bar must un-check
-    // wildcards (and vice versa). They are mutually exclusive in
-    // `LogFilterModel::Matches`, so leaving both checked makes the
-    // bar look like it's running two modes when only one applies.
+    // Toggling regex must un-check wildcards (and vice versa). They
+    // are mutually exclusive in `Matches`, so leaving both checked
+    // would make the bar look like it's running two modes.
     void TestFindBarRegexAndWildcardsAreMutuallyExclusive()
     {
         auto *findRecord = mWindow->findChild<FindRecordWidget *>();
@@ -9885,19 +9790,12 @@ private slots:
         QVERIFY2(!wildcards->isChecked(), "re-enabling regex must auto-un-check wildcards");
     }
 
-    // Regression: an earlier version of the find bar called
-    // `setTabOrder(mEdit, mButtonPrevious)` directly, which severs
-    // the regex/wildcards toggles from the Tab chain and makes
-    // them keyboard-unreachable. Walk the tab chain forward from
-    // the search field and assert that both toggle buttons are
-    // visited before the arrow buttons.
-    //
-    // We can't reliably drive Qt's `focusNextChild` from a
-    // headless test (the offscreen platform plugin is twitchy
-    // about focus events), so instead we verify the static graph:
-    // chase `nextInFocusChain()` forward from `mEdit` and confirm
-    // the regex / wildcards toggle buttons appear before the
-    // arrow buttons in the chain.
+    // Regression: an earlier `setTabOrder(mEdit, mButtonPrevious)`
+    // severed the regex / wildcards toggles from the Tab chain.
+    // We can't reliably drive `focusNextChild` under offscreen-QPA,
+    // so verify the static graph: walk `nextInFocusChain()` from
+    // the search field and confirm the toggles appear before the
+    // arrow buttons.
     void TestFindBarTabOrderIncludesRegexAndWildcardsToggles()
     {
         auto *findRecord = mWindow->findChild<FindRecordWidget *>();
@@ -9913,11 +9811,9 @@ private slots:
         QVERIFY2(prevButton != nullptr, "findPrevious must exist");
         QVERIFY2(nextButton != nullptr, "findNext must exist");
 
-        // Walk forward through the chain a bounded number of
-        // hops; record the first index at which each toggle and
-        // arrow button is seen. Use a generous hop budget so
-        // unrelated children of `findRecord` (or its container)
-        // can't starve us before we encounter the targets.
+        // Walk forward, recording the first hop at which each target
+        // is seen. Generous budget so unrelated children can't
+        // starve us before we encounter the targets.
         constexpr int MAX_HOPS = 64;
         int regexIdx = -1;
         int wildcardsIdx = -1;
@@ -9965,11 +9861,9 @@ private slots:
                 QStringLiteral("arrow buttons must be on the tab chain (prev=%1 next=%2)").arg(prevIdx).arg(nextIdx)
             )
         );
-        // Order: edit -> regex -> wildcards -> prev -> next.
-        // Strict ordering on the toggles vs the arrow buttons is
-        // the actual regression guard; the toggles falling out
-        // of the chain made `regexIdx` either unset or pinned
-        // *after* the arrow buttons.
+        // Expected order: edit -> regex -> wildcards -> prev -> next.
+        // Toggles before arrow buttons is the regression guard --
+        // the bug pinned them after (or out of the chain entirely).
         QVERIFY2(
             regexIdx < prevIdx && wildcardsIdx < prevIdx,
             qPrintable(QStringLiteral("regex/wildcards toggles must precede the arrow buttons in the tab chain "
@@ -9990,10 +9884,9 @@ private slots:
     {
         auto *dock = mWindow->findChild<ParseErrorsDock *>();
         QVERIFY2(dock != nullptr, "MainWindow must own a ParseErrorsDock");
-        // `ResetSessionState`, not `ClearErrors`, so the first-batch
-        // latch is re-armed regardless of what earlier tests in
-        // the shared `mWindow` left it as -- this test wants to
-        // observe `firstBatchArrived` on the first AppendErrors.
+        // `ResetSessionState` (not `ClearErrors`) re-arms the
+        // first-batch latch, so this test can observe
+        // `firstBatchArrived` regardless of prior test state.
         dock->ResetSessionState();
 
         QSignalSpy countSpy(dock, &ParseErrorsDock::countChanged);
@@ -10020,14 +9913,9 @@ private slots:
                  1); // No second emit until a session boundary re-arms the latch.
         QCOMPARE(countSpy.last().at(0).toInt(), 5);
 
-        // ClearErrors zeroes both counters but leaves the
-        // first-batch latch SET so a streaming hiccup right after
-        // a manual Clear does not re-pop the dock the user just
-        // dismissed. (Bug fix: pre-`ResetSessionState`, the
-        // `firstBatchOfSession` heuristic keyed on
-        // `mErrorCount == 0 && mDroppedCount == 0`, which Clear
-        // restored, causing an unwanted auto-raise on the next
-        // batch.)
+        // Clear zeroes the counters but leaves the first-batch latch
+        // SET, so a streaming hiccup right after a manual Clear can't
+        // re-pop the dock the user just dismissed.
         dock->ClearErrors();
         QCOMPARE(dock->Count(), 0);
         QCOMPARE(dock->DroppedCount(), 0);
@@ -10038,8 +9926,8 @@ private slots:
         QCOMPARE(dock->Count(), 1);
         QCOMPARE(firstBatchSpy.count(), 1); // ClearErrors does NOT re-arm.
 
-        // ResetSessionState is the canonical session-boundary
-        // path and DOES re-arm the latch.
+        // `ResetSessionState` is the canonical session boundary
+        // and DOES re-arm the latch.
         dock->ResetSessionState();
         QCOMPARE(dock->Count(), 0);
         QCOMPARE(dock->DroppedCount(), 0);
@@ -10048,14 +9936,11 @@ private slots:
         QCOMPARE(firstBatchSpy.count(), 2); // Re-armed -> second emit.
     }
 
-    // Regression for the Manual-Clear-then-batch auto-raise bug.
-    // Pre-fix: clicking the in-dock Clear button reset the
-    // `firstBatchOfSession` heuristic (which keyed on
-    // `mErrorCount == 0 && mDroppedCount == 0`), so the next
-    // streamed parse-error batch fired `firstBatchArrived` again
-    // and `MainWindow` raised the dock the user had just decided
-    // to dismiss. Fix decouples the latch (`mHasSeenFirstBatch`)
-    // from the counters so only `ResetSessionState()` re-arms it.
+    // Regression: pre-fix, clicking Clear reset the
+    // `firstBatchOfSession` heuristic (it keyed on the counters
+    // being zero), so the next streamed batch fired
+    // `firstBatchArrived` again and re-raised the dock the user
+    // had just dismissed.
     void TestParseErrorsDockClearDoesNotReArmFirstBatchSignal()
     {
         auto *dock = mWindow->findChild<ParseErrorsDock *>();
@@ -10072,33 +9957,25 @@ private slots:
         QCOMPARE(dock->Count(), 0);
         QCOMPARE(dock->DroppedCount(), 0);
 
-        // The simulated streaming hiccup: a fresh batch arrives
-        // after the user manually cleared. The latch must stay
-        // set so MainWindow does not auto-raise the dock again.
+        // Simulated streaming hiccup after a manual Clear. The latch
+        // must stay set so MainWindow does not auto-raise the dock.
         dock->AppendErrors(QStringLiteral("Post-clear hiccup"), {"b"});
         QCOMPARE(dock->Count(), 1);
-        QCOMPARE(firstBatchSpy.count(), 1); // Still 1 -- ClearErrors did NOT re-arm.
+        QCOMPARE(firstBatchSpy.count(), 1); // Still 1 -- Clear did NOT re-arm.
 
-        // Sanity check the inverse: a real session boundary DOES
-        // re-arm.
+        // Inverse: a real session boundary DOES re-arm.
         dock->ResetSessionState();
         dock->AppendErrors(QStringLiteral("Real new session"), {"c"});
         QCOMPARE(firstBatchSpy.count(), 2);
     }
 
-    // Pathologically large batches must evict the leading slice up
-    // front (rather than letting `TrimToCap` walk from the top
-    // after construction). After cap-trimming, `DroppedCount()`
-    // reflects the eviction count, and the overflow footer is the
-    // single tail row marked with `OVERFLOW_FOOTER_ROLE`.
+    // A single batch larger than the cap must pre-trim the input
+    // and still surface the in-list overflow footer.
     //
-    // Regression: a single batch sized just past the cap (cap + N)
-    // pre-trims `N` entries off the input *before* items are
-    // minted, so `mErrorCount` lands exactly at `MAX_DISPLAYED_ERRORS`
-    // after the loop. The old `TrimToCap` short-circuited at that
-    // point and never appended the in-list overflow footer, leaving
-    // the summary header ("N earlier dropped") and the list view
-    // out of sync.
+    // Regression: when `mErrorCount` landed exactly at the cap
+    // after pre-trim, the old `TrimToCap` short-circuited and
+    // skipped appending the footer, leaving the "N dropped"
+    // summary and the list view out of sync.
     void TestParseErrorsDockTrimsToCapAndAddsOverflowFooter()
     {
         auto *dock = mWindow->findChild<ParseErrorsDock *>();
@@ -10119,11 +9996,9 @@ private slots:
         auto *list = dock->findChild<QListWidget *>(QStringLiteral("parseErrorsList"));
         QVERIFY2(list != nullptr, "ParseErrorsDock must expose its internal QListWidget");
 
-        // The footer must be the *last* item (so it floats below
-        // the surviving rows) and must be the only item flagged
-        // with `Qt::UserRole + 1`. Searching from the tail also
-        // guarantees we don't accidentally find a stale footer
-        // sitting somewhere in the middle.
+        // Footer must be the last item and the only one flagged
+        // with `Qt::UserRole + 1` (so we'd also catch a stale
+        // footer left somewhere in the middle).
         const QListWidgetItem *footer = nullptr;
         int footerIndex = -1;
         int footerHits = 0;
@@ -10145,17 +10020,15 @@ private slots:
             footer->text().contains(QStringLiteral("dropped"), Qt::CaseInsensitive),
             qPrintable(QStringLiteral("footer must read like an overflow notice; got: %1").arg(footer->text()))
         );
-        // Footer must be non-selectable so arrow-key navigation
-        // and Ctrl+A don't pull it into the user's selection.
+        // Non-selectable so arrow-key navigation and Ctrl+A don't
+        // pull the footer into the user's selection.
         QVERIFY2(!footer->flags().testFlag(Qt::ItemIsSelectable), "overflow footer must not be user-selectable");
     }
 
-    // Streaming-style: many smaller batches that collectively
-    // overflow the cap. `TrimToCap`'s walk-from-the-top path
-    // handles the eviction here (different code path from the
-    // pathological single-batch case above), so the in-list
-    // footer needs to appear on this path too and stay
-    // monotonic with `mDroppedCount`.
+    // Streaming-style overflow: many small batches sum past the
+    // cap. Exercises `TrimToCap`'s walk-from-the-top path (the
+    // single-batch test above covers the pre-trim path); the
+    // footer must surface here too and track `mDroppedCount`.
     void TestParseErrorsDockOverflowFooterTracksMultipleBatches()
     {
         auto *dock = mWindow->findChild<ParseErrorsDock *>();
@@ -10167,8 +10040,7 @@ private slots:
         const int footerRole = Qt::UserRole + 1;
 
         const int cap = ParseErrorsDock::MAX_DISPLAYED_ERRORS;
-        // Fill exactly to the cap with one moderate batch -- no
-        // overflow yet, so no footer expected.
+        // Fill exactly to the cap -- no overflow yet, no footer.
         std::vector<std::string> first;
         first.reserve(static_cast<size_t>(cap));
         for (int i = 0; i < cap; ++i)
@@ -10183,8 +10055,7 @@ private slots:
             QVERIFY2(item == nullptr || !item->data(footerRole).toBool(), "no footer when nothing has been dropped");
         }
 
-        // Second small batch tips the dock over the cap. Walk
-        // eviction kicks in. Footer must surface.
+        // Tip past the cap; walk eviction kicks in, footer surfaces.
         const int overflow = 50;
         std::vector<std::string> second;
         second.reserve(static_cast<size_t>(overflow));
@@ -10201,9 +10072,8 @@ private slots:
             "overflow footer must be the trailing item after eviction"
         );
 
-        // Third batch grows `mDroppedCount` further; footer text
-        // must update to the new total, and the dock must not
-        // accumulate stale footers.
+        // Third batch grows the drop count; footer text must update
+        // and the dock must not accumulate stale footers.
         std::vector<std::string> third;
         third.reserve(static_cast<size_t>(overflow));
         for (int i = 0; i < overflow; ++i)
@@ -10232,20 +10102,16 @@ private slots:
         );
     }
 
-    // `CopySelection` documents that group headers + overflow
-    // footer are pasted alongside the user's selection so the
-    // copied block reads coherently. Headers and the footer are
-    // non-selectable items, so the implementation has to
-    // synthesise them around the selection rather than rely on
-    // `isSelected()`.
+    // `CopySelection` must synthesise group headers and the
+    // overflow footer around the selection so the pasted block
+    // reads coherently. Headers / footer are non-selectable.
     void TestParseErrorsDockCopySelectionIncludesHeaderAndFooter()
     {
         auto *dock = mWindow->findChild<ParseErrorsDock *>();
         QVERIFY2(dock != nullptr, "MainWindow must own a ParseErrorsDock");
         dock->ClearErrors();
 
-        // Two batches so we have two headers; cap-overflow forces
-        // the footer.
+        // Two batches -> two headers; cap-overflow forces a footer.
         const int cap = ParseErrorsDock::MAX_DISPLAYED_ERRORS;
         std::vector<std::string> batchA;
         batchA.reserve(static_cast<size_t>(cap - 5));
@@ -10262,8 +10128,7 @@ private slots:
         auto *list = dock->findChild<QListWidget *>(QStringLiteral("parseErrorsList"));
         QVERIFY2(list != nullptr, "ParseErrorsDock must expose its internal QListWidget");
 
-        // Locate the "Batch B" header + one of its error rows; the
-        // header sits between A's last row and B's first.
+        // Find Batch B's header + first error row.
         int batchBHeaderRow = -1;
         int firstBRow = -1;
         for (int i = 0; i < list->count(); ++i)
@@ -10294,12 +10159,10 @@ private slots:
         auto *clipboard = QGuiApplication::clipboard();
         clipboard->clear();
 
-        // `CopySelection` is private; invoke via the Ctrl+C
-        // shortcut so we exercise the same path the user sees.
-        // The shortcut is parented on the dock's content widget
-        // (so it stays live even when focus is on the Clear
-        // button instead of the list), so search the whole dock
-        // subtree rather than just the list's children.
+        // `CopySelection` is private; trigger the Ctrl+C shortcut
+        // instead. It's parented on the dock content widget (so it
+        // stays live even when focus is on the Clear button), so
+        // search the whole dock subtree.
         QShortcut *copyShortcut = nullptr;
         const QList<QShortcut *> shortcuts = dock->findChildren<QShortcut *>();
         for (QShortcut *s : shortcuts)
@@ -10324,21 +10187,18 @@ private slots:
             clip.contains(QStringLiteral("B-0")),
             qPrintable(QStringLiteral("clipboard must include the selected error row; got:\n%1").arg(clip))
         );
-        // The overflow footer is rendered by `tr()` so the exact
-        // text is locale-dependent; look for the parenthesised
-        // "dropped" hint instead.
+        // Footer is `tr()`-rendered, so match the locale-stable
+        // "dropped" hint rather than the full string.
         QVERIFY2(
             clip.contains(QStringLiteral("dropped"), Qt::CaseInsensitive),
             qPrintable(QStringLiteral("clipboard must include the overflow footer; got:\n%1").arg(clip))
         );
     }
 
-    // Regression: trimming a multi-batch overflow used to leave
-    // surviving rows from the first batch *headerless* -- their
-    // group label was the first thing evicted, so the rows that
-    // remained floated above the next batch's title with nothing
-    // labelling them. The fix re-mints the evicted header above
-    // the surviving rows.
+    // Regression: trimming evicted the first batch's group header
+    // along with some rows, leaving the surviving rows headerless
+    // above the next batch's title. Fix re-mints the evicted header
+    // above the survivors.
     void TestParseErrorsDockTrimPreservesSurvivingBatchHeader()
     {
         auto *dock = mWindow->findChild<ParseErrorsDock *>();
@@ -10349,9 +10209,8 @@ private slots:
         QVERIFY2(list != nullptr, "ParseErrorsDock must expose its internal QListWidget");
 
         const int cap = ParseErrorsDock::MAX_DISPLAYED_ERRORS;
-        // First batch fills most of the cap. Second batch tips us
-        // over, evicting the first batch's *header* plus a chunk
-        // of its rows but leaving the rest of batch A behind.
+        // Batch A fills most of the cap; batch B tips us over,
+        // evicting A's header plus a chunk of its rows.
         const int batchAStart = cap - 200;
         std::vector<std::string> batchA;
         batchA.reserve(static_cast<size_t>(batchAStart));
@@ -10370,11 +10229,9 @@ private slots:
 
         QVERIFY2(dock->DroppedCount() > 0, "second batch must have evicted some of batch A");
 
-        // Find the first surviving error row. It must be an
-        // `A-...` entry (since A was the older batch), and the
-        // immediately preceding item must be a non-selectable
-        // group header reading "Batch A" -- not "Batch B" floating
-        // above orphan A rows.
+        // First surviving row must be an `A-...` entry, with a
+        // "Batch A" header immediately above it (not "Batch B"
+        // floating above orphan A rows).
         int firstSelectableRow = -1;
         for (int i = 0; i < list->count(); ++i)
         {
@@ -10401,11 +10258,9 @@ private slots:
         QCOMPARE(headerAbove->text(), QStringLiteral("Batch A"));
     }
 
-    // Regression: re-opening the find bar after a model reset
-    // used to show whatever match count the label held when the
-    // bar was last hidden, even when that count referred to a
-    // completely different dataset. The `FindDock::revealed`
-    // signal is the trigger for a catch-up recount.
+    // Regression: re-opening the find bar after a model reset used
+    // to show the stale match count from the previous dataset.
+    // `FindDock::revealed` is the trigger for a catch-up recount.
     void TestFindBarRevealedSignalTriggersCatchUpRecount()
     {
         auto *dock = mWindow->findChild<FindDock *>();
@@ -10427,33 +10282,25 @@ private slots:
 
         emit dock->revealed();
 
-        // Wait up to a second for the debounce (default 120 ms) to
-        // fire. Using `wait()` rather than `processEvents` so we
-        // don't depend on the test driver's clock to tick.
+        // Wait for the 120 ms debounce to fire. `wait()` doesn't
+        // depend on the test driver's clock ticking.
         QVERIFY2(
             spy.count() > 0 || spy.wait(1000),
             "FindDock::revealed must trigger a debounced MatchCountRequested for a non-empty needle"
         );
 
-        // Empty-needle reveal must be a no-op: the bar suppresses
-        // the request, so the cache stays untouched.
+        // Empty needle: the bar suppresses the request.
         edit->clear();
         spy.clear();
         emit dock->revealed();
         QVERIFY2(!spy.wait(300), "FindDock::revealed must NOT trigger MatchCountRequested for an empty needle");
     }
 
-    // Regression: under continuous activity (live-tail streaming,
-    // a held-down key), the trailing 120 ms debounce restarts on
-    // every bump and never fires. The match-count indicator
-    // would then strand at the value from before the activity
-    // started, which is exactly the case where a live indicator
-    // is most useful. `BumpMatchCountDebounce` was extended to
-    // also arm a max-age timer (capped at 750 ms) that is *not*
-    // reset by subsequent bumps, guaranteeing an emit within
-    // that window. This test forces a stream of bumps tighter
-    // than the trailing window and asserts the emit still
-    // arrives within the max-age cap.
+    // Regression: under continuous activity (live-tail, held key)
+    // the trailing 120 ms debounce restarts on every bump and
+    // never fires, stranding the indicator at the pre-activity
+    // count. A max-age timer (capped at 750 ms) that survives
+    // subsequent bumps guarantees an emit within that window.
     void TestFindBarDebounceMaxAgeForcesEmitUnderContinuousActivity()
     {
         auto *findRecord = mWindow->findChild<FindRecordWidget *>();
@@ -10468,10 +10315,9 @@ private slots:
         QVERIFY2(spy.count() > 0 || spy.wait(1500), "initial textChanged must emit");
         spy.clear();
 
-        // Hammer the bump every 50 ms (under the 120 ms trailing
-        // window) for 1000 ms total. Without the max-age cap the
-        // trailing timer never fires; with it, exactly one emit
-        // arrives within ~750 ms of the first bump.
+        // Bump every 50 ms (under the 120 ms trailing window) for
+        // 1 s. Without the max-age cap the trailing timer never
+        // fires; with it, an emit arrives within ~750 ms.
         QElapsedTimer wallClock;
         wallClock.start();
         constexpr int BUMP_INTERVAL_MS = 50;
@@ -10502,28 +10348,15 @@ private slots:
         );
     }
 
-    // Regression: `LogFilterModel::MatchRow` skips hidden columns
-    // (it honours `Column::visible`), but column-visibility flips
-    // do not emit any of the model / proxy signals the find cache
-    // is wired to (`rowsInserted`, `layoutChanged`, `dataChanged`,
-    // ...). Without explicit invalidation the "*i* of *N*"
-    // indicator could strand a count that includes hits in
-    // now-hidden columns. `SetColumnVisible` and
-    // `ApplyColumnVisibility` were updated to call
-    // `OnFindCacheInvalidated`; this test pins that wire.
+    // Regression: `MatchRow` skips hidden columns, but column-
+    // visibility flips don't emit any of the proxy signals the find
+    // cache hooks. Without explicit invalidation the "*i* of *N*"
+    // indicator would strand a count that includes hits in
+    // now-hidden columns. `SetColumnVisible` /
+    // `ApplyColumnVisibility` now call `OnFindCacheInvalidated`.
     //
-    // Driver: set a needle, prime the cache, hide a column, then
-    // verify the indicator is recomputed against the post-hide
-    // visibility set. Two checks lock the wire down:
-    //   - the cached match list reported via `SetMatchInfo`
-    //     decreases (matches that were only in the hidden column
-    //     are gone), and
-    //   - a fresh `MatchCountRequested` arrives, which only
-    //     happens if `OnFindCacheInvalidated` ran.
-    //
-    // We need the main window realised so `mFindDock->isVisible()`
-    // returns true (the visibility gate on the bump is
-    // intentional perf -- a hidden bar doesn't pay the recount).
+    // The main window must be realised so the find dock is visible
+    // (the bump gate skips recounts when the bar is hidden).
     void TestHidingColumnInvalidatesFindCache()
     {
         const int categoryCol = StreamFixtureForColumnTests();
@@ -10536,8 +10369,7 @@ private slots:
         auto *edit = findRecord->findChild<QLineEdit *>(QStringLiteral("findEdit"));
         QVERIFY2(edit != nullptr, "FindRecordWidget must expose its line edit");
 
-        // Realise the window so the visibility gate in
-        // `OnFindCacheInvalidated` lets the bump through.
+        // Realise the window so the bump gate lets through.
         mWindow->show();
         QVERIFY(QTest::qWaitForWindowExposed(mWindow, 5000));
         findDock->show();
@@ -10547,8 +10379,8 @@ private slots:
         edit->setText(QStringLiteral("info"));
         QSignalSpy spy(findRecord, &FindRecordWidget::MatchCountRequested);
         QVERIFY(spy.isValid());
-        // Drain the textChanged-triggered debounce so the next
-        // emit we observe is unambiguously caused by the hide.
+        // Drain the textChanged debounce so the next emit is
+        // unambiguously caused by the hide.
         QVERIFY2(spy.count() > 0 || spy.wait(1500), "initial textChanged must trigger a debounced MatchCountRequested");
         spy.clear();
 
@@ -10559,13 +10391,9 @@ private slots:
         );
     }
 
-    // Regression: `ParseErrorsDock::AppendErrors` used to call
-    // `scrollToBottom()` on every append, yanking the user back
-    // to the tail every time a new batch arrived during a
-    // streaming session. The chat / log convention is to
-    // auto-follow only when the user was already at the tail,
-    // otherwise preserve their scroll position so they can read
-    // earlier rows without being interrupted.
+    // Regression: `AppendErrors` used to `scrollToBottom()` on every
+    // append, yanking the user back to the tail mid-read. Chat/log
+    // convention: auto-follow only when already at the tail.
     void TestParseErrorsDockAutoFollowOnlyWhenAtTail()
     {
         auto *dock = mWindow->findChild<ParseErrorsDock *>();
@@ -10575,20 +10403,17 @@ private slots:
         auto *list = dock->findChild<QListWidget *>(QStringLiteral("parseErrorsList"));
         QVERIFY2(list != nullptr, "ParseErrorsDock must expose its internal QListWidget");
 
-        // Realise the dock so the scrollbar has a real viewport
-        // geometry; offscreen QPA still pumps the scrollbar's
-        // min/max/value updates as long as the widget tree is
-        // shown.
+        // Realise the dock so the scrollbar has a real viewport.
+        // Offscreen QPA still pumps min/max/value updates as long
+        // as the widget tree is shown.
         mWindow->show();
         QVERIFY(QTest::qWaitForWindowExposed(mWindow, 5000));
         dock->show();
         dock->raise();
         QCoreApplication::processEvents();
 
-        // Seed enough entries that the list scrolls. The user is
-        // by definition at the tail (the list was empty before
-        // this append), so the auto-follow path should pin us to
-        // the bottom afterwards.
+        // Seed enough entries that the list scrolls. We start at
+        // the tail (list was empty), so auto-follow pins us there.
         std::vector<std::string> seed;
         seed.reserve(200);
         for (int i = 0; i < 200; ++i)
@@ -10600,26 +10425,21 @@ private slots:
 
         QScrollBar *vBar = list->verticalScrollBar();
         QVERIFY2(vBar != nullptr, "QListWidget must have a vertical scrollbar");
-        // With 200 entries in a small dock the scrollbar should be
-        // non-degenerate; if the offscreen geometry left
-        // `maximum() == minimum()` the auto-follow assertion below
-        // can't distinguish "still at tail" from "moved by us",
-        // so the test is meaningless on this platform / driver.
+        // If offscreen geometry leaves `maximum() == minimum()`
+        // we can't distinguish "still at tail" from "moved by us",
+        // so the test is meaningless on this platform.
         if (vBar->maximum() <= vBar->minimum())
         {
             QSKIP("offscreen QPA produced a degenerate scrollbar -- can't exercise auto-follow");
         }
 
-        // Park the user mid-list. Any position comfortably above
-        // `maximum()` works; pick the middle so the slack
-        // tolerance (4 px) cannot accidentally include us.
+        // Park mid-list -- comfortably outside the 4 px tail slack.
         const int parkedPosition = vBar->minimum() + ((vBar->maximum() - vBar->minimum()) / 2);
         vBar->setValue(parkedPosition);
         QCoreApplication::processEvents();
         QCOMPARE(vBar->value(), parkedPosition);
 
-        // New batch arrives mid-read. The user did not move; the
-        // scrollbar should stay parked.
+        // New batch mid-read must leave the scrollbar parked.
         const std::vector<std::string> later{"late-0", "late-1", "late-2", "late-3", "late-4"};
         dock->AppendErrors(QStringLiteral("Later"), later);
         QCoreApplication::processEvents();
@@ -10632,9 +10452,7 @@ private slots:
                            .arg(vBar->maximum()))
         );
 
-        // Scroll back to the tail. A subsequent batch should
-        // re-pin us there (auto-follow re-engages once the user
-        // returns to the end).
+        // Scroll back to tail; auto-follow must re-engage.
         vBar->setValue(vBar->maximum());
         QCoreApplication::processEvents();
         QCOMPARE(vBar->value(), vBar->maximum());
@@ -10642,8 +10460,8 @@ private slots:
         const std::vector<std::string> trailing{"tail-0", "tail-1", "tail-2"};
         dock->AppendErrors(QStringLiteral("Trailing"), trailing);
         QCoreApplication::processEvents();
-        // After more items land, `maximum()` grew; the auto-follow
-        // path must have moved `value` along with it.
+        // After more items land `maximum()` grew; auto-follow
+        // must have moved `value` along with it.
         QVERIFY2(
             vBar->value() >= vBar->maximum() - 4,
             qPrintable(QStringLiteral("Auto-follow must re-pin to the tail when the user was at the tail "
@@ -10654,14 +10472,10 @@ private slots:
     }
 
     // Regression: `UpdateFindMatchCount` used to run the full
-    // proxy scan even when the find dock was hidden -- a debounce
-    // timer armed while the bar was visible can still fire after
-    // the user dismisses it. The slot now bails when
-    // `mFindDock->isVisible()` is false, matching the gates on
-    // `OnFindCacheInvalidated` and `FindRecords`'s post-jump
-    // refresh. We pin this by inspecting `SetMatchInfo`'s effect:
-    // with the bar hidden, the slot must not populate the
-    // indicator label.
+    // proxy scan even when the find dock was hidden (a debounce
+    // armed while the bar was visible can still fire after the
+    // user dismisses it). The slot now bails on hidden, matching
+    // the gates on `OnFindCacheInvalidated` and `FindRecords`.
     void TestUpdateFindMatchCountSkipsWorkWhenDockHidden()
     {
         auto *findRecord = mWindow->findChild<FindRecordWidget *>();
@@ -10671,18 +10485,13 @@ private slots:
         auto *label = findRecord->findChild<QLabel *>(QStringLiteral("findMatchCount"));
         QVERIFY2(label != nullptr, "FindRecordWidget must expose its match-count label");
 
-        // Make sure the dock is hidden going into the test.
         findDock->hide();
         QVERIFY(!findDock->isVisible());
 
-        // Seed the label with a known non-empty marker so we can
-        // detect any subsequent write -- a successful write would
-        // either clear the label (empty-needle branch) or set it
-        // to "N matches".
+        // Sentinel so any write (clear or "N matches") is detectable.
         label->setText(QStringLiteral("sentinel-do-not-touch"));
 
-        // Invoke the slot directly. The visibility gate must
-        // short-circuit before the label is touched.
+        // The visibility gate must short-circuit before any write.
         QVERIFY2(
             QMetaObject::invokeMethod(
                 mWindow,
@@ -10696,9 +10505,9 @@ private slots:
         );
         QCOMPARE(label->text(), QStringLiteral("sentinel-do-not-touch"));
 
-        // And an empty-needle programmatic call must also
-        // short-circuit -- pre-fix it would have cleared the
-        // label even though nothing was on screen to clear.
+        // Empty needle must also short-circuit -- pre-fix it would
+        // have cleared the sentinel even though nothing was on
+        // screen to clear.
         QVERIFY2(
             QMetaObject::invokeMethod(
                 mWindow,
@@ -10713,13 +10522,10 @@ private slots:
         QCOMPARE(label->text(), QStringLiteral("sentinel-do-not-touch"));
     }
 
-    // Regression: the parse-errors status button used to display
-    // "X parse errors" where X was `count + droppedCount`. The
-    // dock summary read "X errors; Y earlier dropped", so the
-    // button's total didn't match the dock body and a user
-    // clicking through to investigate the discrepancy would
-    // suspect a bug. The fix is to render the dropped count
-    // inline on the button when non-zero.
+    // Regression: the status button used to total `count +
+    // droppedCount`, which didn't match the dock summary ("X
+    // errors; Y earlier dropped"). Now the button renders the
+    // dropped count inline when non-zero.
     void TestParseErrorsStatusButtonShowsDroppedHint()
     {
         auto *dock = mWindow->findChild<ParseErrorsDock *>();
@@ -10728,8 +10534,7 @@ private slots:
         QVERIFY2(statusButton != nullptr, "MainWindow must own the parse-errors status button");
         dock->ClearErrors();
 
-        // No drops yet: the button uses the simple "%n errors"
-        // form, no "dropped" hint anywhere on it.
+        // No drops yet: button uses the plain "%n errors" form.
         dock->AppendErrors(QStringLiteral("First"), {"a", "b", "c"});
         QCoreApplication::processEvents();
         // NOLINTNEXTLINE(clang-analyzer-core.CallAndMessage): false positive; prior `QVERIFY2` aborts on null.
@@ -10739,9 +10544,8 @@ private slots:
                            .arg(statusButton->text()))
         );
 
-        // Force an overflow so `droppedCount > 0`. A single batch
-        // larger than `MAX_DISPLAYED_ERRORS` pre-trims to mint a
-        // dropped count without any prior content getting evicted.
+        // Force an overflow so `droppedCount > 0`. A batch larger
+        // than the cap pre-trims to mint a dropped count.
         const int cap = ParseErrorsDock::MAX_DISPLAYED_ERRORS;
         std::vector<std::string> huge;
         huge.reserve(static_cast<size_t>(cap) + 50);
@@ -10753,9 +10557,9 @@ private slots:
         QCoreApplication::processEvents();
         QVERIFY2(dock->DroppedCount() > 0, "fixture must produce a non-zero dropped count");
 
-        // The button label must now include the dropped hint so
-        // the user can tell from the status bar (without opening
-        // the dock) that the visible total isn't the whole story.
+        // Button must now surface the dropped hint so the user can
+        // tell from the status bar that the visible total isn't
+        // the whole story.
         QVERIFY2(
             statusButton->text().contains(QStringLiteral("dropped"), Qt::CaseInsensitive),
             qPrintable(QStringLiteral("status button must surface dropped count in its label; got: %1")
@@ -10769,11 +10573,9 @@ private slots:
         );
     }
 
-    // The find-bar arrow icons must follow the current palette so a
-    // Light <-> Dark theme switch can't leave the previous-match /
-    // next-match glyphs invisible. Regression for the
-    // `QStyle::SP_ArrowUp` / `SP_ArrowDown` baked-black pixmaps that
-    // disappeared on dark themes.
+    // Regression: the find-bar arrow icons used `SP_ArrowUp` /
+    // `SP_ArrowDown`, whose baked-black pixmaps disappeared on dark
+    // themes. The icons must follow `QPalette::WindowText`.
     void TestFindBarArrowIconsFollowPalette()
     {
         auto *findRecord = mWindow->findChild<FindRecordWidget *>();
@@ -10783,11 +10585,9 @@ private slots:
         QVERIFY2(prevButton != nullptr, "FindRecordWidget must expose its previous button");
         QVERIFY2(nextButton != nullptr, "FindRecordWidget must expose its next button");
 
-        // Counts opaque pixels in @p icon when rendered at its first
-        // available size. A baked-black `SP_ArrowUp` glyph paints
-        // dark pixels regardless of palette, while our palette-aware
-        // icon paints in `QPalette::WindowText`, which we can flip
-        // below to detect the difference.
+        // Count opaque pixels in @p icon matching @p expected (with
+        // a small per-channel tolerance for anti-alias drift). A
+        // baked-black glyph never matches a non-black @p expected.
         auto opaquePixelCount = [](const QIcon &icon, QRgb expected) -> int {
             const QList<QSize> sizes = icon.availableSizes();
             const QSize size = sizes.isEmpty() ? QSize{16, 16} : sizes.front();
@@ -10802,8 +10602,7 @@ private slots:
                     {
                         continue;
                     }
-                    // Tolerate a few units of anti-alias drift on
-                    // each channel: a pure-red apex blends into a
+                    // Tolerate AA drift -- a pure-red apex blends to
                     // half-transparent maroon at the slope's edge.
                     constexpr int CHANNEL_TOLERANCE = 32;
                     if (std::abs(qRed(px) - qRed(expected)) <= CHANNEL_TOLERANCE &&
@@ -10817,10 +10616,9 @@ private slots:
             return matching;
         };
 
-        // Paint the icons in a vivid red palette and assert the
-        // rendered pixmap actually contains red. If the buttons
-        // still used `SP_ArrowUp` / `SP_ArrowDown`, the rendered
-        // glyphs would be black regardless of `WindowText`.
+        // Vivid red palette: the rendered pixmap must contain red.
+        // The old baked-black icons would be black regardless of
+        // `WindowText`.
         QPalette redPalette = findRecord->palette();
         redPalette.setColor(QPalette::Active, QPalette::WindowText, QColor(255, 0, 0));
         redPalette.setColor(QPalette::Inactive, QPalette::WindowText, QColor(255, 0, 0));
@@ -10833,10 +10631,9 @@ private slots:
         QVERIFY2(prevRed > 0, "previous-button icon must paint in the palette's WindowText colour");
         QVERIFY2(nextRed > 0, "next-button icon must paint in the palette's WindowText colour");
 
-        // Flip to a vivid blue and assert the rendered pixmap
-        // changed accordingly. This is the real regression: the
-        // first time the user toggles Light -> Dark, the arrows
-        // have to actually re-paint.
+        // Flip to vivid blue: the rendered pixmap must change too.
+        // The real regression is that the first Light -> Dark
+        // toggle must actually re-paint the arrows.
         QPalette bluePalette = findRecord->palette();
         bluePalette.setColor(QPalette::Active, QPalette::WindowText, QColor(0, 0, 255));
         bluePalette.setColor(QPalette::Inactive, QPalette::WindowText, QColor(0, 0, 255));
@@ -10848,12 +10645,10 @@ private slots:
         QVERIFY2(nextBlue > 0, "next-button icon must repaint after a palette change");
     }
 
-    // The chevron icon backing pixmap must be allocated at the
-    // host's `devicePixelRatioF()` so HiDPI displays render the
-    // arrow at native resolution. Pre-fix the pixmap was minted at
-    // `sizePx x sizePx` regardless of DPR, leaving the chevrons
-    // softer than the surrounding `.*` / `*?` text glyphs on a
-    // 200% scaled monitor.
+    // Regression: the chevron pixmap was minted at logical size
+    // regardless of DPR, leaving the arrows softer than the
+    // surrounding `.*` / `*?` glyphs on a 200%-scaled monitor.
+    // Backing pixmap must scale with `devicePixelRatioF()`.
     void TestFindBarArrowIconsScaleWithDevicePixelRatio()
     {
         auto *findRecord = mWindow->findChild<FindRecordWidget *>();
@@ -10867,10 +10662,9 @@ private slots:
         QVERIFY2(!sizes.isEmpty(), "icon must report at least one size");
 
         // The pixmap returned by `pixmap(size)` is scaled to the
-        // requested logical size; what we want to inspect is the
-        // *backing* pixel count. Pulling at the largest available
-        // size and asserting `devicePixelRatio()` matches the
-        // widget's host DPR is the cleanest probe.
+        // logical size; we want the *backing* pixel count. Pull the
+        // largest available size and check `devicePixelRatio()`
+        // matches the host widget's DPR.
         const QPixmap pix = icon.pixmap(sizes.front());
         QVERIFY2(!pix.isNull(), "pixmap mint must succeed");
         const qreal hostDpr = findRecord->devicePixelRatioF();
@@ -10882,9 +10676,8 @@ private slots:
                                .arg(hostDpr)
                                .arg(pix.devicePixelRatio()))
             );
-            // Backing pixel size should also scale: a sizePx-wide
-            // logical icon at 2x DPR should have a 2*sizePx-wide
-            // backing pixmap.
+            // Backing pixel size scales with DPR: an N-wide logical
+            // icon at 2x DPR has a 2N-wide backing pixmap.
             const int expectedBackingPx = static_cast<int>(std::lround(sizes.front().width() * hostDpr));
             QVERIFY2(
                 pix.size().width() >= expectedBackingPx - 1 && pix.size().width() <= expectedBackingPx + 1,
@@ -10896,16 +10689,15 @@ private slots:
         }
         else
         {
-            // 1x display: just confirm the icon is realised.
+            // 1x display: just confirm the pixmap is realised.
             QVERIFY(pix.devicePixelRatio() >= 1.0 - 0.05);
         }
     }
 
-    // `LogModel::IsStyleOnlyRoleChange` is the helper the find
-    // cache and record-detail dock use to filter out
-    // theme-refresh notifications. Lock down its contract so a
-    // future role addition can't silently flip a value-affecting
-    // role into the "ignore" set.
+    // `IsStyleOnlyRoleChange` is the helper the find cache and
+    // record-detail dock use to ignore theme-refresh emits. Lock
+    // the contract so a future role addition can't silently flip a
+    // value-affecting role into the "ignore" set.
     void TestIsStyleOnlyRoleChangeContract()
     {
         QVERIFY2(
@@ -10925,11 +10717,10 @@ private slots:
         );
     }
 
-    // `LogFilterModel::ComposeFindFlags` is the single source of
-    // truth for find-flag composition. Lock down the priority
-    // (regex > wildcard > contains) and the always-on
-    // `MatchWrap | MatchRecursive` baseline so a future refactor
-    // can't desync the find call sites.
+    // `ComposeFindFlags` is the single source of truth for find-
+    // flag composition. Lock the priority (regex > wildcard >
+    // contains) and the always-on `MatchWrap | MatchRecursive`
+    // baseline so a future refactor can't desync call sites.
     void TestComposeFindFlagsPriorityAndBaseline()
     {
         constexpr Qt::MatchFlags BASELINE = Qt::MatchWrap | Qt::MatchRecursive;
@@ -10945,62 +10736,51 @@ private slots:
             LogFilterModel::ComposeFindFlags(/*wildcards=*/false, /*regularExpressions=*/true),
             BASELINE | Qt::MatchRegularExpression
         );
-        // Both toggles checked: regex wins (the UI enforces this
-        // visually too -- `mWildcardsAction` and `mRegexAction`
-        // are mutually exclusive -- but the helper itself must
-        // not depend on that invariant being upheld upstream).
+        // Both toggles set: regex wins. The UI enforces mutual
+        // exclusion, but the helper must not depend on it.
         QCOMPARE(
             LogFilterModel::ComposeFindFlags(/*wildcards=*/true, /*regularExpressions=*/true),
             BASELINE | Qt::MatchRegularExpression
         );
     }
 
-    // `BumpMatchCountDebounce` was a hot path during streaming
-    // bursts: every `dataChanged` invalidation called
-    // `mMatchCountTimer->start()`, which restarts the trailing
-    // timer. With continuous streaming, the trailing timer was
-    // forever reset and only the max-age timer (cap = 750ms)
-    // fired. Fix: when both timers are already running, skip the
-    // start call so the recount actually fires on the trailing
-    // timer's natural deadline.
+    // Regression: every `dataChanged` invalidation used to call
+    // `mMatchCountTimer->start()`, which restarted the trailing
+    // timer. Under streaming the trailing timer never fired and
+    // only the max-age cap (750 ms) ever delivered. Fix: when both
+    // timers are already running, skip the start so the trailing
+    // timer can run to its natural deadline.
     void TestBumpMatchCountDebounceCoalescesStreamingBursts()
     {
         auto *findRecord = mWindow->findChild<FindRecordWidget *>();
         QVERIFY2(findRecord != nullptr, "MainWindow must own a FindRecordWidget");
         auto *findEdit = findRecord->findChild<QLineEdit *>(QStringLiteral("findEdit"));
         QVERIFY2(findEdit != nullptr, "FindRecordWidget must expose its QLineEdit");
-        // `FindRecordWidget` names both timers via `setObjectName`
-        // so the test can probe them without the fragile "walk
-        // all timers and guess which is which" dance. If either
-        // name disappears the failure surfaces as a clear "the
-        // timer probe regressed" instead of a generic assertion
-        // mid-test.
+        // Both timers carry `objectName` so the test can probe them
+        // without the fragile "walk all timers and guess" dance.
         auto *trailing = findRecord->findChild<QTimer *>(QStringLiteral("matchCountDebounceTimer"));
         auto *maxAge = findRecord->findChild<QTimer *>(QStringLiteral("matchCountMaxAgeTimer"));
         QVERIFY2(trailing != nullptr, "FindRecordWidget must name its trailing debounce timer");
         QVERIFY2(maxAge != nullptr, "FindRecordWidget must name its max-age debounce timer");
 
         findEdit->setText(QStringLiteral("needle"));
-        // First Bump arms both timers (the textChanged emit above
-        // also arms them, but Bump is idempotent on that state).
+        // First bump arms both timers (the textChanged emit above
+        // already armed them; bump is idempotent on that state).
         findRecord->BumpMatchCountDebounce();
         // NOLINTNEXTLINE(clang-analyzer-core.CallAndMessage): false positive; prior `QVERIFY2` aborts on null.
         QVERIFY2(trailing->isActive(), "first BumpMatchCountDebounce must arm the trailing timer");
         // NOLINTNEXTLINE(clang-analyzer-core.CallAndMessage): false positive; prior `QVERIFY2` aborts on null.
         QVERIFY2(maxAge->isActive(), "first BumpMatchCountDebounce must arm the max-age timer");
 
-        // Sleep a couple of ms so the trailing timer's
-        // `remainingTime()` ticks down. Then re-bump and assert
-        // the remaining time did NOT bounce back up (which would
-        // indicate the trailing timer was reset by the second
-        // bump -- the bug this guard is pinning).
+        // Let the trailing timer tick down, then re-bump. Remaining
+        // time must NOT bounce back up -- that would mean the
+        // second bump reset the timer (the bug we're pinning).
         QTest::qWait(20);
         const int remainingBefore = trailing->remainingTime();
         findRecord->BumpMatchCountDebounce();
         const int remainingAfter = trailing->remainingTime();
-        // Tolerate a 5ms drift for scheduler jitter; the key
-        // invariant is that the second bump did NOT *reset* the
-        // timer (which would push remaining back near interval()).
+        // 5 ms slack for scheduler jitter; the invariant is "did
+        // not jump back near `interval()`".
         QVERIFY2(
             remainingAfter <= remainingBefore + 5,
             qPrintable(QStringLiteral("second bump must not reset the trailing timer (before=%1, after=%2, interval=%3)"
@@ -11204,13 +10984,11 @@ private slots:
         model->EndStreaming(false);
     }
 
-    // Regression: a streaming batch through `LogFilterModel` with no
-    // active sort and no filter emits one bracketed `rowsInserted`
-    // pair covering the whole accepted range, not one pair per
-    // source row. The reverse-index rebuild lives inside the
-    // bracket so no O(n) staleness window on `mSourceRowToProxyRow`
-    // is observable.
-    // and rebuilds the reverse index inside it.
+    // Regression: a streaming batch through `LogFilterModel` (no
+    // sort, no filter) must emit one bracketed `rowsInserted` pair
+    // covering the whole range, not one pair per source row. The
+    // reverse-index rebuild lives inside the bracket so no O(n)
+    // staleness window on `mSourceRowToProxyRow` is observable.
     void TestStreamingBatchEmitsSingleRowsInsertedBracket()
     {
         auto *model = mWindow->findChild<LogModel *>();
@@ -11218,9 +10996,8 @@ private slots:
         auto *filterModel = mWindow->FilterModel();
         QVERIFY2(filterModel != nullptr, "MainWindow must own a LogFilterModel");
 
-        // Empty fixture, driven by direct `AppendBatch` calls so the
-        // batch boundary is well-defined and the only `rowsInserted`
-        // emission on the proxy is the one under test.
+        // Drive via direct `AppendBatch` so the batch boundary is
+        // well-defined and the only `rowsInserted` emission is ours.
         const TempJsonFile emptyFixture(QStringList{});
         auto file = std::make_unique<loglib::LogFile>(emptyFixture.Path().toStdString());
         auto fileSource = std::make_unique<loglib::FileLineSource>(std::move(file));
@@ -11259,9 +11036,8 @@ private slots:
         QCOMPARE(args.at(1).toInt(), 0);
         QCOMPARE(args.at(2).toInt(), BATCH_SIZE - 1);
 
-        // Reverse index must be consistent post-bracket: a
-        // `mapToSource` -> `mapFromSource` round-trip pins both
-        // directions of the proxy after the bulk insert.
+        // Reverse index must be consistent: `mapToSource` ->
+        // `mapFromSource` round-trips for every row.
         for (int proxyRow = 0; proxyRow < BATCH_SIZE; ++proxyRow)
         {
             const QModelIndex proxyIdx = filterModel->index(proxyRow, 0);

--- a/test/app/src/main_window_test.cpp
+++ b/test/app/src/main_window_test.cpp
@@ -78,7 +78,6 @@
 #include <QPalette>
 #include <QPlainTextEdit>
 #include <QPushButton>
-#include <QToolButton>
 #include <QRegularExpression>
 #include <QScopeGuard>
 #include <QScopedPointer>
@@ -96,6 +95,7 @@
 #include <QTableView>
 #include <QTableWidget>
 #include <QTemporaryDir>
+#include <QToolButton>
 #include <QUuid>
 #include <QVariant>
 #include <QWheelEvent>
@@ -4403,8 +4403,8 @@ private slots:
             const auto roles = args.at(2).value<QList<int>>();
             // An empty roles list is "all roles changed" in Qt's
             // contract -- counts as styled too.
-            if (roles.isEmpty() || roles.contains(Qt::BackgroundRole) || roles.contains(Qt::ForegroundRole)
-                || roles.contains(Qt::FontRole))
+            if (roles.isEmpty() || roles.contains(Qt::BackgroundRole) || roles.contains(Qt::ForegroundRole) ||
+                roles.contains(Qt::FontRole))
             {
                 foundStyledNotification = true;
                 break;
@@ -4456,8 +4456,7 @@ private slots:
         QVERIFY2(tableView != nullptr, "MainWindow must own a table view");
         const QString initialStyleSheet = tableView->styleSheet();
         QVERIFY2(
-            !initialStyleSheet.isEmpty(),
-            "After a normal load the body stylesheet must include the monospace cell rule"
+            !initialStyleSheet.isEmpty(), "After a normal load the body stylesheet must include the monospace cell rule"
         );
 
         // Externally clear the stylesheet. This mirrors the state
@@ -8165,9 +8164,7 @@ private slots:
         constexpr double R_LUMA = 0.299;
         constexpr double G_LUMA = 0.587;
         constexpr double B_LUMA = 0.114;
-        auto Luma = [](const QColor &c) {
-            return (R_LUMA * c.red()) + (G_LUMA * c.green()) + (B_LUMA * c.blue());
-        };
+        auto Luma = [](const QColor &c) { return (R_LUMA * c.red()) + (G_LUMA * c.green()) + (B_LUMA * c.blue()); };
 
         // Dark mode must use a *dark* highlight bg (otherwise the
         // row punches through the dialog as a near-white slab).
@@ -9961,9 +9958,9 @@ private slots:
         );
         QVERIFY2(
             prevIdx >= 0 && nextIdx >= 0,
-            qPrintable(QStringLiteral("arrow buttons must be on the tab chain (prev=%1 next=%2)")
-                           .arg(prevIdx)
-                           .arg(nextIdx))
+            qPrintable(
+                QStringLiteral("arrow buttons must be on the tab chain (prev=%1 next=%2)").arg(prevIdx).arg(nextIdx)
+            )
         );
         // Order: edit -> regex -> wildcards -> prev -> next.
         // Strict ordering on the toggles vs the arrow buttons is
@@ -10016,10 +10013,8 @@ private slots:
         dock->AppendErrors(QStringLiteral("Second batch"), {"d", "e"});
         QCOMPARE(dock->Count(), 5);
         QCOMPARE(dock->DroppedCount(), 0);
-        QCOMPARE(
-            firstBatchSpy.count(),
-            1
-        ); // No second emit until a session boundary re-arms the latch.
+        QCOMPARE(firstBatchSpy.count(),
+                 1); // No second emit until a session boundary re-arms the latch.
         QCOMPARE(countSpy.last().at(0).toInt(), 5);
 
         // ClearErrors zeroes both counters but leaves the
@@ -10149,10 +10144,7 @@ private slots:
         );
         // Footer must be non-selectable so arrow-key navigation
         // and Ctrl+A don't pull it into the user's selection.
-        QVERIFY2(
-            !footer->flags().testFlag(Qt::ItemIsSelectable),
-            "overflow footer must not be user-selectable"
-        );
+        QVERIFY2(!footer->flags().testFlag(Qt::ItemIsSelectable), "overflow footer must not be user-selectable");
     }
 
     // Streaming-style: many smaller batches that collectively
@@ -10185,10 +10177,7 @@ private slots:
         for (int i = 0; i < list->count(); ++i)
         {
             QListWidgetItem *item = list->item(i);
-            QVERIFY2(
-                item == nullptr || !item->data(footerRole).toBool(),
-                "no footer when nothing has been dropped"
-            );
+            QVERIFY2(item == nullptr || !item->data(footerRole).toBool(), "no footer when nothing has been dropped");
         }
 
         // Second small batch tips the dock over the cap. Walk
@@ -10204,8 +10193,10 @@ private slots:
         QCOMPARE(dock->Count(), cap);
         QCOMPARE(dock->DroppedCount(), overflow);
         QListWidgetItem *tail = list->item(list->count() - 1);
-        QVERIFY2(tail != nullptr && tail->data(footerRole).toBool(),
-                 "overflow footer must be the trailing item after eviction");
+        QVERIFY2(
+            tail != nullptr && tail->data(footerRole).toBool(),
+            "overflow footer must be the trailing item after eviction"
+        );
 
         // Third batch grows `mDroppedCount` further; footer text
         // must update to the new total, and the dock must not
@@ -10446,10 +10437,7 @@ private slots:
         edit->clear();
         spy.clear();
         emit dock->revealed();
-        QVERIFY2(
-            !spy.wait(300),
-            "FindDock::revealed must NOT trigger MatchCountRequested for an empty needle"
-        );
+        QVERIFY2(!spy.wait(300), "FindDock::revealed must NOT trigger MatchCountRequested for an empty needle");
     }
 
     // Regression: under continuous activity (live-tail streaming,
@@ -10634,10 +10622,8 @@ private slots:
         QCoreApplication::processEvents();
         QVERIFY2(
             vBar->value() == parkedPosition,
-            qPrintable(QStringLiteral(
-                           "Scroll position must be preserved when the user was not at the tail "
-                           "(parked=%1, after=%2, max=%3)"
-            )
+            qPrintable(QStringLiteral("Scroll position must be preserved when the user was not at the tail "
+                                      "(parked=%1, after=%2, max=%3)")
                            .arg(parkedPosition)
                            .arg(vBar->value())
                            .arg(vBar->maximum()))
@@ -10657,12 +10643,10 @@ private slots:
         // path must have moved `value` along with it.
         QVERIFY2(
             vBar->value() >= vBar->maximum() - 4,
-            qPrintable(
-                QStringLiteral("Auto-follow must re-pin to the tail when the user was at the tail "
-                               "(value=%1, max=%2)")
-                    .arg(vBar->value())
-                    .arg(vBar->maximum())
-            )
+            qPrintable(QStringLiteral("Auto-follow must re-pin to the tail when the user was at the tail "
+                                      "(value=%1, max=%2)")
+                           .arg(vBar->value())
+                           .arg(vBar->maximum()))
         );
     }
 
@@ -10818,9 +10802,9 @@ private slots:
                     // each channel: a pure-red apex blends into a
                     // half-transparent maroon at the slope's edge.
                     constexpr int CHANNEL_TOLERANCE = 32;
-                    if (std::abs(qRed(px) - qRed(expected)) <= CHANNEL_TOLERANCE
-                        && std::abs(qGreen(px) - qGreen(expected)) <= CHANNEL_TOLERANCE
-                        && std::abs(qBlue(px) - qBlue(expected)) <= CHANNEL_TOLERANCE)
+                    if (std::abs(qRed(px) - qRed(expected)) <= CHANNEL_TOLERANCE &&
+                        std::abs(qGreen(px) - qGreen(expected)) <= CHANNEL_TOLERANCE &&
+                        std::abs(qBlue(px) - qBlue(expected)) <= CHANNEL_TOLERANCE)
                     {
                         ++matching;
                     }
@@ -10929,9 +10913,7 @@ private slots:
         QVERIFY(LogModel::IsStyleOnlyRoleChange({Qt::FontRole}));
         QVERIFY(LogModel::IsStyleOnlyRoleChange({Qt::DecorationRole}));
         QVERIFY(LogModel::IsStyleOnlyRoleChange({Qt::BackgroundRole, Qt::ForegroundRole, Qt::FontRole}));
-        QVERIFY2(
-            !LogModel::IsStyleOnlyRoleChange({Qt::DisplayRole}), "DisplayRole change must trigger a refresh"
-        );
+        QVERIFY2(!LogModel::IsStyleOnlyRoleChange({Qt::DisplayRole}), "DisplayRole change must trigger a refresh");
         QVERIFY2(!LogModel::IsStyleOnlyRoleChange({Qt::EditRole}), "EditRole change must trigger a refresh");
         QVERIFY2(
             !LogModel::IsStyleOnlyRoleChange({Qt::BackgroundRole, Qt::DisplayRole}),
@@ -10947,23 +10929,17 @@ private slots:
     void TestComposeFindFlagsPriorityAndBaseline()
     {
         constexpr Qt::MatchFlags BASELINE = Qt::MatchWrap | Qt::MatchRecursive;
+        QCOMPARE(LogFilterModel::ComposeFindFlags(/*wildcards=*/false, /*regex=*/false), BASELINE | Qt::MatchContains);
+        QCOMPARE(LogFilterModel::ComposeFindFlags(/*wildcards=*/true, /*regex=*/false), BASELINE | Qt::MatchWildcard);
         QCOMPARE(
-            LogFilterModel::ComposeFindFlags(/*wildcards=*/false, /*regex=*/false), BASELINE | Qt::MatchContains
-        );
-        QCOMPARE(
-            LogFilterModel::ComposeFindFlags(/*wildcards=*/true, /*regex=*/false), BASELINE | Qt::MatchWildcard
-        );
-        QCOMPARE(
-            LogFilterModel::ComposeFindFlags(/*wildcards=*/false, /*regex=*/true),
-            BASELINE | Qt::MatchRegularExpression
+            LogFilterModel::ComposeFindFlags(/*wildcards=*/false, /*regex=*/true), BASELINE | Qt::MatchRegularExpression
         );
         // Both toggles checked: regex wins (the UI enforces this
         // visually too -- `mWildcardsAction` and `mRegexAction`
         // are mutually exclusive -- but the helper itself must
         // not depend on that invariant being upheld upstream).
         QCOMPARE(
-            LogFilterModel::ComposeFindFlags(/*wildcards=*/true, /*regex=*/true),
-            BASELINE | Qt::MatchRegularExpression
+            LogFilterModel::ComposeFindFlags(/*wildcards=*/true, /*regex=*/true), BASELINE | Qt::MatchRegularExpression
         );
     }
 
@@ -11013,9 +10989,8 @@ private slots:
         // timer (which would push remaining back near interval()).
         QVERIFY2(
             remainingAfter <= remainingBefore + 5,
-            qPrintable(QStringLiteral(
-                           "second bump must not reset the trailing timer (before=%1, after=%2, interval=%3)"
-                       )
+            qPrintable(QStringLiteral("second bump must not reset the trailing timer (before=%1, after=%2, interval=%3)"
+            )
                            .arg(remainingBefore)
                            .arg(remainingAfter)
                            .arg(trailing->interval()))

--- a/test/app/src/main_window_test.cpp
+++ b/test/app/src/main_window_test.cpp
@@ -12,6 +12,7 @@
 #include "log_table_view.hpp"
 #include "main_window.hpp"
 #include "parse_errors_dock.hpp"
+#include "preferences_editor.hpp"
 #include "qt_streaming_log_sink.hpp"
 #include "record_detail_dock.hpp"
 #include "record_detail_widget.hpp"
@@ -52,6 +53,7 @@
 #include <QBrush>
 #include <QCheckBox>
 #include <QClipboard>
+#include <QColor>
 #include <QComboBox>
 #include <QDataStream>
 #include <QDialogButtonBox>
@@ -63,6 +65,7 @@
 #include <QGroupBox>
 #include <QHeaderView>
 #include <QIcon>
+#include <QImage>
 #include <QLabel>
 #include <QLineEdit>
 #include <QListView>
@@ -72,6 +75,7 @@
 #include <QLockFile>
 #include <QMenu>
 #include <QMenuBar>
+#include <QPalette>
 #include <QPlainTextEdit>
 #include <QPushButton>
 #include <QToolButton>
@@ -89,6 +93,7 @@
 #include <QStatusBar>
 #include <QString>
 #include <QStringList>
+#include <QTableView>
 #include <QTableWidget>
 #include <QTemporaryDir>
 #include <QUuid>
@@ -4273,6 +4278,219 @@ private slots:
         QVERIFY(qvariant_cast<QFont>(fatalFont).bold());
     }
 
+    // Regression: switching themes while the main log table is
+    // visible must repaint the rows in the new colours. The model
+    // already exposes the new theme brush via `data()` (verified
+    // by `TestLogModelDataReturnsThemeBackground`), but the view
+    // needs to be told to re-query. The user-visible symptom of
+    // failure here is "I switched themes and the table still has
+    // the old level colours until I scroll / resize / refresh".
+    // We pin both halves: the model returns a new brush, *and*
+    // the view receives a `dataChanged` notification that covers
+    // the styled roles over the visible rows.
+    void TestThemeSwitchRefreshesLogTableRows()
+    {
+        QVERIFY(mTheme != nullptr);
+
+        // Stream a tiny multi-level fixture so we have an Error row
+        // styled by the theme (the default themes paint Error with
+        // a distinct background).
+        const QStringList lines{
+            QStringLiteral(R"({"level": "info"})"),
+            QStringLiteral(R"({"level": "error"})"),
+            QStringLiteral(R"({"level": "warn"})"),
+        };
+        const TempJsonFile fixture(lines);
+
+        mTheme->SetActiveSelection(QStringLiteral("Light"));
+        const StreamingRun run = RunStreaming(fixture.Path(), mTheme.data());
+        QCOMPARE(run.cancelled, false);
+        QVERIFY(run.model != nullptr);
+
+        const int levelCol = ColumnByHeader(*run.model, QStringLiteral("level"));
+        QVERIFY2(levelCol >= 0, "level column must exist after streaming");
+
+        // Find the Error row by display value rather than fixed
+        // index, so a future fixture reorder doesn't break us.
+        int errorRow = -1;
+        for (int r = 0; r < run.model->rowCount(); ++r)
+        {
+            if (run.model->data(run.model->index(r, levelCol), Qt::DisplayRole).toString() == QStringLiteral("error"))
+            {
+                errorRow = r;
+                break;
+            }
+        }
+        QVERIFY2(errorRow >= 0, "fixture must include an Error-level row");
+
+        const QModelIndex errorIndex = run.model->index(errorRow, levelCol);
+        const QVariant lightErrorBg = run.model->data(errorIndex, Qt::BackgroundRole);
+        QVERIFY2(lightErrorBg.isValid(), "Light theme must style the Error row background");
+        const QBrush lightBrush = qvariant_cast<QBrush>(lightErrorBg);
+
+        // Now flip to Dark. `SetActiveSelection` -> `ApplyTheme`
+        // rebuilds the cache and emits `themeChanged`. The model
+        // shares the `ThemeControl` instance, so the next `data()`
+        // call must see the new brush.
+        mTheme->SetActiveSelection(QStringLiteral("Dark"));
+        QCoreApplication::processEvents();
+
+        const QVariant darkErrorBg = run.model->data(errorIndex, Qt::BackgroundRole);
+        QVERIFY2(darkErrorBg.isValid(), "Dark theme must style the Error row background");
+        const QBrush darkBrush = qvariant_cast<QBrush>(darkErrorBg);
+        QVERIFY2(
+            lightBrush.color() != darkBrush.color(),
+            qPrintable(QStringLiteral("Error row background must differ between Light and Dark themes; "
+                                      "got light=%1, dark=%2")
+                           .arg(lightBrush.color().name(), darkBrush.color().name()))
+        );
+
+        // Sanity-check the inverse direction too: a flip back to
+        // Light returns the original brush.
+        mTheme->SetActiveSelection(QStringLiteral("Light"));
+        QCoreApplication::processEvents();
+        const QBrush lightBrushAgain = qvariant_cast<QBrush>(run.model->data(errorIndex, Qt::BackgroundRole));
+        QCOMPARE(lightBrushAgain.color(), lightBrush.color());
+    }
+
+    // Regression: against the `MainWindow`'s real table view +
+    // proxy chain, a theme switch must emit `dataChanged` on the
+    // styled roles so the view re-queries the new theme brushes.
+    // Calling only `viewport()->update()` schedules a paint but
+    // does not invalidate the view's internal item-style cache in
+    // every Qt 6 release; the user-visible bug is rows that keep
+    // the old level tint until they scroll. We pin the model-side
+    // notification.
+    void TestThemeSwitchEmitsDataChangedOnLogTable()
+    {
+        QVERIFY(mTheme != nullptr);
+        // Stream a small fixture into the live `MainWindow` so its
+        // `LogModel` (not a side-car instance from `RunStreaming`)
+        // is the one we observe -- the production wiring is what
+        // we want to pin.
+        const QStringList lines{
+            QStringLiteral(R"({"level": "info"})"),
+            QStringLiteral(R"({"level": "error"})"),
+            QStringLiteral(R"({"level": "warn"})"),
+        };
+        const TempJsonFile fixture(lines);
+        mTheme->SetActiveSelection(QStringLiteral("Light"));
+        mWindow->OpenFilesForTest({fixture.Path()}, MainWindow::OpenMode::Replace);
+        // Pump until the streaming finishes -- `streamingFinished`
+        // is queued, so a single `processEvents` isn't enough.
+        auto *model = mWindow->findChild<LogModel *>();
+        QVERIFY2(model != nullptr, "MainWindow must own a LogModel");
+        QSignalSpy finishedSpy(model, &LogModel::streamingFinished);
+        if (finishedSpy.count() == 0)
+        {
+            finishedSpy.wait(5000);
+        }
+        QVERIFY2(model->rowCount() > 0, "fixture must produce at least one streamed row");
+
+        QSignalSpy spy(model, &QAbstractItemModel::dataChanged);
+        mTheme->SetActiveSelection(QStringLiteral("Dark"));
+        QCoreApplication::processEvents();
+
+        // Look for a `dataChanged` emission that covers at least
+        // one of the styled roles. Other notifications (e.g.
+        // anchor-related) can ride along; we only care that *some*
+        // styled-role notification arrived.
+        bool foundStyledNotification = false;
+        for (int i = 0; i < spy.count(); ++i)
+        {
+            const QList<QVariant> args = spy.at(i);
+            QVERIFY2(args.size() >= 3, "dataChanged must carry topLeft, bottomRight, roles");
+            const auto roles = args.at(2).value<QList<int>>();
+            // An empty roles list is "all roles changed" in Qt's
+            // contract -- counts as styled too.
+            if (roles.isEmpty() || roles.contains(Qt::BackgroundRole) || roles.contains(Qt::ForegroundRole)
+                || roles.contains(Qt::FontRole))
+            {
+                foundStyledNotification = true;
+                break;
+            }
+        }
+        QVERIFY2(
+            foundStyledNotification,
+            "Theme switch must emit a dataChanged covering BackgroundRole / ForegroundRole / FontRole "
+            "(or all roles) so the table view refreshes the row tints."
+        );
+    }
+
+    // Regression: switching themes must re-apply the table view's
+    // stylesheet so `QStyleSheetStyle` drops its palette-resolved
+    // item cache. Without this, rows whose `data(BackgroundRole)`
+    // returns an invalid `QVariant` (Info / Trace levels that no
+    // theme styles) keep the previous theme's palette default,
+    // producing the user-visible "some rows repainted, some did
+    // not" symptom in dark mode. The polish has to happen even
+    // when the rule TEXT is unchanged -- the previous skip-on-
+    // identical-rule optimisation was the regression vector
+    // introduced when `ApplyTableStyleSheet` started emitting a
+    // monospace font rule (GUI-polish phase 1). We pin the
+    // observable: clearing the body stylesheet externally and
+    // then switching themes must repopulate it.
+    void TestThemeSwitchRepolishesTableStylesheet()
+    {
+        QVERIFY(mTheme != nullptr);
+
+        // Prime the table view's stylesheet via the normal
+        // application path: open a fixture so streaming + initial
+        // `ApplyTableStyleSheet` run.
+        const QStringList lines{
+            QStringLiteral(R"({"level": "info"})"),
+            QStringLiteral(R"({"level": "error"})"),
+        };
+        const TempJsonFile fixture(lines);
+        mTheme->SetActiveSelection(QStringLiteral("Light"));
+        mWindow->OpenFilesForTest({fixture.Path()}, MainWindow::OpenMode::Replace);
+        auto *model = mWindow->findChild<LogModel *>();
+        QVERIFY2(model != nullptr, "MainWindow must own a LogModel");
+        QSignalSpy finishedSpy(model, &LogModel::streamingFinished);
+        if (finishedSpy.count() == 0)
+        {
+            finishedSpy.wait(5000);
+        }
+
+        auto *tableView = mWindow->findChild<QTableView *>();
+        QVERIFY2(tableView != nullptr, "MainWindow must own a table view");
+        const QString initialStyleSheet = tableView->styleSheet();
+        QVERIFY2(
+            !initialStyleSheet.isEmpty(),
+            "After a normal load the body stylesheet must include the monospace cell rule"
+        );
+
+        // Externally clear the stylesheet. This mirrors the state
+        // Qt is in after the "skip unchanged write" optimisation
+        // bypasses `setStyleSheet`: the cached `mLastBodyStyleSheet`
+        // claims the rule is applied but the widget actually has
+        // a stale (or in this synthetic case, empty) stylesheet.
+        // The polish-on-theme-switch fix has to re-apply the rule
+        // regardless of what we cached.
+        tableView->setStyleSheet(QString{});
+        QCOMPARE(tableView->styleSheet(), QString{});
+
+        // Switch theme. `OnThemeChanged` resets the tracker and
+        // forces `ApplyTableStyleSheet` to re-write the rule.
+        mTheme->SetActiveSelection(QStringLiteral("Dark"));
+        QCoreApplication::processEvents();
+
+        QVERIFY2(
+            !tableView->styleSheet().isEmpty(),
+            qPrintable(QStringLiteral("Theme switch must re-apply the body stylesheet so "
+                                      "`QStyleSheetStyle` re-resolves the new palette; got: '%1'")
+                           .arg(tableView->styleSheet()))
+        );
+        // And the re-applied rule must match what `ApplyTableStyleSheet`
+        // would build (i.e. the monospace cell rule, not some
+        // accidental empty fallback).
+        QVERIFY2(
+            tableView->styleSheet().contains(QStringLiteral("QTableView::item")),
+            qPrintable(QStringLiteral("Re-applied stylesheet must carry the monospace cell rule; got: '%1'")
+                           .arg(tableView->styleSheet()))
+        );
+    }
+
     // End-to-end round-trip for `Column::levelMapping`. Saved config
     // pins `Type::Level` with `NOTICE -> Info`, `PANIC -> Fatal`. A
     // filter selecting `Info` expands via the rank cache to match
@@ -7812,6 +8030,213 @@ private slots:
         QVERIFY(mismatchedItem != nullptr);
         // NOLINTNEXTLINE(clang-analyzer-core.CallAndMessage): prior QVERIFY aborts on null.
         QVERIFY2(mismatchedItem->text().toInt() > 0, "Dialog must report a non-zero mismatch count for `msg`");
+
+        // Regression: the mismatched row must pin *both* halves of
+        // the contrast pair (pink background + dark foreground).
+        // Setting only the background leaves the foreground on the
+        // palette default, which is near-white on a dark theme and
+        // renders the row's text invisible (see issue: "Column with
+        // an issue text is not visible in dark theme"). The exact
+        // colours are an implementation detail; what we pin is "the
+        // foreground is dark enough to read against pale pink".
+        for (int c = 0; c < table->columnCount(); ++c)
+        {
+            const QTableWidgetItem *item = table->item(matchedRowIndex, c);
+            QVERIFY2(item != nullptr, qPrintable(QStringLiteral("mismatched row column %1 must have an item").arg(c)));
+            // NOLINTNEXTLINE(clang-analyzer-core.CallAndMessage): prior QVERIFY2 aborts on null.
+            const QBrush bg = item->background();
+            const QBrush fg = item->foreground();
+            QVERIFY2(
+                bg.style() != Qt::NoBrush,
+                qPrintable(QStringLiteral("mismatched row column %1 must paint an explicit background").arg(c))
+            );
+            QVERIFY2(
+                fg.style() != Qt::NoBrush,
+                qPrintable(QStringLiteral("mismatched row column %1 must paint an explicit foreground "
+                                          "so it stays legible on dark themes")
+                               .arg(c))
+            );
+            // ITU-R BT.601 luma: foreground must be visibly darker
+            // than the highlight background, otherwise we're back to
+            // the original bug.
+            const QColor fgColor = fg.color();
+            const QColor bgColor = bg.color();
+            constexpr double R_LUMA = 0.299;
+            constexpr double G_LUMA = 0.587;
+            constexpr double B_LUMA = 0.114;
+            const double fgLuma = (R_LUMA * fgColor.red()) + (G_LUMA * fgColor.green()) + (B_LUMA * fgColor.blue());
+            const double bgLuma = (R_LUMA * bgColor.red()) + (G_LUMA * bgColor.green()) + (B_LUMA * bgColor.blue());
+            constexpr double MIN_LUMA_GAP = 80.0;
+            QVERIFY2(
+                bgLuma - fgLuma >= MIN_LUMA_GAP,
+                qPrintable(
+                    QStringLiteral("mismatched row column %1 must keep a high contrast between fg (%2) and bg (%3); "
+                                   "got fgLuma=%4, bgLuma=%5")
+                        .arg(c)
+                        .arg(fgColor.name(), bgColor.name())
+                        .arg(fgLuma)
+                        .arg(bgLuma)
+                )
+            );
+        }
+    }
+
+    // Regression: the mismatched-row highlight must adapt to the
+    // active palette. The original fix pinned a pale-pink bg + dark
+    // fg, which read as a glaringly bright "white" row on Dark
+    // themes (see issue: "The row with invalid data is white in
+    // dark mode"). Verify that flipping the theme to Dark hands the
+    // dialog a *darker* highlight bg + *lighter* fg, while keeping
+    // the same high contrast (luma gap) the light-mode highlight
+    // already satisfies.
+    void TestDiagnosticsDialogHighlightAdaptsToDarkTheme()
+    {
+        QVERIFY(mTheme != nullptr);
+        const int levelCol = StreamFixtureForColumnTests();
+        QVERIFY2(levelCol >= 0, "level column must exist after streaming");
+        auto *model = mWindow->Model();
+        const int msgCol = ColumnByHeader(*model, QStringLiteral("msg"));
+        QVERIFY2(msgCol >= 0, "msg column must exist after streaming");
+
+        // Force `msg` into a mismatching state so the dialog has a
+        // warning row to paint.
+        model->ConfigurationManager().SetColumnAutoDetect(static_cast<size_t>(msgCol), false);
+        model->ConfigurationManager().SetColumnType(
+            static_cast<size_t>(msgCol), loglib::LogConfiguration::Type::Integer
+        );
+        model->RefreshColumnHealth();
+
+        // Build the dialog under the Light palette and snapshot the
+        // brushes for the `msg` row.
+        mTheme->SetActiveSelection(QStringLiteral("Light"));
+        QCoreApplication::processEvents();
+
+        ConfigurationDiagnosticsDialog dialog(model);
+        auto *table = dialog.findChild<QTableWidget *>();
+        QVERIFY2(table != nullptr, "Dialog must own a diagnosticsTable widget");
+
+        auto FindMsgRow = [table]() {
+            for (int row = 0; row < table->rowCount(); ++row)
+            {
+                const QTableWidgetItem *headerItem = table->item(row, 0);
+                if (headerItem != nullptr && headerItem->text() == QStringLiteral("msg"))
+                {
+                    return row;
+                }
+            }
+            return -1;
+        };
+
+        const int lightRow = FindMsgRow();
+        QVERIFY2(lightRow >= 0, "Light-theme dialog must include a row for the `msg` column");
+        const QTableWidgetItem *lightItem = table->item(lightRow, 0);
+        QVERIFY(lightItem != nullptr);
+        // NOLINTNEXTLINE(clang-analyzer-core.CallAndMessage): prior QVERIFY aborts on null.
+        const QColor lightBg = lightItem->background().color();
+        const QColor lightFg = lightItem->foreground().color();
+
+        // Flip to Dark. `SetActiveSelection` -> `ApplyTheme` swaps
+        // `QApplication::setPalette`, which fires
+        // `QEvent::ApplicationPaletteChange` on the dialog; the
+        // override re-runs `Refresh()` so the brushes pick up the
+        // dark-mode palette branch.
+        mTheme->SetActiveSelection(QStringLiteral("Dark"));
+        QCoreApplication::processEvents();
+
+        const int darkRow = FindMsgRow();
+        QVERIFY2(darkRow >= 0, "Dark-theme dialog must still include a row for the `msg` column");
+        const QTableWidgetItem *darkItem = table->item(darkRow, 0);
+        QVERIFY(darkItem != nullptr);
+        // NOLINTNEXTLINE(clang-analyzer-core.CallAndMessage): prior QVERIFY aborts on null.
+        const QColor darkBg = darkItem->background().color();
+        const QColor darkFg = darkItem->foreground().color();
+
+        QVERIFY2(
+            lightBg != darkBg,
+            qPrintable(QStringLiteral("Highlight bg must differ between Light and Dark; got light=%1, dark=%2")
+                           .arg(lightBg.name(), darkBg.name()))
+        );
+        QVERIFY2(
+            lightFg != darkFg,
+            qPrintable(QStringLiteral("Highlight fg must differ between Light and Dark; got light=%1, dark=%2")
+                           .arg(lightFg.name(), darkFg.name()))
+        );
+
+        constexpr double R_LUMA = 0.299;
+        constexpr double G_LUMA = 0.587;
+        constexpr double B_LUMA = 0.114;
+        auto Luma = [](const QColor &c) {
+            return (R_LUMA * c.red()) + (G_LUMA * c.green()) + (B_LUMA * c.blue());
+        };
+
+        // Dark mode must use a *dark* highlight bg (otherwise the
+        // row punches through the dialog as a near-white slab).
+        constexpr double DARK_BG_MAX_LUMA = 110.0;
+        QVERIFY2(
+            Luma(darkBg) <= DARK_BG_MAX_LUMA,
+            qPrintable(QStringLiteral("Dark-theme highlight bg must be dark; got %1 (luma=%2)")
+                           .arg(darkBg.name())
+                           .arg(Luma(darkBg)))
+        );
+
+        // Dark mode reverses the contrast pair: fg must be *lighter*
+        // than bg, by the same gap the light-mode highlight uses.
+        constexpr double MIN_LUMA_GAP = 80.0;
+        QVERIFY2(
+            Luma(darkFg) - Luma(darkBg) >= MIN_LUMA_GAP,
+            qPrintable(QStringLiteral("Dark-theme highlight must keep high contrast (fg lighter than bg); "
+                                      "got fg=%1 (luma=%2), bg=%3 (luma=%4)")
+                           .arg(darkFg.name())
+                           .arg(Luma(darkFg))
+                           .arg(darkBg.name())
+                           .arg(Luma(darkBg)))
+        );
+
+        // Restore the default before the next test starts.
+        mTheme->SetActiveSelection(QStringLiteral("Light"));
+        QCoreApplication::processEvents();
+    }
+
+    // Regression: closing the Preferences window via the X button
+    // (or any path that goes through `QWidget::close` without first
+    // running the Cancel slot) must revert a live-previewed theme
+    // back to the persisted selection. Without the `closeEvent`
+    // override, the Dark preview leaked past the dialog until the
+    // application restart (see issue: "when I change the theme and
+    // close the configuration window, the original theme is not
+    // restored").
+    void TestPreferencesEditorCloseEventRevertsThemePreview()
+    {
+        QVERIFY(mTheme != nullptr);
+
+        // Persist a known baseline (`Light`) so the close-event
+        // revert has a deterministic target.
+        mTheme->SetActiveSelection(QStringLiteral("Light"));
+        mTheme->SaveConfiguration();
+        QCOMPARE(mTheme->PersistedSelection(), QStringLiteral("Light"));
+        QCOMPARE(mTheme->ActiveSelection(), QStringLiteral("Light"));
+
+        PreferencesEditor editor(mTheme.data());
+
+        // Simulate the user previewing Dark via the combobox. We
+        // bypass the widget's `activated` signal and go straight to
+        // the underlying control to keep the test independent of
+        // QComboBox event quirks under offscreen-QPA.
+        mTheme->SetActiveSelection(QStringLiteral("Dark"));
+        QCoreApplication::processEvents();
+        QCOMPARE(mTheme->ActiveSelection(), QStringLiteral("Dark"));
+        // Persisted selection is unchanged -- only Ok writes that.
+        QCOMPARE(mTheme->PersistedSelection(), QStringLiteral("Light"));
+
+        // Close the window via the same path the X button takes
+        // (programmatic `close()` -> `closeEvent`). Cancel and Ok
+        // also funnel through here but they run their own logic
+        // first; what we pin is the bare path.
+        editor.close();
+        QCoreApplication::processEvents();
+
+        QCOMPARE(mTheme->ActiveSelection(), QStringLiteral("Light"));
+        QCOMPARE(mTheme->PersistedSelection(), QStringLiteral("Light"));
     }
 
     // The Column Editor writes back every user-controllable Column
@@ -10297,6 +10722,85 @@ private slots:
             qPrintable(QStringLiteral("status button tooltip must still spell out the breakdown; got: %1")
                            .arg(statusButton->toolTip()))
         );
+    }
+
+    // The find-bar arrow icons must follow the current palette so a
+    // Light <-> Dark theme switch can't leave the previous-match /
+    // next-match glyphs invisible. Regression for the
+    // `QStyle::SP_ArrowUp` / `SP_ArrowDown` baked-black pixmaps that
+    // disappeared on dark themes.
+    void TestFindBarArrowIconsFollowPalette()
+    {
+        auto *findRecord = mWindow->findChild<FindRecordWidget *>();
+        QVERIFY2(findRecord != nullptr, "MainWindow must own a FindRecordWidget");
+        auto *prevButton = findRecord->findChild<QToolButton *>(QStringLiteral("findPrevious"));
+        auto *nextButton = findRecord->findChild<QToolButton *>(QStringLiteral("findNext"));
+        QVERIFY2(prevButton != nullptr, "FindRecordWidget must expose its previous button");
+        QVERIFY2(nextButton != nullptr, "FindRecordWidget must expose its next button");
+
+        // Counts opaque pixels in @p icon when rendered at its first
+        // available size. A baked-black `SP_ArrowUp` glyph paints
+        // dark pixels regardless of palette, while our palette-aware
+        // icon paints in `QPalette::WindowText`, which we can flip
+        // below to detect the difference.
+        auto OpaquePixelCount = [](const QIcon &icon, QRgb expected) -> int {
+            const QList<QSize> sizes = icon.availableSizes();
+            const QSize size = sizes.isEmpty() ? QSize{16, 16} : sizes.front();
+            const QImage img = icon.pixmap(size).toImage().convertToFormat(QImage::Format_ARGB32);
+            int matching = 0;
+            for (int y = 0; y < img.height(); ++y)
+            {
+                for (int x = 0; x < img.width(); ++x)
+                {
+                    const QRgb px = img.pixel(x, y);
+                    if (qAlpha(px) < 128)
+                    {
+                        continue;
+                    }
+                    // Tolerate a few units of anti-alias drift on
+                    // each channel: a pure-red apex blends into a
+                    // half-transparent maroon at the slope's edge.
+                    constexpr int CHANNEL_TOLERANCE = 32;
+                    if (std::abs(qRed(px) - qRed(expected)) <= CHANNEL_TOLERANCE
+                        && std::abs(qGreen(px) - qGreen(expected)) <= CHANNEL_TOLERANCE
+                        && std::abs(qBlue(px) - qBlue(expected)) <= CHANNEL_TOLERANCE)
+                    {
+                        ++matching;
+                    }
+                }
+            }
+            return matching;
+        };
+
+        // Paint the icons in a vivid red palette and assert the
+        // rendered pixmap actually contains red. If the buttons
+        // still used `SP_ArrowUp` / `SP_ArrowDown`, the rendered
+        // glyphs would be black regardless of `WindowText`.
+        QPalette redPalette = findRecord->palette();
+        redPalette.setColor(QPalette::Active, QPalette::WindowText, QColor(255, 0, 0));
+        redPalette.setColor(QPalette::Inactive, QPalette::WindowText, QColor(255, 0, 0));
+        findRecord->setPalette(redPalette);
+        // `setPalette` posts `PaletteChange`; pump the event loop
+        // so `changeEvent` rebuilds the icons before we sample.
+        QCoreApplication::sendPostedEvents(findRecord, QEvent::PaletteChange);
+        const int prevRed = OpaquePixelCount(prevButton->icon(), qRgb(255, 0, 0));
+        const int nextRed = OpaquePixelCount(nextButton->icon(), qRgb(255, 0, 0));
+        QVERIFY2(prevRed > 0, "previous-button icon must paint in the palette's WindowText colour");
+        QVERIFY2(nextRed > 0, "next-button icon must paint in the palette's WindowText colour");
+
+        // Flip to a vivid blue and assert the rendered pixmap
+        // changed accordingly. This is the real regression: the
+        // first time the user toggles Light -> Dark, the arrows
+        // have to actually re-paint.
+        QPalette bluePalette = findRecord->palette();
+        bluePalette.setColor(QPalette::Active, QPalette::WindowText, QColor(0, 0, 255));
+        bluePalette.setColor(QPalette::Inactive, QPalette::WindowText, QColor(0, 0, 255));
+        findRecord->setPalette(bluePalette);
+        QCoreApplication::sendPostedEvents(findRecord, QEvent::PaletteChange);
+        const int prevBlue = OpaquePixelCount(prevButton->icon(), qRgb(0, 0, 255));
+        const int nextBlue = OpaquePixelCount(nextButton->icon(), qRgb(0, 0, 255));
+        QVERIFY2(prevBlue > 0, "previous-button icon must repaint after a palette change");
+        QVERIFY2(nextBlue > 0, "next-button icon must repaint after a palette change");
     }
 
     // An enum column with an empty dictionary must show the placeholder

--- a/test/app/src/main_window_test.cpp
+++ b/test/app/src/main_window_test.cpp
@@ -9990,7 +9990,11 @@ private slots:
     {
         auto *dock = mWindow->findChild<ParseErrorsDock *>();
         QVERIFY2(dock != nullptr, "MainWindow must own a ParseErrorsDock");
-        dock->ClearErrors();
+        // `ResetSessionState`, not `ClearErrors`, so the first-batch
+        // latch is re-armed regardless of what earlier tests in
+        // the shared `mWindow` left it as -- this test wants to
+        // observe `firstBatchArrived` on the first AppendErrors.
+        dock->ResetSessionState();
 
         QSignalSpy countSpy(dock, &ParseErrorsDock::countChanged);
         QSignalSpy firstBatchSpy(dock, &ParseErrorsDock::firstBatchArrived);
@@ -10015,11 +10019,17 @@ private slots:
         QCOMPARE(
             firstBatchSpy.count(),
             1
-        ); // No second emit until ClearErrors resets the session.
+        ); // No second emit until a session boundary re-arms the latch.
         QCOMPARE(countSpy.last().at(0).toInt(), 5);
 
-        // Clear resets both counters and arms `firstBatchArrived`
-        // for the next session.
+        // ClearErrors zeroes both counters but leaves the
+        // first-batch latch SET so a streaming hiccup right after
+        // a manual Clear does not re-pop the dock the user just
+        // dismissed. (Bug fix: pre-`ResetSessionState`, the
+        // `firstBatchOfSession` heuristic keyed on
+        // `mErrorCount == 0 && mDroppedCount == 0`, which Clear
+        // restored, causing an unwanted auto-raise on the next
+        // batch.)
         dock->ClearErrors();
         QCOMPARE(dock->Count(), 0);
         QCOMPARE(dock->DroppedCount(), 0);
@@ -10028,7 +10038,54 @@ private slots:
 
         dock->AppendErrors(QStringLiteral("After clear"), {"x"});
         QCOMPARE(dock->Count(), 1);
-        QCOMPARE(firstBatchSpy.count(), 2); // New session -> second emit.
+        QCOMPARE(firstBatchSpy.count(), 1); // ClearErrors does NOT re-arm.
+
+        // ResetSessionState is the canonical session-boundary
+        // path and DOES re-arm the latch.
+        dock->ResetSessionState();
+        QCOMPARE(dock->Count(), 0);
+        QCOMPARE(dock->DroppedCount(), 0);
+        dock->AppendErrors(QStringLiteral("New session"), {"y"});
+        QCOMPARE(dock->Count(), 1);
+        QCOMPARE(firstBatchSpy.count(), 2); // Re-armed -> second emit.
+    }
+
+    // Regression for the Manual-Clear-then-batch auto-raise bug.
+    // Pre-fix: clicking the in-dock Clear button reset the
+    // `firstBatchOfSession` heuristic (which keyed on
+    // `mErrorCount == 0 && mDroppedCount == 0`), so the next
+    // streamed parse-error batch fired `firstBatchArrived` again
+    // and `MainWindow` raised the dock the user had just decided
+    // to dismiss. Fix decouples the latch (`mHasSeenFirstBatch`)
+    // from the counters so only `ResetSessionState()` re-arms it.
+    void TestParseErrorsDockClearDoesNotReArmFirstBatchSignal()
+    {
+        auto *dock = mWindow->findChild<ParseErrorsDock *>();
+        QVERIFY2(dock != nullptr, "MainWindow must own a ParseErrorsDock");
+        dock->ResetSessionState();
+
+        QSignalSpy firstBatchSpy(dock, &ParseErrorsDock::firstBatchArrived);
+        QVERIFY(firstBatchSpy.isValid());
+
+        dock->AppendErrors(QStringLiteral("Initial batch"), {"a"});
+        QCOMPARE(firstBatchSpy.count(), 1);
+
+        dock->ClearErrors();
+        QCOMPARE(dock->Count(), 0);
+        QCOMPARE(dock->DroppedCount(), 0);
+
+        // The simulated streaming hiccup: a fresh batch arrives
+        // after the user manually cleared. The latch must stay
+        // set so MainWindow does not auto-raise the dock again.
+        dock->AppendErrors(QStringLiteral("Post-clear hiccup"), {"b"});
+        QCOMPARE(dock->Count(), 1);
+        QCOMPARE(firstBatchSpy.count(), 1); // Still 1 -- ClearErrors did NOT re-arm.
+
+        // Sanity check the inverse: a real session boundary DOES
+        // re-arm.
+        dock->ResetSessionState();
+        dock->AppendErrors(QStringLiteral("Real new session"), {"c"});
+        QCOMPARE(firstBatchSpy.count(), 2);
     }
 
     // Pathologically large batches must evict the leading slice up
@@ -10801,6 +10858,190 @@ private slots:
         const int nextBlue = OpaquePixelCount(nextButton->icon(), qRgb(0, 0, 255));
         QVERIFY2(prevBlue > 0, "previous-button icon must repaint after a palette change");
         QVERIFY2(nextBlue > 0, "next-button icon must repaint after a palette change");
+    }
+
+    // The chevron icon backing pixmap must be allocated at the
+    // host's `devicePixelRatioF()` so HiDPI displays render the
+    // arrow at native resolution. Pre-fix the pixmap was minted at
+    // `sizePx x sizePx` regardless of DPR, leaving the chevrons
+    // softer than the surrounding `.*` / `*?` text glyphs on a
+    // 200% scaled monitor.
+    void TestFindBarArrowIconsScaleWithDevicePixelRatio()
+    {
+        auto *findRecord = mWindow->findChild<FindRecordWidget *>();
+        QVERIFY2(findRecord != nullptr, "MainWindow must own a FindRecordWidget");
+        auto *prevButton = findRecord->findChild<QToolButton *>(QStringLiteral("findPrevious"));
+        QVERIFY2(prevButton != nullptr, "FindRecordWidget must expose its previous button");
+
+        const QIcon icon = prevButton->icon();
+        QVERIFY2(!icon.isNull(), "previous-button icon must be set");
+        const QList<QSize> sizes = icon.availableSizes();
+        QVERIFY2(!sizes.isEmpty(), "icon must report at least one size");
+
+        // The pixmap returned by `pixmap(size)` is scaled to the
+        // requested logical size; what we want to inspect is the
+        // *backing* pixel count. Pulling at the largest available
+        // size and asserting `devicePixelRatio()` matches the
+        // widget's host DPR is the cleanest probe.
+        const QPixmap pix = icon.pixmap(sizes.front());
+        QVERIFY2(!pix.isNull(), "pixmap mint must succeed");
+        const qreal hostDpr = findRecord->devicePixelRatioF();
+        if (hostDpr > 1.0)
+        {
+            QVERIFY2(
+                pix.devicePixelRatio() >= hostDpr - 0.05,
+                qPrintable(QStringLiteral("expected DPR %1, got %2 -- HiDPI mint regressed")
+                               .arg(hostDpr)
+                               .arg(pix.devicePixelRatio()))
+            );
+            // Backing pixel size should also scale: a sizePx-wide
+            // logical icon at 2x DPR should have a 2*sizePx-wide
+            // backing pixmap.
+            const int expectedBackingPx = static_cast<int>(sizes.front().width() * hostDpr + 0.5);
+            QVERIFY2(
+                pix.size().width() >= expectedBackingPx - 1 && pix.size().width() <= expectedBackingPx + 1,
+                qPrintable(QStringLiteral("backing pixmap width %1 should be ~ logical %2 * DPR %3")
+                               .arg(pix.size().width())
+                               .arg(sizes.front().width())
+                               .arg(hostDpr))
+            );
+        }
+        else
+        {
+            // 1x display: just confirm the icon is realised.
+            QVERIFY(pix.devicePixelRatio() >= 1.0 - 0.05);
+        }
+    }
+
+    // `LogModel::IsStyleOnlyRoleChange` is the helper the find
+    // cache and record-detail dock use to filter out
+    // theme-refresh notifications. Lock down its contract so a
+    // future role addition can't silently flip a value-affecting
+    // role into the "ignore" set.
+    void TestIsStyleOnlyRoleChangeContract()
+    {
+        QVERIFY2(
+            !LogModel::IsStyleOnlyRoleChange({}),
+            "empty roles list is the 'I don't know' sentinel; must conservatively refresh"
+        );
+        QVERIFY(LogModel::IsStyleOnlyRoleChange({Qt::BackgroundRole}));
+        QVERIFY(LogModel::IsStyleOnlyRoleChange({Qt::ForegroundRole}));
+        QVERIFY(LogModel::IsStyleOnlyRoleChange({Qt::FontRole}));
+        QVERIFY(LogModel::IsStyleOnlyRoleChange({Qt::DecorationRole}));
+        QVERIFY(LogModel::IsStyleOnlyRoleChange({Qt::BackgroundRole, Qt::ForegroundRole, Qt::FontRole}));
+        QVERIFY2(
+            !LogModel::IsStyleOnlyRoleChange({Qt::DisplayRole}), "DisplayRole change must trigger a refresh"
+        );
+        QVERIFY2(!LogModel::IsStyleOnlyRoleChange({Qt::EditRole}), "EditRole change must trigger a refresh");
+        QVERIFY2(
+            !LogModel::IsStyleOnlyRoleChange({Qt::BackgroundRole, Qt::DisplayRole}),
+            "mixed list with at least one value-role must trigger a refresh"
+        );
+    }
+
+    // `LogFilterModel::ComposeFindFlags` is the single source of
+    // truth for find-flag composition. Lock down the priority
+    // (regex > wildcard > contains) and the always-on
+    // `MatchWrap | MatchRecursive` baseline so a future refactor
+    // can't desync the find call sites.
+    void TestComposeFindFlagsPriorityAndBaseline()
+    {
+        constexpr Qt::MatchFlags BASELINE = Qt::MatchWrap | Qt::MatchRecursive;
+        QCOMPARE(
+            LogFilterModel::ComposeFindFlags(/*wildcards=*/false, /*regex=*/false), BASELINE | Qt::MatchContains
+        );
+        QCOMPARE(
+            LogFilterModel::ComposeFindFlags(/*wildcards=*/true, /*regex=*/false), BASELINE | Qt::MatchWildcard
+        );
+        QCOMPARE(
+            LogFilterModel::ComposeFindFlags(/*wildcards=*/false, /*regex=*/true),
+            BASELINE | Qt::MatchRegularExpression
+        );
+        // Both toggles checked: regex wins (the UI enforces this
+        // visually too -- `mWildcardsAction` and `mRegexAction`
+        // are mutually exclusive -- but the helper itself must
+        // not depend on that invariant being upheld upstream).
+        QCOMPARE(
+            LogFilterModel::ComposeFindFlags(/*wildcards=*/true, /*regex=*/true),
+            BASELINE | Qt::MatchRegularExpression
+        );
+    }
+
+    // `BumpMatchCountDebounce` was a hot path during streaming
+    // bursts: every `dataChanged` invalidation called
+    // `mMatchCountTimer->start()`, which restarts the trailing
+    // timer. With continuous streaming, the trailing timer was
+    // forever reset and only the max-age timer (cap = 750ms)
+    // fired. Fix: when both timers are already running, skip the
+    // start call so the recount actually fires on the trailing
+    // timer's natural deadline.
+    void TestBumpMatchCountDebounceCoalescesStreamingBursts()
+    {
+        auto *findRecord = mWindow->findChild<FindRecordWidget *>();
+        QVERIFY2(findRecord != nullptr, "MainWindow must own a FindRecordWidget");
+        auto *findEdit = findRecord->findChild<QLineEdit *>(QStringLiteral("findEdit"));
+        QVERIFY2(findEdit != nullptr, "FindRecordWidget must expose its QLineEdit");
+        auto *trailingTimer = findRecord->findChild<QTimer *>(QStringLiteral("matchCountDebounceTimer"));
+        auto *maxAgeTimer = findRecord->findChild<QTimer *>(QStringLiteral("matchCountMaxAgeTimer"));
+        // Object names may not be set; fall back to walking timers.
+        if (trailingTimer == nullptr || maxAgeTimer == nullptr)
+        {
+            const QList<QTimer *> timers = findRecord->findChildren<QTimer *>();
+            // Skip the test gracefully if the timers aren't named.
+            if (timers.size() < 2)
+            {
+                QSKIP("FindRecordWidget timers are unnamed; cannot probe directly");
+            }
+        }
+
+        findEdit->setText(QStringLiteral("needle"));
+        // First Bump arms both timers.
+        findRecord->BumpMatchCountDebounce();
+        // Second Bump while both already active: must not perturb
+        // their state. We verify by recording the remaining time
+        // before the second call and asserting it doesn't snap
+        // back to the full interval after.
+        const QList<QTimer *> timers = findRecord->findChildren<QTimer *>();
+        QTimer *trailing = nullptr;
+        QTimer *maxAge = nullptr;
+        for (QTimer *t : timers)
+        {
+            if (!t->isActive())
+            {
+                continue;
+            }
+            if (trailing == nullptr)
+            {
+                trailing = t;
+            }
+            else if (maxAge == nullptr && t != trailing)
+            {
+                maxAge = t;
+            }
+        }
+        QVERIFY2(trailing != nullptr, "first BumpMatchCountDebounce must arm the trailing timer");
+        QVERIFY2(maxAge != nullptr, "first BumpMatchCountDebounce must arm the max-age timer");
+
+        // Sleep a couple of ms so the timer's `remainingTime()`
+        // ticks down. Then re-bump and assert the remaining time
+        // did NOT bounce back up (which would indicate the
+        // trailing timer was reset).
+        QTest::qWait(20);
+        const int remainingBefore = trailing->remainingTime();
+        findRecord->BumpMatchCountDebounce();
+        const int remainingAfter = trailing->remainingTime();
+        // Tolerate a 5ms drift for scheduler jitter; the key
+        // invariant is that the second bump did NOT *reset* the
+        // timer (which would push remaining back near interval()).
+        QVERIFY2(
+            remainingAfter <= remainingBefore + 5,
+            qPrintable(QStringLiteral(
+                           "second bump must not reset the trailing timer (before=%1, after=%2, interval=%3)"
+                       )
+                           .arg(remainingBefore)
+                           .arg(remainingAfter)
+                           .arg(trailing->interval()))
+        );
     }
 
     // An enum column with an empty dictionary must show the placeholder

--- a/test/app/src/main_window_test.cpp
+++ b/test/app/src/main_window_test.cpp
@@ -9720,15 +9720,15 @@ private slots:
 
         auto *clipboard = QGuiApplication::clipboard();
         clipboard->clear();
-        QMetaObject::invokeMethod(dock->findChild<QListWidget *>(QStringLiteral("parseErrorsList")), [list]() {
-            Q_UNUSED(list);
-        });
 
         // `CopySelection` is private; invoke via the Ctrl+C
         // shortcut so we exercise the same path the user sees.
-        // Build a key event and post it via QTest.
+        // The shortcut is parented on the dock's content widget
+        // (so it stays live even when focus is on the Clear
+        // button instead of the list), so search the whole dock
+        // subtree rather than just the list's children.
         QShortcut *copyShortcut = nullptr;
-        const QList<QShortcut *> shortcuts = list->findChildren<QShortcut *>();
+        const QList<QShortcut *> shortcuts = dock->findChildren<QShortcut *>();
         for (QShortcut *s : shortcuts)
         {
             if (s->key() == QKeySequence(QKeySequence::Copy))
@@ -9737,7 +9737,7 @@ private slots:
                 break;
             }
         }
-        QVERIFY2(copyShortcut != nullptr, "ParseErrorsDock must wire Ctrl+C on its list");
+        QVERIFY2(copyShortcut != nullptr, "ParseErrorsDock must wire Ctrl+C somewhere in its subtree");
         emit copyShortcut->activated();
         QCoreApplication::processEvents();
 
@@ -9870,6 +9870,122 @@ private slots:
         QVERIFY2(
             !spy.wait(300),
             "FindDock::revealed must NOT trigger MatchCountRequested for an empty needle"
+        );
+    }
+
+    // Regression: under continuous activity (live-tail streaming,
+    // a held-down key), the trailing 120 ms debounce restarts on
+    // every bump and never fires. The match-count indicator
+    // would then strand at the value from before the activity
+    // started, which is exactly the case where a live indicator
+    // is most useful. `BumpMatchCountDebounce` was extended to
+    // also arm a max-age timer (capped at 750 ms) that is *not*
+    // reset by subsequent bumps, guaranteeing an emit within
+    // that window. This test forces a stream of bumps tighter
+    // than the trailing window and asserts the emit still
+    // arrives within the max-age cap.
+    void TestFindBarDebounceMaxAgeForcesEmitUnderContinuousActivity()
+    {
+        auto *findRecord = mWindow->findChild<FindRecordWidget *>();
+        QVERIFY2(findRecord != nullptr, "MainWindow must own a FindRecordWidget");
+        auto *edit = findRecord->findChild<QLineEdit *>(QStringLiteral("findEdit"));
+        QVERIFY2(edit != nullptr, "FindRecordWidget must expose its line edit");
+
+        edit->setText(QStringLiteral("anything"));
+        QSignalSpy spy(findRecord, &FindRecordWidget::MatchCountRequested);
+        QVERIFY(spy.isValid());
+        // Drain the textChanged-triggered debounce.
+        QVERIFY2(spy.count() > 0 || spy.wait(1500), "initial textChanged must emit");
+        spy.clear();
+
+        // Hammer the bump every 50 ms (under the 120 ms trailing
+        // window) for 1000 ms total. Without the max-age cap the
+        // trailing timer never fires; with it, exactly one emit
+        // arrives within ~750 ms of the first bump.
+        QElapsedTimer wallClock;
+        wallClock.start();
+        constexpr int BUMP_INTERVAL_MS = 50;
+        constexpr int TOTAL_BUMP_DURATION_MS = 1000;
+        constexpr int MAX_AGE_TOLERANCE_MS = 1000; // a bit above the 750 ms cap
+        bool emittedDuringHammer = false;
+        while (wallClock.elapsed() < TOTAL_BUMP_DURATION_MS)
+        {
+            findRecord->BumpMatchCountDebounce();
+            QTest::qWait(BUMP_INTERVAL_MS);
+            if (spy.count() > 0)
+            {
+                emittedDuringHammer = true;
+                break;
+            }
+        }
+        QVERIFY2(
+            emittedDuringHammer,
+            qPrintable(QStringLiteral(
+                           "max-age cap must fire MatchCountRequested under continuous bumps; got %1 emits in %2 ms"
+            )
+                           .arg(spy.count())
+                           .arg(wallClock.elapsed()))
+        );
+        QVERIFY2(
+            wallClock.elapsed() <= MAX_AGE_TOLERANCE_MS,
+            qPrintable(QStringLiteral("first emit took longer than the max-age cap: %1 ms").arg(wallClock.elapsed()))
+        );
+    }
+
+    // Regression: `LogFilterModel::MatchRow` skips hidden columns
+    // (it honours `Column::visible`), but column-visibility flips
+    // do not emit any of the model / proxy signals the find cache
+    // is wired to (`rowsInserted`, `layoutChanged`, `dataChanged`,
+    // ...). Without explicit invalidation the "*i* of *N*"
+    // indicator could strand a count that includes hits in
+    // now-hidden columns. `SetColumnVisible` and
+    // `ApplyColumnVisibility` were updated to call
+    // `OnFindCacheInvalidated`; this test pins that wire.
+    //
+    // Driver: set a needle, prime the cache, hide a column, then
+    // verify the indicator is recomputed against the post-hide
+    // visibility set. Two checks lock the wire down:
+    //   - the cached match list reported via `SetMatchInfo`
+    //     decreases (matches that were only in the hidden column
+    //     are gone), and
+    //   - a fresh `MatchCountRequested` arrives, which only
+    //     happens if `OnFindCacheInvalidated` ran.
+    //
+    // We need the main window realised so `mFindDock->isVisible()`
+    // returns true (the visibility gate on the bump is
+    // intentional perf -- a hidden bar doesn't pay the recount).
+    void TestHidingColumnInvalidatesFindCache()
+    {
+        const int categoryCol = StreamFixtureForColumnTests();
+        QVERIFY2(categoryCol >= 0, "category column must exist after streaming");
+
+        auto *findRecord = mWindow->findChild<FindRecordWidget *>();
+        QVERIFY2(findRecord != nullptr, "MainWindow must own a FindRecordWidget");
+        auto *findDock = mWindow->findChild<FindDock *>();
+        QVERIFY2(findDock != nullptr, "MainWindow must own a FindDock");
+        auto *edit = findRecord->findChild<QLineEdit *>(QStringLiteral("findEdit"));
+        QVERIFY2(edit != nullptr, "FindRecordWidget must expose its line edit");
+
+        // Realise the window so the visibility gate in
+        // `OnFindCacheInvalidated` lets the bump through.
+        mWindow->show();
+        QVERIFY(QTest::qWaitForWindowExposed(mWindow, 5000));
+        findDock->show();
+        QCoreApplication::processEvents();
+        QVERIFY2(findDock->isVisible(), "find dock must be visible for the bump gate to pass");
+
+        edit->setText(QStringLiteral("info"));
+        QSignalSpy spy(findRecord, &FindRecordWidget::MatchCountRequested);
+        QVERIFY(spy.isValid());
+        // Drain the textChanged-triggered debounce so the next
+        // emit we observe is unambiguously caused by the hide.
+        QVERIFY2(spy.count() > 0 || spy.wait(1500), "initial textChanged must trigger a debounced MatchCountRequested");
+        spy.clear();
+
+        mWindow->SetColumnVisible(categoryCol, false);
+        QVERIFY2(
+            spy.count() > 0 || spy.wait(1500),
+            "Hiding a column must invalidate the find cache and trigger a fresh MatchCountRequested"
         );
     }
 

--- a/test/app/src/main_window_test.cpp
+++ b/test/app/src/main_window_test.cpp
@@ -5,10 +5,13 @@
 #include "columns_manager_dialog.hpp"
 #include "configuration_diagnostics_dialog.hpp"
 #include "filter_editor.hpp"
+#include "find_dock.hpp"
+#include "find_record_widget.hpp"
 #include "log_filter_model.hpp"
 #include "log_model.hpp"
 #include "log_table_view.hpp"
 #include "main_window.hpp"
+#include "parse_errors_dock.hpp"
 #include "qt_streaming_log_sink.hpp"
 #include "record_detail_dock.hpp"
 #include "record_detail_widget.hpp"
@@ -76,6 +79,7 @@
 #include <QScopedPointer>
 #include <QScrollBar>
 #include <QSettings>
+#include <QShortcut>
 #include <QSignalSpy>
 #include <QSortFilterProxyModel>
 #include <QStandardItem>
@@ -9251,6 +9255,509 @@ private slots:
         }
 
         model->EndStreaming(false);
+    }
+
+    // Regression: `FindRecords` and `UpdateFindMatchCount` previously
+    // OR-ed `Qt::MatchContains` with the (optional) `MatchWildcard` /
+    // `MatchRegularExpression` flags. `LogFilterModel::Matches`
+    // short-circuits on `MatchContains`, so the regex / wildcard
+    // toggles were silently no-ops -- the bar said "regex on" but
+    // the search ran as plain substring.
+    //
+    // Driver: stream lines whose substring would match plainly but
+    // whose regex / wildcard pattern must reject some of them. Then
+    // assert that find with the right flag lands on a matching row
+    // and that find without the flag still finds the broader set.
+    void TestFindUsesRegexFlagAndIgnoresContainsShadow()
+    {
+        const QStringList lines{
+            QStringLiteral(R"({"msg": "abc-123"})"),
+            QStringLiteral(R"({"msg": "abc-xyz"})"),
+            QStringLiteral(R"({"msg": "zzz-123"})"),
+            QStringLiteral(R"({"msg": "abc-456"})"),
+        };
+        const TempJsonFile fixture(lines);
+
+        auto *model = mWindow->findChild<LogModel *>();
+        QVERIFY2(model != nullptr, "MainWindow must own a LogModel");
+        QSignalSpy finishedSpy(model, &LogModel::streamingFinished);
+        QVERIFY(finishedSpy.isValid());
+
+        auto file = std::make_unique<loglib::LogFile>(fixture.Path().toStdString());
+        auto fileSource = std::make_unique<loglib::FileLineSource>(std::move(file));
+        loglib::FileLineSource *fileSourcePtr = fileSource.get();
+        const loglib::StopToken stopToken = model->BeginStreamingForSyncTest(std::move(fileSource));
+
+        loglib::ParserOptions options;
+        options.stopToken = stopToken;
+        loglib::internal::AdvancedParserOptions advanced;
+        advanced.threads = 1;
+        const loglib::JsonParser parser;
+        loglib::JsonParser::ParseStreaming(*fileSourcePtr, *model->Sink(), options, advanced);
+        QVERIFY2(finishedSpy.count() > 0 || finishedSpy.wait(5000), "streamingFinished must arrive");
+        QCOMPARE(model->rowCount(), lines.size());
+
+        auto *tableView = mWindow->findChild<LogTableView *>();
+        QVERIFY2(tableView != nullptr, "MainWindow must own a LogTableView");
+        auto *filterModel = mWindow->FilterModel();
+        QVERIFY2(filterModel != nullptr, "MainWindow must own a LogFilterModel");
+
+        // Anchor selection at row 0 so `FindRecords` walks forward
+        // from row 1 and lands on the first row whose digits match.
+        tableView->selectionModel()->setCurrentIndex(
+            filterModel->index(0, 0), QItemSelectionModel::ClearAndSelect | QItemSelectionModel::Rows
+        );
+
+        // Regex needle `abc-\d+` matches rows 0 and 3 ("abc-123",
+        // "abc-456") but rejects row 1 ("abc-xyz") and row 2
+        // ("zzz-123"). With the old contains-wins bug this would
+        // have matched all four (substring "abc-\d+" is in none of
+        // them, so it would have *failed* the find entirely and
+        // left the selection at row 0). The fix routes purely
+        // through `MatchRegularExpression`, so we expect a hit at
+        // row 3 (skipping the selected start row 0).
+        QVERIFY2(
+            QMetaObject::invokeMethod(
+                mWindow,
+                "FindRecords",
+                Qt::DirectConnection,
+                Q_ARG(QString, QStringLiteral("abc-\\d+")),
+                Q_ARG(bool, true),
+                Q_ARG(bool, false),
+                Q_ARG(bool, true)
+            ),
+            "FindRecords slot must be invocable via meta-object"
+        );
+        QCoreApplication::processEvents();
+
+        QModelIndex selected = tableView->selectionModel()->currentIndex();
+        QVERIFY2(selected.isValid(), "regex find must advance to a match");
+        QVERIFY2(selected.row() != 0, "regex find must not stall on the start row");
+        const QString cell = filterModel->index(selected.row(), 0).data(Qt::DisplayRole).toString();
+        QVERIFY2(
+            cell.contains(QStringLiteral("abc-")) && cell != QStringLiteral("abc-xyz"),
+            qPrintable(QStringLiteral("regex find landed on unexpected row text: %1").arg(cell))
+        );
+
+        // Wildcard branch: drive the proxy's `MatchRow` directly
+        // with `MatchWildcard` and confirm the wildcard semantics
+        // bind, independently of `FindRecords`'s start-index and
+        // skip-first-N bookkeeping.
+        //
+        // `*xyz*` (anchored to `\A.*xyz.*\z`) must match only the
+        // "abc-xyz" row. The old shadow-by-contains bug would have
+        // returned zero matches (no cell contains a literal `*`),
+        // so testing match-count alone discriminates the two
+        // implementations cleanly.
+        // Drive `MatchRow` directly with `MatchWildcard`. The
+        // bug used to lurk in two layers:
+        //   1. `MainWindow` OR-ed `MatchContains` into the flags
+        //      alongside `MatchWildcard`; and
+        //   2. `Qt::MatchFlag` values are *not* disjoint bit
+        //      flags -- `MatchWildcard = 5` already has the
+        //      `MatchContains = 1` bit set, so the old testFlag
+        //      ladder in `LogFilterModel::Matches` would short
+        //      circuit into `text.contains(needle)` even when
+        //      callers passed `MatchWildcard` alone.
+        // `*xyz*` against a literal substring of `*xyz*` matches
+        // no row, so a hit here proves the wildcard branch took
+        // effect rather than the contains branch.
+        const QModelIndex wildcardStart = filterModel->index(0, 0);
+        QVERIFY(wildcardStart.isValid());
+        const QModelIndexList wildcardHits = filterModel->MatchRow(
+            wildcardStart,
+            Qt::DisplayRole,
+            QVariant::fromValue(QStringLiteral("*xyz*")),
+            LogFilterModel::UNLIMITED_HITS,
+            Qt::MatchWildcard | Qt::MatchWrap | Qt::MatchRecursive,
+            true,
+            0
+        );
+        QCOMPARE(wildcardHits.size(), 1);
+        const QString wildcardCell = filterModel->index(wildcardHits[0].row(), 0).data(Qt::DisplayRole).toString();
+        QVERIFY2(
+            wildcardCell.contains(QStringLiteral("xyz")),
+            qPrintable(QStringLiteral("wildcard hit landed on a non-xyz row: %1").arg(wildcardCell))
+        );
+
+        // And once more via the public `FindRecords` slot to
+        // pin that `MainWindow`'s flag composition is also right.
+        // Anchor selection at row 0 so wrap-around forward search
+        // lands on the only matching row (row 1, `abc-xyz`).
+        tableView->selectionModel()->setCurrentIndex(
+            filterModel->index(0, 0), QItemSelectionModel::ClearAndSelect | QItemSelectionModel::Rows
+        );
+        QVERIFY2(
+            QMetaObject::invokeMethod(
+                mWindow,
+                "FindRecords",
+                Qt::DirectConnection,
+                Q_ARG(QString, QStringLiteral("*xyz*")),
+                Q_ARG(bool, true),
+                Q_ARG(bool, true),
+                Q_ARG(bool, false)
+            ),
+            "FindRecords slot must be invocable via meta-object"
+        );
+        QCoreApplication::processEvents();
+        selected = tableView->selectionModel()->currentIndex();
+        QVERIFY2(selected.isValid(), "FindRecords with wildcards must advance to a match");
+        QCOMPARE(filterModel->index(selected.row(), 0).data(Qt::DisplayRole).toString(), QStringLiteral("abc-xyz"));
+
+        // Contains needle `abc`: should reach every "abc-..." row;
+        // unchanged behaviour from before the fix, but pin it so a
+        // future refactor of the flag composition can't silently
+        // demote contains too.
+        tableView->selectionModel()->setCurrentIndex(
+            filterModel->index(2, 0), QItemSelectionModel::ClearAndSelect | QItemSelectionModel::Rows
+        );
+        QVERIFY2(
+            QMetaObject::invokeMethod(
+                mWindow,
+                "FindRecords",
+                Qt::DirectConnection,
+                Q_ARG(QString, QStringLiteral("abc")),
+                Q_ARG(bool, true),
+                Q_ARG(bool, false),
+                Q_ARG(bool, false)
+            ),
+            "FindRecords slot must be invocable via meta-object"
+        );
+        QCoreApplication::processEvents();
+        selected = tableView->selectionModel()->currentIndex();
+        QVERIFY2(selected.isValid(), "contains find must advance to a match");
+        QVERIFY2(
+            filterModel->index(selected.row(), 0).data(Qt::DisplayRole).toString().startsWith(QStringLiteral("abc-")),
+            "contains find must land on an `abc-...` row"
+        );
+
+        model->EndStreaming(false);
+    }
+
+    // Toggling the regex action in the find bar must un-check
+    // wildcards (and vice versa). They are mutually exclusive in
+    // `LogFilterModel::Matches`, so leaving both checked makes the
+    // bar look like it's running two modes when only one applies.
+    void TestFindBarRegexAndWildcardsAreMutuallyExclusive()
+    {
+        auto *findRecord = mWindow->findChild<FindRecordWidget *>();
+        QVERIFY2(findRecord != nullptr, "MainWindow must own a FindRecordWidget");
+        auto *regex = findRecord->findChild<QAction *>(QStringLiteral("regexToggle"));
+        auto *wildcards = findRecord->findChild<QAction *>(QStringLiteral("wildcardsToggle"));
+        QVERIFY2(regex != nullptr && wildcards != nullptr, "Find bar must expose regex + wildcards toggles");
+
+        regex->setChecked(true);
+        QVERIFY2(regex->isChecked(), "regex toggle must accept setChecked(true)");
+        QVERIFY2(!wildcards->isChecked(), "regex setChecked(true) must leave wildcards off");
+
+        wildcards->setChecked(true);
+        QVERIFY2(wildcards->isChecked(), "wildcards toggle must accept setChecked(true)");
+        QVERIFY2(!regex->isChecked(), "enabling wildcards must auto-un-check regex");
+
+        regex->setChecked(true);
+        QVERIFY2(regex->isChecked(), "regex toggle must re-engage after wildcards turn off");
+        QVERIFY2(!wildcards->isChecked(), "re-enabling regex must auto-un-check wildcards");
+    }
+
+    // `ParseErrorsDock::AppendErrors` must:
+    //   - track Count() / DroppedCount() correctly across batches,
+    //   - emit `countChanged(count, droppedCount)` on every change,
+    //   - emit `firstBatchArrived()` exactly once per session (i.e.
+    //     not on subsequent batches after the first).
+    void TestParseErrorsDockTracksCountsAndFirstBatchSignal()
+    {
+        auto *dock = mWindow->findChild<ParseErrorsDock *>();
+        QVERIFY2(dock != nullptr, "MainWindow must own a ParseErrorsDock");
+        dock->ClearErrors();
+
+        QSignalSpy countSpy(dock, &ParseErrorsDock::countChanged);
+        QSignalSpy firstBatchSpy(dock, &ParseErrorsDock::firstBatchArrived);
+        QVERIFY(countSpy.isValid());
+        QVERIFY(firstBatchSpy.isValid());
+
+        QCOMPARE(dock->Count(), 0);
+        QCOMPARE(dock->DroppedCount(), 0);
+
+        dock->AppendErrors(QStringLiteral("First batch"), {"a", "b", "c"});
+        QCOMPARE(dock->Count(), 3);
+        QCOMPARE(dock->DroppedCount(), 0);
+        QCOMPARE(firstBatchSpy.count(), 1);
+        // countChanged carries (count, droppedCount) -- two ints.
+        QVERIFY2(countSpy.count() >= 1, "countChanged must fire on append");
+        QCOMPARE(countSpy.last().at(0).toInt(), 3);
+        QCOMPARE(countSpy.last().at(1).toInt(), 0);
+
+        dock->AppendErrors(QStringLiteral("Second batch"), {"d", "e"});
+        QCOMPARE(dock->Count(), 5);
+        QCOMPARE(dock->DroppedCount(), 0);
+        QCOMPARE(
+            firstBatchSpy.count(),
+            1
+        ); // No second emit until ClearErrors resets the session.
+        QCOMPARE(countSpy.last().at(0).toInt(), 5);
+
+        // Clear resets both counters and arms `firstBatchArrived`
+        // for the next session.
+        dock->ClearErrors();
+        QCOMPARE(dock->Count(), 0);
+        QCOMPARE(dock->DroppedCount(), 0);
+        QCOMPARE(countSpy.last().at(0).toInt(), 0);
+        QCOMPARE(countSpy.last().at(1).toInt(), 0);
+
+        dock->AppendErrors(QStringLiteral("After clear"), {"x"});
+        QCOMPARE(dock->Count(), 1);
+        QCOMPARE(firstBatchSpy.count(), 2); // New session -> second emit.
+    }
+
+    // Pathologically large batches must evict the leading slice up
+    // front (rather than letting `TrimToCap` walk from the top
+    // after construction). After cap-trimming, `DroppedCount()`
+    // reflects the eviction count, and the overflow footer is the
+    // single tail row marked with `OVERFLOW_FOOTER_ROLE`.
+    //
+    // Regression: a single batch sized just past the cap (cap + N)
+    // pre-trims `N` entries off the input *before* items are
+    // minted, so `mErrorCount` lands exactly at `MAX_DISPLAYED_ERRORS`
+    // after the loop. The old `TrimToCap` short-circuited at that
+    // point and never appended the in-list overflow footer, leaving
+    // the summary header ("N earlier dropped") and the list view
+    // out of sync.
+    void TestParseErrorsDockTrimsToCapAndAddsOverflowFooter()
+    {
+        auto *dock = mWindow->findChild<ParseErrorsDock *>();
+        QVERIFY2(dock != nullptr, "MainWindow must own a ParseErrorsDock");
+        dock->ClearErrors();
+
+        const int cap = ParseErrorsDock::MAX_DISPLAYED_ERRORS;
+        std::vector<std::string> huge;
+        huge.reserve(static_cast<size_t>(cap + 25));
+        for (int i = 0; i < cap + 25; ++i)
+        {
+            huge.emplace_back(std::string("err ") + std::to_string(i));
+        }
+        dock->AppendErrors(QStringLiteral("Huge"), huge);
+        QCOMPARE(dock->Count(), cap);
+        QCOMPARE(dock->DroppedCount(), 25);
+
+        auto *list = dock->findChild<QListWidget *>(QStringLiteral("parseErrorsList"));
+        QVERIFY2(list != nullptr, "ParseErrorsDock must expose its internal QListWidget");
+
+        // The footer must be the *last* item (so it floats below
+        // the surviving rows) and must be the only item flagged
+        // with `Qt::UserRole + 1`. Searching from the tail also
+        // guarantees we don't accidentally find a stale footer
+        // sitting somewhere in the middle.
+        QListWidgetItem *footer = nullptr;
+        int footerIndex = -1;
+        int footerHits = 0;
+        const int footerRole = Qt::UserRole + 1;
+        for (int i = 0; i < list->count(); ++i)
+        {
+            QListWidgetItem *item = list->item(i);
+            if (item != nullptr && item->data(footerRole).toBool())
+            {
+                ++footerHits;
+                footer = item;
+                footerIndex = i;
+            }
+        }
+        QCOMPARE(footerHits, 1);
+        QCOMPARE(footerIndex, list->count() - 1);
+        QVERIFY2(footer != nullptr, "footer item lookup must succeed");
+        QVERIFY2(
+            footer->text().contains(QStringLiteral("dropped"), Qt::CaseInsensitive),
+            qPrintable(QStringLiteral("footer must read like an overflow notice; got: %1").arg(footer->text()))
+        );
+        // Footer must be non-selectable so arrow-key navigation
+        // and Ctrl+A don't pull it into the user's selection.
+        QVERIFY2(
+            !footer->flags().testFlag(Qt::ItemIsSelectable),
+            "overflow footer must not be user-selectable"
+        );
+    }
+
+    // Streaming-style: many smaller batches that collectively
+    // overflow the cap. `TrimToCap`'s walk-from-the-top path
+    // handles the eviction here (different code path from the
+    // pathological single-batch case above), so the in-list
+    // footer needs to appear on this path too and stay
+    // monotonic with `mDroppedCount`.
+    void TestParseErrorsDockOverflowFooterTracksMultipleBatches()
+    {
+        auto *dock = mWindow->findChild<ParseErrorsDock *>();
+        QVERIFY2(dock != nullptr, "MainWindow must own a ParseErrorsDock");
+        dock->ClearErrors();
+
+        auto *list = dock->findChild<QListWidget *>(QStringLiteral("parseErrorsList"));
+        QVERIFY2(list != nullptr, "ParseErrorsDock must expose its internal QListWidget");
+        const int footerRole = Qt::UserRole + 1;
+
+        const int cap = ParseErrorsDock::MAX_DISPLAYED_ERRORS;
+        // Fill exactly to the cap with one moderate batch -- no
+        // overflow yet, so no footer expected.
+        std::vector<std::string> first;
+        first.reserve(static_cast<size_t>(cap));
+        for (int i = 0; i < cap; ++i)
+        {
+            first.emplace_back(std::string("a-") + std::to_string(i));
+        }
+        dock->AppendErrors(QStringLiteral("A"), first);
+        QCOMPARE(dock->DroppedCount(), 0);
+        for (int i = 0; i < list->count(); ++i)
+        {
+            QListWidgetItem *item = list->item(i);
+            QVERIFY2(
+                item == nullptr || !item->data(footerRole).toBool(),
+                "no footer when nothing has been dropped"
+            );
+        }
+
+        // Second small batch tips the dock over the cap. Walk
+        // eviction kicks in. Footer must surface.
+        const int overflow = 50;
+        std::vector<std::string> second;
+        second.reserve(static_cast<size_t>(overflow));
+        for (int i = 0; i < overflow; ++i)
+        {
+            second.emplace_back(std::string("b-") + std::to_string(i));
+        }
+        dock->AppendErrors(QStringLiteral("B"), second);
+        QCOMPARE(dock->Count(), cap);
+        QCOMPARE(dock->DroppedCount(), overflow);
+        QListWidgetItem *tail = list->item(list->count() - 1);
+        QVERIFY2(tail != nullptr && tail->data(footerRole).toBool(),
+                 "overflow footer must be the trailing item after eviction");
+
+        // Third batch grows `mDroppedCount` further; footer text
+        // must update to the new total, and the dock must not
+        // accumulate stale footers.
+        std::vector<std::string> third;
+        third.reserve(static_cast<size_t>(overflow));
+        for (int i = 0; i < overflow; ++i)
+        {
+            third.emplace_back(std::string("c-") + std::to_string(i));
+        }
+        dock->AppendErrors(QStringLiteral("C"), third);
+        QCOMPARE(dock->DroppedCount(), overflow * 2);
+        int footerHits = 0;
+        QListWidgetItem *latestFooter = nullptr;
+        for (int i = 0; i < list->count(); ++i)
+        {
+            QListWidgetItem *item = list->item(i);
+            if (item != nullptr && item->data(footerRole).toBool())
+            {
+                ++footerHits;
+                latestFooter = item;
+            }
+        }
+        QCOMPARE(footerHits, 1);
+        QVERIFY2(latestFooter != nullptr, "footer lookup must succeed after third batch");
+        QVERIFY2(
+            latestFooter->text().contains(QString::number(overflow * 2)) ||
+                latestFooter->text().contains(QLocale::system().toString(static_cast<qlonglong>(overflow * 2))),
+            qPrintable(QStringLiteral("footer must surface the running drop count; got: %1").arg(latestFooter->text()))
+        );
+    }
+
+    // `CopySelection` documents that group headers + overflow
+    // footer are pasted alongside the user's selection so the
+    // copied block reads coherently. Headers and the footer are
+    // non-selectable items, so the implementation has to
+    // synthesise them around the selection rather than rely on
+    // `isSelected()`.
+    void TestParseErrorsDockCopySelectionIncludesHeaderAndFooter()
+    {
+        auto *dock = mWindow->findChild<ParseErrorsDock *>();
+        QVERIFY2(dock != nullptr, "MainWindow must own a ParseErrorsDock");
+        dock->ClearErrors();
+
+        // Two batches so we have two headers; cap-overflow forces
+        // the footer.
+        const int cap = ParseErrorsDock::MAX_DISPLAYED_ERRORS;
+        std::vector<std::string> batchA;
+        batchA.reserve(static_cast<size_t>(cap - 5));
+        for (int i = 0; i < cap - 5; ++i)
+        {
+            batchA.emplace_back("A-" + std::to_string(i));
+        }
+        std::vector<std::string> batchB{"B-0", "B-1", "B-2", "B-3", "B-4", "B-5", "B-6"};
+
+        dock->AppendErrors(QStringLiteral("Batch A"), batchA);
+        dock->AppendErrors(QStringLiteral("Batch B"), batchB);
+        QVERIFY2(dock->DroppedCount() > 0, "cap overflow must mint an overflow footer");
+
+        auto *list = dock->findChild<QListWidget *>(QStringLiteral("parseErrorsList"));
+        QVERIFY2(list != nullptr, "ParseErrorsDock must expose its internal QListWidget");
+
+        // Locate the "Batch B" header + one of its error rows; the
+        // header sits between A's last row and B's first.
+        int batchBHeaderRow = -1;
+        int firstBRow = -1;
+        for (int i = 0; i < list->count(); ++i)
+        {
+            QListWidgetItem *item = list->item(i);
+            if (item == nullptr)
+            {
+                continue;
+            }
+            if (item->text() == QStringLiteral("Batch B") && !item->flags().testFlag(Qt::ItemIsSelectable))
+            {
+                batchBHeaderRow = i;
+            }
+            if (item->text().startsWith(QStringLiteral("B-")) && item->flags().testFlag(Qt::ItemIsSelectable))
+            {
+                if (firstBRow < 0)
+                {
+                    firstBRow = i;
+                }
+            }
+        }
+        QVERIFY2(batchBHeaderRow >= 0, "Batch B header must survive trimming (its rows did)");
+        QVERIFY2(firstBRow > batchBHeaderRow, "Batch B's first error row must follow its header");
+
+        list->clearSelection();
+        list->item(firstBRow)->setSelected(true);
+
+        auto *clipboard = QGuiApplication::clipboard();
+        clipboard->clear();
+        QMetaObject::invokeMethod(dock->findChild<QListWidget *>(QStringLiteral("parseErrorsList")), [list]() {
+            Q_UNUSED(list);
+        });
+
+        // `CopySelection` is private; invoke via the Ctrl+C
+        // shortcut so we exercise the same path the user sees.
+        // Build a key event and post it via QTest.
+        QShortcut *copyShortcut = nullptr;
+        const QList<QShortcut *> shortcuts = list->findChildren<QShortcut *>();
+        for (QShortcut *s : shortcuts)
+        {
+            if (s->key() == QKeySequence(QKeySequence::Copy))
+            {
+                copyShortcut = s;
+                break;
+            }
+        }
+        QVERIFY2(copyShortcut != nullptr, "ParseErrorsDock must wire Ctrl+C on its list");
+        emit copyShortcut->activated();
+        QCoreApplication::processEvents();
+
+        const QString clip = clipboard->text();
+        QVERIFY2(!clip.isEmpty(), "CopySelection must populate the clipboard");
+        QVERIFY2(
+            clip.contains(QStringLiteral("Batch B")),
+            qPrintable(QStringLiteral("clipboard must include the group header; got:\n%1").arg(clip))
+        );
+        QVERIFY2(
+            clip.contains(QStringLiteral("B-0")),
+            qPrintable(QStringLiteral("clipboard must include the selected error row; got:\n%1").arg(clip))
+        );
+        // The overflow footer is rendered by `tr()` so the exact
+        // text is locale-dependent; look for the parenthesised
+        // "dropped" hint instead.
+        QVERIFY2(
+            clip.contains(QStringLiteral("dropped"), Qt::CaseInsensitive),
+            qPrintable(QStringLiteral("clipboard must include the overflow footer; got:\n%1").arg(clip))
+        );
     }
 
     // An enum column with an empty dictionary must show the placeholder

--- a/test/app/src/main_window_test.cpp
+++ b/test/app/src/main_window_test.cpp
@@ -10981,51 +10981,29 @@ private slots:
         QVERIFY2(findRecord != nullptr, "MainWindow must own a FindRecordWidget");
         auto *findEdit = findRecord->findChild<QLineEdit *>(QStringLiteral("findEdit"));
         QVERIFY2(findEdit != nullptr, "FindRecordWidget must expose its QLineEdit");
-        auto *trailingTimer = findRecord->findChild<QTimer *>(QStringLiteral("matchCountDebounceTimer"));
-        auto *maxAgeTimer = findRecord->findChild<QTimer *>(QStringLiteral("matchCountMaxAgeTimer"));
-        // Object names may not be set; fall back to walking timers.
-        if (trailingTimer == nullptr || maxAgeTimer == nullptr)
-        {
-            const QList<QTimer *> timers = findRecord->findChildren<QTimer *>();
-            // Skip the test gracefully if the timers aren't named.
-            if (timers.size() < 2)
-            {
-                QSKIP("FindRecordWidget timers are unnamed; cannot probe directly");
-            }
-        }
+        // `FindRecordWidget` names both timers via `setObjectName`
+        // so the test can probe them without the fragile "walk
+        // all timers and guess which is which" dance. If either
+        // name disappears the failure surfaces as a clear "the
+        // timer probe regressed" instead of a generic assertion
+        // mid-test.
+        auto *trailing = findRecord->findChild<QTimer *>(QStringLiteral("matchCountDebounceTimer"));
+        auto *maxAge = findRecord->findChild<QTimer *>(QStringLiteral("matchCountMaxAgeTimer"));
+        QVERIFY2(trailing != nullptr, "FindRecordWidget must name its trailing debounce timer");
+        QVERIFY2(maxAge != nullptr, "FindRecordWidget must name its max-age debounce timer");
 
         findEdit->setText(QStringLiteral("needle"));
-        // First Bump arms both timers.
+        // First Bump arms both timers (the textChanged emit above
+        // also arms them, but Bump is idempotent on that state).
         findRecord->BumpMatchCountDebounce();
-        // Second Bump while both already active: must not perturb
-        // their state. We verify by recording the remaining time
-        // before the second call and asserting it doesn't snap
-        // back to the full interval after.
-        const QList<QTimer *> timers = findRecord->findChildren<QTimer *>();
-        QTimer *trailing = nullptr;
-        QTimer *maxAge = nullptr;
-        for (QTimer *t : timers)
-        {
-            if (!t->isActive())
-            {
-                continue;
-            }
-            if (trailing == nullptr)
-            {
-                trailing = t;
-            }
-            else if (maxAge == nullptr && t != trailing)
-            {
-                maxAge = t;
-            }
-        }
-        QVERIFY2(trailing != nullptr, "first BumpMatchCountDebounce must arm the trailing timer");
-        QVERIFY2(maxAge != nullptr, "first BumpMatchCountDebounce must arm the max-age timer");
+        QVERIFY2(trailing->isActive(), "first BumpMatchCountDebounce must arm the trailing timer");
+        QVERIFY2(maxAge->isActive(), "first BumpMatchCountDebounce must arm the max-age timer");
 
-        // Sleep a couple of ms so the timer's `remainingTime()`
-        // ticks down. Then re-bump and assert the remaining time
-        // did NOT bounce back up (which would indicate the
-        // trailing timer was reset).
+        // Sleep a couple of ms so the trailing timer's
+        // `remainingTime()` ticks down. Then re-bump and assert
+        // the remaining time did NOT bounce back up (which would
+        // indicate the trailing timer was reset by the second
+        // bump -- the bug this guard is pinning).
         QTest::qWait(20);
         const int remainingBefore = trailing->remainingTime();
         findRecord->BumpMatchCountDebounce();

--- a/test/app/src/main_window_test.cpp
+++ b/test/app/src/main_window_test.cpp
@@ -4326,7 +4326,7 @@ private slots:
         const QModelIndex errorIndex = run.model->index(errorRow, levelCol);
         const QVariant lightErrorBg = run.model->data(errorIndex, Qt::BackgroundRole);
         QVERIFY2(lightErrorBg.isValid(), "Light theme must style the Error row background");
-        const QBrush lightBrush = qvariant_cast<QBrush>(lightErrorBg);
+        const auto lightBrush = qvariant_cast<QBrush>(lightErrorBg);
 
         // Now flip to Dark. `SetActiveSelection` -> `ApplyTheme`
         // rebuilds the cache and emits `themeChanged`. The model
@@ -4337,7 +4337,7 @@ private slots:
 
         const QVariant darkErrorBg = run.model->data(errorIndex, Qt::BackgroundRole);
         QVERIFY2(darkErrorBg.isValid(), "Dark theme must style the Error row background");
-        const QBrush darkBrush = qvariant_cast<QBrush>(darkErrorBg);
+        const auto darkBrush = qvariant_cast<QBrush>(darkErrorBg);
         QVERIFY2(
             lightBrush.color() != darkBrush.color(),
             qPrintable(QStringLiteral("Error row background must differ between Light and Dark themes; "
@@ -4349,7 +4349,7 @@ private slots:
         // Light returns the original brush.
         mTheme->SetActiveSelection(QStringLiteral("Light"));
         QCoreApplication::processEvents();
-        const QBrush lightBrushAgain = qvariant_cast<QBrush>(run.model->data(errorIndex, Qt::BackgroundRole));
+        const auto lightBrushAgain = qvariant_cast<QBrush>(run.model->data(errorIndex, Qt::BackgroundRole));
         QCOMPARE(lightBrushAgain.color(), lightBrush.color());
     }
 
@@ -4385,9 +4385,10 @@ private slots:
         {
             finishedSpy.wait(5000);
         }
+        // NOLINTNEXTLINE(clang-analyzer-core.CallAndMessage): false positive; prior `QVERIFY2` aborts on null.
         QVERIFY2(model->rowCount() > 0, "fixture must produce at least one streamed row");
 
-        QSignalSpy spy(model, &QAbstractItemModel::dataChanged);
+        const QSignalSpy spy(model, &QAbstractItemModel::dataChanged);
         mTheme->SetActiveSelection(QStringLiteral("Dark"));
         QCoreApplication::processEvents();
 
@@ -4398,7 +4399,7 @@ private slots:
         bool foundStyledNotification = false;
         for (int i = 0; i < spy.count(); ++i)
         {
-            const QList<QVariant> args = spy.at(i);
+            const QList<QVariant> &args = spy.at(i);
             QVERIFY2(args.size() >= 3, "dataChanged must carry topLeft, bottomRight, roles");
             const auto roles = args.at(2).value<QList<int>>();
             // An empty roles list is "all roles changed" in Qt's
@@ -8110,11 +8111,12 @@ private slots:
         mTheme->SetActiveSelection(QStringLiteral("Light"));
         QCoreApplication::processEvents();
 
-        ConfigurationDiagnosticsDialog dialog(model);
+        const ConfigurationDiagnosticsDialog dialog(model);
         auto *table = dialog.findChild<QTableWidget *>();
         QVERIFY2(table != nullptr, "Dialog must own a diagnosticsTable widget");
 
-        auto FindMsgRow = [table]() {
+        auto findMsgRow = [table]() {
+            // NOLINTNEXTLINE(clang-analyzer-core.CallAndMessage): false positive; prior `QVERIFY2` aborts on null.
             for (int row = 0; row < table->rowCount(); ++row)
             {
                 const QTableWidgetItem *headerItem = table->item(row, 0);
@@ -8126,7 +8128,7 @@ private slots:
             return -1;
         };
 
-        const int lightRow = FindMsgRow();
+        const int lightRow = findMsgRow();
         QVERIFY2(lightRow >= 0, "Light-theme dialog must include a row for the `msg` column");
         const QTableWidgetItem *lightItem = table->item(lightRow, 0);
         QVERIFY(lightItem != nullptr);
@@ -8142,7 +8144,7 @@ private slots:
         mTheme->SetActiveSelection(QStringLiteral("Dark"));
         QCoreApplication::processEvents();
 
-        const int darkRow = FindMsgRow();
+        const int darkRow = findMsgRow();
         QVERIFY2(darkRow >= 0, "Dark-theme dialog must still include a row for the `msg` column");
         const QTableWidgetItem *darkItem = table->item(darkRow, 0);
         QVERIFY(darkItem != nullptr);
@@ -8164,29 +8166,29 @@ private slots:
         constexpr double R_LUMA = 0.299;
         constexpr double G_LUMA = 0.587;
         constexpr double B_LUMA = 0.114;
-        auto Luma = [](const QColor &c) { return (R_LUMA * c.red()) + (G_LUMA * c.green()) + (B_LUMA * c.blue()); };
+        auto luma = [](const QColor &c) { return (R_LUMA * c.red()) + (G_LUMA * c.green()) + (B_LUMA * c.blue()); };
 
         // Dark mode must use a *dark* highlight bg (otherwise the
         // row punches through the dialog as a near-white slab).
         constexpr double DARK_BG_MAX_LUMA = 110.0;
         QVERIFY2(
-            Luma(darkBg) <= DARK_BG_MAX_LUMA,
+            luma(darkBg) <= DARK_BG_MAX_LUMA,
             qPrintable(QStringLiteral("Dark-theme highlight bg must be dark; got %1 (luma=%2)")
                            .arg(darkBg.name())
-                           .arg(Luma(darkBg)))
+                           .arg(luma(darkBg)))
         );
 
         // Dark mode reverses the contrast pair: fg must be *lighter*
         // than bg, by the same gap the light-mode highlight uses.
         constexpr double MIN_LUMA_GAP = 80.0;
         QVERIFY2(
-            Luma(darkFg) - Luma(darkBg) >= MIN_LUMA_GAP,
+            luma(darkFg) - luma(darkBg) >= MIN_LUMA_GAP,
             qPrintable(QStringLiteral("Dark-theme highlight must keep high contrast (fg lighter than bg); "
                                       "got fg=%1 (luma=%2), bg=%3 (luma=%4)")
                            .arg(darkFg.name())
-                           .arg(Luma(darkFg))
+                           .arg(luma(darkFg))
                            .arg(darkBg.name())
-                           .arg(Luma(darkBg)))
+                           .arg(luma(darkBg)))
         );
 
         // Restore the default before the next test starts.
@@ -9871,6 +9873,7 @@ private slots:
 
         regex->setChecked(true);
         QVERIFY2(regex->isChecked(), "regex toggle must accept setChecked(true)");
+        // NOLINTNEXTLINE(clang-analyzer-core.CallAndMessage): false positive; prior `QVERIFY2` aborts on null.
         QVERIFY2(!wildcards->isChecked(), "regex setChecked(true) must leave wildcards off");
 
         wildcards->setChecked(true);
@@ -9920,7 +9923,7 @@ private slots:
         int wildcardsIdx = -1;
         int prevIdx = -1;
         int nextIdx = -1;
-        QWidget *cursor = edit;
+        const QWidget *cursor = edit;
         for (int hop = 0; hop < MAX_HOPS && cursor != nullptr; ++hop)
         {
             cursor = cursor->nextInFocusChain();
@@ -9994,7 +9997,7 @@ private slots:
         dock->ResetSessionState();
 
         QSignalSpy countSpy(dock, &ParseErrorsDock::countChanged);
-        QSignalSpy firstBatchSpy(dock, &ParseErrorsDock::firstBatchArrived);
+        const QSignalSpy firstBatchSpy(dock, &ParseErrorsDock::firstBatchArrived);
         QVERIFY(countSpy.isValid());
         QVERIFY(firstBatchSpy.isValid());
 
@@ -10059,7 +10062,7 @@ private slots:
         QVERIFY2(dock != nullptr, "MainWindow must own a ParseErrorsDock");
         dock->ResetSessionState();
 
-        QSignalSpy firstBatchSpy(dock, &ParseErrorsDock::firstBatchArrived);
+        const QSignalSpy firstBatchSpy(dock, &ParseErrorsDock::firstBatchArrived);
         QVERIFY(firstBatchSpy.isValid());
 
         dock->AppendErrors(QStringLiteral("Initial batch"), {"a"});
@@ -10104,7 +10107,7 @@ private slots:
 
         const int cap = ParseErrorsDock::MAX_DISPLAYED_ERRORS;
         std::vector<std::string> huge;
-        huge.reserve(static_cast<size_t>(cap + 25));
+        huge.reserve(static_cast<size_t>(cap) + 25);
         for (int i = 0; i < cap + 25; ++i)
         {
             huge.emplace_back(std::string("err ") + std::to_string(i));
@@ -10121,13 +10124,13 @@ private slots:
         // with `Qt::UserRole + 1`. Searching from the tail also
         // guarantees we don't accidentally find a stale footer
         // sitting somewhere in the middle.
-        QListWidgetItem *footer = nullptr;
+        const QListWidgetItem *footer = nullptr;
         int footerIndex = -1;
         int footerHits = 0;
         const int footerRole = Qt::UserRole + 1;
         for (int i = 0; i < list->count(); ++i)
         {
-            QListWidgetItem *item = list->item(i);
+            const QListWidgetItem *item = list->item(i);
             if (item != nullptr && item->data(footerRole).toBool())
             {
                 ++footerHits;
@@ -10176,7 +10179,7 @@ private slots:
         QCOMPARE(dock->DroppedCount(), 0);
         for (int i = 0; i < list->count(); ++i)
         {
-            QListWidgetItem *item = list->item(i);
+            const QListWidgetItem *item = list->item(i);
             QVERIFY2(item == nullptr || !item->data(footerRole).toBool(), "no footer when nothing has been dropped");
         }
 
@@ -10192,7 +10195,7 @@ private slots:
         dock->AppendErrors(QStringLiteral("B"), second);
         QCOMPARE(dock->Count(), cap);
         QCOMPARE(dock->DroppedCount(), overflow);
-        QListWidgetItem *tail = list->item(list->count() - 1);
+        const QListWidgetItem *tail = list->item(list->count() - 1);
         QVERIFY2(
             tail != nullptr && tail->data(footerRole).toBool(),
             "overflow footer must be the trailing item after eviction"
@@ -10210,10 +10213,10 @@ private slots:
         dock->AppendErrors(QStringLiteral("C"), third);
         QCOMPARE(dock->DroppedCount(), overflow * 2);
         int footerHits = 0;
-        QListWidgetItem *latestFooter = nullptr;
+        const QListWidgetItem *latestFooter = nullptr;
         for (int i = 0; i < list->count(); ++i)
         {
-            QListWidgetItem *item = list->item(i);
+            const QListWidgetItem *item = list->item(i);
             if (item != nullptr && item->data(footerRole).toBool())
             {
                 ++footerHits;
@@ -10250,7 +10253,7 @@ private slots:
         {
             batchA.emplace_back("A-" + std::to_string(i));
         }
-        std::vector<std::string> batchB{"B-0", "B-1", "B-2", "B-3", "B-4", "B-5", "B-6"};
+        const std::vector<std::string> batchB{"B-0", "B-1", "B-2", "B-3", "B-4", "B-5", "B-6"};
 
         dock->AppendErrors(QStringLiteral("Batch A"), batchA);
         dock->AppendErrors(QStringLiteral("Batch B"), batchB);
@@ -10265,7 +10268,7 @@ private slots:
         int firstBRow = -1;
         for (int i = 0; i < list->count(); ++i)
         {
-            QListWidgetItem *item = list->item(i);
+            const QListWidgetItem *item = list->item(i);
             if (item == nullptr)
             {
                 continue;
@@ -10375,7 +10378,7 @@ private slots:
         int firstSelectableRow = -1;
         for (int i = 0; i < list->count(); ++i)
         {
-            QListWidgetItem *item = list->item(i);
+            const QListWidgetItem *item = list->item(i);
             if (item != nullptr && item->flags().testFlag(Qt::ItemIsSelectable))
             {
                 firstSelectableRow = i;
@@ -10383,13 +10386,13 @@ private slots:
             }
         }
         QVERIFY2(firstSelectableRow > 0, "surviving error rows must follow at least one header");
-        QListWidgetItem *firstError = list->item(firstSelectableRow);
+        const QListWidgetItem *firstError = list->item(firstSelectableRow);
         QVERIFY2(firstError != nullptr, "first selectable row lookup must succeed");
         QVERIFY2(
             firstError->text().startsWith(QStringLiteral("A-")),
             qPrintable(QStringLiteral("first survivor must be from batch A; got: %1").arg(firstError->text()))
         );
-        QListWidgetItem *headerAbove = list->item(firstSelectableRow - 1);
+        const QListWidgetItem *headerAbove = list->item(firstSelectableRow - 1);
         QVERIFY2(headerAbove != nullptr, "row above first survivor must exist");
         QVERIFY2(
             !headerAbove->flags().testFlag(Qt::ItemIsSelectable),
@@ -10610,14 +10613,14 @@ private slots:
         // Park the user mid-list. Any position comfortably above
         // `maximum()` works; pick the middle so the slack
         // tolerance (4 px) cannot accidentally include us.
-        const int parkedPosition = vBar->minimum() + (vBar->maximum() - vBar->minimum()) / 2;
+        const int parkedPosition = vBar->minimum() + ((vBar->maximum() - vBar->minimum()) / 2);
         vBar->setValue(parkedPosition);
         QCoreApplication::processEvents();
         QCOMPARE(vBar->value(), parkedPosition);
 
         // New batch arrives mid-read. The user did not move; the
         // scrollbar should stay parked.
-        std::vector<std::string> later{"late-0", "late-1", "late-2", "late-3", "late-4"};
+        const std::vector<std::string> later{"late-0", "late-1", "late-2", "late-3", "late-4"};
         dock->AppendErrors(QStringLiteral("Later"), later);
         QCoreApplication::processEvents();
         QVERIFY2(
@@ -10636,7 +10639,7 @@ private slots:
         QCoreApplication::processEvents();
         QCOMPARE(vBar->value(), vBar->maximum());
 
-        std::vector<std::string> trailing{"tail-0", "tail-1", "tail-2"};
+        const std::vector<std::string> trailing{"tail-0", "tail-1", "tail-2"};
         dock->AppendErrors(QStringLiteral("Trailing"), trailing);
         QCoreApplication::processEvents();
         // After more items land, `maximum()` grew; the auto-follow
@@ -10729,6 +10732,7 @@ private slots:
         // form, no "dropped" hint anywhere on it.
         dock->AppendErrors(QStringLiteral("First"), {"a", "b", "c"});
         QCoreApplication::processEvents();
+        // NOLINTNEXTLINE(clang-analyzer-core.CallAndMessage): false positive; prior `QVERIFY2` aborts on null.
         QVERIFY2(
             !statusButton->text().contains(QStringLiteral("dropped"), Qt::CaseInsensitive),
             qPrintable(QStringLiteral("status button must not mention 'dropped' when nothing was dropped: %1")
@@ -10740,7 +10744,7 @@ private slots:
         // dropped count without any prior content getting evicted.
         const int cap = ParseErrorsDock::MAX_DISPLAYED_ERRORS;
         std::vector<std::string> huge;
-        huge.reserve(static_cast<size_t>(cap + 50));
+        huge.reserve(static_cast<size_t>(cap) + 50);
         for (int i = 0; i < cap + 50; ++i)
         {
             huge.emplace_back(std::string("err-") + std::to_string(i));
@@ -10784,7 +10788,7 @@ private slots:
         // dark pixels regardless of palette, while our palette-aware
         // icon paints in `QPalette::WindowText`, which we can flip
         // below to detect the difference.
-        auto OpaquePixelCount = [](const QIcon &icon, QRgb expected) -> int {
+        auto opaquePixelCount = [](const QIcon &icon, QRgb expected) -> int {
             const QList<QSize> sizes = icon.availableSizes();
             const QSize size = sizes.isEmpty() ? QSize{16, 16} : sizes.front();
             const QImage img = icon.pixmap(size).toImage().convertToFormat(QImage::Format_ARGB32);
@@ -10824,8 +10828,8 @@ private slots:
         // `setPalette` posts `PaletteChange`; pump the event loop
         // so `changeEvent` rebuilds the icons before we sample.
         QCoreApplication::sendPostedEvents(findRecord, QEvent::PaletteChange);
-        const int prevRed = OpaquePixelCount(prevButton->icon(), qRgb(255, 0, 0));
-        const int nextRed = OpaquePixelCount(nextButton->icon(), qRgb(255, 0, 0));
+        const int prevRed = opaquePixelCount(prevButton->icon(), qRgb(255, 0, 0));
+        const int nextRed = opaquePixelCount(nextButton->icon(), qRgb(255, 0, 0));
         QVERIFY2(prevRed > 0, "previous-button icon must paint in the palette's WindowText colour");
         QVERIFY2(nextRed > 0, "next-button icon must paint in the palette's WindowText colour");
 
@@ -10838,8 +10842,8 @@ private slots:
         bluePalette.setColor(QPalette::Inactive, QPalette::WindowText, QColor(0, 0, 255));
         findRecord->setPalette(bluePalette);
         QCoreApplication::sendPostedEvents(findRecord, QEvent::PaletteChange);
-        const int prevBlue = OpaquePixelCount(prevButton->icon(), qRgb(0, 0, 255));
-        const int nextBlue = OpaquePixelCount(nextButton->icon(), qRgb(0, 0, 255));
+        const int prevBlue = opaquePixelCount(prevButton->icon(), qRgb(0, 0, 255));
+        const int nextBlue = opaquePixelCount(nextButton->icon(), qRgb(0, 0, 255));
         QVERIFY2(prevBlue > 0, "previous-button icon must repaint after a palette change");
         QVERIFY2(nextBlue > 0, "next-button icon must repaint after a palette change");
     }
@@ -10881,7 +10885,7 @@ private slots:
             // Backing pixel size should also scale: a sizePx-wide
             // logical icon at 2x DPR should have a 2*sizePx-wide
             // backing pixmap.
-            const int expectedBackingPx = static_cast<int>(sizes.front().width() * hostDpr + 0.5);
+            const int expectedBackingPx = static_cast<int>(std::lround(sizes.front().width() * hostDpr));
             QVERIFY2(
                 pix.size().width() >= expectedBackingPx - 1 && pix.size().width() <= expectedBackingPx + 1,
                 qPrintable(QStringLiteral("backing pixmap width %1 should be ~ logical %2 * DPR %3")
@@ -10929,17 +10933,25 @@ private slots:
     void TestComposeFindFlagsPriorityAndBaseline()
     {
         constexpr Qt::MatchFlags BASELINE = Qt::MatchWrap | Qt::MatchRecursive;
-        QCOMPARE(LogFilterModel::ComposeFindFlags(/*wildcards=*/false, /*regex=*/false), BASELINE | Qt::MatchContains);
-        QCOMPARE(LogFilterModel::ComposeFindFlags(/*wildcards=*/true, /*regex=*/false), BASELINE | Qt::MatchWildcard);
         QCOMPARE(
-            LogFilterModel::ComposeFindFlags(/*wildcards=*/false, /*regex=*/true), BASELINE | Qt::MatchRegularExpression
+            LogFilterModel::ComposeFindFlags(/*wildcards=*/false, /*regularExpressions=*/false),
+            BASELINE | Qt::MatchContains
+        );
+        QCOMPARE(
+            LogFilterModel::ComposeFindFlags(/*wildcards=*/true, /*regularExpressions=*/false),
+            BASELINE | Qt::MatchWildcard
+        );
+        QCOMPARE(
+            LogFilterModel::ComposeFindFlags(/*wildcards=*/false, /*regularExpressions=*/true),
+            BASELINE | Qt::MatchRegularExpression
         );
         // Both toggles checked: regex wins (the UI enforces this
         // visually too -- `mWildcardsAction` and `mRegexAction`
         // are mutually exclusive -- but the helper itself must
         // not depend on that invariant being upheld upstream).
         QCOMPARE(
-            LogFilterModel::ComposeFindFlags(/*wildcards=*/true, /*regex=*/true), BASELINE | Qt::MatchRegularExpression
+            LogFilterModel::ComposeFindFlags(/*wildcards=*/true, /*regularExpressions=*/true),
+            BASELINE | Qt::MatchRegularExpression
         );
     }
 
@@ -10972,7 +10984,9 @@ private slots:
         // First Bump arms both timers (the textChanged emit above
         // also arms them, but Bump is idempotent on that state).
         findRecord->BumpMatchCountDebounce();
+        // NOLINTNEXTLINE(clang-analyzer-core.CallAndMessage): false positive; prior `QVERIFY2` aborts on null.
         QVERIFY2(trailing->isActive(), "first BumpMatchCountDebounce must arm the trailing timer");
+        // NOLINTNEXTLINE(clang-analyzer-core.CallAndMessage): false positive; prior `QVERIFY2` aborts on null.
         QVERIFY2(maxAge->isActive(), "first BumpMatchCountDebounce must arm the max-age timer");
 
         // Sleep a couple of ms so the trailing timer's

--- a/test/app/src/main_window_test.cpp
+++ b/test/app/src/main_window_test.cpp
@@ -74,6 +74,7 @@
 #include <QMenuBar>
 #include <QPlainTextEdit>
 #include <QPushButton>
+#include <QToolButton>
 #include <QRegularExpression>
 #include <QScopeGuard>
 #include <QScopedPointer>
@@ -9457,6 +9458,102 @@ private slots:
         regex->setChecked(true);
         QVERIFY2(regex->isChecked(), "regex toggle must re-engage after wildcards turn off");
         QVERIFY2(!wildcards->isChecked(), "re-enabling regex must auto-un-check wildcards");
+    }
+
+    // Regression: an earlier version of the find bar called
+    // `setTabOrder(mEdit, mButtonPrevious)` directly, which severs
+    // the regex/wildcards toggles from the Tab chain and makes
+    // them keyboard-unreachable. Walk the tab chain forward from
+    // the search field and assert that both toggle buttons are
+    // visited before the arrow buttons.
+    //
+    // We can't reliably drive Qt's `focusNextChild` from a
+    // headless test (the offscreen platform plugin is twitchy
+    // about focus events), so instead we verify the static graph:
+    // chase `nextInFocusChain()` forward from `mEdit` and confirm
+    // the regex / wildcards toggle buttons appear before the
+    // arrow buttons in the chain.
+    void TestFindBarTabOrderIncludesRegexAndWildcardsToggles()
+    {
+        auto *findRecord = mWindow->findChild<FindRecordWidget *>();
+        QVERIFY2(findRecord != nullptr, "MainWindow must own a FindRecordWidget");
+        auto *edit = findRecord->findChild<QLineEdit *>(QStringLiteral("findEdit"));
+        auto *regexButton = findRecord->findChild<QToolButton *>(QStringLiteral("regexToggleButton"));
+        auto *wildcardsButton = findRecord->findChild<QToolButton *>(QStringLiteral("wildcardsToggleButton"));
+        auto *prevButton = findRecord->findChild<QToolButton *>(QStringLiteral("findPrevious"));
+        auto *nextButton = findRecord->findChild<QToolButton *>(QStringLiteral("findNext"));
+        QVERIFY2(edit != nullptr, "findEdit must exist");
+        QVERIFY2(regexButton != nullptr, "regexToggleButton must exist");
+        QVERIFY2(wildcardsButton != nullptr, "wildcardsToggleButton must exist");
+        QVERIFY2(prevButton != nullptr, "findPrevious must exist");
+        QVERIFY2(nextButton != nullptr, "findNext must exist");
+
+        // Walk forward through the chain a bounded number of
+        // hops; record the first index at which each toggle and
+        // arrow button is seen. Use a generous hop budget so
+        // unrelated children of `findRecord` (or its container)
+        // can't starve us before we encounter the targets.
+        constexpr int MAX_HOPS = 64;
+        int regexIdx = -1;
+        int wildcardsIdx = -1;
+        int prevIdx = -1;
+        int nextIdx = -1;
+        QWidget *cursor = edit;
+        for (int hop = 0; hop < MAX_HOPS && cursor != nullptr; ++hop)
+        {
+            cursor = cursor->nextInFocusChain();
+            if (cursor == regexButton && regexIdx < 0)
+            {
+                regexIdx = hop;
+            }
+            if (cursor == wildcardsButton && wildcardsIdx < 0)
+            {
+                wildcardsIdx = hop;
+            }
+            if (cursor == prevButton && prevIdx < 0)
+            {
+                prevIdx = hop;
+            }
+            if (cursor == nextButton && nextIdx < 0)
+            {
+                nextIdx = hop;
+            }
+            if (regexIdx >= 0 && wildcardsIdx >= 0 && prevIdx >= 0 && nextIdx >= 0)
+            {
+                break;
+            }
+            if (cursor == edit)
+            {
+                // Wrapped without finding a target -- bail.
+                break;
+            }
+        }
+        QVERIFY2(
+            regexIdx >= 0 && wildcardsIdx >= 0,
+            qPrintable(QStringLiteral("regex/wildcards toggles must be on the tab chain (regex=%1 wildcards=%2)")
+                           .arg(regexIdx)
+                           .arg(wildcardsIdx))
+        );
+        QVERIFY2(
+            prevIdx >= 0 && nextIdx >= 0,
+            qPrintable(QStringLiteral("arrow buttons must be on the tab chain (prev=%1 next=%2)")
+                           .arg(prevIdx)
+                           .arg(nextIdx))
+        );
+        // Order: edit -> regex -> wildcards -> prev -> next.
+        // Strict ordering on the toggles vs the arrow buttons is
+        // the actual regression guard; the toggles falling out
+        // of the chain made `regexIdx` either unset or pinned
+        // *after* the arrow buttons.
+        QVERIFY2(
+            regexIdx < prevIdx && wildcardsIdx < prevIdx,
+            qPrintable(QStringLiteral("regex/wildcards toggles must precede the arrow buttons in the tab chain "
+                                      "(regex=%1 wildcards=%2 prev=%3)")
+                           .arg(regexIdx)
+                           .arg(wildcardsIdx)
+                           .arg(prevIdx))
+        );
+        QVERIFY2(prevIdx < nextIdx, "previous-arrow must come before next-arrow in the tab chain");
     }
 
     // `ParseErrorsDock::AppendErrors` must:

--- a/test/app/src/main_window_test.cpp
+++ b/test/app/src/main_window_test.cpp
@@ -10086,6 +10086,219 @@ private slots:
         );
     }
 
+    // Regression: `ParseErrorsDock::AppendErrors` used to call
+    // `scrollToBottom()` on every append, yanking the user back
+    // to the tail every time a new batch arrived during a
+    // streaming session. The chat / log convention is to
+    // auto-follow only when the user was already at the tail,
+    // otherwise preserve their scroll position so they can read
+    // earlier rows without being interrupted.
+    void TestParseErrorsDockAutoFollowOnlyWhenAtTail()
+    {
+        auto *dock = mWindow->findChild<ParseErrorsDock *>();
+        QVERIFY2(dock != nullptr, "MainWindow must own a ParseErrorsDock");
+        dock->ClearErrors();
+
+        auto *list = dock->findChild<QListWidget *>(QStringLiteral("parseErrorsList"));
+        QVERIFY2(list != nullptr, "ParseErrorsDock must expose its internal QListWidget");
+
+        // Realise the dock so the scrollbar has a real viewport
+        // geometry; offscreen QPA still pumps the scrollbar's
+        // min/max/value updates as long as the widget tree is
+        // shown.
+        mWindow->show();
+        QVERIFY(QTest::qWaitForWindowExposed(mWindow, 5000));
+        dock->show();
+        dock->raise();
+        QCoreApplication::processEvents();
+
+        // Seed enough entries that the list scrolls. The user is
+        // by definition at the tail (the list was empty before
+        // this append), so the auto-follow path should pin us to
+        // the bottom afterwards.
+        std::vector<std::string> seed;
+        seed.reserve(200);
+        for (int i = 0; i < 200; ++i)
+        {
+            seed.emplace_back(std::string("seed-") + std::to_string(i));
+        }
+        dock->AppendErrors(QStringLiteral("Seed"), seed);
+        QCoreApplication::processEvents();
+
+        QScrollBar *vBar = list->verticalScrollBar();
+        QVERIFY2(vBar != nullptr, "QListWidget must have a vertical scrollbar");
+        // With 200 entries in a small dock the scrollbar should be
+        // non-degenerate; if the offscreen geometry left
+        // `maximum() == minimum()` the auto-follow assertion below
+        // can't distinguish "still at tail" from "moved by us",
+        // so the test is meaningless on this platform / driver.
+        if (vBar->maximum() <= vBar->minimum())
+        {
+            QSKIP("offscreen QPA produced a degenerate scrollbar -- can't exercise auto-follow");
+        }
+
+        // Park the user mid-list. Any position comfortably above
+        // `maximum()` works; pick the middle so the slack
+        // tolerance (4 px) cannot accidentally include us.
+        const int parkedPosition = vBar->minimum() + (vBar->maximum() - vBar->minimum()) / 2;
+        vBar->setValue(parkedPosition);
+        QCoreApplication::processEvents();
+        QCOMPARE(vBar->value(), parkedPosition);
+
+        // New batch arrives mid-read. The user did not move; the
+        // scrollbar should stay parked.
+        std::vector<std::string> later{"late-0", "late-1", "late-2", "late-3", "late-4"};
+        dock->AppendErrors(QStringLiteral("Later"), later);
+        QCoreApplication::processEvents();
+        QVERIFY2(
+            vBar->value() == parkedPosition,
+            qPrintable(QStringLiteral(
+                           "Scroll position must be preserved when the user was not at the tail "
+                           "(parked=%1, after=%2, max=%3)"
+            )
+                           .arg(parkedPosition)
+                           .arg(vBar->value())
+                           .arg(vBar->maximum()))
+        );
+
+        // Scroll back to the tail. A subsequent batch should
+        // re-pin us there (auto-follow re-engages once the user
+        // returns to the end).
+        vBar->setValue(vBar->maximum());
+        QCoreApplication::processEvents();
+        QCOMPARE(vBar->value(), vBar->maximum());
+
+        std::vector<std::string> trailing{"tail-0", "tail-1", "tail-2"};
+        dock->AppendErrors(QStringLiteral("Trailing"), trailing);
+        QCoreApplication::processEvents();
+        // After more items land, `maximum()` grew; the auto-follow
+        // path must have moved `value` along with it.
+        QVERIFY2(
+            vBar->value() >= vBar->maximum() - 4,
+            qPrintable(
+                QStringLiteral("Auto-follow must re-pin to the tail when the user was at the tail "
+                               "(value=%1, max=%2)")
+                    .arg(vBar->value())
+                    .arg(vBar->maximum())
+            )
+        );
+    }
+
+    // Regression: `UpdateFindMatchCount` used to run the full
+    // proxy scan even when the find dock was hidden -- a debounce
+    // timer armed while the bar was visible can still fire after
+    // the user dismisses it. The slot now bails when
+    // `mFindDock->isVisible()` is false, matching the gates on
+    // `OnFindCacheInvalidated` and `FindRecords`'s post-jump
+    // refresh. We pin this by inspecting `SetMatchInfo`'s effect:
+    // with the bar hidden, the slot must not populate the
+    // indicator label.
+    void TestUpdateFindMatchCountSkipsWorkWhenDockHidden()
+    {
+        auto *findRecord = mWindow->findChild<FindRecordWidget *>();
+        QVERIFY2(findRecord != nullptr, "MainWindow must own a FindRecordWidget");
+        auto *findDock = mWindow->findChild<FindDock *>();
+        QVERIFY2(findDock != nullptr, "MainWindow must own a FindDock");
+        auto *label = findRecord->findChild<QLabel *>(QStringLiteral("findMatchCount"));
+        QVERIFY2(label != nullptr, "FindRecordWidget must expose its match-count label");
+
+        // Make sure the dock is hidden going into the test.
+        findDock->hide();
+        QVERIFY(!findDock->isVisible());
+
+        // Seed the label with a known non-empty marker so we can
+        // detect any subsequent write -- a successful write would
+        // either clear the label (empty-needle branch) or set it
+        // to "N matches".
+        label->setText(QStringLiteral("sentinel-do-not-touch"));
+
+        // Invoke the slot directly. The visibility gate must
+        // short-circuit before the label is touched.
+        QVERIFY2(
+            QMetaObject::invokeMethod(
+                mWindow,
+                "UpdateFindMatchCount",
+                Qt::DirectConnection,
+                Q_ARG(QString, QStringLiteral("info")),
+                Q_ARG(bool, false),
+                Q_ARG(bool, false)
+            ),
+            "UpdateFindMatchCount must be invocable via meta-object"
+        );
+        QCOMPARE(label->text(), QStringLiteral("sentinel-do-not-touch"));
+
+        // And an empty-needle programmatic call must also
+        // short-circuit -- pre-fix it would have cleared the
+        // label even though nothing was on screen to clear.
+        QVERIFY2(
+            QMetaObject::invokeMethod(
+                mWindow,
+                "UpdateFindMatchCount",
+                Qt::DirectConnection,
+                Q_ARG(QString, QString()),
+                Q_ARG(bool, false),
+                Q_ARG(bool, false)
+            ),
+            "UpdateFindMatchCount must accept an empty needle"
+        );
+        QCOMPARE(label->text(), QStringLiteral("sentinel-do-not-touch"));
+    }
+
+    // Regression: the parse-errors status button used to display
+    // "X parse errors" where X was `count + droppedCount`. The
+    // dock summary read "X errors; Y earlier dropped", so the
+    // button's total didn't match the dock body and a user
+    // clicking through to investigate the discrepancy would
+    // suspect a bug. The fix is to render the dropped count
+    // inline on the button when non-zero.
+    void TestParseErrorsStatusButtonShowsDroppedHint()
+    {
+        auto *dock = mWindow->findChild<ParseErrorsDock *>();
+        QVERIFY2(dock != nullptr, "MainWindow must own a ParseErrorsDock");
+        auto *statusButton = mWindow->findChild<QPushButton *>(QStringLiteral("parseErrorsStatusButton"));
+        QVERIFY2(statusButton != nullptr, "MainWindow must own the parse-errors status button");
+        dock->ClearErrors();
+
+        // No drops yet: the button uses the simple "%n errors"
+        // form, no "dropped" hint anywhere on it.
+        dock->AppendErrors(QStringLiteral("First"), {"a", "b", "c"});
+        QCoreApplication::processEvents();
+        QVERIFY2(
+            !statusButton->text().contains(QStringLiteral("dropped"), Qt::CaseInsensitive),
+            qPrintable(QStringLiteral("status button must not mention 'dropped' when nothing was dropped: %1")
+                           .arg(statusButton->text()))
+        );
+
+        // Force an overflow so `droppedCount > 0`. A single batch
+        // larger than `MAX_DISPLAYED_ERRORS` pre-trims to mint a
+        // dropped count without any prior content getting evicted.
+        const int cap = ParseErrorsDock::MAX_DISPLAYED_ERRORS;
+        std::vector<std::string> huge;
+        huge.reserve(static_cast<size_t>(cap + 50));
+        for (int i = 0; i < cap + 50; ++i)
+        {
+            huge.emplace_back(std::string("err-") + std::to_string(i));
+        }
+        dock->AppendErrors(QStringLiteral("Huge"), huge);
+        QCoreApplication::processEvents();
+        QVERIFY2(dock->DroppedCount() > 0, "fixture must produce a non-zero dropped count");
+
+        // The button label must now include the dropped hint so
+        // the user can tell from the status bar (without opening
+        // the dock) that the visible total isn't the whole story.
+        QVERIFY2(
+            statusButton->text().contains(QStringLiteral("dropped"), Qt::CaseInsensitive),
+            qPrintable(QStringLiteral("status button must surface dropped count in its label; got: %1")
+                           .arg(statusButton->text()))
+        );
+        // And the tooltip continues to spell out the breakdown.
+        QVERIFY2(
+            statusButton->toolTip().contains(QStringLiteral("dropped"), Qt::CaseInsensitive),
+            qPrintable(QStringLiteral("status button tooltip must still spell out the breakdown; got: %1")
+                           .arg(statusButton->toolTip()))
+        );
+    }
+
     // An enum column with an empty dictionary must show the placeholder
     // and disable OK so a "hide everything" filter cannot be submitted.
     void TestFilterEditorEmptyEnumPickerDisablesOk()

--- a/test/app/src/main_window_test.cpp
+++ b/test/app/src/main_window_test.cpp
@@ -9760,6 +9760,119 @@ private slots:
         );
     }
 
+    // Regression: trimming a multi-batch overflow used to leave
+    // surviving rows from the first batch *headerless* -- their
+    // group label was the first thing evicted, so the rows that
+    // remained floated above the next batch's title with nothing
+    // labelling them. The fix re-mints the evicted header above
+    // the surviving rows.
+    void TestParseErrorsDockTrimPreservesSurvivingBatchHeader()
+    {
+        auto *dock = mWindow->findChild<ParseErrorsDock *>();
+        QVERIFY2(dock != nullptr, "MainWindow must own a ParseErrorsDock");
+        dock->ClearErrors();
+
+        auto *list = dock->findChild<QListWidget *>(QStringLiteral("parseErrorsList"));
+        QVERIFY2(list != nullptr, "ParseErrorsDock must expose its internal QListWidget");
+
+        const int cap = ParseErrorsDock::MAX_DISPLAYED_ERRORS;
+        // First batch fills most of the cap. Second batch tips us
+        // over, evicting the first batch's *header* plus a chunk
+        // of its rows but leaving the rest of batch A behind.
+        const int batchAStart = cap - 200;
+        std::vector<std::string> batchA;
+        batchA.reserve(static_cast<size_t>(batchAStart));
+        for (int i = 0; i < batchAStart; ++i)
+        {
+            batchA.emplace_back("A-" + std::to_string(i));
+        }
+        std::vector<std::string> batchB;
+        batchB.reserve(300);
+        for (int i = 0; i < 300; ++i)
+        {
+            batchB.emplace_back("B-" + std::to_string(i));
+        }
+        dock->AppendErrors(QStringLiteral("Batch A"), batchA);
+        dock->AppendErrors(QStringLiteral("Batch B"), batchB);
+
+        QVERIFY2(dock->DroppedCount() > 0, "second batch must have evicted some of batch A");
+
+        // Find the first surviving error row. It must be an
+        // `A-...` entry (since A was the older batch), and the
+        // immediately preceding item must be a non-selectable
+        // group header reading "Batch A" -- not "Batch B" floating
+        // above orphan A rows.
+        int firstSelectableRow = -1;
+        for (int i = 0; i < list->count(); ++i)
+        {
+            QListWidgetItem *item = list->item(i);
+            if (item != nullptr && item->flags().testFlag(Qt::ItemIsSelectable))
+            {
+                firstSelectableRow = i;
+                break;
+            }
+        }
+        QVERIFY2(firstSelectableRow > 0, "surviving error rows must follow at least one header");
+        QListWidgetItem *firstError = list->item(firstSelectableRow);
+        QVERIFY2(firstError != nullptr, "first selectable row lookup must succeed");
+        QVERIFY2(
+            firstError->text().startsWith(QStringLiteral("A-")),
+            qPrintable(QStringLiteral("first survivor must be from batch A; got: %1").arg(firstError->text()))
+        );
+        QListWidgetItem *headerAbove = list->item(firstSelectableRow - 1);
+        QVERIFY2(headerAbove != nullptr, "row above first survivor must exist");
+        QVERIFY2(
+            !headerAbove->flags().testFlag(Qt::ItemIsSelectable),
+            "row above first survivor must be a group header (non-selectable)"
+        );
+        QCOMPARE(headerAbove->text(), QStringLiteral("Batch A"));
+    }
+
+    // Regression: re-opening the find bar after a model reset
+    // used to show whatever match count the label held when the
+    // bar was last hidden, even when that count referred to a
+    // completely different dataset. The `FindDock::revealed`
+    // signal is the trigger for a catch-up recount.
+    void TestFindBarRevealedSignalTriggersCatchUpRecount()
+    {
+        auto *dock = mWindow->findChild<FindDock *>();
+        QVERIFY2(dock != nullptr, "MainWindow must own a FindDock");
+        auto *bar = dock->Widget();
+        QVERIFY2(bar != nullptr, "FindDock must host a FindRecordWidget");
+        auto *edit = bar->findChild<QLineEdit *>(QStringLiteral("findEdit"));
+        QVERIFY2(edit != nullptr, "FindRecordWidget must expose its line edit");
+
+        // Drive the signal directly rather than going through Qt's
+        // tab system (which needs a realised main window): the
+        // wiring under test is "revealed -> BumpMatchCountDebounce".
+        // With a non-empty needle, the debounce timer should arm and
+        // eventually emit `MatchCountRequested`.
+        edit->setText(QStringLiteral("anything"));
+        QSignalSpy spy(bar, &FindRecordWidget::MatchCountRequested);
+        QVERIFY(spy.isValid());
+        spy.clear();
+
+        emit dock->revealed();
+
+        // Wait up to a second for the debounce (default 120 ms) to
+        // fire. Using `wait()` rather than `processEvents` so we
+        // don't depend on the test driver's clock to tick.
+        QVERIFY2(
+            spy.count() > 0 || spy.wait(1000),
+            "FindDock::revealed must trigger a debounced MatchCountRequested for a non-empty needle"
+        );
+
+        // Empty-needle reveal must be a no-op: the bar suppresses
+        // the request, so the cache stays untouched.
+        edit->clear();
+        spy.clear();
+        emit dock->revealed();
+        QVERIFY2(
+            !spy.wait(300),
+            "FindDock::revealed must NOT trigger MatchCountRequested for an empty needle"
+        );
+    }
+
     // An enum column with an empty dictionary must show the placeholder
     // and disable OK so a "hide everything" filter cannot be submitted.
     void TestFilterEditorEmptyEnumPickerDisablesOk()


### PR DESCRIPTION
A modern incremental find bar and dockable **Find** / **Parse Errors** panels — plus eight rounds of self-review fixes (bug fixes, dark-mode polish, HiDPI icons, clang-tidy sweep).

Headline changes: `FindRecordWidget` rebuilt as a VS Code / QtCreator-class incremental find bar with a live "*i* of *N*" counter, regex / wildcards toggles, debounced match counts and HiDPI-correct chevron arrows; promoted into a new `FindDock` so it floats / docks / round-trips through `restoreState`. The modal `QMessageBox::warning` parse-error popups become a new `ParseErrorsDock` — append-only list, bold per-batch headers, status-bar indicator mirroring `mDiagnosticsButton`, `O(1)` count, hard cap with overflow footer, auto-raise once per session. Dark-mode rendering across the find bar / parse-errors dock / configuration diagnostics dialog is theme-aware end-to-end. A trailing `clang-tidy` sweep over the touched files is included.

## Why

`FindRecordWidget` had been a bare `QLineEdit` plus two separate buttons hosted under the central widget for a long time. Streaming logs in particular suffer: with no match counter the user could not tell whether `xyz` had no hits or 12,000; `Return` only fired find-next; theme switches left the icons baked black on dark backgrounds. The dock conversion (item 14) was already a pre-requisite for the upcoming filter-chip and structured status-bar work (items 3 / 4): once Find is a dock, its visibility, focus, and geometry persist alongside every other dock with no special-case central-widget code, and `ShowParseErrors`'s repeated modal popups can be replaced with a non-blocking surface that does not interrupt the user mid-triage.

The eight follow-up rounds are a self-review trail: every round started from a fresh read of the diff, surfaced bugs and rough edges, and landed fixes plus regression tests. Round 6 swapped the find-toggle icons that QStyle was rendering as misleading file-view glyphs; round 7 fixed dark-mode rendering of the chevrons, the diagnostics dialog highlight, and the "rows freeze in old palette" theme-switch artifact; round 8 minted HiDPI-correct chevron pixmaps, decoupled the parse-errors auto-raise latch from the row counters, and pinned the new `IsStyleOnlyRoleChange` and `ComposeFindFlags` contracts via tests. The final commit tightens the docstrings to match the surrounding codebase.

## What changed

**Modern incremental find bar (item 2).** `FindRecordWidget` (`app/src/find_record_widget.cpp`) rebuilt:

- `mEdit` has `setPlaceholderText(tr("Find in logs…"))`, `setClearButtonEnabled(true)`, and a leading magnifying-glass `QAction`.
- Regex / wildcards live as flat `QToolButton`s beside the line edit (glyphs `.*` and `*?`) instead of `addAction` icons that QStyle was rendering as file-view glyphs and that can't render text. The two toggles are mutually exclusive in the UI, mirroring the now-exclusive backend semantics.
- Next / Previous use `QToolButton` with custom-painted chevron icons minted in `QPalette::WindowText` at `devicePixelRatioF()` and re-minted on `PaletteChange` / `StyleChange` / `ApplicationPaletteChange` / `DevicePixelRatioChange` so dark-mode users see the arrows and dragging the dock between monitors of different DPI keeps them pixel-sharp.
- `mMatchCountLabel` renders "i of N" live; populated by the parent through a `MatchCountRequested` signal answered by `MainWindow::UpdateFindMatchCount`. Two debouncers (`setObjectName`-named so tests can probe them): a 250 ms trailing timer for typing bursts plus a 750 ms max-age cap so streaming `dataChanged` invalidations cannot starve the recount indefinitely. `BumpMatchCountDebounce` skips the timer restart when both timers are already active, so a hot stream's invalidations no longer re-arm the trailing timer per batch.
- `Return` -> find-next, `Shift+Return` -> find-previous (event filter on `mEdit` so the line edit does not consume the modifier first), `Esc` walks to the host dock and `close()`s it.
- `Ctrl+F` is a smart toggle (Chrome / VS Code convention): hidden -> open + focus, open-but-unfocused -> focus, open-and-focused -> close.
- `FindDock::RevealAndFocus` re-stashes the previously-focused widget (with an `isAncestorOf` guard) on every reveal so `Esc` routes focus back to the most recent target rather than the one captured on the very first reveal; `hideEvent` hands focus back on every dismissal path.

**Dockable Find / Parse Errors (item 14).** Two new docks built on the `RecordDetailDock` pattern:

- `FindDock` (`app/src/find_dock.cpp`) hosts `FindRecordWidget`, `setAllowedAreas(Qt::Top | Qt::Bottom)` (vertical docking squeezes the search field uselessly), `objectName("findDock")` so it round-trips through `saveGeometry` / `saveState`.
- `ParseErrorsDock` (`app/src/parse_errors_dock.cpp`) replaces the modal `QMessageBox::warning` popups that `MainWindow::ShowParseErrors` used to raise. Append-only `QListWidget` with bold per-batch group headers; `AppendErrors(title, errors)` groups consecutive batches under one header; `Count()` is `O(1)` via a maintained `mErrorCount`; hard cap (`MAX_DISPLAYED_ERRORS = 1000`) with whole-batch eviction, orphan-header sweep, and a single italic overflow footer so pathological streams cannot OOM the GUI; `ResetSessionState` re-arms the first-batch latch and is wired into all five session-boundary callers; auto-follow scroll only when the scrollbar was already at the tail (4 px slack absorbs integer rounding); `Ctrl+C` synthesises the per-group header above the first selected row and the overflow footer so the pasted block reads as standalone text. Status-bar `mParseErrorsStatusButton` mirrors the dock's `countChanged(count, droppedCount)` signal — surfaces dropped counts in the tooltip, uses `SP_MessageBoxWarning` to match the per-row icon and the recoverable semantics. Auto-raise is decided in `MainWindow` (a new `firstBatchArrived` signal) so the dock has no business knowing about siblings, and the parent skips the raise when the find dock holds focus.
- Both docks register View-menu toggles via `RebuildViewMenu`. Default `tabifyDockWidget` for `(Find, ParseErrors)` and `(Anchors, RecordDetails)` so they share an area as tabs. Each dock now exposes a `closed()` signal emitted only from `closeEvent`; `visibilityChanged(true)` handles the on-edge of the View-menu sync and `closed()` handles the off-edge — without this, Qt's `visibilityChanged(false)` fires on tab inactivation too, so menu entries were unchecking themselves whenever the user clicked a sibling tab.

**Find match-count machinery.** `MainWindow::UpdateFindMatchCount` runs a single `LogFilterModel::MatchRow` scan with `LogFilterModel::UNLIMITED_HITS`, caches the resulting sorted, row-deduplicated match-row list keyed on `(needle, wildcards, regex)`, and resolves the current selection's *i* via binary search. Cache invalidates on `modelReset`, `rowsInserted` / `rowsRemoved`, `layoutChanged`, and `dataChanged` (in-place cell updates can flip a row's match status without shifting the row set). The full scan short-circuits when the find dock is hidden (a debounce timer armed while the bar was visible can fire after dismissal). The defensive `rows.resize(cap)` is now guarded on `rows.size() > cap` so it cannot grow the vector with default-constructed zeros that look like phantom row-0 matches. `LogFilterModel::ComposeFindFlags` moved from an anonymous namespace in `main_window.cpp` onto the proxy itself (now reachable from tests) and pins the regex > wildcard > contains priority and the always-on `MatchWrap | MatchRecursive` baseline.

**Theme handling.** `LogTableView::OnThemeChanged` resets the stylesheet-skip cache so `setStyleSheet` runs and Qt's QSS engine re-polishes the view against the new palette — root cause of "some rows are repainted, some are not" after a theme switch (`c5d1c47`'s `setStyleSheet` skip optimization left rows that relied on default palette colours frozen in the old palette). `LogModel::RefreshAllRowStyles` emits `dataChanged` on `Background` / `Foreground` / `Font` roles across the entire table so the view re-queries theme brushes; `RecordDetailDock` filters out style-only `dataChanged` emits (new `LogModel::IsStyleOnlyRoleChange` predicate, contract pinned by `TestIsStyleOnlyRoleChangeContract`) so the detail pane does not refresh on every theme flip. `viewport()->update() + update() + header update()` guarantees a full visual repaint for cells where `data()` returns invalid `QVariant`. `ConfigurationDiagnosticsDialog` derives its warning row tint from `QPalette::Base` / `QPalette::Text` and `QStyleHints::colorScheme()` so user themes (high-contrast, custom palettes) get sane warning highlights, and `changeEvent` refreshes the dialog on `PaletteChange` / `StyleChange` / `ApplicationPaletteChange` / `ThemeChange`. `PreferencesEditor::closeEvent` mirrors the `Cancel` revert (live-previewed theme rolled back, streaming config reloaded from disk) on `X` / `Alt+F4` / programmatic `close()`, but skips the disk reload when `Ok` or `Cancel` routed the close (`mClosingViaButton`) so a normal `Ok` does not surface a transient I/O error.

**Refactors.** A `WireDockToggle` member template collapses ~80 lines of inlined toggle wiring across four docks (Anchors, Find, ParseErrors, RecordDetails) into one helper with optional `onShow` / `onShown` callbacks. `IsFindBarVisible` / `FindBarHoldsFocus` inline `noexcept` predicates replace four duplicated null-and-visible probes (the Qt 6 tabified-dock `isVisible()` semantics are documented at the helper). A new `MainWindow::OnFindCacheInvalidated` slot is wired via PMF to every model / proxy signal (relying on Qt's arg trimming for `dataChanged`), removing the inline lambda + wrapper used to marshal `MatchCountRequested`. All four dock toggles use `close()` (which fires `closeEvent` -> `closed` -> menu sync) instead of a mix of `hide()` / `setVisible(false)`. `mFindDock` / `mFindRecord` / `mParseErrorsDock` are `QPointer`s so a model / proxy signal firing during shutdown cannot dereference a dangling pointer.

**clang-tidy sweep.** `run-clang-tidy` over the new / heavily-modified TUs reports zero warnings after the trailing `Clang-tidy fixes` commit. Scope: `find_dock.{hpp,cpp}`, `find_record_widget.{hpp,cpp}`, `parse_errors_dock.{hpp,cpp}`, `log_filter_model.{hpp,cpp}`, `log_model.{hpp,cpp}`, `main_window.{hpp,cpp}`, `configuration_diagnostics_dialog.cpp`, `preferences_editor.cpp`, `record_detail_dock.cpp`, `anchors_dock.cpp`. Diagnostics addressed: `misc-const-correctness`, `*-magic-numbers` (named constants for debounce intervals, error caps, scroll-tail slack, devicePixelRatio fallbacks, palette luma thresholds), `readability-identifier-naming` (UPPER_SNAKE_CASE constants, `lower_case` namespaces), `readability-avoid-nested-conditional-operator`, `performance-no-automatic-move`, `misc-override-with-different-visibility`, plus `Q_ASSERT_X` annotations on the `LogFilterModel::Matches` flag-set contract and the `RebuildOverflowFooter` precondition. The trailing `Tighten branch comments and docstrings` commit condenses the multi-paragraph explanations added over earlier rounds into 1-2 sentence comments matching the surrounding codebase style.

**Tests.** `test/app/src/main_window_test.cpp` grows ~1,560 lines of coverage:

- `TestFindBarRegexAndWildcardsAreMutuallyExclusive`, `TestFindUsesRegexFlagAndIgnoresContainsShadow`, `TestComposeFindFlagsPriorityAndBaseline` lock down the regex / wildcard fix at both the UI mutual-exclusion and the proxy `MatchRow` layers.
- `TestParseErrorsDockTracksCountsAndFirstBatchSignal`, `TestParseErrorsDockTrimsToCapAndAddsOverflowFooter`, `TestParseErrorsDockOverflowFooterTracksMultipleBatches`, `TestParseErrorsDockCopySelectionIncludesHeaderAndFooter`, `TestParseErrorsDockAutoFollowOnlyWhenAtTail`, `TestParseErrorsDockClearDoesNotReArmFirstBatchSignal`, `TestParseErrorsStatusButtonShowsDroppedHint` pin the dock contracts.
- `TestUpdateFindMatchCountSkipsWorkWhenDockHidden`, `TestBumpMatchCountDebounceCoalescesStreamingBursts` pin the streaming-burst optimisations.
- `TestFindBarArrowIconsFollowPalette`, `TestFindBarArrowIconsScaleWithDevicePixelRatio` pin the dark-mode and HiDPI chevron mints.
- `TestThemeSwitchRefreshesLogTableRows`, `TestThemeSwitchEmitsDataChangedOnLogTable`, `TestThemeSwitchRepolishesTableStylesheet`, `TestDiagnosticsDialogHighlightAdaptsToDarkTheme`, `TestPreferencesEditorCloseEventRevertsThemePreview`, `TestIsStyleOnlyRoleChangeContract` pin the theme-handling fixes.

All 334 apptests pass locally on Windows + MSVC + Release + IPO.

## Test plan

- [x] `ctest -LE benchmark` green locally on Windows + MSVC + Release + IPO (334 / 334).
- [x] `run-clang-tidy` over the touched files reports zero warnings.
- [x] Manual smoke: `Ctrl+F` opens / focuses / closes the find bar; typing shows live "i of N"; `Return` / `Shift+Return` walk matches; `Esc` returns focus to the table; regex / wildcards toggles are mutually exclusive; chevrons stay visible after a Light <-> Dark theme switch and stay sharp when dragging the dock between monitors of different DPI.
- [x] Manual smoke: open a malformed JSON Lines file — `ParseErrorsDock` surfaces the errors with bold per-batch headers; status-bar button shows the count; `Ctrl+C` on a selection includes the group header and overflow footer; clearing and reopening a session re-arms the auto-raise latch.
- [x] Manual smoke: live-tail a hot stream — find match-count debounce coalesces bursts (at most one full-table scan per 250 ms / 750 ms ceiling); `ParseErrorsDock` only auto-follows when already at the tail.
- [x] Manual smoke: switch themes via Preferences — every row repaints in the new palette; close Preferences via the X button — the live-previewed theme reverts to the persisted selection.
- [x] CI: `build-linux`, `build-macos`, `build-windows`, `clang-ci (asan-ubsan / tsan / coverage)`, `pre-commit`, CodeQL all green on this PR.
