### PR TITLE
GUI polish: rows-shown status indicator + movable stream toolbar

### DIFF
--- a/app/include/main_window.hpp
+++ b/app/include/main_window.hpp
@@ -443,10 +443,11 @@ private slots:
 
     /// Refresh the "*n* shown of *m*" status-bar label and toggle
     /// the inline Clear-filters button. Wired to source + proxy
-    /// row signals and called from the tail of
-    /// `UpdateStreamingStatus` so every existing status-update
-    /// path picks the new figures up for free. Hides both widgets
-    /// when no session is active.
+    /// row signals; the label tracks `mModel->rowCount()` (not
+    /// `IsSessionActive`) so the indicator survives the post-load
+    /// `Static -> Idle` flip and stays visible while the user
+    /// browses the parsed rows. Hides both widgets when the source
+    /// model is empty.
     void UpdateRowsShownStatus();
 
     /// Recount matches for the current find query and push the
@@ -914,17 +915,16 @@ private:
     /// Status-bar label shown while a streaming session is active.
     QLabel *mStatusLabel = nullptr;
 
-    /// Status-bar label that reads "*n* shown of *m*" while a
+    /// Status-bar label that reads "*n* of *m* shown" while a
     /// filter is hiding rows, or "*m* lines" otherwise. Hidden
-    /// outside an active session. Updated via
-    /// `UpdateRowsShownStatus` from both source / proxy row
-    /// signals and the tail of `UpdateStreamingStatus`.
+    /// when the source model is empty. Updated via
+    /// `UpdateRowsShownStatus` from source / proxy row signals.
     QLabel *mRowsShownLabel = nullptr;
 
-    /// Status-bar funnel button that triggers
-    /// `actionClearAllFilters`. Visible only when at least one
-    /// filter is active and a session is loaded. Mirrors the UX
-    /// of `mDiagnosticsButton` / `mParseErrorsStatusButton`.
+    /// Status-bar button that triggers `actionClearAllFilters`.
+    /// Visible only when at least one filter is active and the
+    /// source model has rows. Mirrors the UX of
+    /// `mDiagnosticsButton` / `mParseErrorsStatusButton`.
     QPushButton *mClearFiltersStatusButton = nullptr;
 
     /// Status-bar button showing the per-column type-mismatch

--- a/app/include/main_window.hpp
+++ b/app/include/main_window.hpp
@@ -441,6 +441,14 @@ private slots:
     /// `ParseErrorsDock::countChanged`; hides when the dock is empty.
     void UpdateParseErrorsStatus(int count, int droppedCount);
 
+    /// Refresh the "*n* shown of *m*" status-bar label and toggle
+    /// the inline Clear-filters button. Wired to source + proxy
+    /// row signals and called from the tail of
+    /// `UpdateStreamingStatus` so every existing status-update
+    /// path picks the new figures up for free. Hides both widgets
+    /// when no session is active.
+    void UpdateRowsShownStatus();
+
     /// Recount matches for the current find query and push the
     /// result back into the find bar. Caches the row list keyed by
     /// `(needle, wildcards, regex)` so Next / Previous clicks reuse
@@ -905,6 +913,19 @@ private:
 
     /// Status-bar label shown while a streaming session is active.
     QLabel *mStatusLabel = nullptr;
+
+    /// Status-bar label that reads "*n* shown of *m*" while a
+    /// filter is hiding rows, or "*m* lines" otherwise. Hidden
+    /// outside an active session. Updated via
+    /// `UpdateRowsShownStatus` from both source / proxy row
+    /// signals and the tail of `UpdateStreamingStatus`.
+    QLabel *mRowsShownLabel = nullptr;
+
+    /// Status-bar funnel button that triggers
+    /// `actionClearAllFilters`. Visible only when at least one
+    /// filter is active and a session is loaded. Mirrors the UX
+    /// of `mDiagnosticsButton` / `mParseErrorsStatusButton`.
+    QPushButton *mClearFiltersStatusButton = nullptr;
 
     /// Status-bar button showing the per-column type-mismatch
     /// summary. Hidden when zero columns are mismatched; opens the

