### PR TITLE
GUI polish: column-header filter indicators (funnel + tooltip)

### DIFF
--- a/app/include/log_model.hpp
+++ b/app/include/log_model.hpp
@@ -217,31 +217,21 @@ public:
     /// the header tooltip / warning icon and the status-bar summary.
     [[nodiscard]] std::optional<loglib::LogTable::ColumnTypeHealth> ColumnHealth(int section) const;
 
-    /// Replace the per-column "active filter titles" cache that
-    /// feeds the funnel decoration + tooltip section in
-    /// `headerData`. Each entry is the human-readable title of one
-    /// active filter on that column (already sorted by the caller
-    /// for stable display). An empty `QStringList` means "no
-    /// filter on this column". `perColumnTitles` is padded /
-    /// trimmed to the current `columnCount()` so out-of-range
-    /// lookups stay safe across structural changes.
-    ///
-    /// Idempotent: emits `headerDataChanged` only for the
-    /// `[firstChanged, lastChanged]` range and is a no-op when
-    /// every column matches its previous titles list.
+    /// Replace the per-column active-filter titles cache used by
+    /// the funnel decoration and tooltip in `headerData`. Each
+    /// entry holds the titles of one column's active filters
+    /// (caller pre-sorts them); empty entry = no filter.
+    /// `perColumnTitles` is resized to `columnCount()`. Idempotent:
+    /// emits `headerDataChanged` only for the changed range.
     void SetColumnFilterDetails(std::vector<QStringList> perColumnTitles);
 
-    /// True iff @p section has at least one cached filter title.
-    /// Drives the funnel decoration branch of `headerData`;
-    /// out-of-range returns `false`.
+    /// True if @p section has any cached filter title. Out-of-range
+    /// returns `false`.
     [[nodiscard]] bool HasFilterForColumn(int section) const noexcept;
 
-    /// Drop the cached themed funnel pixmap and re-emit
-    /// `headerDataChanged` across columns that currently have a
-    /// filter, so the header view re-fetches a glyph tinted for
-    /// the new palette. No-op when no column has a filter.
-    /// `MainWindow::OnThemeChanged` invokes this after a Light <->
-    /// Dark flip.
+    /// Drop the cached funnel icon and re-emit `headerDataChanged`
+    /// for filtered columns so the header re-renders against the
+    /// new palette. Called from `MainWindow::OnThemeChanged`.
     void RefreshHeaderIcons();
 
     /// Recompute every column's `ColumnTypeHealth` snapshot. Emits
@@ -382,31 +372,21 @@ private:
     /// Written only by `RefreshColumnHealth`; empty until first refresh.
     std::vector<loglib::LogTable::ColumnTypeHealth> mColumnHealth;
 
-    /// Per-column titles of currently-active filters, parallel to
+    /// Per-column active-filter titles, parallel to
     /// `Configuration().columns`. Written only by
-    /// `SetColumnFilterDetails`; empty entry = no filter on that
-    /// column. Drives the funnel decoration + tooltip section in
-    /// `headerData`.
+    /// `SetColumnFilterDetails`; empty entry = no filter.
     std::vector<QStringList> mColumnFilterDetails;
 
-    /// Lazily-rendered themed funnel glyph for the header
-    /// "column has a filter" indicator. Populated on first
-    /// `Qt::DecorationRole` hit; cleared by `RefreshHeaderIcons`
-    /// when the palette changes. `mutable` because `headerData` is
-    /// `const` and the cache fill is a pure speedup -- the
-    /// observable return value is the same icon every time until
-    /// the next theme flip.
-    ///
-    /// Paired with `mFunnelIconAttempted` so a failed first load
-    /// (e.g. a future qrc rename leaves the resource missing)
-    /// caches the empty `QIcon` rather than re-attempting the
-    /// load on every header repaint.
+    /// Themed funnel glyph for the "column has a filter" header
+    /// decoration, rendered lazily on first decoration query and
+    /// cleared by `RefreshHeaderIcons` on palette changes.
+    /// `mutable` so `headerData` (const) can populate the cache.
+    /// `mFunnelIconAttempted` guards against re-rendering on every
+    /// repaint if the resource ever fails to load.
     mutable QIcon mFunnelIconCache;
 
-    /// Set after the first attempted load of `mFunnelIconCache`.
-    /// `RefreshHeaderIcons` clears it back to `false` to force a
-    /// re-render at the new palette / DPR. See the comment on
-    /// `mFunnelIconCache` for the failed-load motivation.
+    /// Latched after the first `mFunnelIconCache` load attempt;
+    /// reset by `RefreshHeaderIcons` to force a re-render.
     mutable bool mFunnelIconAttempted = false;
 
     /// Cached first-`Type::Level` column index. Sentinel

--- a/app/include/log_model.hpp
+++ b/app/include/log_model.hpp
@@ -396,7 +396,18 @@ private:
     /// `const` and the cache fill is a pure speedup -- the
     /// observable return value is the same icon every time until
     /// the next theme flip.
+    ///
+    /// Paired with `mFunnelIconAttempted` so a failed first load
+    /// (e.g. a future qrc rename leaves the resource missing)
+    /// caches the empty `QIcon` rather than re-attempting the
+    /// load on every header repaint.
     mutable QIcon mFunnelIconCache;
+
+    /// Set after the first attempted load of `mFunnelIconCache`.
+    /// `RefreshHeaderIcons` clears it back to `false` to force a
+    /// re-render at the new palette / DPR. See the comment on
+    /// `mFunnelIconCache` for the failed-load motivation.
+    mutable bool mFunnelIconAttempted = false;
 
     /// Cached first-`Type::Level` column index. Sentinel
     /// `LEVEL_COLUMN_UNCACHED` before first scan, `LEVEL_COLUMN_NONE`

--- a/app/include/log_model.hpp
+++ b/app/include/log_model.hpp
@@ -12,6 +12,8 @@
 
 #include <QAbstractTableModel>
 #include <QFuture>
+#include <QIcon>
+#include <QStringList>
 
 #include <cstddef>
 #include <cstdint>
@@ -215,6 +217,33 @@ public:
     /// the header tooltip / warning icon and the status-bar summary.
     [[nodiscard]] std::optional<loglib::LogTable::ColumnTypeHealth> ColumnHealth(int section) const;
 
+    /// Replace the per-column "active filter titles" cache that
+    /// feeds the funnel decoration + tooltip section in
+    /// `headerData`. Each entry is the human-readable title of one
+    /// active filter on that column (already sorted by the caller
+    /// for stable display). An empty `QStringList` means "no
+    /// filter on this column". `perColumnTitles` is padded /
+    /// trimmed to the current `columnCount()` so out-of-range
+    /// lookups stay safe across structural changes.
+    ///
+    /// Idempotent: emits `headerDataChanged` only for the
+    /// `[firstChanged, lastChanged]` range and is a no-op when
+    /// every column matches its previous titles list.
+    void SetColumnFilterDetails(std::vector<QStringList> perColumnTitles);
+
+    /// True iff @p section has at least one cached filter title.
+    /// Drives the funnel decoration branch of `headerData`;
+    /// out-of-range returns `false`.
+    [[nodiscard]] bool HasFilterForColumn(int section) const noexcept;
+
+    /// Drop the cached themed funnel pixmap and re-emit
+    /// `headerDataChanged` across columns that currently have a
+    /// filter, so the header view re-fetches a glyph tinted for
+    /// the new palette. No-op when no column has a filter.
+    /// `MainWindow::OnThemeChanged` invokes this after a Light <->
+    /// Dark flip.
+    void RefreshHeaderIcons();
+
     /// Recompute every column's `ColumnTypeHealth` snapshot. Emits
     /// `headerDataChanged` and `columnHealthChanged` when something
     /// moved. Walks the whole table; meant for end-of-stream and
@@ -352,6 +381,22 @@ private:
     /// Per-column health cache, parallel to `Configuration().columns`.
     /// Written only by `RefreshColumnHealth`; empty until first refresh.
     std::vector<loglib::LogTable::ColumnTypeHealth> mColumnHealth;
+
+    /// Per-column titles of currently-active filters, parallel to
+    /// `Configuration().columns`. Written only by
+    /// `SetColumnFilterDetails`; empty entry = no filter on that
+    /// column. Drives the funnel decoration + tooltip section in
+    /// `headerData`.
+    std::vector<QStringList> mColumnFilterDetails;
+
+    /// Lazily-rendered themed funnel glyph for the header
+    /// "column has a filter" indicator. Populated on first
+    /// `Qt::DecorationRole` hit; cleared by `RefreshHeaderIcons`
+    /// when the palette changes. `mutable` because `headerData` is
+    /// `const` and the cache fill is a pure speedup -- the
+    /// observable return value is the same icon every time until
+    /// the next theme flip.
+    mutable QIcon mFunnelIconCache;
 
     /// Cached first-`Type::Level` column index. Sentinel
     /// `LEVEL_COLUMN_UNCACHED` before first scan, `LEVEL_COLUMN_NONE`

--- a/app/include/main_window.hpp
+++ b/app/include/main_window.hpp
@@ -872,22 +872,14 @@ private:
     /// remove.)
     void RebuildClearFiltersMenu(QMenu *menu);
 
-    /// Rebuild the per-column "active filter titles" snapshot from
-    /// `mFilters` and push it into `LogModel::SetColumnFilterDetails`.
-    /// The model side then drives the funnel decoration + tooltip
-    /// "Filters:" section in `headerData`.
+    /// Snapshot active filter titles per column from `mFilters` and
+    /// push them into `LogModel::SetColumnFilterDetails`, which
+    /// drives the funnel decoration + "Filters:" tooltip section.
+    /// Sorts each column's titles for stable display.
     ///
-    /// Called from every `mFilters` mutation point (`AddLogFilter`,
-    /// `ClearFilter`, `ClearAllFilters`, `RebuildFiltersFromConfiguration`)
-    /// and from the column-shape signals that can shift `filter.row`
-    /// or hide the column they target (`OnSourceColumnsMoved`,
-    /// `ApplyColumnVisibility`, `SetColumnVisible`). Idempotent: a
-    /// no-change run flows through the model's diff guard without
-    /// emitting `headerDataChanged`, so calling on every row-storm
-    /// signal would still be safe.
-    ///
-    /// Per-column entries are sorted by display title for stable
-    /// tooltip ordering across `mFilters`'s unordered iteration.
+    /// Called from every `mFilters` mutation point and from
+    /// column-shape signals that can shift `filter.row`. Idempotent
+    /// via the model-side diff guard.
     void SyncColumnFilterIndicators();
 
     /// Re-evaluate the stream toolbar's visibility against the current

--- a/app/include/main_window.hpp
+++ b/app/include/main_window.hpp
@@ -872,6 +872,24 @@ private:
     /// remove.)
     void RebuildClearFiltersMenu(QMenu *menu);
 
+    /// Rebuild the per-column "active filter titles" snapshot from
+    /// `mFilters` and push it into `LogModel::SetColumnFilterDetails`.
+    /// The model side then drives the funnel decoration + tooltip
+    /// "Filters:" section in `headerData`.
+    ///
+    /// Called from every `mFilters` mutation point (`AddLogFilter`,
+    /// `ClearFilter`, `ClearAllFilters`, `RebuildFiltersFromConfiguration`)
+    /// and from the column-shape signals that can shift `filter.row`
+    /// or hide the column they target (`OnSourceColumnsMoved`,
+    /// `ApplyColumnVisibility`, `SetColumnVisible`). Idempotent: a
+    /// no-change run flows through the model's diff guard without
+    /// emitting `headerDataChanged`, so calling on every row-storm
+    /// signal would still be safe.
+    ///
+    /// Per-column entries are sorted by display title for stable
+    /// tooltip ordering across `mFilters`'s unordered iteration.
+    void SyncColumnFilterIndicators();
+
     /// Re-evaluate the stream toolbar's visibility against the current
     /// session mode.
     void UpdateStreamToolbarVisibility();

--- a/app/src/log_model.cpp
+++ b/app/src/log_model.cpp
@@ -973,9 +973,8 @@ QString BuildHeaderTooltip(
     lines.append(QStringLiteral("type: %1").arg(FormatTypeName(column.type, column.autoDetect)));
     QString tooltip = lines.join(QStringLiteral("<br/>"));
 
-    // Filters section sits between the static column metadata and
-    // the (red) warning section so the warning, when present,
-    // stays the visually dominant trailing block.
+    // Filters section sits between metadata and the warning so the
+    // warning stays the visually dominant trailing block.
     if (!filterTitles.isEmpty())
     {
         QStringList bullets;
@@ -1025,9 +1024,8 @@ QVariant LogModel::headerData(int section, Qt::Orientation orientation, int role
     }
     if (role == Qt::DecorationRole)
     {
-        // Warning wins: a type-mismatch needs the user's attention
-        // more than a "filter present" reminder, and pixel real
-        // estate in a header cell only holds one decoration icon.
+        // Warning wins over the funnel: only one decoration fits
+        // in a header cell and a type mismatch is more important.
         if (auto health = ColumnHealth(section); health.has_value())
         {
             const size_t mismatched =
@@ -1041,18 +1039,10 @@ QVariant LogModel::headerData(int section, Qt::Orientation orientation, int role
         {
             if (!mFunnelIconAttempted)
             {
-                // Render at `PM_SmallIconSize` (typically 16 px),
-                // not `MakeThemedIcon`'s default `FALLBACK_ICON_PX`
-                // (20 px). Header views paint decorations at the
-                // small-icon metric, so a 20 px source forces Qt
-                // to downscale on every paint. Tint and DPR still
-                // come from the application (the header tracks
-                // the app palette in every theme we ship).
-                //
-                // The latch is set unconditionally so a missing
-                // resource (theoretical -- `funnel.svg` is bundled)
-                // caches the empty `QIcon` instead of re-attempting
-                // the load on every header repaint.
+                // Render at `PM_SmallIconSize` so the header view
+                // doesn't downscale on every paint. The latch is
+                // set unconditionally: a missing resource caches
+                // the empty `QIcon` instead of retrying each paint.
                 const QPalette appPalette = QApplication::palette();
                 const QColor tint = appPalette.color(QPalette::Active, QPalette::WindowText);
                 const qreal dpr = qApp->devicePixelRatio();
@@ -1167,15 +1157,9 @@ void LogModel::SetColumnFilterDetails(std::vector<QStringList> perColumnTitles)
     const int cols = columnCount();
     if (cols <= 0)
     {
-        // Structural reset in flight; drop the cache so a stale
-        // entry can't survive into the next configuration. We
-        // skip the `headerDataChanged` emit here because the only
-        // legitimate caller (`MainWindow::ClearAllFilters` reached
-        // via `MainWindow::Reset` -> `mModel->Reset()`) is paired
-        // with a `beginResetModel`/`endResetModel` that already
-        // invalidates every cached header on the view side --
-        // emitting now would force a redundant header repaint
-        // that's about to be superseded.
+        // Structural reset in flight: drop the cache. No emit -
+        // the surrounding `beginResetModel`/`endResetModel` already
+        // invalidates the header on the view side.
         if (mColumnFilterDetails.empty())
         {
             return;
@@ -1184,11 +1168,8 @@ void LogModel::SetColumnFilterDetails(std::vector<QStringList> perColumnTitles)
         return;
     }
 
-    // Normalise the input length to the current column count.
-    // Over-long input is trimmed (extra entries can't reach a
-    // valid section index anyway); under-long is padded with
-    // empty `QStringList`s so a column whose filters were all
-    // removed is reset rather than left at its previous titles.
+    // Normalise input length to current column count: trim extras,
+    // pad with empty lists so cleared columns get reset.
     perColumnTitles.resize(static_cast<size_t>(cols));
     if (mColumnFilterDetails.size() != perColumnTitles.size())
     {
@@ -1210,10 +1191,8 @@ void LogModel::SetColumnFilterDetails(std::vector<QStringList> perColumnTitles)
     }
     if (firstChanged < 0)
     {
-        // Idempotent no-op: same titles in same order on every
-        // column. The MainWindow sync helper calls us on every
-        // row-storm signal; suppressing the redundant emit keeps
-        // the header view from repainting on every batch.
+        // Idempotent no-op: suppress the emit so row-storm signals
+        // don't trigger redundant header repaints.
         return;
     }
     mColumnFilterDetails = std::move(perColumnTitles);
@@ -1232,15 +1211,11 @@ bool LogModel::HasFilterForColumn(int section) const noexcept
 void LogModel::RefreshHeaderIcons()
 {
     mFunnelIconCache = QIcon{};
-    // Reset the "load attempted" latch so the next decoration
-    // query re-renders the funnel against the new palette / DPR.
-    // Without this, a Light <-> Dark flip would leave the empty
-    // (or pre-flip-tinted) icon pinned for the rest of the session.
+    // Reset the latch so the next decoration query re-renders the
+    // funnel against the new palette / DPR.
     mFunnelIconAttempted = false;
-    // Re-emit only across the contiguous range of columns that
-    // currently have a filter. Columns without a filter don't
-    // display the funnel and don't need to re-render. When no
-    // column has a filter we skip the emit entirely.
+    // Re-emit only the contiguous range of filtered columns; the
+    // rest don't show the funnel and need no repaint.
     int firstWith = -1;
     int lastWith = -1;
     for (size_t i = 0; i < mColumnFilterDetails.size(); ++i)

--- a/app/src/log_model.cpp
+++ b/app/src/log_model.cpp
@@ -1051,9 +1051,8 @@ QVariant LogModel::headerData(int section, Qt::Orientation orientation, int role
                 {
                     smallIconPx = style->pixelMetric(QStyle::PM_SmallIconSize);
                 }
-                mFunnelIconCache = icon_loader::MakeThemedIcon(
-                    QStringLiteral(":/icons/funnel.svg"), tint, smallIconPx, dpr
-                );
+                mFunnelIconCache =
+                    icon_loader::MakeThemedIcon(QStringLiteral(":/icons/funnel.svg"), tint, smallIconPx, dpr);
                 mFunnelIconAttempted = true;
             }
             return mFunnelIconCache;

--- a/app/src/log_model.cpp
+++ b/app/src/log_model.cpp
@@ -18,12 +18,14 @@
 
 #include <QApplication>
 #include <QBrush>
+#include <QColor>
 #include <QCoreApplication>
 #include <QFont>
 #include <QFutureWatcher>
 #include <QIcon>
 #include <QMetaObject>
 #include <QModelIndex>
+#include <QPalette>
 #include <QPointer>
 #include <QString>
 #include <QStringList>
@@ -1037,15 +1039,32 @@ QVariant LogModel::headerData(int section, Qt::Orientation orientation, int role
         }
         if (HasFilterForColumn(section))
         {
-            if (mFunnelIconCache.isNull())
+            if (!mFunnelIconAttempted)
             {
-                // Anchor is `nullptr` so the loader resolves
-                // tint / DPR / size from `QApplication`. The
-                // header view's palette tracks the app palette
-                // in every theme we ship, so the result reads
-                // as "default text colour" against the header.
-                mFunnelIconCache =
-                    icon_loader::MakeThemedIcon(QStringLiteral(":/icons/funnel.svg"), nullptr);
+                // Render at `PM_SmallIconSize` (typically 16 px),
+                // not `MakeThemedIcon`'s default `FALLBACK_ICON_PX`
+                // (20 px). Header views paint decorations at the
+                // small-icon metric, so a 20 px source forces Qt
+                // to downscale on every paint. Tint and DPR still
+                // come from the application (the header tracks
+                // the app palette in every theme we ship).
+                //
+                // The latch is set unconditionally so a missing
+                // resource (theoretical -- `funnel.svg` is bundled)
+                // caches the empty `QIcon` instead of re-attempting
+                // the load on every header repaint.
+                const QPalette appPalette = QApplication::palette();
+                const QColor tint = appPalette.color(QPalette::Active, QPalette::WindowText);
+                const qreal dpr = qApp->devicePixelRatio();
+                int smallIconPx = 0;
+                if (const QStyle *style = QApplication::style(); style != nullptr)
+                {
+                    smallIconPx = style->pixelMetric(QStyle::PM_SmallIconSize);
+                }
+                mFunnelIconCache = icon_loader::MakeThemedIcon(
+                    QStringLiteral(":/icons/funnel.svg"), tint, smallIconPx, dpr
+                );
+                mFunnelIconAttempted = true;
             }
             return mFunnelIconCache;
         }
@@ -1149,7 +1168,14 @@ void LogModel::SetColumnFilterDetails(std::vector<QStringList> perColumnTitles)
     if (cols <= 0)
     {
         // Structural reset in flight; drop the cache so a stale
-        // entry can't survive into the next configuration.
+        // entry can't survive into the next configuration. We
+        // skip the `headerDataChanged` emit here because the only
+        // legitimate caller (`MainWindow::ClearAllFilters` reached
+        // via `MainWindow::Reset` -> `mModel->Reset()`) is paired
+        // with a `beginResetModel`/`endResetModel` that already
+        // invalidates every cached header on the view side --
+        // emitting now would force a redundant header repaint
+        // that's about to be superseded.
         if (mColumnFilterDetails.empty())
         {
             return;
@@ -1206,6 +1232,11 @@ bool LogModel::HasFilterForColumn(int section) const noexcept
 void LogModel::RefreshHeaderIcons()
 {
     mFunnelIconCache = QIcon{};
+    // Reset the "load attempted" latch so the next decoration
+    // query re-renders the funnel against the new palette / DPR.
+    // Without this, a Light <-> Dark flip would leave the empty
+    // (or pre-flip-tinted) icon pinned for the rest of the session.
+    mFunnelIconAttempted = false;
     // Re-emit only across the contiguous range of columns that
     // currently have a filter. Columns without a filter don't
     // display the funnel and don't need to re-render. When no

--- a/app/src/log_model.cpp
+++ b/app/src/log_model.cpp
@@ -1,6 +1,7 @@
 #include "log_model.hpp"
 
 #include "anchor_manager.hpp"
+#include "icon_loader.hpp"
 #include "qt_streaming_log_sink.hpp"
 #include "streaming_control.hpp"
 #include "theme_control.hpp"
@@ -946,7 +947,9 @@ QString FormatTypeName(loglib::LogConfiguration::Type type, bool autoDetect)
 }
 
 QString BuildHeaderTooltip(
-    const loglib::LogConfiguration::Column &column, std::optional<loglib::LogTable::ColumnTypeHealth> health
+    const loglib::LogConfiguration::Column &column,
+    std::optional<loglib::LogTable::ColumnTypeHealth> health,
+    const QStringList &filterTitles
 )
 {
     // Join with `<br/>` so missing sections don't produce blank lines.
@@ -967,6 +970,20 @@ QString BuildHeaderTooltip(
     }
     lines.append(QStringLiteral("type: %1").arg(FormatTypeName(column.type, column.autoDetect)));
     QString tooltip = lines.join(QStringLiteral("<br/>"));
+
+    // Filters section sits between the static column metadata and
+    // the (red) warning section so the warning, when present,
+    // stays the visually dominant trailing block.
+    if (!filterTitles.isEmpty())
+    {
+        QStringList bullets;
+        bullets.reserve(filterTitles.size());
+        for (const auto &title : filterTitles)
+        {
+            bullets.append(QStringLiteral("&bull; %1").arg(title.toHtmlEscaped()));
+        }
+        tooltip += QStringLiteral("<br/><b>Filters:</b><br/>%1").arg(bullets.join(QStringLiteral("<br/>")));
+    }
 
     if (health.has_value())
     {
@@ -999,10 +1016,16 @@ QVariant LogModel::headerData(int section, Qt::Orientation orientation, int role
     if (role == Qt::ToolTipRole)
     {
         const auto &columns = mLogTable.Configuration().Configuration().columns;
-        return BuildHeaderTooltip(columns[static_cast<size_t>(section)], ColumnHealth(section));
+        const QStringList titles = (static_cast<size_t>(section) < mColumnFilterDetails.size())
+                                       ? mColumnFilterDetails[static_cast<size_t>(section)]
+                                       : QStringList{};
+        return BuildHeaderTooltip(columns[static_cast<size_t>(section)], ColumnHealth(section), titles);
     }
     if (role == Qt::DecorationRole)
     {
+        // Warning wins: a type-mismatch needs the user's attention
+        // more than a "filter present" reminder, and pixel real
+        // estate in a header cell only holds one decoration icon.
         if (auto health = ColumnHealth(section); health.has_value())
         {
             const size_t mismatched =
@@ -1011,6 +1034,20 @@ QVariant LogModel::headerData(int section, Qt::Orientation orientation, int role
             {
                 return QApplication::style()->standardIcon(QStyle::SP_MessageBoxWarning);
             }
+        }
+        if (HasFilterForColumn(section))
+        {
+            if (mFunnelIconCache.isNull())
+            {
+                // Anchor is `nullptr` so the loader resolves
+                // tint / DPR / size from `QApplication`. The
+                // header view's palette tracks the app palette
+                // in every theme we ship, so the result reads
+                // as "default text colour" against the header.
+                mFunnelIconCache =
+                    icon_loader::MakeThemedIcon(QStringLiteral(":/icons/funnel.svg"), nullptr);
+            }
+            return mFunnelIconCache;
         }
         return {};
     }
@@ -1104,6 +1141,93 @@ std::optional<loglib::LogTable::ColumnTypeHealth> LogModel::ColumnHealth(int sec
         return std::nullopt;
     }
     return mColumnHealth[static_cast<size_t>(section)];
+}
+
+void LogModel::SetColumnFilterDetails(std::vector<QStringList> perColumnTitles)
+{
+    const int cols = columnCount();
+    if (cols <= 0)
+    {
+        // Structural reset in flight; drop the cache so a stale
+        // entry can't survive into the next configuration.
+        if (mColumnFilterDetails.empty())
+        {
+            return;
+        }
+        mColumnFilterDetails.clear();
+        return;
+    }
+
+    // Normalise the input length to the current column count.
+    // Over-long input is trimmed (extra entries can't reach a
+    // valid section index anyway); under-long is padded with
+    // empty `QStringList`s so a column whose filters were all
+    // removed is reset rather than left at its previous titles.
+    perColumnTitles.resize(static_cast<size_t>(cols));
+    if (mColumnFilterDetails.size() != perColumnTitles.size())
+    {
+        mColumnFilterDetails.resize(perColumnTitles.size());
+    }
+
+    int firstChanged = -1;
+    int lastChanged = -1;
+    for (int i = 0; i < cols; ++i)
+    {
+        if (mColumnFilterDetails[static_cast<size_t>(i)] != perColumnTitles[static_cast<size_t>(i)])
+        {
+            if (firstChanged < 0)
+            {
+                firstChanged = i;
+            }
+            lastChanged = i;
+        }
+    }
+    if (firstChanged < 0)
+    {
+        // Idempotent no-op: same titles in same order on every
+        // column. The MainWindow sync helper calls us on every
+        // row-storm signal; suppressing the redundant emit keeps
+        // the header view from repainting on every batch.
+        return;
+    }
+    mColumnFilterDetails = std::move(perColumnTitles);
+    emit headerDataChanged(Qt::Horizontal, firstChanged, lastChanged);
+}
+
+bool LogModel::HasFilterForColumn(int section) const noexcept
+{
+    if (section < 0 || static_cast<size_t>(section) >= mColumnFilterDetails.size())
+    {
+        return false;
+    }
+    return !mColumnFilterDetails[static_cast<size_t>(section)].isEmpty();
+}
+
+void LogModel::RefreshHeaderIcons()
+{
+    mFunnelIconCache = QIcon{};
+    // Re-emit only across the contiguous range of columns that
+    // currently have a filter. Columns without a filter don't
+    // display the funnel and don't need to re-render. When no
+    // column has a filter we skip the emit entirely.
+    int firstWith = -1;
+    int lastWith = -1;
+    for (size_t i = 0; i < mColumnFilterDetails.size(); ++i)
+    {
+        if (!mColumnFilterDetails[i].isEmpty())
+        {
+            if (firstWith < 0)
+            {
+                firstWith = static_cast<int>(i);
+            }
+            lastWith = static_cast<int>(i);
+        }
+    }
+    if (firstWith < 0)
+    {
+        return;
+    }
+    emit headerDataChanged(Qt::Horizontal, firstWith, lastWith);
 }
 
 void LogModel::RefreshColumnHealth()

--- a/app/src/main_window.cpp
+++ b/app/src/main_window.cpp
@@ -35,6 +35,7 @@
 #include <QApplication>
 #include <QCheckBox>
 #include <QCloseEvent>
+#include <QCollator>
 #include <QCoreApplication>
 #include <QDateTime>
 #include <QFileDialog>
@@ -1003,6 +1004,24 @@ MainWindow::MainWindow(ThemeControl *theme, SessionHistoryManager *historyManage
                 if (const auto *levelMapping = mModel->LastBatchLevelDemoteMappingFor(columnIndex);
                     levelMapping != nullptr)
                 {
+                    // Re-entrancy guard: the rewrite + downstream
+                    // `MirrorSessionStateToConfiguration` /
+                    // `SyncColumnFilterIndicators` calls walk
+                    // `mFilters` and the configuration. If any
+                    // of those ever transitively re-emits
+                    // `enumColumnsChanged` for the same column
+                    // (today they don't, but the guard makes the
+                    // invariant local rather than global), the
+                    // re-entrant lambda would see half-rewritten
+                    // `filter.filterValues`. Released before the
+                    // trailing rebuild block so its own
+                    // `mApplyingEnumRebuild` latch can do its job.
+                    if (mApplyingEnumRebuild)
+                    {
+                        return;
+                    }
+                    mApplyingEnumRebuild = true;
+                    const auto demoteGuard = qScopeGuard([this]() { mApplyingEnumRebuild = false; });
                     const auto &columnsCfg = mModel->Configuration().columns;
                     const loglib::LogConfiguration::Column *demotedColumn =
                         std::cmp_less(columnIndex, columnsCfg.size()) ? &columnsCfg[static_cast<size_t>(columnIndex)]
@@ -3126,6 +3145,17 @@ void MainWindow::BuildMainToolbar()
 
 void MainWindow::RefreshThemedIcons()
 {
+    // Drop the model's cached funnel pixmap first, before the
+    // toolbar guard below: the model is built earlier than the
+    // toolbar and outlives it during teardown, so the funnel
+    // refresh needs to run even when the toolbar leg is a no-op.
+    // Constructor-time + shutdown-time refreshes both pass the
+    // model's own null check harmlessly.
+    if (mModel != nullptr)
+    {
+        mModel->RefreshHeaderIcons();
+    }
+
     // Constructor-time `changeEvent` (an initial palette
     // notification can land before `BuildMainToolbar` runs) and
     // shutdown-time refreshes (Qt has already cleared the
@@ -3183,18 +3213,6 @@ void MainWindow::RefreshThemedIcons()
         // going stale.
         const QWidget *anchor = entry.anchor.data();
         action->setIcon(buildIcon(path, onPath, anchor != nullptr ? anchor : this));
-    }
-
-    // Drop the model's cached funnel pixmap so the header decoration
-    // re-renders against the new palette / DPR. No-op when no column
-    // has a filter. Centralised here (rather than in `OnThemeChanged`
-    // alone) so OS-driven `changeEvent` paths -- palette, theme, and
-    // DPI updates -- refresh the funnel alongside toolbar icons; the
-    // funnel is also a tinted glyph and must track the same render
-    // policy.
-    if (mModel != nullptr)
-    {
-        mModel->RefreshHeaderIcons();
     }
 }
 
@@ -5181,6 +5199,14 @@ void MainWindow::AddLogFilter(const QString &id, const loglib::LogConfiguration:
     connect(removeAction, &QAction::triggered, this, [this, id]() { ClearFilter(id); });
     ui->actionClearAllFilters->setDisabled(false);
 
+    // Sync mirrors the gating of `MirrorSessionStateToConfiguration`
+    // / `UpdateFilters` above: bulk callers (e.g.
+    // `RebuildFiltersFromConfiguration`) defer this work to a single
+    // trailing call after their loop. `MarkFiltersDirty` above is
+    // intentionally NOT gated -- it's an idempotent boolean flip,
+    // so paying it per-filter during a config reload is free, and a
+    // future caller that forgets to mark dirty after a deferred run
+    // would leak unsaved state.
     if (!deferSync)
     {
         SyncColumnFilterIndicators();
@@ -5212,11 +5238,23 @@ void MainWindow::SyncColumnFilterIndicators()
         }
         // Sort each per-column list by display title so tooltip
         // ordering is stable across `mFilters`'s unordered iteration.
+        // `QCollator` (locale-aware, case-insensitive) reads more
+        // naturally than the default `QString::operator<` for users
+        // running translated locales -- the latter is purely
+        // codepoint-ordered and would put `"Banana"` before
+        // `"apple"` because `'B' < 'a'`. Numeric mode keeps
+        // numeric prefixes in natural order ("9", "10" not "10",
+        // "9").
+        QCollator collator;
+        collator.setCaseSensitivity(Qt::CaseInsensitive);
+        collator.setNumericMode(true);
         for (auto &titles : perColumnTitles)
         {
             if (titles.size() > 1)
             {
-                std::sort(titles.begin(), titles.end());
+                std::sort(titles.begin(), titles.end(), [&collator](const QString &a, const QString &b) {
+                    return collator.compare(a, b) < 0;
+                });
             }
         }
     }
@@ -5847,18 +5885,17 @@ void MainWindow::OnSourceColumnsMoved(
     {
         UpdateFilters();
     }
-    // Always sync header indicators after a move: even when no
-    // `filter.row` changed (so `runtimeFilterChanged` is false),
-    // the model emitted `columnsMoved` and a parallel column
-    // cache that didn't see the move would now be aligned to the
-    // wrong indices. The diff guard inside `SetColumnFilterDetails`
-    // makes the no-op case free.
-    SyncColumnFilterIndicators();
-
     // Re-apply hidden flags after the move. Qt usually carries them
     // through `columnsMoved`, but `initializeSections()` clears them
     // when the source has zero rows. Pinned by
     // `TestSourceColumnMovePreservesHiddenColumn`.
+    //
+    // `ApplyColumnVisibility` ends with its own
+    // `SyncColumnFilterIndicators` call, so the funnel cache picks
+    // up the new section indices in the same pass. Calling sync
+    // before this would emit `headerDataChanged` while hidden flags
+    // are still mid-flight -- a header repaint at that moment could
+    // briefly show the funnel on the wrong column.
     ApplyColumnVisibility();
 }
 

--- a/app/src/main_window.cpp
+++ b/app/src/main_window.cpp
@@ -4380,6 +4380,7 @@ void MainWindow::RebuildFiltersFromConfiguration()
     }
     MirrorSessionStateToConfiguration();
     UpdateFilters();
+    SyncColumnFilterIndicators();
 
     if (!dropped.empty())
     {
@@ -4838,6 +4839,7 @@ void MainWindow::ClearAllFilters()
 
     ui->actionClearAllFilters->setDisabled(true);
     MarkFiltersDirty();
+    SyncColumnFilterIndicators();
 }
 
 void MainWindow::ClearFilter(const QString &filterID, bool deferSync)
@@ -4870,6 +4872,11 @@ void MainWindow::ClearFilter(const QString &filterID, bool deferSync)
     if (filters == 0)
     {
         ui->actionClearAllFilters->setDisabled(true);
+    }
+
+    if (!deferSync)
+    {
+        SyncColumnFilterIndicators();
     }
 }
 
@@ -5153,6 +5160,47 @@ void MainWindow::AddLogFilter(const QString &id, const loglib::LogConfiguration:
     const QAction *removeAction = menuItem->addAction(tr("Remove"));
     connect(removeAction, &QAction::triggered, this, [this, id]() { ClearFilter(id); });
     ui->actionClearAllFilters->setDisabled(false);
+
+    if (!deferSync)
+    {
+        SyncColumnFilterIndicators();
+    }
+}
+
+void MainWindow::SyncColumnFilterIndicators()
+{
+    if (mModel == nullptr)
+    {
+        return;
+    }
+    const int cols = mModel->columnCount();
+    std::vector<QStringList> perColumnTitles;
+    if (cols > 0)
+    {
+        perColumnTitles.resize(static_cast<size_t>(cols));
+        for (const auto &[id, filter] : mFilters)
+        {
+            if (filter.row < 0 || filter.row >= cols)
+            {
+                // Stale row from a concurrent column drop; skip
+                // silently. The next mutation that touches this
+                // filter (or the next `RebuildFiltersFromConfiguration`)
+                // will either remap or evict it.
+                continue;
+            }
+            perColumnTitles[static_cast<size_t>(filter.row)].append(BuildFilterTitle(filter));
+        }
+        // Sort each per-column list by display title so tooltip
+        // ordering is stable across `mFilters`'s unordered iteration.
+        for (auto &titles : perColumnTitles)
+        {
+            if (titles.size() > 1)
+            {
+                std::sort(titles.begin(), titles.end());
+            }
+        }
+    }
+    mModel->SetColumnFilterDetails(std::move(perColumnTitles));
 }
 
 void MainWindow::OnThemeChanged()
@@ -5208,6 +5256,14 @@ void MainWindow::OnThemeChanged()
     // can land without an event-loop palette change (e.g. a Force
     // mode toggle that pins the same OS scheme).
     RefreshThemedIcons();
+
+    // Drop the model's cached funnel pixmap so the header decoration
+    // re-renders against the new palette. No-op when no column has
+    // a filter.
+    if (mModel != nullptr)
+    {
+        mModel->RefreshHeaderIcons();
+    }
 }
 
 void MainWindow::ApplyThemedWindowIcon()
@@ -5776,6 +5832,13 @@ void MainWindow::OnSourceColumnsMoved(
     {
         UpdateFilters();
     }
+    // Always sync header indicators after a move: even when no
+    // `filter.row` changed (so `runtimeFilterChanged` is false),
+    // the model emitted `columnsMoved` and a parallel column
+    // cache that didn't see the move would now be aligned to the
+    // wrong indices. The diff guard inside `SetColumnFilterDetails`
+    // makes the no-op case free.
+    SyncColumnFilterIndicators();
 
     // Re-apply hidden flags after the move. Qt usually carries them
     // through `columnsMoved`, but `initializeSections()` clears them
@@ -6191,6 +6254,11 @@ void MainWindow::SetColumnVisible(int logicalIndex, bool visible)
     // to. Invalidate explicitly so the indicator can't strand a
     // count that still includes hits from hidden columns.
     OnFindCacheInvalidated();
+    // Header indicator cache is normally a no-op here (hide/show
+    // doesn't change `filter.row` or `BuildFilterTitle`), but
+    // re-syncing keeps the wiring symmetric with `ApplyColumnVisibility`
+    // and costs only a model-side diff when nothing actually moved.
+    SyncColumnFilterIndicators();
 }
 
 void MainWindow::ApplyColumnVisibility()
@@ -6210,6 +6278,10 @@ void MainWindow::ApplyColumnVisibility()
     // called from header-recovery and configuration-load paths. Drop
     // the find cache for the same reason as `SetColumnVisible`.
     OnFindCacheInvalidated();
+    // Same reasoning as `SetColumnVisible`: the cache rarely needs
+    // updating but the sync is cheap and keeps the column-shape
+    // signal points symmetric.
+    SyncColumnFilterIndicators();
 }
 
 void MainWindow::RebuildViewMenu()

--- a/app/src/main_window.cpp
+++ b/app/src/main_window.cpp
@@ -1005,17 +1005,9 @@ MainWindow::MainWindow(ThemeControl *theme, SessionHistoryManager *historyManage
                     levelMapping != nullptr)
                 {
                     // Re-entrancy guard: the rewrite + downstream
-                    // `MirrorSessionStateToConfiguration` /
-                    // `SyncColumnFilterIndicators` calls walk
-                    // `mFilters` and the configuration. If any
-                    // of those ever transitively re-emits
-                    // `enumColumnsChanged` for the same column
-                    // (today they don't, but the guard makes the
-                    // invariant local rather than global), the
-                    // re-entrant lambda would see half-rewritten
-                    // `filter.filterValues`. Released before the
-                    // trailing rebuild block so its own
-                    // `mApplyingEnumRebuild` latch can do its job.
+                    // sync calls walk `mFilters`, so a transitive
+                    // re-emit of `enumColumnsChanged` for the same
+                    // column would see half-rewritten state.
                     if (mApplyingEnumRebuild)
                     {
                         return;
@@ -1082,13 +1074,9 @@ MainWindow::MainWindow(ThemeControl *theme, SessionHistoryManager *historyManage
                     // snapshotted whole, so per-filter mirroring would
                     // redo the same work.
                     MirrorSessionStateToConfiguration();
-                    // Header funnel titles cache `BuildFilterTitle`,
-                    // which walked the canonical names (`"Info"`, ...)
-                    // before the rewrite and now needs the raw bytes.
-                    // Without this resync the tooltip keeps listing
-                    // the pre-demote names until the next filter
-                    // mutation or `RebuildFiltersFromConfiguration`
-                    // call lands.
+                    // Resync the tooltip cache: it was built from
+                    // the canonical names (`"Info"`, ...) and now
+                    // needs the rewritten raw bytes.
                     SyncColumnFilterIndicators();
                 }
             }
@@ -3145,12 +3133,10 @@ void MainWindow::BuildMainToolbar()
 
 void MainWindow::RefreshThemedIcons()
 {
-    // Drop the model's cached funnel pixmap first, before the
-    // toolbar guard below: the model is built earlier than the
-    // toolbar and outlives it during teardown, so the funnel
-    // refresh needs to run even when the toolbar leg is a no-op.
-    // Constructor-time + shutdown-time refreshes both pass the
-    // model's own null check harmlessly.
+    // Drop the model's cached funnel pixmap before the toolbar
+    // null guard below: the model outlives the toolbar across
+    // construction and teardown, so the funnel refresh needs to
+    // run even when the toolbar leg is a no-op.
     if (mModel != nullptr)
     {
         mModel->RefreshHeaderIcons();
@@ -5199,14 +5185,9 @@ void MainWindow::AddLogFilter(const QString &id, const loglib::LogConfiguration:
     connect(removeAction, &QAction::triggered, this, [this, id]() { ClearFilter(id); });
     ui->actionClearAllFilters->setDisabled(false);
 
-    // Sync mirrors the gating of `MirrorSessionStateToConfiguration`
-    // / `UpdateFilters` above: bulk callers (e.g.
-    // `RebuildFiltersFromConfiguration`) defer this work to a single
-    // trailing call after their loop. `MarkFiltersDirty` above is
-    // intentionally NOT gated -- it's an idempotent boolean flip,
-    // so paying it per-filter during a config reload is free, and a
-    // future caller that forgets to mark dirty after a deferred run
-    // would leak unsaved state.
+    // Mirror the deferSync gating used for
+    // `MirrorSessionStateToConfiguration` / `UpdateFilters`: bulk
+    // callers run a single trailing sync after their loop.
     if (!deferSync)
     {
         SyncColumnFilterIndicators();
@@ -5228,23 +5209,16 @@ void MainWindow::SyncColumnFilterIndicators()
         {
             if (filter.row < 0 || filter.row >= cols)
             {
-                // Stale row from a concurrent column drop; skip
-                // silently. The next mutation that touches this
-                // filter (or the next `RebuildFiltersFromConfiguration`)
-                // will either remap or evict it.
+                // Stale row from a concurrent column drop; the
+                // next filter mutation will remap or evict it.
                 continue;
             }
             perColumnTitles[static_cast<size_t>(filter.row)].append(BuildFilterTitle(filter));
         }
-        // Sort each per-column list by display title so tooltip
-        // ordering is stable across `mFilters`'s unordered iteration.
-        // `QCollator` (locale-aware, case-insensitive) reads more
-        // naturally than the default `QString::operator<` for users
-        // running translated locales -- the latter is purely
-        // codepoint-ordered and would put `"Banana"` before
-        // `"apple"` because `'B' < 'a'`. Numeric mode keeps
-        // numeric prefixes in natural order ("9", "10" not "10",
-        // "9").
+        // Sort titles so tooltip ordering is stable across
+        // `mFilters`'s unordered iteration. Use `QCollator` for
+        // locale-aware, case-insensitive ordering with numeric
+        // mode (so "9" sorts before "10").
         QCollator collator;
         collator.setCaseSensitivity(Qt::CaseInsensitive);
         collator.setNumericMode(true);
@@ -5309,13 +5283,10 @@ void MainWindow::OnThemeChanged()
     }
 
     // Re-tint the Lucide icons so a Light <-> Dark flip keeps them
-    // visible. `changeEvent` also fires for OS-driven palette
-    // changes, but `themeChanged` is the in-app entry point and
-    // can land without an event-loop palette change (e.g. a Force
-    // mode toggle that pins the same OS scheme).
-    // `RefreshThemedIcons` also drops the model's cached funnel
-    // pixmap so the header decoration re-renders against the new
-    // palette.
+    // visible. `themeChanged` is the in-app entry point and can
+    // land without an event-loop palette change (e.g. a Force-mode
+    // toggle that pins the same OS scheme). Also drops the model's
+    // cached funnel pixmap so the header decoration re-renders.
     RefreshThemedIcons();
 }
 
@@ -5890,12 +5861,10 @@ void MainWindow::OnSourceColumnsMoved(
     // when the source has zero rows. Pinned by
     // `TestSourceColumnMovePreservesHiddenColumn`.
     //
-    // `ApplyColumnVisibility` ends with its own
-    // `SyncColumnFilterIndicators` call, so the funnel cache picks
-    // up the new section indices in the same pass. Calling sync
-    // before this would emit `headerDataChanged` while hidden flags
-    // are still mid-flight -- a header repaint at that moment could
-    // briefly show the funnel on the wrong column.
+    // The trailing `SyncColumnFilterIndicators` inside
+    // `ApplyColumnVisibility` picks up the new section indices.
+    // Syncing earlier could flash the funnel on the wrong column
+    // while hidden flags are still mid-flight.
     ApplyColumnVisibility();
 }
 
@@ -6306,10 +6275,9 @@ void MainWindow::SetColumnVisible(int logicalIndex, bool visible)
     // to. Invalidate explicitly so the indicator can't strand a
     // count that still includes hits from hidden columns.
     OnFindCacheInvalidated();
-    // Header indicator cache is normally a no-op here (hide/show
-    // doesn't change `filter.row` or `BuildFilterTitle`), but
-    // re-syncing keeps the wiring symmetric with `ApplyColumnVisibility`
-    // and costs only a model-side diff when nothing actually moved.
+    // Hide/show doesn't change `filter.row`, so this sync is
+    // usually a model-side no-op. Kept for symmetry with
+    // `ApplyColumnVisibility`.
     SyncColumnFilterIndicators();
 }
 
@@ -6330,9 +6298,8 @@ void MainWindow::ApplyColumnVisibility()
     // called from header-recovery and configuration-load paths. Drop
     // the find cache for the same reason as `SetColumnVisible`.
     OnFindCacheInvalidated();
-    // Same reasoning as `SetColumnVisible`: the cache rarely needs
-    // updating but the sync is cheap and keeps the column-shape
-    // signal points symmetric.
+    // See `SetColumnVisible`: usually a no-op, kept for symmetry
+    // across column-shape signal points.
     SyncColumnFilterIndicators();
 }
 

--- a/app/src/main_window.cpp
+++ b/app/src/main_window.cpp
@@ -1063,6 +1063,14 @@ MainWindow::MainWindow(ThemeControl *theme, SessionHistoryManager *historyManage
                     // snapshotted whole, so per-filter mirroring would
                     // redo the same work.
                     MirrorSessionStateToConfiguration();
+                    // Header funnel titles cache `BuildFilterTitle`,
+                    // which walked the canonical names (`"Info"`, ...)
+                    // before the rewrite and now needs the raw bytes.
+                    // Without this resync the tooltip keeps listing
+                    // the pre-demote names until the next filter
+                    // mutation or `RebuildFiltersFromConfiguration`
+                    // call lands.
+                    SyncColumnFilterIndicators();
                 }
             }
         }
@@ -3176,6 +3184,18 @@ void MainWindow::RefreshThemedIcons()
         const QWidget *anchor = entry.anchor.data();
         action->setIcon(buildIcon(path, onPath, anchor != nullptr ? anchor : this));
     }
+
+    // Drop the model's cached funnel pixmap so the header decoration
+    // re-renders against the new palette / DPR. No-op when no column
+    // has a filter. Centralised here (rather than in `OnThemeChanged`
+    // alone) so OS-driven `changeEvent` paths -- palette, theme, and
+    // DPI updates -- refresh the funnel alongside toolbar icons; the
+    // funnel is also a tinted glyph and must track the same render
+    // policy.
+    if (mModel != nullptr)
+    {
+        mModel->RefreshHeaderIcons();
+    }
 }
 
 void MainWindow::RebuildAddFilterMenu(QMenu *menu)
@@ -5255,15 +5275,10 @@ void MainWindow::OnThemeChanged()
     // changes, but `themeChanged` is the in-app entry point and
     // can land without an event-loop palette change (e.g. a Force
     // mode toggle that pins the same OS scheme).
+    // `RefreshThemedIcons` also drops the model's cached funnel
+    // pixmap so the header decoration re-renders against the new
+    // palette.
     RefreshThemedIcons();
-
-    // Drop the model's cached funnel pixmap so the header decoration
-    // re-renders against the new palette. No-op when no column has
-    // a filter.
-    if (mModel != nullptr)
-    {
-        mModel->RefreshHeaderIcons();
-    }
 }
 
 void MainWindow::ApplyThemedWindowIcon()

--- a/cmake/license_snippets/lucide.txt
+++ b/cmake/license_snippets/lucide.txt
@@ -1,11 +1,11 @@
 Lucide icons -- https://lucide.dev
 ==================================
 
-The 13 SVG files under `resources/icons/` (registered through
+The 14 SVG files under `resources/icons/` (registered through
 `resources/resources.qrc` and rendered by `app/src/icon_loader.cpp`)
 are taken verbatim from the Lucide project's icon set:
 
-    arrow-down-to-line, bookmark, file-clock, folder-open,
+    arrow-down-to-line, bookmark, file-clock, folder-open, funnel,
     funnel-plus, funnel-x, panel-right-open, pause, radio-tower,
     search, settings-2, square-play, square
 

--- a/resources/icons/funnel.svg
+++ b/resources/icons/funnel.svg
@@ -1,0 +1,13 @@
+<svg
+  xmlns="http://www.w3.org/2000/svg"
+  width="24"
+  height="24"
+  viewBox="0 0 24 24"
+  fill="none"
+  stroke="currentColor"
+  stroke-width="2"
+  stroke-linecap="round"
+  stroke-linejoin="round"
+>
+  <path d="M10 20a1 1 0 0 0 .553.895l2 1A1 1 0 0 0 14 21v-7a2 2 0 0 1 .517-1.341L21.74 4.67A1 1 0 0 0 21 3H3a1 1 0 0 0-.742 1.67l7.225 7.989A2 2 0 0 1 10 14z" />
+</svg>

--- a/resources/resources.qrc
+++ b/resources/resources.qrc
@@ -17,6 +17,7 @@
         <file>icons/bookmark.svg</file>
         <file>icons/file-clock.svg</file>
         <file>icons/folder-open.svg</file>
+        <file>icons/funnel.svg</file>
         <file>icons/funnel-plus.svg</file>
         <file>icons/funnel-x.svg</file>
         <file>icons/panel-right-open.svg</file>

--- a/test/app/src/main_window_test.cpp
+++ b/test/app/src/main_window_test.cpp
@@ -7966,8 +7966,7 @@ private slots:
         const QVariant decoration = model->headerData(msgCol, Qt::Horizontal, Qt::DecorationRole);
         QVERIFY(decoration.canConvert<QIcon>());
         QVERIFY2(
-            !decoration.value<QIcon>().isNull(),
-            "filtered column header must surface a (themed funnel) decoration"
+            !decoration.value<QIcon>().isNull(), "filtered column header must surface a (themed funnel) decoration"
         );
 
         const QString tooltip = model->headerData(msgCol, Qt::Horizontal, Qt::ToolTipRole).toString();
@@ -8046,8 +8045,7 @@ private slots:
 
         QVERIFY2(mWindow->Filters().empty(), "ClearAllFilters must drain mFilters");
         QVERIFY2(
-            !model->HasFilterForColumn(msgCol),
-            "ClearAllFilters must propagate into LogModel::HasFilterForColumn"
+            !model->HasFilterForColumn(msgCol), "ClearAllFilters must propagate into LogModel::HasFilterForColumn"
         );
 
         const QVariant decoration = model->headerData(msgCol, Qt::Horizontal, Qt::DecorationRole);
@@ -8106,10 +8104,7 @@ private slots:
         // Warning precedence: the painted glyph must have switched
         // from the funnel to the warning icon. Comparing pixmaps
         // (not QIcons) avoids cache-key flakiness.
-        QVERIFY2(
-            combinedImage != funnelOnlyImage,
-            "warning must replace funnel decoration when both conditions apply"
-        );
+        QVERIFY2(combinedImage != funnelOnlyImage, "warning must replace funnel decoration when both conditions apply");
 
         const QString tooltip = model->headerData(msgCol, Qt::Horizontal, Qt::ToolTipRole).toString();
         QVERIFY2(
@@ -8205,20 +8200,13 @@ private slots:
         QVERIFY2(msgColAfter != src, "fixture sanity: msg must have actually moved sections");
 
         QVERIFY2(
-            model->HasFilterForColumn(msgColAfter),
-            "funnel cache must follow the moved column to its new section index"
+            model->HasFilterForColumn(msgColAfter), "funnel cache must follow the moved column to its new section index"
         );
-        QVERIFY2(
-            !model->HasFilterForColumn(src),
-            "funnel must not be left stranded at the pre-move section"
-        );
+        QVERIFY2(!model->HasFilterForColumn(src), "funnel must not be left stranded at the pre-move section");
 
         const QVariant decoration = model->headerData(msgColAfter, Qt::Horizontal, Qt::DecorationRole);
         QVERIFY(decoration.canConvert<QIcon>());
-        QVERIFY2(
-            !decoration.value<QIcon>().isNull(),
-            "funnel decoration must render at the post-move section index"
-        );
+        QVERIFY2(!decoration.value<QIcon>().isNull(), "funnel decoration must render at the post-move section index");
     }
 
     // Hiding then re-showing a filtered column keeps the funnel
@@ -8248,17 +8236,11 @@ private slots:
         mWindow->SetColumnVisible(msgCol, false);
         QCoreApplication::processEvents();
         // Hiding is a header-view concern; the filter cache stays.
-        QVERIFY2(
-            model->HasFilterForColumn(msgCol),
-            "hiding a column must not drop the per-column filter cache entry"
-        );
+        QVERIFY2(model->HasFilterForColumn(msgCol), "hiding a column must not drop the per-column filter cache entry");
 
         mWindow->SetColumnVisible(msgCol, true);
         QCoreApplication::processEvents();
-        QVERIFY2(
-            model->HasFilterForColumn(msgCol),
-            "re-showing the column must surface the same cache entry"
-        );
+        QVERIFY2(model->HasFilterForColumn(msgCol), "re-showing the column must surface the same cache entry");
 
         const QVariant decoration = model->headerData(msgCol, Qt::Horizontal, Qt::DecorationRole);
         QVERIFY(decoration.canConvert<QIcon>());
@@ -8352,12 +8334,10 @@ private slots:
 
         const QString tooltipAfter = model->headerData(levelCol, Qt::Horizontal, Qt::ToolTipRole).toString();
         QVERIFY2(
-            tooltipAfter.contains(QStringLiteral("Filters:")),
-            "tooltip post-demote must keep its Filters section"
+            tooltipAfter.contains(QStringLiteral("Filters:")), "tooltip post-demote must keep its Filters section"
         );
         QVERIFY2(
-            tooltipAfter.contains(QStringLiteral("info")),
-            "tooltip post-demote must list the rewritten raw value"
+            tooltipAfter.contains(QStringLiteral("info")), "tooltip post-demote must list the rewritten raw value"
         );
         // The canonical-name bullet `&bull; Info` must be gone.
         // We can't just `!contains("Info")` because raw `info`
@@ -8529,8 +8509,7 @@ private slots:
 
         const QString numericTooltip = model->headerData(msgCol, Qt::Horizontal, Qt::ToolTipRole).toString();
         QVERIFY2(
-            numericTooltip.contains(QStringLiteral("Filters:")),
-            "numeric filter must show in the Filters section"
+            numericTooltip.contains(QStringLiteral("Filters:")), "numeric filter must show in the Filters section"
         );
         // Both bounds must appear; the separator (`>=`, `<=`,
         // dash) is an implementation detail.

--- a/test/app/src/main_window_test.cpp
+++ b/test/app/src/main_window_test.cpp
@@ -7903,6 +7903,281 @@ private slots:
         QCOMPARE(levelHealth->matchingSlots, levelHealth->presentSlots);
     }
 
+    // Without any active filter the column header is silent: the
+    // decoration role returns a null variant and the tooltip
+    // carries no "Filters:" section. Pin the baseline so the
+    // tests below regress against drift -- a stray funnel here
+    // would mean `SyncColumnFilterIndicators` is being called
+    // with stale state.
+    void TestHeaderFilterIndicatorAbsentWithoutFilters()
+    {
+        const int levelCol = StreamFixtureForColumnTests();
+        QVERIFY2(levelCol >= 0, "level column must exist after streaming");
+        auto *model = mWindow->Model();
+        const int msgCol = ColumnByHeader(*model, QStringLiteral("msg"));
+        QVERIFY2(msgCol >= 0, "msg column must exist after streaming");
+
+        QVERIFY2(mWindow->Filters().empty(), "no filters submitted; baseline state");
+
+        const QVariant decoration = model->headerData(msgCol, Qt::Horizontal, Qt::DecorationRole);
+        // Either a default-constructed QVariant or an empty QIcon
+        // counts as "no decoration"; the warning-mismatch path
+        // uses the same null sentinel and is exercised separately
+        // by `TestColumnHealthFlagsMismatchedType`.
+        if (decoration.canConvert<QIcon>())
+        {
+            QVERIFY2(decoration.value<QIcon>().isNull(), "decoration must be empty when no filter is active");
+        }
+
+        const QVariant tooltip = model->headerData(msgCol, Qt::Horizontal, Qt::ToolTipRole);
+        QVERIFY(tooltip.canConvert<QString>());
+        QVERIFY2(
+            !tooltip.toString().contains(QStringLiteral("Filters:")),
+            "tooltip must not advertise a Filters section when no filter is active"
+        );
+    }
+
+    // Submitting a String filter on a column installs the funnel
+    // decoration and appends a "Filters:" bullet list to the
+    // tooltip carrying the filter title (`BuildFilterTitle`
+    // returns the raw filter string for String filters).
+    void TestHeaderFilterIndicatorAppearsOnAddFilter()
+    {
+        const int levelCol = StreamFixtureForColumnTests();
+        QVERIFY2(levelCol >= 0, "level column must exist after streaming");
+        auto *model = mWindow->Model();
+        const int msgCol = ColumnByHeader(*model, QStringLiteral("msg"));
+        QVERIFY2(msgCol >= 0, "msg column must exist after streaming");
+
+        const QString filterId = QStringLiteral("hf-single");
+        const QString needle = QStringLiteral("m42");
+        QMetaObject::invokeMethod(
+            mWindow,
+            "FilterSubmitted",
+            Qt::DirectConnection,
+            Q_ARG(QString, filterId),
+            Q_ARG(int, msgCol),
+            Q_ARG(QString, needle),
+            Q_ARG(int, static_cast<int>(loglib::LogConfiguration::LogFilter::Match::Contains))
+        );
+        QCoreApplication::processEvents();
+
+        QCOMPARE(mWindow->Filters().size(), static_cast<size_t>(1));
+
+        const QVariant decoration = model->headerData(msgCol, Qt::Horizontal, Qt::DecorationRole);
+        QVERIFY(decoration.canConvert<QIcon>());
+        QVERIFY2(
+            !decoration.value<QIcon>().isNull(),
+            "filtered column header must surface a (themed funnel) decoration"
+        );
+
+        const QString tooltip = model->headerData(msgCol, Qt::Horizontal, Qt::ToolTipRole).toString();
+        QVERIFY2(tooltip.contains(QStringLiteral("Filters:")), "tooltip must include a Filters section");
+        QVERIFY2(tooltip.contains(needle), "tooltip must list the submitted filter title");
+    }
+
+    // Two filters on the same column render as two tooltip
+    // bullets in alphabetical order regardless of insertion
+    // order. Pins the canonical sort that
+    // `MainWindow::SyncColumnFilterIndicators` applies before
+    // pushing into `LogModel::SetColumnFilterDetails`, so
+    // `mFilters`'s unordered iteration cannot flake the rendered
+    // order.
+    void TestHeaderFilterTooltipListsMultipleFiltersSortedAlphabetically()
+    {
+        const int levelCol = StreamFixtureForColumnTests();
+        QVERIFY2(levelCol >= 0, "level column must exist after streaming");
+        auto *model = mWindow->Model();
+        const int msgCol = ColumnByHeader(*model, QStringLiteral("msg"));
+        QVERIFY2(msgCol >= 0, "msg column must exist after streaming");
+
+        // Insert deliberately reverse-sorted to prove the sort runs.
+        QMetaObject::invokeMethod(
+            mWindow,
+            "FilterSubmitted",
+            Qt::DirectConnection,
+            Q_ARG(QString, QStringLiteral("hf-zebra")),
+            Q_ARG(int, msgCol),
+            Q_ARG(QString, QStringLiteral("zebra")),
+            Q_ARG(int, static_cast<int>(loglib::LogConfiguration::LogFilter::Match::Contains))
+        );
+        QMetaObject::invokeMethod(
+            mWindow,
+            "FilterSubmitted",
+            Qt::DirectConnection,
+            Q_ARG(QString, QStringLiteral("hf-apple")),
+            Q_ARG(int, msgCol),
+            Q_ARG(QString, QStringLiteral("apple")),
+            Q_ARG(int, static_cast<int>(loglib::LogConfiguration::LogFilter::Match::Contains))
+        );
+        QCoreApplication::processEvents();
+
+        QCOMPARE(mWindow->Filters().size(), static_cast<size_t>(2));
+
+        const QString tooltip = model->headerData(msgCol, Qt::Horizontal, Qt::ToolTipRole).toString();
+        const int applePos = tooltip.indexOf(QStringLiteral("apple"));
+        const int zebraPos = tooltip.indexOf(QStringLiteral("zebra"));
+        QVERIFY2(applePos >= 0 && zebraPos >= 0, "tooltip must mention both filter titles");
+        QVERIFY2(applePos < zebraPos, "tooltip must list filter titles in alphabetical order");
+    }
+
+    // `ClearAllFilters` returns the header to the baseline pinned
+    // in `TestHeaderFilterIndicatorAbsentWithoutFilters`: no
+    // decoration, no "Filters:" tooltip section. Catches the
+    // missing trailing `SyncColumnFilterIndicators()` regression
+    // (the bug where `mColumnFilterDetails` would survive a wipe).
+    void TestHeaderFilterIndicatorClearsOnClearAll()
+    {
+        const int levelCol = StreamFixtureForColumnTests();
+        QVERIFY2(levelCol >= 0, "level column must exist after streaming");
+        auto *model = mWindow->Model();
+        const int msgCol = ColumnByHeader(*model, QStringLiteral("msg"));
+        QVERIFY2(msgCol >= 0, "msg column must exist after streaming");
+
+        QMetaObject::invokeMethod(
+            mWindow,
+            "FilterSubmitted",
+            Qt::DirectConnection,
+            Q_ARG(QString, QStringLiteral("hf-temporary")),
+            Q_ARG(int, msgCol),
+            Q_ARG(QString, QStringLiteral("m1")),
+            Q_ARG(int, static_cast<int>(loglib::LogConfiguration::LogFilter::Match::Contains))
+        );
+        QCoreApplication::processEvents();
+        QCOMPARE(mWindow->Filters().size(), static_cast<size_t>(1));
+        QVERIFY2(model->HasFilterForColumn(msgCol), "precondition: filter recorded on msg column");
+
+        QMetaObject::invokeMethod(mWindow, "ClearAllFilters", Qt::DirectConnection);
+        QCoreApplication::processEvents();
+
+        QVERIFY2(mWindow->Filters().empty(), "ClearAllFilters must drain mFilters");
+        QVERIFY2(
+            !model->HasFilterForColumn(msgCol),
+            "ClearAllFilters must propagate into LogModel::HasFilterForColumn"
+        );
+
+        const QVariant decoration = model->headerData(msgCol, Qt::Horizontal, Qt::DecorationRole);
+        if (decoration.canConvert<QIcon>())
+        {
+            QVERIFY2(decoration.value<QIcon>().isNull(), "decoration must be empty after ClearAllFilters");
+        }
+        const QString tooltip = model->headerData(msgCol, Qt::Horizontal, Qt::ToolTipRole).toString();
+        QVERIFY2(
+            !tooltip.contains(QStringLiteral("Filters:")),
+            "tooltip must not advertise a Filters section after ClearAllFilters"
+        );
+    }
+
+    // A column that mismatches its configured type AND has an
+    // active filter still surfaces the warning text in the
+    // tooltip; the "Filters:" section coexists. Per the icon
+    // precedence decision the warning glyph wins the decoration
+    // slot, which we verify by snapshotting the icon both with
+    // and without the warning condition active and asserting the
+    // returned QIcon's pixmap actually changes.
+    void TestHeaderWarningAndFilterCoexistInTooltip()
+    {
+        const int levelCol = StreamFixtureForColumnTests();
+        QVERIFY2(levelCol >= 0, "level column must exist after streaming");
+        auto *model = mWindow->Model();
+        const int msgCol = ColumnByHeader(*model, QStringLiteral("msg"));
+        QVERIFY2(msgCol >= 0, "msg column must exist after streaming");
+
+        QMetaObject::invokeMethod(
+            mWindow,
+            "FilterSubmitted",
+            Qt::DirectConnection,
+            Q_ARG(QString, QStringLiteral("hf-coexist")),
+            Q_ARG(int, msgCol),
+            Q_ARG(QString, QStringLiteral("m7")),
+            Q_ARG(int, static_cast<int>(loglib::LogConfiguration::LogFilter::Match::Contains))
+        );
+        QCoreApplication::processEvents();
+        const QVariant funnelOnlyVariant = model->headerData(msgCol, Qt::Horizontal, Qt::DecorationRole);
+        QVERIFY(funnelOnlyVariant.canConvert<QIcon>());
+        const QIcon funnelOnly = funnelOnlyVariant.value<QIcon>();
+        QVERIFY2(!funnelOnly.isNull(), "filter-only decoration must be the funnel icon");
+        const QImage funnelOnlyImage = funnelOnly.pixmap(16, 16).toImage();
+
+        model->ConfigurationManager().SetColumnAutoDetect(static_cast<size_t>(msgCol), false);
+        model->ConfigurationManager().SetColumnType(
+            static_cast<size_t>(msgCol), loglib::LogConfiguration::Type::Integer
+        );
+        model->RefreshColumnHealth();
+        QCoreApplication::processEvents();
+
+        const QVariant combinedVariant = model->headerData(msgCol, Qt::Horizontal, Qt::DecorationRole);
+        QVERIFY(combinedVariant.canConvert<QIcon>());
+        const QIcon combined = combinedVariant.value<QIcon>();
+        QVERIFY2(!combined.isNull(), "warning+filter decoration must still be non-null");
+
+        const QImage combinedImage = combined.pixmap(16, 16).toImage();
+        // Warning precedence: the glyph painted into the header
+        // cell must have switched from the funnel to the warning
+        // icon. Comparing pixmaps tolerates QIcon cache-key churn
+        // across two separate `headerData` calls.
+        QVERIFY2(
+            combinedImage != funnelOnlyImage,
+            "warning must replace funnel decoration when both conditions apply"
+        );
+
+        const QString tooltip = model->headerData(msgCol, Qt::Horizontal, Qt::ToolTipRole).toString();
+        QVERIFY2(
+            tooltip.contains(QStringLiteral("Filters:")),
+            "tooltip must keep the Filters section even when the warning is active"
+        );
+        QVERIFY2(
+            tooltip.contains(QStringLiteral("do not match the configured type")),
+            "tooltip must include the type-mismatch warning section"
+        );
+    }
+
+    // A column rename (`SetColumnHeader` + `NotifyColumnEdited`)
+    // refreshes the bold header line of the tooltip but leaves
+    // the "Filters:" section intact and keeps the funnel
+    // decoration. Anchors that `mColumnFilterDetails` is keyed
+    // by section index, not by column header text -- a rename
+    // must not strand the indicator on an outdated label.
+    void TestHeaderFilterIndicatorSurvivesColumnRename()
+    {
+        const int levelCol = StreamFixtureForColumnTests();
+        QVERIFY2(levelCol >= 0, "level column must exist after streaming");
+        auto *model = mWindow->Model();
+        const int msgCol = ColumnByHeader(*model, QStringLiteral("msg"));
+        QVERIFY2(msgCol >= 0, "msg column must exist after streaming");
+
+        const QString needle = QStringLiteral("m9");
+        QMetaObject::invokeMethod(
+            mWindow,
+            "FilterSubmitted",
+            Qt::DirectConnection,
+            Q_ARG(QString, QStringLiteral("hf-rename")),
+            Q_ARG(int, msgCol),
+            Q_ARG(QString, needle),
+            Q_ARG(int, static_cast<int>(loglib::LogConfiguration::LogFilter::Match::Contains))
+        );
+        QCoreApplication::processEvents();
+        QVERIFY2(model->HasFilterForColumn(msgCol), "precondition: filter recorded on msg column");
+
+        model->ConfigurationManager().SetColumnHeader(static_cast<size_t>(msgCol), std::string("message"));
+        model->NotifyColumnEdited(msgCol);
+        QCoreApplication::processEvents();
+
+        QVERIFY2(
+            model->HasFilterForColumn(msgCol),
+            "rename must not clear the per-column filter cache (keyed by section, not label)"
+        );
+
+        const QVariant decoration = model->headerData(msgCol, Qt::Horizontal, Qt::DecorationRole);
+        QVERIFY(decoration.canConvert<QIcon>());
+        QVERIFY2(!decoration.value<QIcon>().isNull(), "funnel decoration must survive a column rename");
+
+        const QString tooltip = model->headerData(msgCol, Qt::Horizontal, Qt::ToolTipRole).toString();
+        QVERIFY2(tooltip.contains(QStringLiteral("message")), "tooltip header line must reflect the renamed label");
+        QVERIFY2(tooltip.contains(QStringLiteral("Filters:")), "tooltip must keep its Filters section after rename");
+        QVERIFY2(tooltip.contains(needle), "Filters section must still list the active filter title after rename");
+    }
+
     // Status-bar diagnostics button + dialog summary are driven by
     // `ConfigurationDiagnosticsDialog::MismatchedColumnCount`, so they
     // both flip together. Verify the aggregate stays in lockstep with

--- a/test/app/src/main_window_test.cpp
+++ b/test/app/src/main_window_test.cpp
@@ -7903,12 +7903,8 @@ private slots:
         QCOMPARE(levelHealth->matchingSlots, levelHealth->presentSlots);
     }
 
-    // Without any active filter the column header is silent: the
-    // decoration role returns a null variant and the tooltip
-    // carries no "Filters:" section. Pin the baseline so the
-    // tests below regress against drift -- a stray funnel here
-    // would mean `SyncColumnFilterIndicators` is being called
-    // with stale state.
+    // With no active filter, the header has no decoration and no
+    // "Filters:" tooltip section. Baseline for the tests below.
     void TestHeaderFilterIndicatorAbsentWithoutFilters()
     {
         const int levelCol = StreamFixtureForColumnTests();
@@ -7918,13 +7914,8 @@ private slots:
         QVERIFY2(msgCol >= 0, "msg column must exist after streaming");
 
         QVERIFY2(mWindow->Filters().empty(), "no filters submitted; baseline state");
-        // Pin the implicit fixture precondition: the `msg` column
-        // is auto-detected as `Type::String` and every cell is a
-        // string ("m0", "m1", ...), so no warning glyph occupies
-        // the decoration slot. If a future fixture change ever
-        // introduces a type mismatch, this assertion makes the
-        // failure mode obvious instead of silently passing through
-        // the canConvert branch below.
+        // Fixture precondition: `msg` is type-clean (every cell is
+        // a string), so no warning glyph competes for the slot.
         const auto msgHealth = model->ColumnHealth(msgCol);
         const size_t mismatched = (msgHealth.has_value() && msgHealth->presentSlots > msgHealth->matchingSlots)
                                       ? msgHealth->presentSlots - msgHealth->matchingSlots
@@ -7932,10 +7923,8 @@ private slots:
         QVERIFY2(mismatched == 0, "fixture precondition: msg column must be type-clean (no warning decoration)");
 
         const QVariant decoration = model->headerData(msgCol, Qt::Horizontal, Qt::DecorationRole);
-        // Either a default-constructed QVariant or an empty QIcon
-        // counts as "no decoration"; the warning-mismatch path
-        // uses the same null sentinel and is exercised separately
-        // by `TestColumnHealthFlagsMismatchedType`.
+        // A null `QVariant` and an empty `QIcon` both mean "no
+        // decoration"; accept either.
         if (decoration.canConvert<QIcon>())
         {
             QVERIFY2(decoration.value<QIcon>().isNull(), "decoration must be empty when no filter is active");
@@ -7949,10 +7938,8 @@ private slots:
         );
     }
 
-    // Submitting a String filter on a column installs the funnel
-    // decoration and appends a "Filters:" bullet list to the
-    // tooltip carrying the filter title (`BuildFilterTitle`
-    // returns the raw filter string for String filters).
+    // Submitting a String filter installs the funnel decoration
+    // and adds a "Filters:" bullet listing the filter title.
     void TestHeaderFilterIndicatorAppearsOnAddFilter()
     {
         const int levelCol = StreamFixtureForColumnTests();
@@ -7988,13 +7975,10 @@ private slots:
         QVERIFY2(tooltip.contains(needle), "tooltip must list the submitted filter title");
     }
 
-    // Two filters on the same column render as two tooltip
-    // bullets in alphabetical order regardless of insertion
-    // order. Pins the canonical sort that
-    // `MainWindow::SyncColumnFilterIndicators` applies before
-    // pushing into `LogModel::SetColumnFilterDetails`, so
-    // `mFilters`'s unordered iteration cannot flake the rendered
-    // order.
+    // Two filters on the same column render as bullets in
+    // alphabetical order regardless of insertion order. Pins the
+    // sort in `MainWindow::SyncColumnFilterIndicators` against
+    // `mFilters`'s unordered iteration.
     void TestHeaderFilterTooltipListsMultipleFiltersSortedAlphabetically()
     {
         const int levelCol = StreamFixtureForColumnTests();
@@ -8033,11 +8017,9 @@ private slots:
         QVERIFY2(applePos < zebraPos, "tooltip must list filter titles in alphabetical order");
     }
 
-    // `ClearAllFilters` returns the header to the baseline pinned
-    // in `TestHeaderFilterIndicatorAbsentWithoutFilters`: no
-    // decoration, no "Filters:" tooltip section. Catches the
-    // missing trailing `SyncColumnFilterIndicators()` regression
-    // (the bug where `mColumnFilterDetails` would survive a wipe).
+    // `ClearAllFilters` returns the header to the no-filter
+    // baseline: no decoration, no "Filters:" section. Catches the
+    // missing trailing `SyncColumnFilterIndicators()` regression.
     void TestHeaderFilterIndicatorClearsOnClearAll()
     {
         const int levelCol = StreamFixtureForColumnTests();
@@ -8080,13 +8062,10 @@ private slots:
         );
     }
 
-    // A column that mismatches its configured type AND has an
-    // active filter still surfaces the warning text in the
-    // tooltip; the "Filters:" section coexists. Per the icon
-    // precedence decision the warning glyph wins the decoration
-    // slot, which we verify by snapshotting the icon both with
-    // and without the warning condition active and asserting the
-    // returned QIcon's pixmap actually changes.
+    // A column with both a type mismatch AND an active filter
+    // shows both sections in the tooltip, but the warning glyph
+    // wins the single decoration slot. Verified by snapshotting
+    // the icon pixmap with and without the warning active.
     void TestHeaderWarningAndFilterCoexistInTooltip()
     {
         const int levelCol = StreamFixtureForColumnTests();
@@ -8124,10 +8103,9 @@ private slots:
         QVERIFY2(!combined.isNull(), "warning+filter decoration must still be non-null");
 
         const QImage combinedImage = combined.pixmap(16, 16).toImage();
-        // Warning precedence: the glyph painted into the header
-        // cell must have switched from the funnel to the warning
-        // icon. Comparing pixmaps tolerates QIcon cache-key churn
-        // across two separate `headerData` calls.
+        // Warning precedence: the painted glyph must have switched
+        // from the funnel to the warning icon. Comparing pixmaps
+        // (not QIcons) avoids cache-key flakiness.
         QVERIFY2(
             combinedImage != funnelOnlyImage,
             "warning must replace funnel decoration when both conditions apply"
@@ -8144,12 +8122,9 @@ private slots:
         );
     }
 
-    // A column rename (`SetColumnHeader` + `NotifyColumnEdited`)
-    // refreshes the bold header line of the tooltip but leaves
-    // the "Filters:" section intact and keeps the funnel
-    // decoration. Anchors that `mColumnFilterDetails` is keyed
-    // by section index, not by column header text -- a rename
-    // must not strand the indicator on an outdated label.
+    // Renaming a column refreshes the tooltip header but keeps
+    // the funnel and "Filters:" section. Pins that
+    // `mColumnFilterDetails` is keyed by section, not by label.
     void TestHeaderFilterIndicatorSurvivesColumnRename()
     {
         const int levelCol = StreamFixtureForColumnTests();
@@ -8190,13 +8165,9 @@ private slots:
         QVERIFY2(tooltip.contains(needle), "Filters section must still list the active filter title after rename");
     }
 
-    // Moving a filtered column over another column re-aligns the
-    // funnel decoration with the filter's new section index. Pins
-    // the trailing `SyncColumnFilterIndicators` call inside
-    // `MainWindow::ApplyColumnVisibility` (reached at the end of
-    // `OnSourceColumnsMoved`): without it, the model's
-    // `mColumnFilterDetails` would still report the funnel at the
-    // pre-move section, leaving the decoration stranded.
+    // Moving a filtered column re-aligns the funnel with the new
+    // section index. Pins the `SyncColumnFilterIndicators` call
+    // reached via `OnSourceColumnsMoved -> ApplyColumnVisibility`.
     void TestHeaderFilterIndicatorFollowsColumnMove()
     {
         const int levelColBefore = StreamFixtureForColumnTests();
@@ -8207,9 +8178,8 @@ private slots:
         const int msgCol = ColumnByHeader(*model, QStringLiteral("msg"));
         QVERIFY2(msgCol >= 0, "msg column must exist after streaming");
 
-        // Filter on `msg`; after the move below the filter row
-        // remaps onto the new section index, and the funnel must
-        // follow.
+        // Filter on `msg`; the funnel must follow the column to
+        // its new section index after the move below.
         const QString filterId = QStringLiteral("hf-move");
         QMetaObject::invokeMethod(
             mWindow,
@@ -8252,12 +8222,9 @@ private slots:
     }
 
     // Hiding then re-showing a filtered column keeps the funnel
-    // attached to the filter's section index. Pins the trailing
-    // `SyncColumnFilterIndicators` calls in
-    // `MainWindow::SetColumnVisible` and `ApplyColumnVisibility` --
-    // visibility doesn't change `filter.row`, so the diff guard
-    // makes both calls free, but the symmetric wiring is what
-    // keeps the seam from drifting in either direction.
+    // attached. Visibility doesn't change `filter.row`, so the
+    // sync calls in `SetColumnVisible` / `ApplyColumnVisibility`
+    // are no-ops -- but the symmetric wiring is what we pin.
     void TestHeaderFilterIndicatorSurvivesColumnHideShow()
     {
         const int levelCol = StreamFixtureForColumnTests();
@@ -8280,8 +8247,7 @@ private slots:
 
         mWindow->SetColumnVisible(msgCol, false);
         QCoreApplication::processEvents();
-        // Cache survives a hide -- visibility is a header-view
-        // concern, not a filter-state concern.
+        // Hiding is a header-view concern; the filter cache stays.
         QVERIFY2(
             model->HasFilterForColumn(msgCol),
             "hiding a column must not drop the per-column filter cache entry"
@@ -8302,13 +8268,10 @@ private slots:
         );
     }
 
-    // After a `Type::Level -> Type::String` mid-batch demote the
-    // tooltip's "Filters:" section must reflect the rewritten raw
-    // bytes (`info`, lowercase) rather than the canonical names
-    // the user originally submitted (`Info`). Pins the
-    // `SyncColumnFilterIndicators()` call inside the
-    // `enumColumnsChanged(Demoted)` rewrite block (commit b65edf6).
-    // Mirrors the fixture in `TestLevelFilterTranslatesOnDemoteToString`.
+    // After a mid-batch `Level -> String` demote, the "Filters:"
+    // section must list the rewritten raw bytes (`info`) rather
+    // than the canonical name (`Info`) the user originally
+    // submitted. Pins the resync inside the demote handler.
     void TestHeaderFilterTooltipReflectsRawValuesAfterLevelDemote()
     {
         auto *model = mWindow->findChild<LogModel *>();
@@ -8320,8 +8283,8 @@ private slots:
         loglib::FileLineSource *sourcePtr = fileSource.get();
         (void)model->BeginStreamingForSyncTest(std::move(fileSource));
 
-        // Cap of 3 lets batch 1 promote to Level (dict size 2);
-        // batch 2 trips it and demotes back to String.
+        // Cap of 3: batch 1 promotes to Level (dict size 2);
+        // batch 2 trips the cap and demotes back to String.
         constexpr uint16_t TEST_CAP = 3;
         model->Table().SetEnumValueCap(TEST_CAP);
 
@@ -8348,8 +8311,8 @@ private slots:
             model->Configuration().columns[static_cast<size_t>(levelCol)].type, loglib::LogConfiguration::Type::Level
         );
 
-        // Submit the canonical-name filter `Info` while the column
-        // is still Level. Tooltip pre-demote lists `Info`.
+        // Submit `Info` while the column is still Level; the
+        // pre-demote tooltip lists the canonical name.
         const QString filterId = QStringLiteral("hf-level-demote");
         QVERIFY2(
             QMetaObject::invokeMethod(
@@ -8370,11 +8333,9 @@ private slots:
             "tooltip pre-demote must list the canonical Level name the user submitted"
         );
 
-        // Batch 2: three new distinct values overflow the cap and
-        // demote `level` to String. `MainWindow`'s `Demoted`
-        // handler rewrites `filterValues` from `["Info"]` to
-        // `["info"]` and the trailing
-        // `SyncColumnFilterIndicators` resyncs the tooltip cache.
+        // Batch 2 overflows the cap and demotes `level` to String.
+        // The `Demoted` handler rewrites `["Info"] -> ["info"]`
+        // and resyncs the tooltip cache.
         {
             loglib::StreamedBatch batch;
             batch.firstLineNumber = 4;
@@ -8398,12 +8359,9 @@ private slots:
             tooltipAfter.contains(QStringLiteral("info")),
             "tooltip post-demote must list the rewritten raw value"
         );
-        // Stricter: the canonical-name `Info` (capital I followed
-        // by lowercase) must NOT appear post-demote -- the
-        // rewrite replaced it with the raw byte form `info`. We
-        // can't just check `!contains("Info")` because the raw
-        // `info` is a substring of `Info`; instead we look for the
-        // exact bullet form.
+        // The canonical-name bullet `&bull; Info` must be gone.
+        // We can't just `!contains("Info")` because raw `info`
+        // is a substring of `Info`, so we look for the bullet.
         QVERIFY2(
             !tooltipAfter.contains(QStringLiteral("&bull; Info")),
             "tooltip post-demote must not still list the pre-demote canonical name"
@@ -8412,12 +8370,10 @@ private slots:
         model->EndStreaming(false);
     }
 
-    // Flipping the application palette (e.g. a Light <-> Dark
-    // theme toggle) must re-tint the funnel decoration. Pins the
-    // `mModel->RefreshHeaderIcons()` call that `RefreshThemedIcons`
-    // makes against the model: without it, the cached funnel
-    // pixmap rendered against the old `WindowText` colour would
-    // stay pinned for the rest of the session.
+    // A palette flip must re-tint the funnel decoration. Pins
+    // the `RefreshHeaderIcons` call inside `RefreshThemedIcons`:
+    // without it, the cached pixmap would stay pinned to the
+    // pre-flip `WindowText` colour.
     void TestHeaderFilterFunnelRetintsAfterPaletteChange()
     {
         const int levelCol = StreamFixtureForColumnTests();
@@ -8462,9 +8418,9 @@ private slots:
             return matching;
         };
 
-        // Save + restore the app palette: `QApplication::setPalette`
-        // is process-global and the cleanup-per-test fixture only
-        // resets `mWindow`, not Qt's globals.
+        // `QApplication::setPalette` is process-global; the
+        // per-test fixture only resets `mWindow`, so we save and
+        // restore the app palette ourselves.
         const QPalette savedAppPalette = QApplication::palette();
         const QPalette savedWindowPalette = mWindow->palette();
         const auto paletteGuard = qScopeGuard([&]() {
@@ -8473,11 +8429,9 @@ private slots:
             QCoreApplication::processEvents();
         });
 
-        // Vivid red palette as the first WindowText. The funnel
-        // tints at `MakeThemedPixmap` time using
-        // `QApplication::palette()` so we have to flip the app
-        // palette, not just the window's, for the model-side
-        // re-render to pick up the new colour.
+        // The funnel tints from `QApplication::palette()`, so we
+        // must flip the app palette (not just the window's) for
+        // the re-render to pick up the new colour.
         QPalette redPalette = QApplication::palette();
         redPalette.setColor(QPalette::Active, QPalette::WindowText, QColor(255, 0, 0));
         redPalette.setColor(QPalette::Inactive, QPalette::WindowText, QColor(255, 0, 0));
@@ -8492,9 +8446,8 @@ private slots:
         const int redPixels = opaquePixelCount(redIcon, qRgb(255, 0, 0));
         QVERIFY2(redPixels > 0, "funnel must paint in the red WindowText colour after the first palette flip");
 
-        // Flip to vivid blue. Without `RefreshHeaderIcons` the
-        // cached red pixmap would stay pinned and the blue-pixel
-        // count would be zero.
+        // Flip to blue. Without `RefreshHeaderIcons` the cached
+        // red pixmap would stay pinned and bluePixels would be 0.
         QPalette bluePalette = QApplication::palette();
         bluePalette.setColor(QPalette::Active, QPalette::WindowText, QColor(0, 0, 255));
         bluePalette.setColor(QPalette::Inactive, QPalette::WindowText, QColor(0, 0, 255));
@@ -8510,10 +8463,9 @@ private slots:
         QVERIFY2(bluePixels > 0, "funnel must repaint in the blue WindowText colour after a palette flip");
     }
 
-    // `BuildFilterTitle` has 5 type branches; the existing tests
-    // only exercise the String branch. Pin the Enumeration and
-    // numeric-range branches so a future formatting change to
-    // either renders into the tooltip the way users expect.
+    // The other tests only cover `BuildFilterTitle`'s String
+    // branch. Pin the Enumeration and numeric-range branches so
+    // their tooltip rendering stays correct.
     void TestHeaderFilterTooltipForEnumAndNumericFilters()
     {
         const int levelCol = StreamFixtureForColumnTests();
@@ -8524,12 +8476,10 @@ private slots:
             loglib::LogConfiguration::Type::Enumeration
         );
 
-        // Enumeration branch: `BuildFilterTitle` joins the
-        // selected values. We assert each value is mentioned;
-        // the exact separator is an implementation detail.
-        // Two-value list lifted into a local so the comma inside
-        // `QStringList{...}` doesn't trip the `Q_ARG` macro
-        // expansion.
+        // Enum branch: assert each selected value is mentioned;
+        // the exact separator is an implementation detail. The
+        // local lifts the `{a, b}` list out of the `Q_ARG` macro,
+        // which would mis-parse the embedded comma.
         const QStringList enumValues{QStringLiteral("info"), QStringLiteral("warn")};
         QVERIFY2(
             QMetaObject::invokeMethod(
@@ -8551,18 +8501,16 @@ private slots:
             "enum tooltip must list every selected value"
         );
 
-        // Wipe the enum filter before testing numeric so the two
-        // branches don't share a section and their bullets don't
-        // collide.
+        // Wipe the enum filter so the numeric branch starts clean
+        // and the two filter bullets don't collide.
         QMetaObject::invokeMethod(mWindow, "ClearAllFilters", Qt::DirectConnection);
         QCoreApplication::processEvents();
         QVERIFY2(mWindow->Filters().empty(), "ClearAllFilters must drain mFilters between branches");
 
-        // Numeric-range branch: install a synthetic numeric
-        // filter via the meta-object slot. The fixture's `msg`
-        // column is a string but `BuildFilterTitle` doesn't probe
-        // the column type -- it formats from `LogFilter::Type` --
-        // so a Number filter on any column exercises the branch.
+        // Numeric branch: `BuildFilterTitle` formats from
+        // `LogFilter::Type`, not the column's declared type, so a
+        // numeric filter on the (string) `msg` column still
+        // exercises this branch.
         const int msgCol = ColumnByHeader(*model, QStringLiteral("msg"));
         QVERIFY2(msgCol >= 0, "msg column must exist after streaming");
         QVERIFY2(
@@ -8584,9 +8532,8 @@ private slots:
             numericTooltip.contains(QStringLiteral("Filters:")),
             "numeric filter must show in the Filters section"
         );
-        // Both bounds must be visible somewhere in the rendered
-        // title. The exact separator (`>=`, `<=`, dash) is an
-        // implementation detail; the bound numerals are not.
+        // Both bounds must appear; the separator (`>=`, `<=`,
+        // dash) is an implementation detail.
         QVERIFY2(
             numericTooltip.contains(QStringLiteral("1.5")) && numericTooltip.contains(QStringLiteral("42")),
             "numeric tooltip must list both bounds"

--- a/test/app/src/main_window_test.cpp
+++ b/test/app/src/main_window_test.cpp
@@ -8010,8 +8010,8 @@ private slots:
         QCOMPARE(mWindow->Filters().size(), static_cast<size_t>(2));
 
         const QString tooltip = model->headerData(msgCol, Qt::Horizontal, Qt::ToolTipRole).toString();
-        const int applePos = tooltip.indexOf(QStringLiteral("apple"));
-        const int zebraPos = tooltip.indexOf(QStringLiteral("zebra"));
+        const qsizetype applePos = tooltip.indexOf(QStringLiteral("apple"));
+        const qsizetype zebraPos = tooltip.indexOf(QStringLiteral("zebra"));
         QVERIFY2(applePos >= 0 && zebraPos >= 0, "tooltip must mention both filter titles");
         QVERIFY2(applePos < zebraPos, "tooltip must list filter titles in alphabetical order");
     }
@@ -8084,7 +8084,7 @@ private slots:
         QCoreApplication::processEvents();
         const QVariant funnelOnlyVariant = model->headerData(msgCol, Qt::Horizontal, Qt::DecorationRole);
         QVERIFY(funnelOnlyVariant.canConvert<QIcon>());
-        const QIcon funnelOnly = funnelOnlyVariant.value<QIcon>();
+        const auto funnelOnly = funnelOnlyVariant.value<QIcon>();
         QVERIFY2(!funnelOnly.isNull(), "filter-only decoration must be the funnel icon");
         const QImage funnelOnlyImage = funnelOnly.pixmap(16, 16).toImage();
 
@@ -8097,7 +8097,7 @@ private slots:
 
         const QVariant combinedVariant = model->headerData(msgCol, Qt::Horizontal, Qt::DecorationRole);
         QVERIFY(combinedVariant.canConvert<QIcon>());
-        const QIcon combined = combinedVariant.value<QIcon>();
+        const auto combined = combinedVariant.value<QIcon>();
         QVERIFY2(!combined.isNull(), "warning+filter decoration must still be non-null");
 
         const QImage combinedImage = combined.pixmap(16, 16).toImage();
@@ -8421,7 +8421,7 @@ private slots:
 
         const QVariant redVariant = model->headerData(msgCol, Qt::Horizontal, Qt::DecorationRole);
         QVERIFY(redVariant.canConvert<QIcon>());
-        const QIcon redIcon = redVariant.value<QIcon>();
+        const auto redIcon = redVariant.value<QIcon>();
         QVERIFY2(!redIcon.isNull(), "funnel decoration must be present under the red palette");
         const int redPixels = opaquePixelCount(redIcon, qRgb(255, 0, 0));
         QVERIFY2(redPixels > 0, "funnel must paint in the red WindowText colour after the first palette flip");
@@ -8437,7 +8437,7 @@ private slots:
 
         const QVariant blueVariant = model->headerData(msgCol, Qt::Horizontal, Qt::DecorationRole);
         QVERIFY(blueVariant.canConvert<QIcon>());
-        const QIcon blueIcon = blueVariant.value<QIcon>();
+        const auto blueIcon = blueVariant.value<QIcon>();
         QVERIFY2(!blueIcon.isNull(), "funnel decoration must be present under the blue palette");
         const int bluePixels = opaquePixelCount(blueIcon, qRgb(0, 0, 255));
         QVERIFY2(bluePixels > 0, "funnel must repaint in the blue WindowText colour after a palette flip");

--- a/test/app/src/main_window_test.cpp
+++ b/test/app/src/main_window_test.cpp
@@ -7918,6 +7918,18 @@ private slots:
         QVERIFY2(msgCol >= 0, "msg column must exist after streaming");
 
         QVERIFY2(mWindow->Filters().empty(), "no filters submitted; baseline state");
+        // Pin the implicit fixture precondition: the `msg` column
+        // is auto-detected as `Type::String` and every cell is a
+        // string ("m0", "m1", ...), so no warning glyph occupies
+        // the decoration slot. If a future fixture change ever
+        // introduces a type mismatch, this assertion makes the
+        // failure mode obvious instead of silently passing through
+        // the canConvert branch below.
+        const auto msgHealth = model->ColumnHealth(msgCol);
+        const size_t mismatched = (msgHealth.has_value() && msgHealth->presentSlots > msgHealth->matchingSlots)
+                                      ? msgHealth->presentSlots - msgHealth->matchingSlots
+                                      : 0;
+        QVERIFY2(mismatched == 0, "fixture precondition: msg column must be type-clean (no warning decoration)");
 
         const QVariant decoration = model->headerData(msgCol, Qt::Horizontal, Qt::DecorationRole);
         // Either a default-constructed QVariant or an empty QIcon
@@ -8176,6 +8188,409 @@ private slots:
         QVERIFY2(tooltip.contains(QStringLiteral("message")), "tooltip header line must reflect the renamed label");
         QVERIFY2(tooltip.contains(QStringLiteral("Filters:")), "tooltip must keep its Filters section after rename");
         QVERIFY2(tooltip.contains(needle), "Filters section must still list the active filter title after rename");
+    }
+
+    // Moving a filtered column over another column re-aligns the
+    // funnel decoration with the filter's new section index. Pins
+    // the trailing `SyncColumnFilterIndicators` call inside
+    // `MainWindow::ApplyColumnVisibility` (reached at the end of
+    // `OnSourceColumnsMoved`): without it, the model's
+    // `mColumnFilterDetails` would still report the funnel at the
+    // pre-move section, leaving the decoration stranded.
+    void TestHeaderFilterIndicatorFollowsColumnMove()
+    {
+        const int levelColBefore = StreamFixtureForColumnTests();
+        QVERIFY2(levelColBefore >= 0, "category column must exist after streaming");
+        auto *model = mWindow->Model();
+        QVERIFY2(model->columnCount() >= 2, "fixture must have at least two columns for a move");
+
+        const int msgCol = ColumnByHeader(*model, QStringLiteral("msg"));
+        QVERIFY2(msgCol >= 0, "msg column must exist after streaming");
+
+        // Filter on `msg`; after the move below the filter row
+        // remaps onto the new section index, and the funnel must
+        // follow.
+        const QString filterId = QStringLiteral("hf-move");
+        QMetaObject::invokeMethod(
+            mWindow,
+            "FilterSubmitted",
+            Qt::DirectConnection,
+            Q_ARG(QString, filterId),
+            Q_ARG(int, msgCol),
+            Q_ARG(QString, QStringLiteral("m1")),
+            Q_ARG(int, static_cast<int>(loglib::LogConfiguration::LogFilter::Match::Contains))
+        );
+        QCoreApplication::processEvents();
+        QVERIFY2(model->HasFilterForColumn(msgCol), "precondition: filter installed on msg column");
+
+        // Move `msg` past `category` (or vice versa). `RemapColumnIndexAfterMove`
+        // shifts the filter row alongside the column itself.
+        const int src = msgCol;
+        const int dest = (msgCol == 0) ? model->columnCount() - 1 : 0;
+        QVERIFY2(model->MoveColumn(src, dest), "MoveColumn must succeed");
+        QCoreApplication::processEvents();
+
+        const int msgColAfter = ColumnByHeader(*model, QStringLiteral("msg"));
+        QVERIFY2(msgColAfter >= 0, "msg column must still exist after move");
+        QVERIFY2(msgColAfter != src, "fixture sanity: msg must have actually moved sections");
+
+        QVERIFY2(
+            model->HasFilterForColumn(msgColAfter),
+            "funnel cache must follow the moved column to its new section index"
+        );
+        QVERIFY2(
+            !model->HasFilterForColumn(src),
+            "funnel must not be left stranded at the pre-move section"
+        );
+
+        const QVariant decoration = model->headerData(msgColAfter, Qt::Horizontal, Qt::DecorationRole);
+        QVERIFY(decoration.canConvert<QIcon>());
+        QVERIFY2(
+            !decoration.value<QIcon>().isNull(),
+            "funnel decoration must render at the post-move section index"
+        );
+    }
+
+    // Hiding then re-showing a filtered column keeps the funnel
+    // attached to the filter's section index. Pins the trailing
+    // `SyncColumnFilterIndicators` calls in
+    // `MainWindow::SetColumnVisible` and `ApplyColumnVisibility` --
+    // visibility doesn't change `filter.row`, so the diff guard
+    // makes both calls free, but the symmetric wiring is what
+    // keeps the seam from drifting in either direction.
+    void TestHeaderFilterIndicatorSurvivesColumnHideShow()
+    {
+        const int levelCol = StreamFixtureForColumnTests();
+        QVERIFY2(levelCol >= 0, "category column must exist after streaming");
+        auto *model = mWindow->Model();
+        const int msgCol = ColumnByHeader(*model, QStringLiteral("msg"));
+        QVERIFY2(msgCol >= 0, "msg column must exist after streaming");
+
+        QMetaObject::invokeMethod(
+            mWindow,
+            "FilterSubmitted",
+            Qt::DirectConnection,
+            Q_ARG(QString, QStringLiteral("hf-visibility")),
+            Q_ARG(int, msgCol),
+            Q_ARG(QString, QStringLiteral("m4")),
+            Q_ARG(int, static_cast<int>(loglib::LogConfiguration::LogFilter::Match::Contains))
+        );
+        QCoreApplication::processEvents();
+        QVERIFY2(model->HasFilterForColumn(msgCol), "precondition: filter installed on msg column");
+
+        mWindow->SetColumnVisible(msgCol, false);
+        QCoreApplication::processEvents();
+        // Cache survives a hide -- visibility is a header-view
+        // concern, not a filter-state concern.
+        QVERIFY2(
+            model->HasFilterForColumn(msgCol),
+            "hiding a column must not drop the per-column filter cache entry"
+        );
+
+        mWindow->SetColumnVisible(msgCol, true);
+        QCoreApplication::processEvents();
+        QVERIFY2(
+            model->HasFilterForColumn(msgCol),
+            "re-showing the column must surface the same cache entry"
+        );
+
+        const QVariant decoration = model->headerData(msgCol, Qt::Horizontal, Qt::DecorationRole);
+        QVERIFY(decoration.canConvert<QIcon>());
+        QVERIFY2(
+            !decoration.value<QIcon>().isNull(),
+            "funnel decoration must reappear with the column on a hide -> show round trip"
+        );
+    }
+
+    // After a `Type::Level -> Type::String` mid-batch demote the
+    // tooltip's "Filters:" section must reflect the rewritten raw
+    // bytes (`info`, lowercase) rather than the canonical names
+    // the user originally submitted (`Info`). Pins the
+    // `SyncColumnFilterIndicators()` call inside the
+    // `enumColumnsChanged(Demoted)` rewrite block (commit b65edf6).
+    // Mirrors the fixture in `TestLevelFilterTranslatesOnDemoteToString`.
+    void TestHeaderFilterTooltipReflectsRawValuesAfterLevelDemote()
+    {
+        auto *model = mWindow->findChild<LogModel *>();
+        QVERIFY2(model != nullptr, "MainWindow must own a LogModel");
+
+        const TempJsonFile emptyFixture(QStringList{});
+        auto file = std::make_unique<loglib::LogFile>(emptyFixture.Path().toStdString());
+        auto fileSource = std::make_unique<loglib::FileLineSource>(std::move(file));
+        loglib::FileLineSource *sourcePtr = fileSource.get();
+        (void)model->BeginStreamingForSyncTest(std::move(fileSource));
+
+        // Cap of 3 lets batch 1 promote to Level (dict size 2);
+        // batch 2 trips it and demotes back to String.
+        constexpr uint16_t TEST_CAP = 3;
+        model->Table().SetEnumValueCap(TEST_CAP);
+
+        loglib::KeyIndex &keys = model->Table().Keys();
+        const auto makeLine = [&](const std::string &value) {
+            std::vector<std::pair<loglib::KeyId, loglib::LogValue>> values;
+            values.emplace_back(keys.GetOrInsert("level"), loglib::LogValue(value));
+            return loglib::LogLine{std::move(values), keys, *sourcePtr, 0};
+        };
+
+        {
+            loglib::StreamedBatch batch;
+            batch.firstLineNumber = 1;
+            batch.newKeys.emplace_back("level");
+            batch.lines.push_back(makeLine("info"));
+            batch.lines.push_back(makeLine("info"));
+            batch.lines.push_back(makeLine("warn"));
+            model->AppendBatch(std::move(batch));
+        }
+
+        const int levelCol = ColumnByHeader(*model, QStringLiteral("level"));
+        QVERIFY2(levelCol >= 0, "level column must exist after promotion");
+        QCOMPARE(
+            model->Configuration().columns[static_cast<size_t>(levelCol)].type, loglib::LogConfiguration::Type::Level
+        );
+
+        // Submit the canonical-name filter `Info` while the column
+        // is still Level. Tooltip pre-demote lists `Info`.
+        const QString filterId = QStringLiteral("hf-level-demote");
+        QVERIFY2(
+            QMetaObject::invokeMethod(
+                mWindow,
+                "FilterEnumSubmitted",
+                Qt::DirectConnection,
+                Q_ARG(QString, filterId),
+                Q_ARG(int, levelCol),
+                Q_ARG(QStringList, QStringList{QStringLiteral("Info")})
+            ),
+            "FilterEnumSubmitted slot must be invocable via meta-object"
+        );
+        QCoreApplication::processEvents();
+
+        const QString tooltipBefore = model->headerData(levelCol, Qt::Horizontal, Qt::ToolTipRole).toString();
+        QVERIFY2(
+            tooltipBefore.contains(QStringLiteral("Info")),
+            "tooltip pre-demote must list the canonical Level name the user submitted"
+        );
+
+        // Batch 2: three new distinct values overflow the cap and
+        // demote `level` to String. `MainWindow`'s `Demoted`
+        // handler rewrites `filterValues` from `["Info"]` to
+        // `["info"]` and the trailing
+        // `SyncColumnFilterIndicators` resyncs the tooltip cache.
+        {
+            loglib::StreamedBatch batch;
+            batch.firstLineNumber = 4;
+            batch.lines.push_back(makeLine("error"));
+            batch.lines.push_back(makeLine("debug"));
+            batch.lines.push_back(makeLine("trace"));
+            model->AppendBatch(std::move(batch));
+        }
+        QCoreApplication::processEvents();
+
+        QCOMPARE(
+            model->Configuration().columns[static_cast<size_t>(levelCol)].type, loglib::LogConfiguration::Type::String
+        );
+
+        const QString tooltipAfter = model->headerData(levelCol, Qt::Horizontal, Qt::ToolTipRole).toString();
+        QVERIFY2(
+            tooltipAfter.contains(QStringLiteral("Filters:")),
+            "tooltip post-demote must keep its Filters section"
+        );
+        QVERIFY2(
+            tooltipAfter.contains(QStringLiteral("info")),
+            "tooltip post-demote must list the rewritten raw value"
+        );
+        // Stricter: the canonical-name `Info` (capital I followed
+        // by lowercase) must NOT appear post-demote -- the
+        // rewrite replaced it with the raw byte form `info`. We
+        // can't just check `!contains("Info")` because the raw
+        // `info` is a substring of `Info`; instead we look for the
+        // exact bullet form.
+        QVERIFY2(
+            !tooltipAfter.contains(QStringLiteral("&bull; Info")),
+            "tooltip post-demote must not still list the pre-demote canonical name"
+        );
+
+        model->EndStreaming(false);
+    }
+
+    // Flipping the application palette (e.g. a Light <-> Dark
+    // theme toggle) must re-tint the funnel decoration. Pins the
+    // `mModel->RefreshHeaderIcons()` call that `RefreshThemedIcons`
+    // makes against the model: without it, the cached funnel
+    // pixmap rendered against the old `WindowText` colour would
+    // stay pinned for the rest of the session.
+    void TestHeaderFilterFunnelRetintsAfterPaletteChange()
+    {
+        const int levelCol = StreamFixtureForColumnTests();
+        QVERIFY2(levelCol >= 0, "category column must exist after streaming");
+        auto *model = mWindow->Model();
+        const int msgCol = ColumnByHeader(*model, QStringLiteral("msg"));
+        QVERIFY2(msgCol >= 0, "msg column must exist after streaming");
+
+        QMetaObject::invokeMethod(
+            mWindow,
+            "FilterSubmitted",
+            Qt::DirectConnection,
+            Q_ARG(QString, QStringLiteral("hf-palette")),
+            Q_ARG(int, msgCol),
+            Q_ARG(QString, QStringLiteral("m2")),
+            Q_ARG(int, static_cast<int>(loglib::LogConfiguration::LogFilter::Match::Contains))
+        );
+        QCoreApplication::processEvents();
+
+        auto opaquePixelCount = [](const QIcon &icon, QRgb expected) -> int {
+            const QSize size{16, 16};
+            const QImage img = icon.pixmap(size).toImage().convertToFormat(QImage::Format_ARGB32);
+            int matching = 0;
+            for (int y = 0; y < img.height(); ++y)
+            {
+                for (int x = 0; x < img.width(); ++x)
+                {
+                    const QRgb px = img.pixel(x, y);
+                    if (qAlpha(px) < 128)
+                    {
+                        continue;
+                    }
+                    constexpr int CHANNEL_TOLERANCE = 32;
+                    if (std::abs(qRed(px) - qRed(expected)) <= CHANNEL_TOLERANCE &&
+                        std::abs(qGreen(px) - qGreen(expected)) <= CHANNEL_TOLERANCE &&
+                        std::abs(qBlue(px) - qBlue(expected)) <= CHANNEL_TOLERANCE)
+                    {
+                        ++matching;
+                    }
+                }
+            }
+            return matching;
+        };
+
+        // Save + restore the app palette: `QApplication::setPalette`
+        // is process-global and the cleanup-per-test fixture only
+        // resets `mWindow`, not Qt's globals.
+        const QPalette savedAppPalette = QApplication::palette();
+        const QPalette savedWindowPalette = mWindow->palette();
+        const auto paletteGuard = qScopeGuard([&]() {
+            QApplication::setPalette(savedAppPalette);
+            mWindow->setPalette(savedWindowPalette);
+            QCoreApplication::processEvents();
+        });
+
+        // Vivid red palette as the first WindowText. The funnel
+        // tints at `MakeThemedPixmap` time using
+        // `QApplication::palette()` so we have to flip the app
+        // palette, not just the window's, for the model-side
+        // re-render to pick up the new colour.
+        QPalette redPalette = QApplication::palette();
+        redPalette.setColor(QPalette::Active, QPalette::WindowText, QColor(255, 0, 0));
+        redPalette.setColor(QPalette::Inactive, QPalette::WindowText, QColor(255, 0, 0));
+        QApplication::setPalette(redPalette);
+        mWindow->setPalette(redPalette);
+        QCoreApplication::processEvents();
+
+        const QVariant redVariant = model->headerData(msgCol, Qt::Horizontal, Qt::DecorationRole);
+        QVERIFY(redVariant.canConvert<QIcon>());
+        const QIcon redIcon = redVariant.value<QIcon>();
+        QVERIFY2(!redIcon.isNull(), "funnel decoration must be present under the red palette");
+        const int redPixels = opaquePixelCount(redIcon, qRgb(255, 0, 0));
+        QVERIFY2(redPixels > 0, "funnel must paint in the red WindowText colour after the first palette flip");
+
+        // Flip to vivid blue. Without `RefreshHeaderIcons` the
+        // cached red pixmap would stay pinned and the blue-pixel
+        // count would be zero.
+        QPalette bluePalette = QApplication::palette();
+        bluePalette.setColor(QPalette::Active, QPalette::WindowText, QColor(0, 0, 255));
+        bluePalette.setColor(QPalette::Inactive, QPalette::WindowText, QColor(0, 0, 255));
+        QApplication::setPalette(bluePalette);
+        mWindow->setPalette(bluePalette);
+        QCoreApplication::processEvents();
+
+        const QVariant blueVariant = model->headerData(msgCol, Qt::Horizontal, Qt::DecorationRole);
+        QVERIFY(blueVariant.canConvert<QIcon>());
+        const QIcon blueIcon = blueVariant.value<QIcon>();
+        QVERIFY2(!blueIcon.isNull(), "funnel decoration must be present under the blue palette");
+        const int bluePixels = opaquePixelCount(blueIcon, qRgb(0, 0, 255));
+        QVERIFY2(bluePixels > 0, "funnel must repaint in the blue WindowText colour after a palette flip");
+    }
+
+    // `BuildFilterTitle` has 5 type branches; the existing tests
+    // only exercise the String branch. Pin the Enumeration and
+    // numeric-range branches so a future formatting change to
+    // either renders into the tooltip the way users expect.
+    void TestHeaderFilterTooltipForEnumAndNumericFilters()
+    {
+        const int levelCol = StreamFixtureForColumnTests();
+        QVERIFY2(levelCol >= 0, "category column must exist after streaming");
+        auto *model = mWindow->Model();
+        QCOMPARE(
+            model->Configuration().columns[static_cast<size_t>(levelCol)].type,
+            loglib::LogConfiguration::Type::Enumeration
+        );
+
+        // Enumeration branch: `BuildFilterTitle` joins the
+        // selected values. We assert each value is mentioned;
+        // the exact separator is an implementation detail.
+        // Two-value list lifted into a local so the comma inside
+        // `QStringList{...}` doesn't trip the `Q_ARG` macro
+        // expansion.
+        const QStringList enumValues{QStringLiteral("info"), QStringLiteral("warn")};
+        QVERIFY2(
+            QMetaObject::invokeMethod(
+                mWindow,
+                "FilterEnumSubmitted",
+                Qt::DirectConnection,
+                Q_ARG(QString, QStringLiteral("hf-enum")),
+                Q_ARG(int, levelCol),
+                Q_ARG(QStringList, enumValues)
+            ),
+            "FilterEnumSubmitted slot must be invocable via meta-object"
+        );
+        QCoreApplication::processEvents();
+
+        const QString enumTooltip = model->headerData(levelCol, Qt::Horizontal, Qt::ToolTipRole).toString();
+        QVERIFY2(enumTooltip.contains(QStringLiteral("Filters:")), "enum filter must show in the Filters section");
+        QVERIFY2(
+            enumTooltip.contains(QStringLiteral("info")) && enumTooltip.contains(QStringLiteral("warn")),
+            "enum tooltip must list every selected value"
+        );
+
+        // Wipe the enum filter before testing numeric so the two
+        // branches don't share a section and their bullets don't
+        // collide.
+        QMetaObject::invokeMethod(mWindow, "ClearAllFilters", Qt::DirectConnection);
+        QCoreApplication::processEvents();
+        QVERIFY2(mWindow->Filters().empty(), "ClearAllFilters must drain mFilters between branches");
+
+        // Numeric-range branch: install a synthetic numeric
+        // filter via the meta-object slot. The fixture's `msg`
+        // column is a string but `BuildFilterTitle` doesn't probe
+        // the column type -- it formats from `LogFilter::Type` --
+        // so a Number filter on any column exercises the branch.
+        const int msgCol = ColumnByHeader(*model, QStringLiteral("msg"));
+        QVERIFY2(msgCol >= 0, "msg column must exist after streaming");
+        QVERIFY2(
+            QMetaObject::invokeMethod(
+                mWindow,
+                "FilterNumericRangeSubmitted",
+                Qt::DirectConnection,
+                Q_ARG(QString, QStringLiteral("hf-numeric")),
+                Q_ARG(int, msgCol),
+                Q_ARG(std::optional<double>, std::optional<double>{1.5}),
+                Q_ARG(std::optional<double>, std::optional<double>{42.0})
+            ),
+            "FilterNumericRangeSubmitted slot must be invocable via meta-object"
+        );
+        QCoreApplication::processEvents();
+
+        const QString numericTooltip = model->headerData(msgCol, Qt::Horizontal, Qt::ToolTipRole).toString();
+        QVERIFY2(
+            numericTooltip.contains(QStringLiteral("Filters:")),
+            "numeric filter must show in the Filters section"
+        );
+        // Both bounds must be visible somewhere in the rendered
+        // title. The exact separator (`>=`, `<=`, dash) is an
+        // implementation detail; the bound numerals are not.
+        QVERIFY2(
+            numericTooltip.contains(QStringLiteral("1.5")) && numericTooltip.contains(QStringLiteral("42")),
+            "numeric tooltip must list both bounds"
+        );
     }
 
     // Status-bar diagnostics button + dialog summary are driven by


### PR DESCRIPTION
Active filters used to live only in the `Filters` menu and the per-column header context menu -- both invisible until the user knew to open them. *"Where did my rows go?"* and *"is this column filtered?"* were the two recurring questions a filtered session surfaced. We prototyped the Sentry / Kibana / Datadog-style chips bar on `feature/filter-chips-bar`, but parked it after first review: the extra strip ate vertical real estate and added a third place to remove filters (menu, header context menu, chip `x`). The header-indicator design ships the same "make filters visible without opening a menu" UX with zero new chrome -- Excel / Sheets / Numbers all do exactly this, so the funnel reads as a filter affordance the moment a user lands on the column.

Surfacing the filter list in the header tooltip pairs naturally with the warning tooltip already there: the user hovers the column header and gets *every* per-column piece of state (label, key, type, active filters, type-mismatch warning) in one place. The model-side cache on `LogModel` keeps the `headerData(DecorationRole)` / `(ToolTipRole)` calls cheap (a header view repaints these on every scroll / sort / column move) and lets the funnel pixmap render once per palette / DPR generation.

## What changed

**Funnel SVG asset (item 8 / item 3 asset-half).** `resources/icons/funnel.svg` -- the plain Lucide funnel glyph, dropped next to the existing `funnel-plus` / `funnel-x` assets and registered in `resources/resources.qrc`. License attribution updated in `cmake/license_snippets/lucide.txt` (icon count 13 -> 14).

**Model API extension (`app/include/log_model.hpp` + `app/src/log_model.cpp`).** Three new public methods on `LogModel`:

- `SetColumnFilterDetails(std::vector<QStringList> perColumnTitles)` -- bulk-replace the per-column titles cache. Pads / trims to `columnCount()`, diffs against the previous state, emits `headerDataChanged(Qt::Horizontal, firstChanged, lastChanged)` only over the contiguous moved range. A no-change call is a silent no-op so callers can safely fire on every row-storm signal. The `cols <= 0` branch (structural reset in flight) silently drops the cache without emitting -- the surrounding `beginResetModel` / `endResetModel` already invalidates the header on the view side.
- `HasFilterForColumn(int)` -- cheap bounds-checked accessor used by `headerData(DecorationRole)`; out-of-range returns `false`.
- `RefreshHeaderIcons()` -- drop the cached themed funnel pixmap, reset the `mFunnelIconAttempted` latch, and re-emit `headerDataChanged` for the contiguous range of currently-filtered columns. Called from `MainWindow::RefreshThemedIcons` so OS-driven `PaletteChange` / `StyleChange` / `ApplicationPaletteChange` / `ThemeChange` / `DevicePixelRatioChange` all re-tint the funnel.

`headerData` was extended:

- **`Qt::ToolTipRole`** -- now passes the per-column titles into the extended `BuildHeaderTooltip(column, health, filterTitles)`. The new `Filters:` bullet block (`<b>Filters:</b><br/>&bull; <title>...`) sits between the static column metadata and the (red) warning section, so the warning stays the visually dominant trailing block.
- **`Qt::DecorationRole`** -- warning still wins (per design decision: only one decoration fits in a header cell and a type mismatch is more important). When no warning is present and the column has a filter, returns the lazily-rendered themed funnel icon. The cache (`mFunnelIconCache`) is `mutable QIcon` because `headerData` is `const` but the fill is a pure speedup -- every call returns the same icon until `RefreshHeaderIcons()` clears it. The `mFunnelIconAttempted` latch is set unconditionally on the first attempt so a missing-resource load (theoretical -- `funnel.svg` is bundled) caches the empty `QIcon` instead of retrying every paint. Render size is `QStyle::PM_SmallIconSize` (the metric the header view actually paints decorations at) so Qt does not downscale on every paint.

**`MainWindow::SyncColumnFilterIndicators` (`app/include/main_window.hpp` + `app/src/main_window.cpp`).** The bridge between `mFilters` and the model cache. Walks `mFilters`, buckets `BuildFilterTitle(filter)` by `filter.row`, sorts each per-column list with `QCollator` (case-insensitive, numeric mode -- so "9" sorts before "10" and locale rules apply), pushes the snapshot through `LogModel::SetColumnFilterDetails`. Stale rows from a concurrent column drop are skipped (the next filter mutation will remap or evict them). The model-side diff guard makes a no-change call free.

Wired into the seven mutation control points the chips-bar prototype used (and that the new design inherits):

1. `AddLogFilter` -- trailing sync inside `!deferSync`.
2. `ClearFilter` -- trailing sync inside `!deferSync`.
3. `ClearAllFilters` -- unconditional trailing sync.
4. `RebuildFiltersFromConfiguration` -- after the trailing `UpdateFilters()` (the early `ClearAllFilters()` already wipes the cache, so this rebuilds it).
5. `OnSourceColumnsMoved` -- folded into the trailing `ApplyColumnVisibility` (which also syncs) so `headerDataChanged` is not emitted while hidden flags are still mid-flight.
6. `ApplyColumnVisibility` -- trailing (no-op in the common case, kept for symmetry).
7. `SetColumnVisible` -- trailing (same rationale).

`OnThemeChanged` additionally routes through `LogModel::RefreshHeaderIcons` (now centralised inside `RefreshThemedIcons`) so a Light <-> Dark flip re-themes the cached funnel pixmap. The funnel cache drop sits *above* the `mMainToolbar == nullptr` early-return so palette / DPR changes always re-tint the funnel even outside the toolbar lifetime window (the model outlives the toolbar across construction and teardown).

**Demote-rewrite re-entrancy fix.** The `enumColumnsChanged(Demoted)` handler rewrites `filter.filterValues` in place (canonical level names like `"Info"` -> raw bytes captured pre-demote) and used to leave the funnel tooltip listing the pre-demote names until the next filter mutation. Two follow-up changes:

- A trailing `SyncColumnFilterIndicators()` after the rewrite + `MirrorSessionStateToConfiguration()` block resyncs the tooltip cache against the rewritten raw bytes.
- A new `mApplyingEnumRebuild` re-entrancy guard (released through `qScopeGuard`) guards against a transitive re-emit of `enumColumnsChanged` for the same column re-entering on half-rewritten state.

**Tests (`test/app/src/main_window_test.cpp`, +616 lines).** 11 new cases pinning the contract:

- `TestHeaderFilterIndicatorAbsentWithoutFilters` -- baseline: no filter -> null decoration + no `Filters:` tooltip section. Includes an explicit `ColumnHealth` precondition so a future fixture drift can't silently hide a regression behind the `canConvert` branch.
- `TestHeaderFilterIndicatorAppearsOnAddFilter` -- a single String filter installs a non-null decoration and adds a `Filters:` bullet carrying `BuildFilterTitle(filter)`.
- `TestHeaderFilterTooltipListsMultipleFiltersSortedAlphabetically` -- two filters on the same column render alphabetically regardless of insertion order (anchors the canonical `QCollator` sort so `mFilters`'s unordered iteration cannot flake the rendered order).
- `TestHeaderFilterIndicatorClearsOnClearAll` -- `ClearAllFilters` drains both `mFilters` and `LogModel::HasFilterForColumn`; catches a missing trailing `SyncColumnFilterIndicators()` regression.
- `TestHeaderWarningAndFilterCoexistInTooltip` -- when a column has both a type-mismatch warning and an active filter, the tooltip carries both sections, and the warning icon wins the decoration slot (verified by comparing the rendered `QImage` against the filter-only snapshot -- pixmap comparison sidesteps `QIcon` cache-key churn across two `headerData` calls).
- `TestHeaderFilterIndicatorSurvivesColumnRename` -- renaming a column refreshes the bold tooltip header but keeps the `Filters:` section + funnel decoration; pins that `mColumnFilterDetails` is keyed by section index, not label.
- `TestHeaderFilterIndicatorFollowsColumnMove` -- moving a filtered column carries the funnel and tooltip section to the new logical index.
- `TestHeaderFilterIndicatorSurvivesColumnHideShow` -- hide / show round-trip leaves the indicator intact.
- `TestHeaderFilterTooltipReflectsRawValuesAfterLevelDemote` -- pins the `b65edf6` demote-rewrite resync (tooltip carries the post-demote raw bytes, not the canonical names).
- `TestHeaderFilterFunnelRetintsAfterPaletteChange` -- with an application-palette save/restore guard, flips the palette and confirms the funnel re-renders against the new palette.
- `TestHeaderFilterTooltipForEnumAndNumericFilters` -- covers the Enumeration + Numeric branches of `BuildFilterTitle` that the initial String-only tests left uncovered.

All 344 / 344 apptest cases pass locally on Windows + MSVC + Release + IPO under the offscreen QPA plugin (333 prior + 11 new).

**clang-tidy / pre-commit sweep.** The trailing `eb442d4` + `1185184` + `0ea725d` commits address every diagnostic `run-clang-tidy` raised on the new / heavily-modified TUs (`log_model.{hpp,cpp}`, `main_window.{hpp,cpp}`, `main_window_test.cpp`) and tighten the docstrings to match the surrounding codebase style.

## Test plan

- [x] `ctest -LE benchmark` green locally on Windows + MSVC + Release + IPO (344 / 344 offscreen).
- [x] `run-clang-tidy` over `log_model.cpp`, `main_window.cpp`, `main_window_test.cpp` reports zero warnings.
- [x] Manual smoke: open a JSON Lines log, add a String filter on a column -- the column header gets the Lucide funnel glyph; hover -- the tooltip carries a `Filters:` bullet section. Add a second filter on the same column -- both bullets render alphabetically; remove one -- only the remaining filter shows. Clear all filters -- decoration and section disappear.
- [x] Manual smoke: column with a type-mismatch warning + an active filter -- tooltip carries both sections; the warning icon (not the funnel) wins the decoration slot.
- [x] Manual smoke: rename / move / hide / show a filtered column -- the funnel and tooltip section follow the column to its new section index.
- [x] Manual smoke: switch themes via Preferences (Light <-> Dark) and via the OS theme switcher -- the funnel re-tints to the new `WindowText` colour. Drag the window between monitors of different DPR -- the funnel stays sharp.
- [x] Manual smoke: demote a String column to Level via the column editor -- the rewritten filter values surface in the tooltip immediately (no stale canonical names).
- [x] CI: `build-linux`, `build-macos`, `build-windows`, `clang-ci (asan-ubsan / tsan / coverage)`, `pre-commit`, CodeQL all green on this PR.