--- a/app/src/main_window.cpp
+++ b/app/src/main_window.cpp
@@ -892,9 +892,7 @@ MainWindow::MainWindow(ThemeControl *theme, SessionHistoryManager *historyManage
     // logic stays the single source of truth and the menu, the
     // toolbar (when it lands), and this button all stay in lock-
     // step.
-    connect(
-        mClearFiltersStatusButton, &QPushButton::clicked, ui->actionClearAllFilters, &QAction::trigger
-    );
+    connect(mClearFiltersStatusButton, &QPushButton::clicked, ui->actionClearAllFilters, &QAction::trigger);
 
     // 1 Hz tick that refreshes the live-tail elapsed time and the title's
     // running line count, so neither has to be rewritten per batch.
@@ -2813,9 +2811,9 @@ void MainWindow::UpdateRowsShownStatus()
     QString text;
     if (proxyRows < sourceRows)
     {
-        text = tr("%1 of %2 shown")
-                   .arg(loc.toString(static_cast<qlonglong>(proxyRows)),
-                        loc.toString(static_cast<qlonglong>(sourceRows)));
+        text =
+            tr("%1 of %2 shown")
+                .arg(loc.toString(static_cast<qlonglong>(proxyRows)), loc.toString(static_cast<qlonglong>(sourceRows)));
     }
     else if (sourceRows == 1)
     {

--- a/app/src/main_window.cpp
+++ b/app/src/main_window.cpp
@@ -605,6 +605,13 @@ MainWindow::MainWindow(ThemeControl *theme, SessionHistoryManager *historyManage
     mStreamToolbar->addAction(ui->actionFollowTail);
     mStreamToolbar->addAction(ui->actionStopStream);
     mStreamToolbar->setVisible(false);
+    // Power users can dock the stream toolbar to any edge (top is
+    // the QMainWindow default; bottom / left / right are options
+    // for vertical-monitor setups). The chosen position round-
+    // trips through `SaveWindowChrome` / `RestoreWindowChrome`
+    // because the toolbar already has `objectName` set above.
+    mStreamToolbar->setMovable(true);
+    mStreamToolbar->setAllowedAreas(Qt::AllToolBarAreas);
 
     // Disable while idle so a checked state cannot leak into the next
     // session; `UpdateStreamToolbarVisibility` keeps these in sync after.
@@ -669,6 +676,26 @@ MainWindow::MainWindow(ThemeControl *theme, SessionHistoryManager *historyManage
             OnFindCacheInvalidated();
         }
     );
+
+    // Status-bar rows-shown indicator. Subscribes to both source
+    // and proxy because either can shift independently:
+    //   - source `rowsInserted/Removed/modelReset`: streaming
+    //     batches, session boundaries.
+    //   - proxy `rowsInserted/Removed/modelReset/layoutChanged`:
+    //     filter rule changes (which can move rows without
+    //     changing the source row count). `layoutChanged` is
+    //     proxy-only because it's how `LogFilterModel` reports
+    //     "the predicate changed but the row pool didn't".
+    // The slot itself is idempotent and cheap (two `rowCount()`
+    // calls + a label assign), so duplicate fires from
+    // adjacent signals are harmless.
+    connect(mModel, &QAbstractItemModel::rowsInserted, this, &MainWindow::UpdateRowsShownStatus);
+    connect(mModel, &QAbstractItemModel::rowsRemoved, this, &MainWindow::UpdateRowsShownStatus);
+    connect(mModel, &QAbstractItemModel::modelReset, this, &MainWindow::UpdateRowsShownStatus);
+    connect(mSortFilterProxyModel, &QAbstractItemModel::rowsInserted, this, &MainWindow::UpdateRowsShownStatus);
+    connect(mSortFilterProxyModel, &QAbstractItemModel::rowsRemoved, this, &MainWindow::UpdateRowsShownStatus);
+    connect(mSortFilterProxyModel, &QAbstractItemModel::modelReset, this, &MainWindow::UpdateRowsShownStatus);
+    connect(mSortFilterProxyModel, &QAbstractItemModel::layoutChanged, this, &MainWindow::UpdateRowsShownStatus);
 
     mActionToggleFind = new QAction(tr("Find Bar"), this);
     mActionToggleFind->setObjectName(QStringLiteral("actionToggleFind"));
@@ -841,6 +868,37 @@ MainWindow::MainWindow(ThemeControl *theme, SessionHistoryManager *historyManage
     mStatusLabel = new QLabel(this);
     statusBar()->addPermanentWidget(mStatusLabel);
     mStatusLabel->hide();
+
+    // Rows-shown indicator + inline Clear-filters button. Placed
+    // immediately after `mStatusLabel` so the status reads
+    // left-to-right as "Parsing foo - 12,345 lines | 8,432 of
+    // 12,345 shown [Clear filters] [diagnostics] [parse errors]".
+    // Both widgets are hidden outside an active session by
+    // `UpdateRowsShownStatus`.
+    mRowsShownLabel = new QLabel(this);
+    mRowsShownLabel->setObjectName(QStringLiteral("rowsShownLabel"));
+    mRowsShownLabel->hide();
+    statusBar()->addPermanentWidget(mRowsShownLabel);
+
+    mClearFiltersStatusButton = new QPushButton(this);
+    mClearFiltersStatusButton->setObjectName(QStringLiteral("clearFiltersStatusButton"));
+    // `SP_FileDialogListView` reads as a funnel-ish list-with-rule
+    // glyph across the Qt-supplied styles (Windows / Fusion /
+    // macOS) and matches Excel/Sheets' filter affordance closely
+    // enough without bringing in a custom asset.
+    mClearFiltersStatusButton->setIcon(QApplication::style()->standardIcon(QStyle::SP_FileDialogListView));
+    mClearFiltersStatusButton->setText(tr("Clear filters"));
+    mClearFiltersStatusButton->setFlat(true);
+    mClearFiltersStatusButton->setCursor(Qt::PointingHandCursor);
+    mClearFiltersStatusButton->hide();
+    statusBar()->addPermanentWidget(mClearFiltersStatusButton);
+    // Route through the existing action so its enable/disable
+    // logic stays the single source of truth and the menu, the
+    // toolbar (when it lands), and this button all stay in lock-
+    // step.
+    connect(
+        mClearFiltersStatusButton, &QPushButton::clicked, ui->actionClearAllFilters, &QAction::trigger
+    );
 
     // 1 Hz tick that refreshes the live-tail elapsed time and the title's
     // running line count, so neither has to be rewritten per batch.
@@ -2679,6 +2737,10 @@ void MainWindow::UpdateStreamingStatus()
     {
         mStatusLabel->clear();
         mStatusLabel->hide();
+        // Rows-shown / clear-filters affordances also hide when no
+        // session is loaded; reuse the dedicated slot so the
+        // visibility rule lives in one place.
+        UpdateRowsShownStatus();
         return;
     }
 
@@ -2731,6 +2793,66 @@ void MainWindow::UpdateStreamingStatus()
 
     mStatusLabel->setText(text);
     mStatusLabel->show();
+
+    // Picks up the source-vs-proxy row count and the
+    // `mFilters.empty()` flip every time the streaming status is
+    // refreshed -- which is the same set of paths that already
+    // need to redraw the chrome. Direct row-signal subscriptions
+    // cover the cases where row counts change without anyone
+    // touching `UpdateStreamingStatus` (e.g. a filter rule that
+    // only flips `layoutChanged`).
+    UpdateRowsShownStatus();
+}
+
+void MainWindow::UpdateRowsShownStatus()
+{
+    if (mRowsShownLabel == nullptr || mClearFiltersStatusButton == nullptr)
+    {
+        return;
+    }
+
+    if (!IsSessionActive() || mModel == nullptr || mSortFilterProxyModel == nullptr)
+    {
+        mRowsShownLabel->clear();
+        mRowsShownLabel->hide();
+        mClearFiltersStatusButton->hide();
+        return;
+    }
+
+    const int sourceRows = mModel->rowCount();
+    const int proxyRows = mSortFilterProxyModel->rowCount();
+
+    if (sourceRows <= 0)
+    {
+        // A session can be active before any batch has landed
+        // (e.g. live-tail just opened). Keep the label hidden so
+        // the status bar reads "Streaming foo.log - 0 lines"
+        // without a trailing "0 lines" echo from the new widget.
+        mRowsShownLabel->clear();
+        mRowsShownLabel->hide();
+        mClearFiltersStatusButton->hide();
+        return;
+    }
+
+    const QLocale loc = QLocale::system();
+    if (proxyRows < sourceRows)
+    {
+        mRowsShownLabel->setText(tr("%1 of %2 shown")
+                                     .arg(loc.toString(static_cast<qlonglong>(proxyRows)),
+                                          loc.toString(static_cast<qlonglong>(sourceRows))));
+    }
+    else
+    {
+        // `%Ln` picks the right plural form per locale.
+        mRowsShownLabel->setText(tr("%Ln line(s)", nullptr, sourceRows));
+    }
+    mRowsShownLabel->show();
+
+    // Decoupled from `proxyRows < sourceRows`: a filter that
+    // matches every row leaves the counts equal but `mFilters`
+    // populated, and the user still wants the affordance to
+    // clear it.
+    mClearFiltersStatusButton->setVisible(!mFilters.empty());
 }
 
 void MainWindow::StartLiveTailTicker()
@@ -4237,6 +4359,11 @@ void MainWindow::ClearAllFilters()
 
     ui->actionClearAllFilters->setDisabled(true);
     MarkFiltersDirty();
+    // `mFilters.empty()` flipped to true; the proxy signals fire
+    // only when the row pool actually changes, so a filter that
+    // hid no rows (or every row) would otherwise leave the
+    // Clear-filters affordance visible.
+    UpdateRowsShownStatus();
 }
 
 void MainWindow::ClearFilter(const QString &filterID, bool deferSync)
@@ -4270,6 +4397,10 @@ void MainWindow::ClearFilter(const QString &filterID, bool deferSync)
     {
         ui->actionClearAllFilters->setDisabled(true);
     }
+    // Mirrors `ClearAllFilters`: an outgoing filter that hid no
+    // rows leaves the proxy row pool unchanged, so the row-count
+    // signal subscriptions don't fire. Refresh explicitly.
+    UpdateRowsShownStatus();
 }
 
 void MainWindow::FilterSubmitted(const QString &filterID, int row, const QString &filterString, int matchType)
@@ -4552,6 +4683,10 @@ void MainWindow::AddLogFilter(const QString &id, const loglib::LogConfiguration:
     const QAction *removeAction = menuItem->addAction(tr("Remove"));
     connect(removeAction, &QAction::triggered, this, [this, id]() { ClearFilter(id); });
     ui->actionClearAllFilters->setDisabled(false);
+    // `mFilters.empty()` flipped to false here. Row-count signals
+    // fire only when the proxy pool actually shrinks; a filter
+    // that hides no rows still needs the affordance visible.
+    UpdateRowsShownStatus();
 }
 
 void MainWindow::OnThemeChanged()

--- a/app/src/main_window.cpp
+++ b/app/src/main_window.cpp
@@ -600,16 +600,13 @@ MainWindow::MainWindow(ThemeControl *theme, SessionHistoryManager *historyManage
     // Stream toolbar; hidden until a live-tail stream is opened. The
     // same actions are also in the Stream menu.
     mStreamToolbar = addToolBar(tr("Stream"));
-    mStreamToolbar->setObjectName("streamToolbar");
+    mStreamToolbar->setObjectName(QStringLiteral("streamToolbar"));
     mStreamToolbar->addAction(ui->actionPauseStream);
     mStreamToolbar->addAction(ui->actionFollowTail);
     mStreamToolbar->addAction(ui->actionStopStream);
     mStreamToolbar->setVisible(false);
-    // Power users can dock the stream toolbar to any edge (top is
-    // the QMainWindow default; bottom / left / right are options
-    // for vertical-monitor setups). The chosen position round-
-    // trips through `SaveWindowChrome` / `RestoreWindowChrome`
-    // because the toolbar already has `objectName` set above.
+    // Both are Qt defaults; pinned explicitly so `TestStreamToolbarIsMovable`
+    // keeps them from regressing.
     mStreamToolbar->setMovable(true);
     mStreamToolbar->setAllowedAreas(Qt::AllToolBarAreas);
 
@@ -873,8 +870,9 @@ MainWindow::MainWindow(ThemeControl *theme, SessionHistoryManager *historyManage
     // immediately after `mStatusLabel` so the status reads
     // left-to-right as "Parsing foo - 12,345 lines | 8,432 of
     // 12,345 shown [Clear filters] [diagnostics] [parse errors]".
-    // Both widgets are hidden outside an active session by
-    // `UpdateRowsShownStatus`.
+    // Both widgets are hidden by `UpdateRowsShownStatus` when the
+    // source model is empty (e.g. before the first batch lands or
+    // after `LogModel::Reset`).
     mRowsShownLabel = new QLabel(this);
     mRowsShownLabel->setObjectName(QStringLiteral("rowsShownLabel"));
     mRowsShownLabel->hide();
@@ -882,12 +880,10 @@ MainWindow::MainWindow(ThemeControl *theme, SessionHistoryManager *historyManage
 
     mClearFiltersStatusButton = new QPushButton(this);
     mClearFiltersStatusButton->setObjectName(QStringLiteral("clearFiltersStatusButton"));
-    // `SP_FileDialogListView` reads as a funnel-ish list-with-rule
-    // glyph across the Qt-supplied styles (Windows / Fusion /
-    // macOS) and matches Excel/Sheets' filter affordance closely
-    // enough without bringing in a custom asset.
-    mClearFiltersStatusButton->setIcon(QApplication::style()->standardIcon(QStyle::SP_FileDialogListView));
+    mClearFiltersStatusButton->setIcon(QApplication::style()->standardIcon(QStyle::SP_LineEditClearButton));
     mClearFiltersStatusButton->setText(tr("Clear filters"));
+    mClearFiltersStatusButton->setToolTip(tr("Clear all active filters and show every row."));
+    mClearFiltersStatusButton->setAccessibleName(tr("Clear all filters"));
     mClearFiltersStatusButton->setFlat(true);
     mClearFiltersStatusButton->setCursor(Qt::PointingHandCursor);
     mClearFiltersStatusButton->hide();
@@ -2737,10 +2733,6 @@ void MainWindow::UpdateStreamingStatus()
     {
         mStatusLabel->clear();
         mStatusLabel->hide();
-        // Rows-shown / clear-filters affordances also hide when no
-        // session is loaded; reuse the dedicated slot so the
-        // visibility rule lives in one place.
-        UpdateRowsShownStatus();
         return;
     }
 
@@ -2793,15 +2785,6 @@ void MainWindow::UpdateStreamingStatus()
 
     mStatusLabel->setText(text);
     mStatusLabel->show();
-
-    // Picks up the source-vs-proxy row count and the
-    // `mFilters.empty()` flip every time the streaming status is
-    // refreshed -- which is the same set of paths that already
-    // need to redraw the chrome. Direct row-signal subscriptions
-    // cover the cases where row counts change without anyone
-    // touching `UpdateStreamingStatus` (e.g. a filter rule that
-    // only flips `layoutChanged`).
-    UpdateRowsShownStatus();
 }
 
 void MainWindow::UpdateRowsShownStatus()
@@ -2811,23 +2794,15 @@ void MainWindow::UpdateRowsShownStatus()
         return;
     }
 
-    if (!IsSessionActive() || mModel == nullptr || mSortFilterProxyModel == nullptr)
-    {
-        mRowsShownLabel->clear();
-        mRowsShownLabel->hide();
-        mClearFiltersStatusButton->hide();
-        return;
-    }
-
-    const int sourceRows = mModel->rowCount();
-    const int proxyRows = mSortFilterProxyModel->rowCount();
-
+    // Gate on "is there data to count?" rather than session state.
+    // `OnStreamingFinished` flips `mSessionMode` back to `Idle` for
+    // finite static loads, but the user keeps browsing the rows --
+    // hiding the count there would surface only during streaming
+    // and disappear the moment the parse completed.
+    const int sourceRows = (mModel != nullptr) ? mModel->rowCount() : 0;
+    const int proxyRows = (mSortFilterProxyModel != nullptr) ? mSortFilterProxyModel->rowCount() : 0;
     if (sourceRows <= 0)
     {
-        // A session can be active before any batch has landed
-        // (e.g. live-tail just opened). Keep the label hidden so
-        // the status bar reads "Streaming foo.log - 0 lines"
-        // without a trailing "0 lines" echo from the new widget.
         mRowsShownLabel->clear();
         mRowsShownLabel->hide();
         mClearFiltersStatusButton->hide();
@@ -2835,23 +2810,35 @@ void MainWindow::UpdateRowsShownStatus()
     }
 
     const QLocale loc = QLocale::system();
+    QString text;
     if (proxyRows < sourceRows)
     {
-        mRowsShownLabel->setText(tr("%1 of %2 shown")
-                                     .arg(loc.toString(static_cast<qlonglong>(proxyRows)),
-                                          loc.toString(static_cast<qlonglong>(sourceRows))));
+        text = tr("%1 of %2 shown")
+                   .arg(loc.toString(static_cast<qlonglong>(proxyRows)),
+                        loc.toString(static_cast<qlonglong>(sourceRows)));
+    }
+    else if (sourceRows == 1)
+    {
+        text = tr("%1 line").arg(loc.toString(static_cast<qlonglong>(sourceRows)));
     }
     else
     {
-        // `%Ln` picks the right plural form per locale.
-        mRowsShownLabel->setText(tr("%Ln line(s)", nullptr, sourceRows));
+        text = tr("%1 lines").arg(loc.toString(static_cast<qlonglong>(sourceRows)));
+    }
+    // Skip the `setText` (and the resulting repaint / re-layout of the
+    // permanent status-bar area) when the digits haven't moved.
+    // `rowsInserted` fires multiple times per streaming batch -- once
+    // from the source and once from the proxy -- so this elides one
+    // of every two paints under load.
+    if (mRowsShownLabel->text() != text)
+    {
+        mRowsShownLabel->setText(text);
     }
     mRowsShownLabel->show();
 
-    // Decoupled from `proxyRows < sourceRows`: a filter that
-    // matches every row leaves the counts equal but `mFilters`
-    // populated, and the user still wants the affordance to
-    // clear it.
+    // Decoupled from `proxyRows < sourceRows`: a filter that matches
+    // every row leaves the counts equal but `mFilters` populated,
+    // and the user still wants the affordance to clear it.
     mClearFiltersStatusButton->setVisible(!mFilters.empty());
 }
 
@@ -4359,11 +4346,6 @@ void MainWindow::ClearAllFilters()
 
     ui->actionClearAllFilters->setDisabled(true);
     MarkFiltersDirty();
-    // `mFilters.empty()` flipped to true; the proxy signals fire
-    // only when the row pool actually changes, so a filter that
-    // hid no rows (or every row) would otherwise leave the
-    // Clear-filters affordance visible.
-    UpdateRowsShownStatus();
 }
 
 void MainWindow::ClearFilter(const QString &filterID, bool deferSync)
@@ -4397,10 +4379,6 @@ void MainWindow::ClearFilter(const QString &filterID, bool deferSync)
     {
         ui->actionClearAllFilters->setDisabled(true);
     }
-    // Mirrors `ClearAllFilters`: an outgoing filter that hid no
-    // rows leaves the proxy row pool unchanged, so the row-count
-    // signal subscriptions don't fire. Refresh explicitly.
-    UpdateRowsShownStatus();
 }
 
 void MainWindow::FilterSubmitted(const QString &filterID, int row, const QString &filterString, int matchType)
@@ -4683,10 +4661,6 @@ void MainWindow::AddLogFilter(const QString &id, const loglib::LogConfiguration:
     const QAction *removeAction = menuItem->addAction(tr("Remove"));
     connect(removeAction, &QAction::triggered, this, [this, id]() { ClearFilter(id); });
     ui->actionClearAllFilters->setDisabled(false);
-    // `mFilters.empty()` flipped to false here. Row-count signals
-    // fire only when the proxy pool actually shrinks; a filter
-    // that hides no rows still needs the affordance visible.
-    UpdateRowsShownStatus();
 }
 
 void MainWindow::OnThemeChanged()

--- a/test/app/src/main_window_test.cpp
+++ b/test/app/src/main_window_test.cpp
@@ -95,6 +95,7 @@
 #include <QTableView>
 #include <QTableWidget>
 #include <QTemporaryDir>
+#include <QToolBar>
 #include <QToolButton>
 #include <QUuid>
 #include <QVariant>
@@ -10571,6 +10572,101 @@ private slots:
             qPrintable(QStringLiteral("status button tooltip must still spell out the breakdown; got: %1")
                            .arg(statusButton->toolTip()))
         );
+    }
+
+    // Item 5: status-bar "*n* shown of *m*" indicator + inline
+    // Clear-filters button. Tracks the proxy / source row count
+    // ratio plus `mFilters.empty()`.
+    void TestRowsShownStatusReflectsFilter()
+    {
+        const int levelCol = StreamFixtureForColumnTests();
+        QVERIFY2(levelCol >= 0, "level column must exist after streaming");
+
+        // `StreamFixtureForColumnTests` drives the model directly
+        // and never flips `mSessionMode` off Idle, but the
+        // rows-shown widgets gate on `IsSessionActive()`. Pin the
+        // mode to Static for the duration of this test.
+        mWindow->SetSessionModeForTest(MainWindow::TestSessionMode::Static);
+        auto restore = qScopeGuard([this]() { mWindow->SetSessionModeForTest(MainWindow::TestSessionMode::Idle); });
+        // Refresh the chrome so the label / button observe the
+        // session-active flip without waiting for a row signal.
+        // `UpdateRowsShownStatus` is a private slot; meta-call so
+        // the test driver doesn't need access to private members.
+        QVERIFY2(
+            QMetaObject::invokeMethod(mWindow, "UpdateRowsShownStatus", Qt::DirectConnection),
+            "UpdateRowsShownStatus slot must be invocable via meta-object"
+        );
+        QCoreApplication::processEvents();
+
+        auto *label = mWindow->findChild<QLabel *>(QStringLiteral("rowsShownLabel"));
+        QVERIFY2(label != nullptr, "MainWindow must own the rows-shown status label");
+        auto *button = mWindow->findChild<QPushButton *>(QStringLiteral("clearFiltersStatusButton"));
+        QVERIFY2(button != nullptr, "MainWindow must own the clear-filters status button");
+
+        // No filter: the label reads the total only and the
+        // Clear-filters button hides. `isHidden()` (not
+        // `isVisible()`) so the assertion exercises only the slot's
+        // intent -- offscreen-QPA keeps the parent window hidden,
+        // collapsing `isVisible()` regardless.
+        // NOLINTNEXTLINE(clang-analyzer-core.CallAndMessage): prior QVERIFY2 aborts on null.
+        QVERIFY2(!label->isHidden(), "rows-shown label must show with an active session and non-empty source");
+        QVERIFY2(button->isHidden(), "clear-filters button must hide when no filter is active");
+        QVERIFY2(
+            !label->text().contains(QStringLiteral("of")),
+            qPrintable(QStringLiteral("with no filter, label must read total only; got: %1").arg(label->text()))
+        );
+
+        // Apply a filter that hides most rows -- the fixture
+        // streams 200 lines across 4 categories, so "info" alone
+        // leaves ~50 rows visible.
+        const QString filterId = QStringLiteral("rows-shown-test-filter");
+        QVERIFY2(
+            QMetaObject::invokeMethod(
+                mWindow,
+                "FilterEnumSubmitted",
+                Qt::DirectConnection,
+                Q_ARG(QString, filterId),
+                Q_ARG(int, levelCol),
+                Q_ARG(QStringList, QStringList{QStringLiteral("info")})
+            ),
+            "FilterEnumSubmitted must be invocable via meta-object"
+        );
+        QCoreApplication::processEvents();
+
+        QVERIFY2(!button->isHidden(), "clear-filters button must un-hide when at least one filter is active");
+        QVERIFY2(
+            label->text().contains(QStringLiteral("of")),
+            qPrintable(QStringLiteral("filtered label must use the 'X of Y' form; got: %1").arg(label->text()))
+        );
+
+        // Clicking the status button must route through
+        // `actionClearAllFilters`. Triggering the action directly
+        // is the same end-state and avoids needing a real click on
+        // a hidden parent window. The action also exercises the
+        // signal wiring on the button itself (`clicked ->
+        // actionClearAllFilters::trigger`).
+        auto *clearAction = mWindow->findChild<QAction *>(QStringLiteral("actionClearAllFilters"));
+        QVERIFY2(clearAction != nullptr, "MainWindow must own actionClearAllFilters");
+        // NOLINTNEXTLINE(clang-analyzer-core.CallAndMessage): prior QVERIFY2 aborts on null.
+        clearAction->trigger();
+        QCoreApplication::processEvents();
+
+        QVERIFY2(button->isHidden(), "clear-filters button must re-hide after clearing all filters");
+        QVERIFY2(
+            !label->text().contains(QStringLiteral("of")),
+            qPrintable(QStringLiteral("after clear, label must drop the 'X of Y' form; got: %1").arg(label->text()))
+        );
+    }
+
+    // Item 9 (partial): the stream toolbar is movable and may be
+    // docked to any of the four `QMainWindow` toolbar areas.
+    void TestStreamToolbarIsMovable()
+    {
+        auto *toolbar = mWindow->findChild<QToolBar *>(QStringLiteral("streamToolbar"));
+        QVERIFY2(toolbar != nullptr, "MainWindow must own the stream toolbar");
+        // NOLINTNEXTLINE(clang-analyzer-core.CallAndMessage): prior QVERIFY2 aborts on null.
+        QVERIFY2(toolbar->isMovable(), "stream toolbar must be user-movable");
+        QCOMPARE(toolbar->allowedAreas(), Qt::ToolBarAreas(Qt::AllToolBarAreas));
     }
 
     // Regression: the find-bar arrow icons used `SP_ArrowUp` /

--- a/test/app/src/main_window_test.cpp
+++ b/test/app/src/main_window_test.cpp
@@ -10574,28 +10574,21 @@ private slots:
         );
     }
 
-    // Item 5: status-bar "*n* shown of *m*" indicator + inline
-    // Clear-filters button. Tracks the proxy / source row count
-    // ratio plus `mFilters.empty()`.
+    // Item 5: status-bar "*n* of *m* shown" indicator + inline
+    // Clear-filters button. Three branches:
+    //   - no filter             -> "N lines",   button hidden
+    //   - filter hides rows     -> "M of N shown", button shown
+    //   - filter matches every row -> "N lines", button still shown
+    //     (the comment in `UpdateRowsShownStatus` calls this out
+    //      explicitly; left untested in the original change).
     void TestRowsShownStatusReflectsFilter()
     {
-        const int levelCol = StreamFixtureForColumnTests();
-        QVERIFY2(levelCol >= 0, "level column must exist after streaming");
+        const int categoryCol = StreamFixtureForColumnTests();
+        QVERIFY2(categoryCol >= 0, "category column must exist after streaming");
 
-        // `StreamFixtureForColumnTests` drives the model directly
-        // and never flips `mSessionMode` off Idle, but the
-        // rows-shown widgets gate on `IsSessionActive()`. Pin the
-        // mode to Static for the duration of this test.
-        mWindow->SetSessionModeForTest(MainWindow::TestSessionMode::Static);
-        auto restore = qScopeGuard([this]() { mWindow->SetSessionModeForTest(MainWindow::TestSessionMode::Idle); });
-        // Refresh the chrome so the label / button observe the
-        // session-active flip without waiting for a row signal.
-        // `UpdateRowsShownStatus` is a private slot; meta-call so
-        // the test driver doesn't need access to private members.
-        QVERIFY2(
-            QMetaObject::invokeMethod(mWindow, "UpdateRowsShownStatus", Qt::DirectConnection),
-            "UpdateRowsShownStatus slot must be invocable via meta-object"
-        );
+        // The fixture leaves `mSessionMode` at Idle, but the
+        // rows-shown slot now gates on `mModel->rowCount() > 0`,
+        // so no `SetSessionModeForTest` dance is needed.
         QCoreApplication::processEvents();
 
         auto *label = mWindow->findChild<QLabel *>(QStringLiteral("rowsShownLabel"));
@@ -10603,30 +10596,36 @@ private slots:
         auto *button = mWindow->findChild<QPushButton *>(QStringLiteral("clearFiltersStatusButton"));
         QVERIFY2(button != nullptr, "MainWindow must own the clear-filters status button");
 
-        // No filter: the label reads the total only and the
-        // Clear-filters button hides. `isHidden()` (not
-        // `isVisible()`) so the assertion exercises only the slot's
-        // intent -- offscreen-QPA keeps the parent window hidden,
-        // collapsing `isVisible()` regardless.
+        // Locale-formatted total used in every "no filter" / "vacuous
+        // filter" assertion below. Matches the slot's own
+        // `QLocale::system()` + `qlonglong` round-trip.
         // NOLINTNEXTLINE(clang-analyzer-core.CallAndMessage): prior QVERIFY2 aborts on null.
-        QVERIFY2(!label->isHidden(), "rows-shown label must show with an active session and non-empty source");
-        QVERIFY2(button->isHidden(), "clear-filters button must hide when no filter is active");
-        QVERIFY2(
-            !label->text().contains(QStringLiteral("of")),
-            qPrintable(QStringLiteral("with no filter, label must read total only; got: %1").arg(label->text()))
-        );
+        auto *model = mWindow->Model();
+        QVERIFY2(model != nullptr, "MainWindow must own a LogModel");
+        // NOLINTNEXTLINE(clang-analyzer-core.CallAndMessage): prior QVERIFY2 aborts on null.
+        const int totalRows = model->rowCount();
+        QVERIFY2(totalRows > 1, "fixture must stream more than one row for the plural branch");
+        const QString totalText = QLocale::system().toString(static_cast<qlonglong>(totalRows));
+        const QString unfilteredText = QStringLiteral("%1 lines").arg(totalText);
 
-        // Apply a filter that hides most rows -- the fixture
-        // streams 200 lines across 4 categories, so "info" alone
-        // leaves ~50 rows visible.
-        const QString filterId = QStringLiteral("rows-shown-test-filter");
+        // Branch 1: no filter. Label reads "<N> lines"; button is
+        // hidden. `isHidden()` (not `isVisible()`) so the assertion
+        // exercises the slot's intent -- offscreen-QPA keeps the
+        // parent hidden, collapsing `isVisible()` regardless.
+        QCOMPARE(label->text(), unfilteredText);
+        QVERIFY2(!label->isHidden(), "rows-shown label must show with a non-empty source");
+        QVERIFY2(button->isHidden(), "clear-filters button must hide when no filter is active");
+
+        // Branch 2: filter hides most rows. The fixture streams 200
+        // lines across 4 categories, so "info" alone leaves ~50.
+        const QString hideFilterId = QStringLiteral("rows-shown-test-filter");
         QVERIFY2(
             QMetaObject::invokeMethod(
                 mWindow,
                 "FilterEnumSubmitted",
                 Qt::DirectConnection,
-                Q_ARG(QString, filterId),
-                Q_ARG(int, levelCol),
+                Q_ARG(QString, hideFilterId),
+                Q_ARG(int, categoryCol),
                 Q_ARG(QStringList, QStringList{QStringLiteral("info")})
             ),
             "FilterEnumSubmitted must be invocable via meta-object"
@@ -10634,10 +10633,43 @@ private slots:
         QCoreApplication::processEvents();
 
         QVERIFY2(!button->isHidden(), "clear-filters button must un-hide when at least one filter is active");
+        auto *filterModel = mWindow->FilterModel();
+        QVERIFY2(filterModel != nullptr, "MainWindow must own a LogFilterModel");
+        // NOLINTNEXTLINE(clang-analyzer-core.CallAndMessage): prior QVERIFY2 aborts on null.
+        const int visibleRows = filterModel->rowCount();
+        QVERIFY2(visibleRows > 0 && visibleRows < totalRows, "fixture filter must hide some but not all rows");
+        const QString expectedFiltered = QStringLiteral("%1 of %2 shown")
+                                             .arg(QLocale::system().toString(static_cast<qlonglong>(visibleRows)),
+                                                  totalText);
+        QCOMPARE(label->text(), expectedFiltered);
+
+        // Branch 3: vacuous filter -- every category selected, so
+        // proxyRows == sourceRows but `mFilters` is still populated.
+        // Label drops the "of" form; button stays visible.
+        // Build the selection outside `Q_ARG`: brace-initializer commas
+        // are not protected from the macro's argument splitter.
+        const QStringList allCategories{
+            QStringLiteral("info"), QStringLiteral("warn"), QStringLiteral("error"), QStringLiteral("debug")
+        };
         QVERIFY2(
-            label->text().contains(QStringLiteral("of")),
-            qPrintable(QStringLiteral("filtered label must use the 'X of Y' form; got: %1").arg(label->text()))
+            QMetaObject::invokeMethod(
+                mWindow,
+                "FilterEnumSubmitted",
+                Qt::DirectConnection,
+                Q_ARG(QString, hideFilterId),
+                Q_ARG(int, categoryCol),
+                Q_ARG(QStringList, allCategories)
+            ),
+            "FilterEnumSubmitted (vacuous) must be invocable via meta-object"
         );
+        QCoreApplication::processEvents();
+
+        QCOMPARE(filterModel->rowCount(), totalRows);
+        QVERIFY2(
+            !button->isHidden(),
+            "clear-filters button must stay visible even when the filter matches every row"
+        );
+        QCOMPARE(label->text(), unfilteredText);
 
         // Clicking the status button must route through
         // `actionClearAllFilters`. Triggering the action directly
@@ -10652,10 +10684,7 @@ private slots:
         QCoreApplication::processEvents();
 
         QVERIFY2(button->isHidden(), "clear-filters button must re-hide after clearing all filters");
-        QVERIFY2(
-            !label->text().contains(QStringLiteral("of")),
-            qPrintable(QStringLiteral("after clear, label must drop the 'X of Y' form; got: %1").arg(label->text()))
-        );
+        QCOMPARE(label->text(), unfilteredText);
     }
 
     // Item 9 (partial): the stream toolbar is movable and may be

--- a/test/app/src/main_window_test.cpp
+++ b/test/app/src/main_window_test.cpp
@@ -10638,9 +10638,9 @@ private slots:
         // NOLINTNEXTLINE(clang-analyzer-core.CallAndMessage): prior QVERIFY2 aborts on null.
         const int visibleRows = filterModel->rowCount();
         QVERIFY2(visibleRows > 0 && visibleRows < totalRows, "fixture filter must hide some but not all rows");
-        const QString expectedFiltered = QStringLiteral("%1 of %2 shown")
-                                             .arg(QLocale::system().toString(static_cast<qlonglong>(visibleRows)),
-                                                  totalText);
+        const QString expectedFiltered =
+            QStringLiteral("%1 of %2 shown")
+                .arg(QLocale::system().toString(static_cast<qlonglong>(visibleRows)), totalText);
         QCOMPARE(label->text(), expectedFiltered);
 
         // Branch 3: vacuous filter -- every category selected, so
@@ -10665,10 +10665,7 @@ private slots:
         QCoreApplication::processEvents();
 
         QCOMPARE(filterModel->rowCount(), totalRows);
-        QVERIFY2(
-            !button->isHidden(),
-            "clear-filters button must stay visible even when the filter matches every row"
-        );
+        QVERIFY2(!button->isHidden(), "clear-filters button must stay visible even when the filter matches every row");
         QCOMPARE(label->text(), unfilteredText);
 
         // Clicking the status button must route through


### PR DESCRIPTION
Two user-visible additions: a permanent status-bar `n of m shown` indicator with an inline `Clear filters` button, and a movable stream toolbar that round-trips its dock position through the existing `saveState` / `restoreState` chrome persistence. The trailing review-fixup commit retunes the gating predicate, swaps a misleading icon, drops a handful of redundant explicit refresh calls, and tightens the singular / plural handling and tests.

## Why

Filtered sessions used to be silent about how many rows the active filter was hiding -- the only way to tell was to open the **Filters** menu. *Where did my rows go?* was the most common confusion in filtered views. The new permanent status-bar widgets surface the source-vs-proxy ratio plus a one-click escape hatch back to the unfiltered view, mirroring the pattern already established by `mDiagnosticsButton` / `mParseErrorsStatusButton` in #54.

The stream-toolbar mobility removes a fixed Top-only constraint that was awkward on tall side monitors and conflicted with upcoming chrome (the primary toolbar in item 1). Now that #53 wired up `restoreState` and every dock / toolbar carries an `objectName`, making `mStreamToolbar` movable is a two-line change with no new persistence work.

## What changed

**Item 5 -- `n of m shown` + Clear filters.** Two new permanent status-bar widgets, both threaded through a single `MainWindow::UpdateRowsShownStatus` slot:

- `mRowsShownLabel` reads `n of m shown` while a filter is hiding rows, `m lines` (or `1 line`) otherwise. Locale-grouped digits via `QLocale::system().toString(qlonglong)` match the streaming status text. The plural / singular forms are explicit `tr()` strings rather than `%Ln` so the UI doesn't fall back to a literal `(s)` without a translation file.
- `mClearFiltersStatusButton` (flat, `SP_LineEditClearButton` glyph) appears whenever `mFilters` is non-empty *and* the source model has rows. Clicking routes through `ui->actionClearAllFilters->trigger()` so the menu, the eventual primary-toolbar entry, and this button share one source of truth. `setAccessibleName` and `setToolTip` are wired so screen readers and hover-help surface the action verb.

The slot subscribes to `rowsInserted` / `rowsRemoved` / `modelReset` on both `mModel` and `mSortFilterProxyModel`, plus `layoutChanged` on the proxy (the only signal that flips the predicate without shifting the row pool). It's idempotent and cheap (two `rowCount()` calls plus a label assign), so duplicate fires from adjacent signals are harmless. The `setText` call is elided when the digits haven't moved, which drops one repaint of the permanent status-bar area per streaming batch on the source / proxy double-fire.

The visibility predicate gates on `mModel->rowCount() > 0` rather than `IsSessionActive()`. `OnStreamingFinished` flips `mSessionMode` back to `Idle` for finite static loads, but the user keeps browsing the rows -- gating on the session would surface the indicator only during streaming and hide it the moment the parse completed. The Clear-filters visibility is decoupled from `proxyRows < sourceRows`: a filter that matches every row leaves the counts equal but `mFilters` populated, and the user still wants the affordance to clear it.

This is deliberately status-bar-only -- the richer floating affordance above the table viewport is deferred to the filter-chip bar (item 3) so the chip-vs-button concerns land together.

**Item 9 (partial) -- movable stream toolbar.** Two-line change: `mStreamToolbar->setMovable(true)` plus `setAllowedAreas(Qt::AllToolBarAreas)`. Both are Qt defaults, but they are pinned explicitly so `TestStreamToolbarIsMovable` keeps them from regressing. The existing `objectName(QStringLiteral("streamToolbar"))` (also normalised to `QStringLiteral` in this branch) means the user's chosen dock area round-trips through `SaveWindowChrome` / `RestoreWindowChrome` with no new persistence work. `setUnifiedTitleAndToolBarOnMac` remains outstanding; it pairs naturally with the primary toolbar (item 1) so both ship in the same pass.

**Self-review fixups.** The trailing `b35b117` and `e9abb79` commits address a fresh re-read of the diff:

- Gate on `mModel->rowCount() > 0` instead of `IsSessionActive()` (covered above) so the indicator survives the post-load `Static -> Idle` flip and stays visible while the user browses a finished static load.
- Swap the Clear-filters icon from `SP_FileDialogListView` (a list-view glyph, not a filter) to `SP_LineEditClearButton`; add tooltip + accessible name.
- Drop three redundant explicit `UpdateRowsShownStatus()` calls in `ClearAllFilters` / `ClearFilter` / `AddLogFilter` -- the `LogFilterModel::layoutChanged` subscription already covers them, and the `ClearFilter(deferSync=true)` call was painting a transient bad state during `FilterEnumSubmitted`'s replace flow.
- Drop the two `UpdateRowsShownStatus()` tail-calls in `UpdateStreamingStatus` for the same reason.
- Split `%Ln line(s)` into explicit singular / plural strings so the UI no longer shows literal `(s)` without a translation file.
- Cache the label text and skip `setText` when unchanged, eliding one repaint per streaming batch on the source / proxy double-fire.
- Drop the long, partly-inaccurate stream-toolbar comment; keep `setMovable(true)` + `setAllowedAreas(...)` as explicit pins for `TestStreamToolbarIsMovable`. Normalise the `objectName` literal to `QStringLiteral`.

**Tests.** Two new functions in `test/app/src/main_window_test.cpp`:

- `TestRowsShownStatusReflectsFilter` streams the 200-row fixture and walks unfiltered -> filter that hides rows -> vacuous filter (every category selected) -> cleared, asserting the locale-formatted label text and button visibility through each transition. Triggers `actionClearAllFilters` directly via `findChild<QAction *>` (offscreen QPA cannot dispatch real clicks). The vacuous-filter sub-case is new in the fixup pass -- previously called out in the slot comment but never exercised. The brittle `contains("of")` substring assertions were replaced with exact `QCOMPARE` against the locale-formatted expected text so the test no longer assumes English.
- `TestStreamToolbarIsMovable` checks `isMovable()` and `allowedAreas() == Qt::AllToolBarAreas` on the toolbar found via `objectName("streamToolbar")`.

Both pass alongside the adjacent status / filter / theme tests under `-platform offscreen` (314 / 314 locally on Windows + MSVC + Release + IPO).

## Test plan

- [x] `ctest -LE benchmark` green locally on Windows + MSVC + Release + IPO (314 / 314).
- [x] Manual smoke: open a JSON Lines log -- status bar reads `12,345 lines`, no Clear-filters button. Apply a category filter that hides rows -- label flips to `8,432 of 12,345 shown` and the Clear-filters button appears with the line-edit-clear glyph. Click the button -- filters clear, label reverts to the unfiltered form.
- [x] Manual smoke: apply a filter that matches every row (e.g. select every category) -- label drops back to `12,345 lines` but the Clear-filters button stays visible.
- [x] Manual smoke: live-tail a hot stream -- label updates at the same 1 Hz cadence as the streaming status text, no per-batch flicker; locale-grouped digits read `12,345`.
- [x] Manual smoke: drag the stream toolbar from Top to Left / Right / Bottom; close and reopen the app -- toolbar restores in the user's chosen area.
- [x] CI: `build-linux`, `build-macos`, `build-windows`, `clang-ci (asan-ubsan / tsan / coverage)`, `pre-commit`, CodeQL all green on this PR.
