### PR TITLE
GUI polish: Sort menu, toolbar split + Clear Sort, header right-click block, status-bar indicator

### DIFF
--- a/app/include/main_window.hpp
+++ b/app/include/main_window.hpp
@@ -918,7 +918,12 @@ private:
     /// Mirrors `UpdateRowsShownStatus`'s shape: hidden when the
     /// model is empty, visible whenever a sort is active. Called
     /// from `LogFilterModel::layoutChanged`, source row signals,
-    /// and `ApplyDeferredSortFromConfig`.
+    /// the source's horizontal `headerDataChanged` (so a column
+    /// rename refreshes the tooltip without waiting for the next
+    /// sort/filter event), and once at the end of construction so
+    /// the initial idle state matches before any signal fires.
+    /// `ApplyDeferredSortFromConfig` reaches it transitively via
+    /// the `sortByColumn` it issues.
     void UpdateSortStatus();
 
     /// Repopulate the Clear-filters split-button dropdown with

--- a/app/include/main_window.hpp
+++ b/app/include/main_window.hpp
@@ -924,6 +924,14 @@ private:
     /// surface a placeholder when every column is hidden).
     bool AppendSortByEntries(QMenu *menu);
 
+    /// Wrap `AppendSortByEntries` with the two disabled-placeholder
+    /// branches both Sort surfaces share: `(no columns yet)` when
+    /// the configuration is empty, and `(every column is hidden ...)`
+    /// when nothing visible remains to sort by. Single point of
+    /// truth for the placeholder wording, used by `RebuildSortMenu`
+    /// and `RebuildSortByMenu`.
+    void AppendSortEntriesOrPlaceholder(QMenu *menu);
+
     /// Refresh the enable state of `actionClearSort` and the
     /// visibility of `mClearSortStatusButton` against the live
     /// `LogFilterModel::SortColumn()` and the source row count.

--- a/app/include/main_window.hpp
+++ b/app/include/main_window.hpp
@@ -507,11 +507,11 @@ private slots:
         int initialColumn = -1
     );
     void ClearAllFilters();
-    /// Drop the active column sort. Routes through
-    /// `mTableView->sortByColumn(-1, ...)` so the proxy, header
-    /// indicator, and persisted configuration all stay in lockstep.
-    /// Bound to `actionClearSort` (toolbar plain button + Sort menu
-    /// + status-bar indicator).
+    /// Drop the active column sort via
+    /// `mTableView->sortByColumn(-1, ...)` so proxy, header, and
+    /// persisted config stay in lockstep. Bound to
+    /// `actionClearSort` (Sort menu, toolbar, status bar,
+    /// header right-click).
     void ClearSort();
     /// Remove a single filter rule. Pass `deferSync = true` when the
     /// caller (e.g. a submit slot) immediately re-adds the filter
@@ -885,65 +885,44 @@ private:
     /// silently empty.
     void RebuildAddFilterMenu(QMenu *menu);
 
-    /// Repopulate the top-level Sort menu (`menuSort`). Keeps
-    /// `actionClearSort` + a separator on top, then adds two
-    /// flat checkable rows per visible column
+    /// Repopulate `menuSort`: `actionClearSort` + separator,
+    /// then two checkable rows per visible column
     /// (`▲ "<col>"` / `▼ "<col>"`) whose check state mirrors
-    /// `LogFilterModel::SortColumn() / SortOrder()`.
-    /// Sort is single-column / single-direction, so at most one
-    /// row across the menu is ever checked at a time. Connected
-    /// to `menuSort->aboutToShow` so the listing always reflects
-    /// the current configuration without invalidation hooks at
-    /// every column-mutation site (same idiom as
-    /// `RebuildAddFilterMenu`).
+    /// the proxy's current sort. Hooked to `aboutToShow` so the
+    /// menu always reflects the live configuration.
     void RebuildSortMenu();
 
     /// Repopulate the Sort split-button dropdown with the same
-    /// per-column flat rows `RebuildSortMenu` produces, but
-    /// without the leading `actionClearSort` row (the toolbar has
-    /// a dedicated plain Clear-Sort button next to the split
-    /// button, so a duplicate dropdown entry would be redundant).
-    /// Hidden columns are skipped to mirror the header context
-    /// menu and Add-filter dropdown.
+    /// per-column rows as `RebuildSortMenu`, minus the
+    /// Clear-sort row (the toolbar has its own Clear-Sort button
+    /// next to this one).
     void RebuildSortByMenu(QMenu *menu);
 
-    /// Append two flat checkable rows per visible column to
-    /// @p menu (`▲ "<col>"` / `▼ "<col>"`) whose check state
-    /// mirrors `LogFilterModel::SortColumn() / SortOrder()`. The
-    /// leading triangle is the same glyph `QHeaderView` uses for
-    /// its sort indicator, so the menu entry visually mirrors
-    /// what the table will show once the sort is active. Rows are
-    /// disabled when the model has no rows or when the column's
-    /// data does not match its configured type
-    /// (`ColumnHealth::presentSlots > matchingSlots`); a tooltip
-    /// on each disabled row points the user at Configuration
-    /// Diagnostics, and the host menu opts into per-action
-    /// tooltips so the explanation surfaces on hover. Shared core
-    /// for `RebuildSortMenu` and `RebuildSortByMenu`; returns
-    /// true iff at least one row was added (lets the caller
-    /// surface a placeholder when every column is hidden).
+    /// Append two checkable rows per visible column to @p menu
+    /// (`▲ "<col>"` / `▼ "<col>"`) whose check state mirrors
+    /// the proxy's sort. The triangle is the same glyph
+    /// `QHeaderView` paints as its sort indicator. Rows are
+    /// disabled when the model has no rows or the column's data
+    /// doesn't match its configured type; disabled rows carry a
+    /// tooltip pointing at Configuration Diagnostics. Shared
+    /// core for `RebuildSortMenu` and `RebuildSortByMenu`;
+    /// returns true if any row was added (so the caller can
+    /// fall back to a placeholder when every column is hidden).
     bool AppendSortByEntries(QMenu *menu);
 
-    /// Wrap `AppendSortByEntries` with the two disabled-placeholder
-    /// branches both Sort surfaces share: `(no columns yet)` when
-    /// the configuration is empty, and `(every column is hidden ...)`
-    /// when nothing visible remains to sort by. Single point of
-    /// truth for the placeholder wording, used by `RebuildSortMenu`
-    /// and `RebuildSortByMenu`.
+    /// `AppendSortByEntries` plus the placeholder fallbacks both
+    /// Sort surfaces share: `(no columns yet)` for an empty
+    /// configuration and `(every column is hidden ...)` when
+    /// nothing visible remains.
     void AppendSortEntriesOrPlaceholder(QMenu *menu);
 
-    /// Refresh the enable state of `actionClearSort` and the
-    /// visibility of `mClearSortStatusButton` against the live
-    /// `LogFilterModel::SortColumn()` and the source row count.
-    /// Mirrors `UpdateRowsShownStatus`'s shape: hidden when the
-    /// model is empty, visible whenever a sort is active. Called
-    /// from `LogFilterModel::layoutChanged`, source row signals,
-    /// the source's horizontal `headerDataChanged` (so a column
-    /// rename refreshes the tooltip without waiting for the next
-    /// sort/filter event), and once at the end of construction so
-    /// the initial idle state matches before any signal fires.
-    /// `ApplyDeferredSortFromConfig` reaches it transitively via
-    /// the `sortByColumn` it issues.
+    /// Sync `actionClearSort`'s enabled state and
+    /// `mClearSortStatusButton`'s visibility with the proxy's
+    /// current sort. Hidden when the model is empty; visible
+    /// while a sort is active. Hooked to `layoutChanged`, the
+    /// source's row signals, and horizontal `headerDataChanged`
+    /// (so a column rename refreshes the tooltip without
+    /// waiting for the next sort / filter event).
     void UpdateSortStatus();
 
     /// Repopulate the Clear-filters split-button dropdown with
@@ -1125,10 +1104,10 @@ private:
     /// `mDiagnosticsButton` / `mParseErrorsStatusButton`.
     QPushButton *mClearFiltersStatusButton = nullptr;
 
-    /// Status-bar button that triggers `actionClearSort`. Visible
-    /// only when a column sort is active (`SortColumn() >= 0`)
-    /// and the source model has rows. Same flat / clickable
-    /// styling as `mClearFiltersStatusButton`.
+    /// Status-bar button bound to `actionClearSort`. Visible
+    /// only while a sort is active and the source has rows.
+    /// Same flat / clickable styling as
+    /// `mClearFiltersStatusButton`.
     QPushButton *mClearSortStatusButton = nullptr;
 
     /// Status-bar button showing the per-column type-mismatch

--- a/app/include/main_window.hpp
+++ b/app/include/main_window.hpp
@@ -507,6 +507,12 @@ private slots:
         int initialColumn = -1
     );
     void ClearAllFilters();
+    /// Drop the active column sort. Routes through
+    /// `mTableView->sortByColumn(-1, ...)` so the proxy, header
+    /// indicator, and persisted configuration all stay in lockstep.
+    /// Bound to `actionClearSort` (toolbar plain button + Sort menu
+    /// + status-bar indicator).
+    void ClearSort();
     /// Remove a single filter rule. Pass `deferSync = true` when the
     /// caller (e.g. a submit slot) immediately re-adds the filter
     /// so the mirror + rule rebuild only run once.
@@ -879,6 +885,42 @@ private:
     /// silently empty.
     void RebuildAddFilterMenu(QMenu *menu);
 
+    /// Repopulate the top-level Sort menu (`menuSort`). Keeps
+    /// `actionClearSort` + a separator on top, then adds two
+    /// checkable entries per visible column (`Sort by "<col>"
+    /// ascending` / `... descending`) whose check state mirrors
+    /// `LogFilterModel::SortColumn() / SortOrder()`. Connected to
+    /// `menuSort->aboutToShow` so the listing always reflects the
+    /// current configuration without invalidation hooks at every
+    /// column-mutation site (same idiom as `RebuildAddFilterMenu`).
+    void RebuildSortMenu();
+
+    /// Repopulate the Sort split-button dropdown with the same
+    /// per-column Asc/Desc entries `RebuildSortMenu` produces, but
+    /// without the leading `actionClearSort` row (the toolbar has
+    /// a dedicated plain Clear-Sort button next to the split
+    /// button, so a duplicate dropdown entry would be redundant).
+    /// Hidden columns are skipped to mirror the header context
+    /// menu and Add-filter dropdown.
+    void RebuildSortByMenu(QMenu *menu);
+
+    /// Append two checkable per-column entries (`Sort by "<col>"
+    /// ascending` / `... descending`) for every visible column to
+    /// @p menu. Shared core for `RebuildSortMenu` and
+    /// `RebuildSortByMenu`; returns true iff at least one entry
+    /// was added (lets the caller surface a placeholder when every
+    /// column is hidden).
+    bool AppendSortByEntries(QMenu *menu);
+
+    /// Refresh the enable state of `actionClearSort` and the
+    /// visibility of `mClearSortStatusButton` against the live
+    /// `LogFilterModel::SortColumn()` and the source row count.
+    /// Mirrors `UpdateRowsShownStatus`'s shape: hidden when the
+    /// model is empty, visible whenever a sort is active. Called
+    /// from `LogFilterModel::layoutChanged`, source row signals,
+    /// and `ApplyDeferredSortFromConfig`.
+    void UpdateSortStatus();
+
     /// Repopulate the Clear-filters split-button dropdown with
     /// one `Remove "<col>": <title>` entry per active filter,
     /// grouped by column index then sorted by display title.
@@ -1057,6 +1099,12 @@ private:
     /// source model has rows. Mirrors the UX of
     /// `mDiagnosticsButton` / `mParseErrorsStatusButton`.
     QPushButton *mClearFiltersStatusButton = nullptr;
+
+    /// Status-bar button that triggers `actionClearSort`. Visible
+    /// only when a column sort is active (`SortColumn() >= 0`)
+    /// and the source model has rows. Same flat / clickable
+    /// styling as `mClearFiltersStatusButton`.
+    QPushButton *mClearSortStatusButton = nullptr;
 
     /// Status-bar button showing the per-column type-mismatch
     /// summary. Hidden when zero columns are mismatched; opens the

--- a/app/include/main_window.hpp
+++ b/app/include/main_window.hpp
@@ -886,9 +886,10 @@ private:
     void RebuildAddFilterMenu(QMenu *menu);
 
     /// Repopulate the top-level Sort menu (`menuSort`). Keeps
-    /// `actionClearSort` + a separator on top, then adds two
-    /// checkable entries per visible column (`Sort by "<col>"
-    /// ascending` / `... descending`) whose check state mirrors
+    /// `actionClearSort` + a separator on top, then adds one
+    /// submenu per visible column (titled `"<col>"`) carrying
+    /// three radio-checkable rows -- `Ascending`, `Descending`,
+    /// `None` -- whose check state mirrors
     /// `LogFilterModel::SortColumn() / SortOrder()`. Connected to
     /// `menuSort->aboutToShow` so the listing always reflects the
     /// current configuration without invalidation hooks at every
@@ -896,7 +897,7 @@ private:
     void RebuildSortMenu();
 
     /// Repopulate the Sort split-button dropdown with the same
-    /// per-column Asc/Desc entries `RebuildSortMenu` produces, but
+    /// per-column submenus `RebuildSortMenu` produces, but
     /// without the leading `actionClearSort` row (the toolbar has
     /// a dedicated plain Clear-Sort button next to the split
     /// button, so a duplicate dropdown entry would be redundant).
@@ -904,12 +905,21 @@ private:
     /// menu and Add-filter dropdown.
     void RebuildSortByMenu(QMenu *menu);
 
-    /// Append two checkable per-column entries (`Sort by "<col>"
-    /// ascending` / `... descending`) for every visible column to
-    /// @p menu. Shared core for `RebuildSortMenu` and
-    /// `RebuildSortByMenu`; returns true iff at least one entry
-    /// was added (lets the caller surface a placeholder when every
-    /// column is hidden).
+    /// Append one submenu per visible column to @p menu, each
+    /// carrying three radio-checkable rows (`Ascending`,
+    /// `Descending`, `None`) whose check state mirrors
+    /// `LogFilterModel::SortColumn() / SortOrder()`. The `None`
+    /// row routes through `actionClearSort` when the column is
+    /// the live sort column, otherwise it is a structural no-op
+    /// (already the resting radio state for non-sorted columns).
+    /// Asc / Desc are disabled when the model has no rows or
+    /// when the column's data does not match its configured type
+    /// (`ColumnHealth::presentSlots > matchingSlots`); a tooltip
+    /// on each disabled row points the user at Configuration
+    /// Diagnostics. Shared core for `RebuildSortMenu` and
+    /// `RebuildSortByMenu`; returns true iff at least one submenu
+    /// was added (lets the caller surface a placeholder when
+    /// every column is hidden).
     bool AppendSortByEntries(QMenu *menu);
 
     /// Refresh the enable state of `actionClearSort` and the

--- a/app/include/main_window.hpp
+++ b/app/include/main_window.hpp
@@ -886,18 +886,20 @@ private:
     void RebuildAddFilterMenu(QMenu *menu);
 
     /// Repopulate the top-level Sort menu (`menuSort`). Keeps
-    /// `actionClearSort` + a separator on top, then adds one
-    /// submenu per visible column (titled `"<col>"`) carrying
-    /// three radio-checkable rows -- `Ascending`, `Descending`,
-    /// `None` -- whose check state mirrors
-    /// `LogFilterModel::SortColumn() / SortOrder()`. Connected to
-    /// `menuSort->aboutToShow` so the listing always reflects the
-    /// current configuration without invalidation hooks at every
-    /// column-mutation site (same idiom as `RebuildAddFilterMenu`).
+    /// `actionClearSort` + a separator on top, then adds two
+    /// flat checkable rows per visible column
+    /// (`▲ "<col>"` / `▼ "<col>"`) whose check state mirrors
+    /// `LogFilterModel::SortColumn() / SortOrder()`.
+    /// Sort is single-column / single-direction, so at most one
+    /// row across the menu is ever checked at a time. Connected
+    /// to `menuSort->aboutToShow` so the listing always reflects
+    /// the current configuration without invalidation hooks at
+    /// every column-mutation site (same idiom as
+    /// `RebuildAddFilterMenu`).
     void RebuildSortMenu();
 
     /// Repopulate the Sort split-button dropdown with the same
-    /// per-column submenus `RebuildSortMenu` produces, but
+    /// per-column flat rows `RebuildSortMenu` produces, but
     /// without the leading `actionClearSort` row (the toolbar has
     /// a dedicated plain Clear-Sort button next to the split
     /// button, so a duplicate dropdown entry would be redundant).
@@ -905,21 +907,21 @@ private:
     /// menu and Add-filter dropdown.
     void RebuildSortByMenu(QMenu *menu);
 
-    /// Append one submenu per visible column to @p menu, each
-    /// carrying three radio-checkable rows (`Ascending`,
-    /// `Descending`, `None`) whose check state mirrors
-    /// `LogFilterModel::SortColumn() / SortOrder()`. The `None`
-    /// row routes through `actionClearSort` when the column is
-    /// the live sort column, otherwise it is a structural no-op
-    /// (already the resting radio state for non-sorted columns).
-    /// Asc / Desc are disabled when the model has no rows or
-    /// when the column's data does not match its configured type
+    /// Append two flat checkable rows per visible column to
+    /// @p menu (`▲ "<col>"` / `▼ "<col>"`) whose check state
+    /// mirrors `LogFilterModel::SortColumn() / SortOrder()`. The
+    /// leading triangle is the same glyph `QHeaderView` uses for
+    /// its sort indicator, so the menu entry visually mirrors
+    /// what the table will show once the sort is active. Rows are
+    /// disabled when the model has no rows or when the column's
+    /// data does not match its configured type
     /// (`ColumnHealth::presentSlots > matchingSlots`); a tooltip
     /// on each disabled row points the user at Configuration
-    /// Diagnostics. Shared core for `RebuildSortMenu` and
-    /// `RebuildSortByMenu`; returns true iff at least one submenu
-    /// was added (lets the caller surface a placeholder when
-    /// every column is hidden).
+    /// Diagnostics, and the host menu opts into per-action
+    /// tooltips so the explanation surfaces on hover. Shared core
+    /// for `RebuildSortMenu` and `RebuildSortByMenu`; returns
+    /// true iff at least one row was added (lets the caller
+    /// surface a placeholder when every column is hidden).
     bool AppendSortByEntries(QMenu *menu);
 
     /// Refresh the enable state of `actionClearSort` and the

--- a/app/src/main_window.cpp
+++ b/app/src/main_window.cpp
@@ -989,6 +989,22 @@ MainWindow::MainWindow(ThemeControl *theme, SessionHistoryManager *historyManage
     // step.
     connect(mClearFiltersStatusButton, &QPushButton::clicked, ui->actionClearAllFilters, &QAction::trigger);
 
+    // Status-bar Clear-sort indicator. Mirrors the Clear-filters
+    // button: hidden by default, surfaced by `UpdateSortStatus`
+    // whenever a column sort is active and the source has rows,
+    // routes a click through `actionClearSort` so the menu / the
+    // toolbar / this button all share one slot.
+    mClearSortStatusButton = new QPushButton(this);
+    mClearSortStatusButton->setObjectName(QStringLiteral("clearSortStatusButton"));
+    mClearSortStatusButton->setIcon(QApplication::style()->standardIcon(QStyle::SP_LineEditClearButton));
+    mClearSortStatusButton->setText(tr("Clear sort"));
+    mClearSortStatusButton->setAccessibleName(tr("Clear column sort"));
+    mClearSortStatusButton->setFlat(true);
+    mClearSortStatusButton->setCursor(Qt::PointingHandCursor);
+    mClearSortStatusButton->hide();
+    statusBar()->addPermanentWidget(mClearSortStatusButton);
+    connect(mClearSortStatusButton, &QPushButton::clicked, ui->actionClearSort, &QAction::trigger);
+
     // 1 Hz tick that refreshes the live-tail elapsed time and the title's
     // running line count, so neither has to be rewritten per batch.
     constexpr int LIVE_TAIL_TICK_INTERVAL_MS = 1000;
@@ -1244,6 +1260,13 @@ MainWindow::MainWindow(ThemeControl *theme, SessionHistoryManager *historyManage
     // Run after every dock/toolbar has its `objectName` so `restoreState`
     // can resolve them. No-op on first launch.
     RestoreWindowChrome();
+
+    // Settle the sort indicator's initial state. Constructor-time
+    // signal hooks fire before the status-bar button exists; this
+    // single sync after both ends are wired ensures `actionClearSort`
+    // and the status-bar button start with consistent enable /
+    // visibility state matching the (idle) proxy.
+    UpdateSortStatus();
 
     // Timezone database initialisation lives in
     // `MainWindow::InitializeTimezoneDatabase`, called synchronously

--- a/app/src/main_window.cpp
+++ b/app/src/main_window.cpp
@@ -774,19 +774,23 @@ MainWindow::MainWindow(ThemeControl *theme, SessionHistoryManager *historyManage
     // full disambiguated-label vector on every call, so renames on
     // unrelated columns would waste an O(N) pass while the
     // visible tooltip can't possibly change.
-    connect(mModel, &QAbstractItemModel::headerDataChanged, this,
-            [this](Qt::Orientation orientation, int first, int last) {
-                if (orientation != Qt::Horizontal || mSortFilterProxyModel == nullptr)
-                {
-                    return;
-                }
-                const int sortColumn = mSortFilterProxyModel->SortColumn();
-                if (sortColumn < 0 || sortColumn < first || sortColumn > last)
-                {
-                    return;
-                }
-                UpdateSortStatus();
-            });
+    connect(
+        mModel,
+        &QAbstractItemModel::headerDataChanged,
+        this,
+        [this](Qt::Orientation orientation, int first, int last) {
+            if (orientation != Qt::Horizontal || mSortFilterProxyModel == nullptr)
+            {
+                return;
+            }
+            const int sortColumn = mSortFilterProxyModel->SortColumn();
+            if (sortColumn < 0 || sortColumn < first || sortColumn > last)
+            {
+                return;
+            }
+            UpdateSortStatus();
+        }
+    );
 
     mActionToggleFind = new QAction(tr("Find Bar"), this);
     mActionToggleFind->setObjectName(QStringLiteral("actionToggleFind"));
@@ -3649,8 +3653,7 @@ bool MainWindow::AppendSortByEntries(QMenu *menu)
         // mislead. Tooltip explains the cause and points at the
         // diagnostics dialog (the canonical fix for the pin).
         const auto health = mModel->ColumnHealth(columnIdx);
-        const bool typeMismatch =
-            health.has_value() && health->presentSlots > health->matchingSlots;
+        const bool typeMismatch = health.has_value() && health->presentSlots > health->matchingSlots;
         const bool ascDescEnabled = modelHasRows && !typeMismatch;
         const QString mismatchTooltip =
             tr("This column's data does not match its configured type, so sorting is disabled. "
@@ -3774,8 +3777,7 @@ void MainWindow::RebuildSortByMenu(QMenu *menu)
 
 void MainWindow::UpdateSortStatus()
 {
-    const int sortColumn =
-        (mSortFilterProxyModel != nullptr) ? mSortFilterProxyModel->SortColumn() : -1;
+    const int sortColumn = (mSortFilterProxyModel != nullptr) ? mSortFilterProxyModel->SortColumn() : -1;
     const int sourceRows = (mModel != nullptr) ? mModel->rowCount() : 0;
     const bool sortActive = sortColumn >= 0;
 
@@ -3799,15 +3801,11 @@ void MainWindow::UpdateSortStatus()
     // headers via `[keys]` so the tooltip is unambiguous even on
     // configurations with header collisions.
     const std::vector<QString> labels = BuildAllColumnMenuLabels();
-    QString columnLabel = (sortColumn < static_cast<int>(labels.size()))
-                              ? labels[static_cast<size_t>(sortColumn)]
-                              : tr("(unknown column)");
-    const QString directionWord = (mSortFilterProxyModel->SortOrder() == Qt::DescendingOrder)
-                                      ? tr("descending")
-                                      : tr("ascending");
-    mClearSortStatusButton->setToolTip(
-        tr("Sorted by \"%1\" (%2) - click to clear.").arg(columnLabel, directionWord)
-    );
+    QString columnLabel = (sortColumn < static_cast<int>(labels.size())) ? labels[static_cast<size_t>(sortColumn)]
+                                                                         : tr("(unknown column)");
+    const QString directionWord =
+        (mSortFilterProxyModel->SortOrder() == Qt::DescendingOrder) ? tr("descending") : tr("ascending");
+    mClearSortStatusButton->setToolTip(tr("Sorted by \"%1\" (%2) - click to clear.").arg(columnLabel, directionWord));
     mClearSortStatusButton->show();
 }
 
@@ -6581,8 +6579,7 @@ MainWindow::HeaderContextMenu MainWindow::BuildHeaderContextMenu(int logicalColu
         {
             menu->addSeparator();
         }
-        const int currentSortColumn =
-            (mSortFilterProxyModel != nullptr) ? mSortFilterProxyModel->SortColumn() : -1;
+        const int currentSortColumn = (mSortFilterProxyModel != nullptr) ? mSortFilterProxyModel->SortColumn() : -1;
         const Qt::SortOrder currentSortOrder =
             (mSortFilterProxyModel != nullptr) ? mSortFilterProxyModel->SortOrder() : Qt::AscendingOrder;
 
@@ -6593,8 +6590,7 @@ MainWindow::HeaderContextMenu MainWindow::BuildHeaderContextMenu(int logicalColu
         // up-front rather than mislead. `BuildHeaderTooltip`
         // already exposes the diagnostic on the header itself.
         const auto sortHealth = mModel->ColumnHealth(logicalColumn);
-        const bool sortTypeMismatch =
-            sortHealth.has_value() && sortHealth->presentSlots > sortHealth->matchingSlots;
+        const bool sortTypeMismatch = sortHealth.has_value() && sortHealth->presentSlots > sortHealth->matchingSlots;
         const bool sortAscDescEnabled = modelHasRows && !sortTypeMismatch;
         const QString sortMismatchTooltip =
             tr("This column's data does not match its configured type, so sorting is disabled. "

--- a/app/src/main_window.cpp
+++ b/app/src/main_window.cpp
@@ -637,18 +637,14 @@ MainWindow::MainWindow(ThemeControl *theme, SessionHistoryManager *historyManage
     connect(ui->actionClearAllFilters, &QAction::triggered, this, &MainWindow::ClearAllFilters);
     ui->actionClearAllFilters->setDisabled(true);
 
-    // Sort affordances. The bare `actionSortBy` is the split
-    // button's face -- triggering it programmatically opens the
-    // toolbar dropdown (sort has no useful generic editor like
-    // filters do, so the face routes straight to the per-column
-    // menu). `actionClearSort` is shared by the top-level Sort
-    // menu, the toolbar plain button, and the status-bar
-    // indicator; all three trigger the same slot through the
-    // single-source-of-truth action.
+    // Sort actions. `actionSortBy` is the split-button face;
+    // it just opens the per-column dropdown (sort has no
+    // generic editor). `actionClearSort` is the single slot
+    // shared across the Sort menu, toolbar, status-bar
+    // indicator, and header right-click.
     connect(ui->actionClearSort, &QAction::triggered, this, &MainWindow::ClearSort);
     ui->actionClearSort->setDisabled(true);
-    // `menuSort->aboutToShow` rebuilds the per-column entries on
-    // every open, same idiom as `menuView` / the filter dropdowns.
+    // Rebuild per-column entries on every open.
     if (ui->menuSort != nullptr)
     {
         connect(ui->menuSort, &QMenu::aboutToShow, this, &MainWindow::RebuildSortMenu);
@@ -751,29 +747,23 @@ MainWindow::MainWindow(ThemeControl *theme, SessionHistoryManager *historyManage
     connect(mSortFilterProxyModel, &QAbstractItemModel::modelReset, this, &MainWindow::UpdateRowsShownStatus);
     connect(mSortFilterProxyModel, &QAbstractItemModel::layoutChanged, this, &MainWindow::UpdateRowsShownStatus);
 
-    // Sort indicator: keep `actionClearSort` enabled state and the
-    // status-bar Clear-sort button in lockstep with the proxy's
-    // sort. `layoutChanged` fires on every sort permutation, so a
-    // single hook covers user-driven `sortByColumn` calls
-    // (header click, menu, dropdown, programmatic `ClearSort`)
-    // and the deferred-restore path (`ApplyDeferredSortFromConfig`
-    // calls `sortByColumn` which emits the same signal). Source
-    // row signals trigger the same slot so the indicator hides
-    // when the model goes empty -- mirroring the rows-shown
-    // status logic.
+    // Sort indicator: keep `actionClearSort` and the status-bar
+    // button in sync with the proxy's sort. `layoutChanged`
+    // covers every sort permutation (header click, menu,
+    // dropdown, programmatic clear, and the deferred-restore
+    // path). Source row signals hide the indicator when the
+    // model goes empty.
     connect(mSortFilterProxyModel, &QAbstractItemModel::layoutChanged, this, &MainWindow::UpdateSortStatus);
     connect(mSortFilterProxyModel, &QAbstractItemModel::modelReset, this, &MainWindow::UpdateSortStatus);
     connect(mModel, &QAbstractItemModel::rowsInserted, this, &MainWindow::UpdateSortStatus);
     connect(mModel, &QAbstractItemModel::rowsRemoved, this, &MainWindow::UpdateSortStatus);
     connect(mModel, &QAbstractItemModel::modelReset, this, &MainWindow::UpdateSortStatus);
-    // Column rename (via Edit Column...) emits `headerDataChanged`
-    // but no `layoutChanged`, so without this hook the status-bar
-    // tooltip would freeze on the previous label until the next
-    // sort/filter event. Filter to horizontal pings that actually
-    // touch the sorted column -- `UpdateSortStatus` rebuilds the
-    // full disambiguated-label vector on every call, so renames on
-    // unrelated columns would waste an O(N) pass while the
-    // visible tooltip can't possibly change.
+    // Column rename emits `headerDataChanged` but no
+    // `layoutChanged`, so without this hook the status-bar
+    // tooltip would freeze on the old label. Only refresh when
+    // the rename touches the sorted column - `UpdateSortStatus`
+    // rebuilds all column labels and that's wasted work
+    // otherwise.
     connect(
         mModel,
         &QAbstractItemModel::headerDataChanged,
@@ -1014,20 +1004,17 @@ MainWindow::MainWindow(ThemeControl *theme, SessionHistoryManager *historyManage
     // step.
     connect(mClearFiltersStatusButton, &QPushButton::clicked, ui->actionClearAllFilters, &QAction::trigger);
 
-    // Status-bar Clear-sort indicator. Mirrors the Clear-filters
-    // button: hidden by default, surfaced by `UpdateSortStatus`
-    // whenever a column sort is active and the source has rows,
-    // routes a click through `actionClearSort` so the menu / the
-    // toolbar / this button all share one slot.
+    // Status-bar Clear-sort indicator. Mirrors the
+    // Clear-filters button: hidden by default, surfaced by
+    // `UpdateSortStatus` while a sort is active, click-routes
+    // through `actionClearSort`.
     mClearSortStatusButton = new QPushButton(this);
     mClearSortStatusButton->setObjectName(QStringLiteral("clearSortStatusButton"));
     mClearSortStatusButton->setIcon(QApplication::style()->standardIcon(QStyle::SP_LineEditClearButton));
     mClearSortStatusButton->setText(tr("Clear sort"));
     mClearSortStatusButton->setAccessibleName(tr("Clear column sort"));
-    // Static fallback tooltip so the button advertises its action
-    // even before the first `UpdateSortStatus` populates the
-    // column-aware variant. The dynamic tooltip overrides this
-    // whenever a sort is active.
+    // Fallback tooltip until `UpdateSortStatus` writes the
+    // column-aware variant.
     mClearSortStatusButton->setToolTip(tr("Clear the active column sort."));
     mClearSortStatusButton->setFlat(true);
     mClearSortStatusButton->setCursor(Qt::PointingHandCursor);
@@ -1291,11 +1278,9 @@ MainWindow::MainWindow(ThemeControl *theme, SessionHistoryManager *historyManage
     // can resolve them. No-op on first launch.
     RestoreWindowChrome();
 
-    // Settle the sort indicator's initial state. Constructor-time
-    // signal hooks fire before the status-bar button exists; this
-    // single sync after both ends are wired ensures `actionClearSort`
-    // and the status-bar button start with consistent enable /
-    // visibility state matching the (idle) proxy.
+    // Settle the sort indicator's initial state. Earlier signal
+    // hooks fired before the status-bar button existed, so sync
+    // once now that both ends are wired.
     UpdateSortStatus();
 
     // Timezone database initialisation lives in
@@ -3272,21 +3257,12 @@ void MainWindow::BuildMainToolbar()
     });
     mMainToolbar->addWidget(clearFiltersButton);
 
-    // Sort dropdown button. Sort has no useful generic editor
-    // like filters do (the per-column choice *is* the action),
-    // so the entire button face opens the per-column dropdown
-    // rather than splitting click-vs-arrow as the Add-filter
-    // button does. `InstantPopup` makes the whole button surface
-    // open the menu and suppresses default-action triggering, so
-    // we don't need a face-click → `showMenu()` lambda (which
-    // would otherwise capture a raw `QToolButton*` and dangle if
-    // `BuildMainToolbar` ever ran twice).
-    //
-    // The menu carries the same `Sort by "<col>" ascending` /
-    // `... descending` checkable rows the top-level Sort menu
-    // produces, minus the leading Clear-sort row -- the toolbar
-    // has a dedicated plain Clear-sort button next to this one,
-    // so a duplicate dropdown entry would be redundant.
+    // Sort dropdown button. The whole face opens the per-column
+    // menu (`InstantPopup`); sort has no generic editor, so a
+    // click-vs-arrow split would be redundant. The menu carries
+    // the same per-column rows as the Sort menu, minus the
+    // Clear-sort row (that lives in the dedicated button next
+    // to this one).
     auto *sortByButton = new QToolButton(mMainToolbar);
     sortByButton->setObjectName(QStringLiteral("sortBySplitButton"));
     sortByButton->setDefaultAction(ui->actionSortBy);
@@ -3299,10 +3275,9 @@ void MainWindow::BuildMainToolbar()
     connect(sortByMenu, &QMenu::aboutToShow, this, [this, sortByMenu]() { RebuildSortByMenu(sortByMenu); });
     mMainToolbar->addWidget(sortByButton);
 
-    // Clear-sort plain action. Sort is single-column, so a per-X
-    // dropdown would only ever hold one entry -- a plain button
-    // is the honest shape here. Enable state is driven by
-    // `UpdateSortStatus` in lockstep with `LogFilterModel::SortColumn()`.
+    // Clear-sort plain button. Sort is single-column, so a
+    // per-X dropdown would always hold one entry. Enable state
+    // is driven by `UpdateSortStatus`.
     mMainToolbar->addAction(ui->actionClearSort);
 
     mMainToolbar->addSeparator();
@@ -3574,19 +3549,12 @@ void MainWindow::ClearSort()
     {
         return;
     }
-    // Same call shape used by `SetColumnVisible` (when the user
-    // hides the sorted column) and the post-load rebuild paths,
-    // so the proxy / header / configuration stay in lockstep
-    // through one well-trodden code path.
-    //
-    // No-op safe: `LogFilterModel::sort(-1, ...)` short-circuits
-    // when no sort is active, so a stray call never emits
-    // `layoutChanged` (and `UpdateSortStatus` is therefore not
-    // re-fired). All five surfaces gate on `actionClearSort`'s
-    // enabled state, which `UpdateSortStatus` ties to the live
-    // sort, so this branch is unreachable in production -- the
-    // guard exists for the test seam and any future programmatic
-    // caller.
+    // Same call shape `SetColumnVisible` and post-load rebuild
+    // paths use, so proxy / header / config stay in lockstep
+    // through one well-trodden path. No-op safe when no sort
+    // is active. All UI surfaces already gate on
+    // `actionClearSort`'s enabled state; the guard is for the
+    // test seam and any future programmatic caller.
     mTableView->sortByColumn(-1, Qt::AscendingOrder);
 }
 
@@ -3603,34 +3571,29 @@ bool MainWindow::AppendSortByEntries(QMenu *menu)
         return false;
     }
 
-    // Hoisted out of `tr()` so a future translator can't strip or
-    // alter the glyph: it must match `QHeaderView`'s asc/desc
-    // sort-indicator triangles for the menu entry to mirror what
-    // the table shows once the sort is active. Tests pin the
-    // prefix on the same code-points, so a stray retranslation
-    // would silently break two contracts.
+    // Kept out of `tr()` so a translator can't alter the
+    // glyphs - they must match `QHeaderView`'s sort-indicator
+    // triangles. Tests pin these code points.
     static constexpr QChar kSortAscGlyph(u'\u25B2');  // ▲
     static constexpr QChar kSortDescGlyph(u'\u25BC'); // ▼
 
-    // `sortByColumn` would be a structural no-op when the model
-    // has no rows -- the proxy still updates its sort column /
-    // order, but no permutation is visible. Disable the entries
-    // up-front to mirror Add-filter's "model has rows" gate; the
-    // header click already short-circuits in this state.
+    // Disable rows when the model has no rows: a sort would be
+    // a structural no-op but the action would still appear
+    // available. Mirrors Add-filter's "model has rows" gate.
     const bool modelHasRows = mModel->rowCount() > 0;
     const int currentColumn = mSortFilterProxyModel->SortColumn();
     const Qt::SortOrder currentOrder = mSortFilterProxyModel->SortOrder();
 
     // Header-disambiguated labels (`name` vs `name [user|id]`),
-    // same helper the View / Add-filter / Clear-filters menus use.
+    // same helper the View / Add-filter / Clear-filters menus
+    // use.
     const std::vector<QString> labels = BuildAllColumnMenuLabels();
 
     bool addedAny = false;
     for (size_t i = 0; i < columns.size(); ++i)
     {
-        // Hidden columns are skipped to mirror Add-filter and the
-        // header right-click. Re-show is delegated to the View
-        // menu, same as for filtering.
+        // Skip hidden columns - re-show is delegated to the
+        // View menu (same as the filter menus).
         if (!columns[i].visible)
         {
             continue;
@@ -3638,20 +3601,16 @@ bool MainWindow::AppendSortByEntries(QMenu *menu)
         const QString &label = labels[i];
         const int columnIdx = static_cast<int>(i);
 
-        // Capture stable `keys` so a column reorder landing
-        // between menu build and click still hits the right
-        // column. Same pattern the Add-filter dropdown uses.
+        // Capture stable `keys` so a column reorder between
+        // menu build and click still hits the right column.
         const auto &keys = columns[i].keys;
 
         const bool isActiveSortColumn = (currentColumn == columnIdx);
 
-        // Disable Asc/Desc when the column's data does not match
-        // its configured `Type` (`presentSlots > matchingSlots`).
-        // The sort comparator dispatches on the configured type,
-        // so a mismatched column produces an order that does not
-        // reflect the on-screen values -- we'd rather refuse than
-        // mislead. Tooltip explains the cause and points at the
-        // diagnostics dialog (the canonical fix for the pin).
+        // Disable Asc/Desc when the column's data doesn't
+        // match its configured type: the sort would use the
+        // wrong comparator and produce a misleading order.
+        // The tooltip points at Configuration Diagnostics.
         const auto health = mModel->ColumnHealth(columnIdx);
         const bool typeMismatch = health.has_value() && health->presentSlots > health->matchingSlots;
         const bool ascDescEnabled = modelHasRows && !typeMismatch;
@@ -3659,17 +3618,11 @@ bool MainWindow::AppendSortByEntries(QMenu *menu)
             tr("This column's data does not match its configured type, so sorting is disabled. "
                "Open Configuration Diagnostics to inspect or change the type.");
 
-        // Two flat checkable rows per column. The leading glyph
-        // is the same triangle Qt's `QHeaderView` uses for its
-        // sort indicator, so the menu entry visually mirrors what
-        // the table will show once the sort is active. Sort is
-        // single-column / single-direction, so at most one row in
-        // the entire menu is ever checked at a time. The text is
-        // just the disambiguated column label in quotes -- the
-        // host menu's title ("Sort") and the glyph carry the
-        // verb / direction, so adding "Sort by" prefix would
-        // double up the obvious. Only the quoted-label portion is
-        // wrapped in `tr()`; the glyph stays a code-point literal.
+        // Two checkable rows per column: glyph + quoted column
+        // label. The host menu's title and the triangle carry
+        // the verb and direction; no "Sort by" prefix needed.
+        // Only the label is translated; the glyph stays a
+        // literal code-point.
         const QString quotedLabel = tr("\"%1\"").arg(label);
         const QString ascText = QString(kSortAscGlyph) + QLatin1Char(' ') + quotedLabel;
         const QString descText = QString(kSortDescGlyph) + QLatin1Char(' ') + quotedLabel;
@@ -3713,10 +3666,9 @@ bool MainWindow::AppendSortByEntries(QMenu *menu)
 
     if (addedAny)
     {
-        // QMenu hides per-action tooltips by default. Enable them
-        // on the host menu so the type-mismatch explanation
-        // surfaces when the user hovers over a disabled row.
-        // Idempotent: harmless to re-set on repeat builds.
+        // Enable per-action tooltips so the type-mismatch
+        // explanation surfaces on hover (QMenu hides them by
+        // default).
         menu->setToolTipsVisible(true);
     }
 
@@ -3737,10 +3689,9 @@ void MainWindow::AppendSortEntriesOrPlaceholder(QMenu *menu)
     }
     if (!AppendSortByEntries(menu))
     {
-        // Every column hidden -- legal end state. Surface the
-        // condition explicitly so the user understands why the
-        // menu is otherwise empty (and where to re-show columns).
-        // Same wording as `RebuildAddFilterMenu`.
+        // Every column hidden - surface a placeholder pointing
+        // at the View menu. Same wording as
+        // `RebuildAddFilterMenu`.
         QAction *placeholder = menu->addAction(tr("(every column is hidden – use View menu to show one)"));
         placeholder->setEnabled(false);
     }
@@ -3754,12 +3705,10 @@ void MainWindow::RebuildSortMenu()
         return;
     }
     menu->clear();
-    // `actionClearSort` is the .ui-declared first child of
-    // `menuSort`; re-add it (the `clear()` above strips action
-    // attachments without destroying the action itself) so the
-    // top-of-menu Clear entry survives the rebuild. Its enabled
-    // state is driven by `UpdateSortStatus` against every signal
-    // that can move the sort, so we don't need to re-sync it here.
+    // Re-attach `actionClearSort` (the `clear()` above
+    // detached it without destroying the action). Its enabled
+    // state is already driven by `UpdateSortStatus`, so no
+    // resync is needed here.
     menu->addAction(ui->actionClearSort);
     menu->addSeparator();
     AppendSortEntriesOrPlaceholder(menu);
@@ -3796,10 +3745,9 @@ void MainWindow::UpdateSortStatus()
         return;
     }
 
-    // Tooltip names the live column so a rename / reorder shows
-    // through. `BuildAllColumnMenuLabels` disambiguates duplicate
-    // headers via `[keys]` so the tooltip is unambiguous even on
-    // configurations with header collisions.
+    // Name the live column in the tooltip so renames and
+    // reorders show through. Labels are disambiguated by
+    // `[keys]` for duplicate headers.
     const std::vector<QString> labels = BuildAllColumnMenuLabels();
     QString columnLabel = (sortColumn < static_cast<int>(labels.size())) ? labels[static_cast<size_t>(sortColumn)]
                                                                          : tr("(unknown column)");
@@ -6567,12 +6515,10 @@ MainWindow::HeaderContextMenu MainWindow::BuildHeaderContextMenu(int logicalColu
         connect(removeAction, &QAction::triggered, this, [this, filterId]() { ClearFilter(filterId); });
     }
 
-    // Sort block: `Sort ascending by "<col>"`, `Sort descending by
-    // "<col>"`, and `Clear sort`. Mirrors the Sort menu entries but
-    // contextualised to the clicked column. Hidden columns are
-    // skipped (production right-clicks always hit a visible
-    // section; the test seam may pass a hidden index, where the
-    // sort indicator wouldn't render anyway).
+    // Sort block: `Sort ascending|descending by "<col>"` and
+    // `Clear sort`, contextualised to the clicked column.
+    // Hidden columns are skipped (production right-clicks
+    // always hit a visible section).
     if (thisColumn.visible)
     {
         if (!menu->isEmpty())
@@ -6583,21 +6529,18 @@ MainWindow::HeaderContextMenu MainWindow::BuildHeaderContextMenu(int logicalColu
         const Qt::SortOrder currentSortOrder =
             (mSortFilterProxyModel != nullptr) ? mSortFilterProxyModel->SortOrder() : Qt::AscendingOrder;
 
-        // Same type-mismatch gate the Sort menu submenus apply --
-        // a column whose data does not match its configured type
-        // sorts via the wrong comparator and produces an order
-        // that does not reflect the on-screen values, so refuse
-        // up-front rather than mislead. `BuildHeaderTooltip`
-        // already exposes the diagnostic on the header itself.
+        // Same type-mismatch gate as the Sort menu - a
+        // mismatched column would sort via the wrong comparator
+        // and mislead. The header tooltip already exposes the
+        // diagnostic.
         const auto sortHealth = mModel->ColumnHealth(logicalColumn);
         const bool sortTypeMismatch = sortHealth.has_value() && sortHealth->presentSlots > sortHealth->matchingSlots;
         const bool sortAscDescEnabled = modelHasRows && !sortTypeMismatch;
         const QString sortMismatchTooltip =
             tr("This column's data does not match its configured type, so sorting is disabled. "
                "Open Configuration Diagnostics to inspect or change the type.");
-        // QMenu hides per-action tooltips by default. Enable them
-        // so the type-mismatch explanation surfaces when the user
-        // hovers over a disabled Asc / Desc row.
+        // Enable per-action tooltips so the type-mismatch
+        // explanation surfaces on hover.
         menu->setToolTipsVisible(true);
 
         QAction *sortAscAction = menu->addAction(tr("Sort ascending by \"%1\"").arg(thisLabel));
@@ -6634,15 +6577,12 @@ MainWindow::HeaderContextMenu MainWindow::BuildHeaderContextMenu(int logicalColu
             mTableView->sortByColumn(idx, Qt::DescendingOrder);
         });
 
-        // Re-add `actionClearSort` directly so the header menu
-        // shares the action's text, enabled state (driven by
-        // `UpdateSortStatus`), tooltip, and any future shortcut /
-        // icon assignment with the top-level Sort menu, the
-        // toolbar plain button, and the status-bar indicator --
-        // single source of truth across all five surfaces. The
-        // host menu is built fresh per right-click and destroyed
-        // via `deleteLater` when dismissed, so re-attaching the
-        // global action is safe (no double-parent / dangling).
+        // Re-attach the shared `actionClearSort` so the header
+        // menu inherits its text, enabled state, tooltip, and
+        // any future shortcut / icon - one source of truth
+        // across every Sort surface. The host menu is built
+        // fresh per right-click and `deleteLater`d on dismiss,
+        // so re-attaching is safe.
         if (ui->actionClearSort != nullptr)
         {
             menu->addAction(ui->actionClearSort);

--- a/app/src/main_window.cpp
+++ b/app/src/main_window.cpp
@@ -3107,6 +3107,8 @@ void MainWindow::BuildMainToolbar()
     tag(ui->actionOpenNetworkStream, mMainToolbar, QStringLiteral(":/icons/radio-tower.svg"));
     tag(ui->actionAddFilter, mMainToolbar, QStringLiteral(":/icons/funnel-plus.svg"));
     tag(ui->actionClearAllFilters, mMainToolbar, QStringLiteral(":/icons/funnel-x.svg"));
+    tag(ui->actionSortBy, mMainToolbar, QStringLiteral(":/icons/arrow-down-up.svg"));
+    tag(ui->actionClearSort, mMainToolbar, QStringLiteral(":/icons/circle-x.svg"));
     tag(mActionToggleFind, mMainToolbar, QStringLiteral(":/icons/search.svg"));
     tag(ui->actionToggleRecordDetails, mMainToolbar, QStringLiteral(":/icons/panel-right-open.svg"));
     tag(mActionToggleAnchors, mMainToolbar, QStringLiteral(":/icons/bookmark.svg"));
@@ -3216,6 +3218,43 @@ void MainWindow::BuildMainToolbar()
         RebuildClearFiltersMenu(clearFiltersMenu);
     });
     mMainToolbar->addWidget(clearFiltersButton);
+
+    // Sort split button. Face = `actionSortBy`; the action's slot
+    // pops the dropdown so a click on the face surfaces the
+    // per-column shortcut instead of opening a (non-existent)
+    // generic sort editor. Dropdown = the same `Sort by "<col>"
+    // ascending` / `... descending` checkable rows the top-level
+    // Sort menu produces, minus the leading Clear-sort row (the
+    // toolbar has a dedicated plain Clear-sort button next to
+    // this split button, so a duplicate would be redundant).
+    //
+    // `MenuButtonPopup` (matching the Add-filter button) keeps
+    // the arrow visible as a discoverable affordance; the click
+    // on the face triggers `actionSortBy`, which our slot reroutes
+    // into `showMenu()` to open the dropdown.
+    auto *sortByButton = new QToolButton(mMainToolbar);
+    sortByButton->setObjectName(QStringLiteral("sortBySplitButton"));
+    sortByButton->setDefaultAction(ui->actionSortBy);
+    sortByButton->setPopupMode(QToolButton::MenuButtonPopup);
+    sortByButton->setIconSize(toolbarIconSize);
+    sortByButton->setToolButtonStyle(Qt::ToolButtonIconOnly);
+    auto *sortByMenu = new QMenu(sortByButton);
+    sortByMenu->setObjectName(QStringLiteral("sortBySplitMenu"));
+    sortByButton->setMenu(sortByMenu);
+    connect(sortByMenu, &QMenu::aboutToShow, this, [this, sortByMenu]() { RebuildSortByMenu(sortByMenu); });
+    // Route the face's `actionSortBy` trigger into `showMenu()` so
+    // a face click opens the per-column dropdown. Connect on the
+    // button (not the action) so the menu pops at the button's
+    // position; triggering the action programmatically would not
+    // anchor the popup.
+    connect(ui->actionSortBy, &QAction::triggered, sortByButton, [sortByButton]() { sortByButton->showMenu(); });
+    mMainToolbar->addWidget(sortByButton);
+
+    // Clear-sort plain action. Sort is single-column, so a per-X
+    // dropdown would only ever hold one entry -- a plain button
+    // is the honest shape here. Enable state is driven by
+    // `UpdateSortStatus` in lockstep with `LogFilterModel::SortColumn()`.
+    mMainToolbar->addAction(ui->actionClearSort);
 
     mMainToolbar->addSeparator();
     if (mActionToggleFind != nullptr)

--- a/app/src/main_window.cpp
+++ b/app/src/main_window.cpp
@@ -3574,8 +3574,8 @@ bool MainWindow::AppendSortByEntries(QMenu *menu)
     // Kept out of `tr()` so a translator can't alter the
     // glyphs - they must match `QHeaderView`'s sort-indicator
     // triangles. Tests pin these code points.
-    static constexpr QChar kSortAscGlyph(u'\u25B2');  // ▲
-    static constexpr QChar kSortDescGlyph(u'\u25BC'); // ▼
+    static constexpr QChar SORT_ASC_GLYPH(u'\u25B2');  // ▲
+    static constexpr QChar SORT_DESC_GLYPH(u'\u25BC'); // ▼
 
     // Disable rows when the model has no rows: a sort would be
     // a structural no-op but the action would still appear
@@ -3624,8 +3624,8 @@ bool MainWindow::AppendSortByEntries(QMenu *menu)
         // Only the label is translated; the glyph stays a
         // literal code-point.
         const QString quotedLabel = tr("\"%1\"").arg(label);
-        const QString ascText = QString(kSortAscGlyph) + QLatin1Char(' ') + quotedLabel;
-        const QString descText = QString(kSortDescGlyph) + QLatin1Char(' ') + quotedLabel;
+        const QString ascText = QString(SORT_ASC_GLYPH) + QLatin1Char(' ') + quotedLabel;
+        const QString descText = QString(SORT_DESC_GLYPH) + QLatin1Char(' ') + quotedLabel;
 
         QAction *ascAct = menu->addAction(ascText);
         ascAct->setCheckable(true);
@@ -3749,8 +3749,8 @@ void MainWindow::UpdateSortStatus()
     // reorders show through. Labels are disambiguated by
     // `[keys]` for duplicate headers.
     const std::vector<QString> labels = BuildAllColumnMenuLabels();
-    QString columnLabel = (sortColumn < static_cast<int>(labels.size())) ? labels[static_cast<size_t>(sortColumn)]
-                                                                         : tr("(unknown column)");
+    const QString columnLabel =
+        std::cmp_less(sortColumn, labels.size()) ? labels[static_cast<size_t>(sortColumn)] : tr("(unknown column)");
     const QString directionWord =
         (mSortFilterProxyModel->SortOrder() == Qt::DescendingOrder) ? tr("descending") : tr("ascending");
     mClearSortStatusButton->setToolTip(tr("Sorted by \"%1\" (%2) - click to clear.").arg(columnLabel, directionWord));

--- a/app/src/main_window.cpp
+++ b/app/src/main_window.cpp
@@ -769,14 +769,24 @@ MainWindow::MainWindow(ThemeControl *theme, SessionHistoryManager *historyManage
     // Column rename (via Edit Column...) emits `headerDataChanged`
     // but no `layoutChanged`, so without this hook the status-bar
     // tooltip would freeze on the previous label until the next
-    // sort/filter event. Filter on `Qt::Horizontal` so vertical
-    // header pings don't waste a refresh.
-    connect(mModel, &QAbstractItemModel::headerDataChanged, this, [this](Qt::Orientation orientation) {
-        if (orientation == Qt::Horizontal)
-        {
-            UpdateSortStatus();
-        }
-    });
+    // sort/filter event. Filter to horizontal pings that actually
+    // touch the sorted column -- `UpdateSortStatus` rebuilds the
+    // full disambiguated-label vector on every call, so renames on
+    // unrelated columns would waste an O(N) pass while the
+    // visible tooltip can't possibly change.
+    connect(mModel, &QAbstractItemModel::headerDataChanged, this,
+            [this](Qt::Orientation orientation, int first, int last) {
+                if (orientation != Qt::Horizontal || mSortFilterProxyModel == nullptr)
+                {
+                    return;
+                }
+                const int sortColumn = mSortFilterProxyModel->SortColumn();
+                if (sortColumn < 0 || sortColumn < first || sortColumn > last)
+                {
+                    return;
+                }
+                UpdateSortStatus();
+            });
 
     mActionToggleFind = new QAction(tr("Find Bar"), this);
     mActionToggleFind->setObjectName(QStringLiteral("actionToggleFind"));
@@ -3589,6 +3599,15 @@ bool MainWindow::AppendSortByEntries(QMenu *menu)
         return false;
     }
 
+    // Hoisted out of `tr()` so a future translator can't strip or
+    // alter the glyph: it must match `QHeaderView`'s asc/desc
+    // sort-indicator triangles for the menu entry to mirror what
+    // the table shows once the sort is active. Tests pin the
+    // prefix on the same code-points, so a stray retranslation
+    // would silently break two contracts.
+    static constexpr QChar kSortAscGlyph(u'\u25B2');  // ▲
+    static constexpr QChar kSortDescGlyph(u'\u25BC'); // ▼
+
     // `sortByColumn` would be a structural no-op when the model
     // has no rows -- the proxy still updates its sort column /
     // order, but no permutation is visible. Disable the entries
@@ -3646,9 +3665,11 @@ bool MainWindow::AppendSortByEntries(QMenu *menu)
         // just the disambiguated column label in quotes -- the
         // host menu's title ("Sort") and the glyph carry the
         // verb / direction, so adding "Sort by" prefix would
-        // double up the obvious.
-        const QString ascText = tr("\u25B2 \"%1\"").arg(label);
-        const QString descText = tr("\u25BC \"%1\"").arg(label);
+        // double up the obvious. Only the quoted-label portion is
+        // wrapped in `tr()`; the glyph stays a code-point literal.
+        const QString quotedLabel = tr("\"%1\"").arg(label);
+        const QString ascText = QString(kSortAscGlyph) + QLatin1Char(' ') + quotedLabel;
+        const QString descText = QString(kSortDescGlyph) + QLatin1Char(' ') + quotedLabel;
 
         QAction *ascAct = menu->addAction(ascText);
         ascAct->setCheckable(true);
@@ -3699,34 +3720,18 @@ bool MainWindow::AppendSortByEntries(QMenu *menu)
     return addedAny;
 }
 
-void MainWindow::RebuildSortMenu()
+void MainWindow::AppendSortEntriesOrPlaceholder(QMenu *menu)
 {
-    QMenu *menu = ui->menuSort;
     if (menu == nullptr)
     {
         return;
     }
-    // Refresh the action's enable state up-front so the entry
-    // looks right whether the rebuild produces per-column rows
-    // or not. `UpdateSortStatus` is the same wiring that drives
-    // the toolbar plain button + status-bar indicator.
-    UpdateSortStatus();
-
-    menu->clear();
-    // `actionClearSort` is the .ui-declared first child of
-    // `menuSort`; re-add it (the `clear()` above strips action
-    // attachments without destroying the action itself) so the
-    // top-of-menu Clear entry survives the rebuild.
-    menu->addAction(ui->actionClearSort);
-    menu->addSeparator();
-
     if (mModel == nullptr || mModel->Configuration().columns.empty())
     {
         QAction *placeholder = menu->addAction(tr("(no columns yet)"));
         placeholder->setEnabled(false);
         return;
     }
-
     if (!AppendSortByEntries(menu))
     {
         // Every column hidden -- legal end state. Surface the
@@ -3738,6 +3743,25 @@ void MainWindow::RebuildSortMenu()
     }
 }
 
+void MainWindow::RebuildSortMenu()
+{
+    QMenu *menu = ui->menuSort;
+    if (menu == nullptr)
+    {
+        return;
+    }
+    menu->clear();
+    // `actionClearSort` is the .ui-declared first child of
+    // `menuSort`; re-add it (the `clear()` above strips action
+    // attachments without destroying the action itself) so the
+    // top-of-menu Clear entry survives the rebuild. Its enabled
+    // state is driven by `UpdateSortStatus` against every signal
+    // that can move the sort, so we don't need to re-sync it here.
+    menu->addAction(ui->actionClearSort);
+    menu->addSeparator();
+    AppendSortEntriesOrPlaceholder(menu);
+}
+
 void MainWindow::RebuildSortByMenu(QMenu *menu)
 {
     if (menu == nullptr)
@@ -3745,19 +3769,7 @@ void MainWindow::RebuildSortByMenu(QMenu *menu)
         return;
     }
     menu->clear();
-
-    if (mModel == nullptr || mModel->Configuration().columns.empty())
-    {
-        QAction *placeholder = menu->addAction(tr("(no columns yet)"));
-        placeholder->setEnabled(false);
-        return;
-    }
-
-    if (!AppendSortByEntries(menu))
-    {
-        QAction *placeholder = menu->addAction(tr("(every column is hidden – use View menu to show one)"));
-        placeholder->setEnabled(false);
-    }
+    AppendSortEntriesOrPlaceholder(menu);
 }
 
 void MainWindow::UpdateSortStatus()
@@ -6626,15 +6638,19 @@ MainWindow::HeaderContextMenu MainWindow::BuildHeaderContextMenu(int logicalColu
             mTableView->sortByColumn(idx, Qt::DescendingOrder);
         });
 
-        // Route through `actionClearSort` so the header menu, the
-        // top-level Sort menu, the toolbar plain button, and the
-        // status-bar indicator all share one enable-state source
-        // (`UpdateSortStatus`). Re-using the action here also
-        // means a future shortcut / icon assignment shows up on
-        // this entry without extra wiring.
-        QAction *clearSortAction = menu->addAction(tr("Clear sort"));
-        clearSortAction->setEnabled(ui->actionClearSort != nullptr && ui->actionClearSort->isEnabled());
-        connect(clearSortAction, &QAction::triggered, ui->actionClearSort, &QAction::trigger);
+        // Re-add `actionClearSort` directly so the header menu
+        // shares the action's text, enabled state (driven by
+        // `UpdateSortStatus`), tooltip, and any future shortcut /
+        // icon assignment with the top-level Sort menu, the
+        // toolbar plain button, and the status-bar indicator --
+        // single source of truth across all five surfaces. The
+        // host menu is built fresh per right-click and destroyed
+        // via `deleteLater` when dismissed, so re-attaching the
+        // global action is safe (no double-parent / dangling).
+        if (ui->actionClearSort != nullptr)
+        {
+            menu->addAction(ui->actionClearSort);
+        }
     }
 
     // Re-showing hidden columns is intentionally not offered here:

--- a/app/src/main_window.cpp
+++ b/app/src/main_window.cpp
@@ -33,7 +33,6 @@
 #include <loglib/udp_server_producer.hpp>
 
 #include <QAbstractProxyModel>
-#include <QActionGroup>
 #include <QApplication>
 #include <QCheckBox>
 #include <QCloseEvent>
@@ -3621,23 +3620,6 @@ bool MainWindow::AppendSortByEntries(QMenu *menu)
         // column. Same pattern the Add-filter dropdown uses.
         const auto &keys = columns[i].keys;
 
-        // Per-column submenu carrying three radio-checkable
-        // entries (Ascending / Descending / None). The submenu
-        // title is the disambiguated column label wrapped in
-        // quotes for parity with the previous flat-action wording
-        // ("Sort by \"<col>\" ascending").
-        QMenu *colMenu = menu->addMenu(QStringLiteral("\"%1\"").arg(label));
-        // QMenu hides per-action tooltips by default. Enable them
-        // so the type-mismatch explanation surfaces when the user
-        // hovers over a disabled Asc / Desc row.
-        colMenu->setToolTipsVisible(true);
-
-        // Exclusive group so exactly one of the three rows is
-        // checked at all times -- this is the "radio" semantic
-        // the user expects for Asc/Desc/None.
-        auto *group = new QActionGroup(colMenu);
-        group->setExclusive(true);
-
         const bool isActiveSortColumn = (currentColumn == columnIdx);
 
         // Disable Asc/Desc when the column's data does not match
@@ -3655,7 +3637,20 @@ bool MainWindow::AppendSortByEntries(QMenu *menu)
             tr("This column's data does not match its configured type, so sorting is disabled. "
                "Open Configuration Diagnostics to inspect or change the type.");
 
-        QAction *ascAct = colMenu->addAction(tr("Ascending"));
+        // Two flat checkable rows per column. The leading glyph
+        // is the same triangle Qt's `QHeaderView` uses for its
+        // sort indicator, so the menu entry visually mirrors what
+        // the table will show once the sort is active. Sort is
+        // single-column / single-direction, so at most one row in
+        // the entire menu is ever checked at a time. The text is
+        // just the disambiguated column label in quotes -- the
+        // host menu's title ("Sort") and the glyph carry the
+        // verb / direction, so adding "Sort by" prefix would
+        // double up the obvious.
+        const QString ascText = tr("\u25B2 \"%1\"").arg(label);
+        const QString descText = tr("\u25BC \"%1\"").arg(label);
+
+        QAction *ascAct = menu->addAction(ascText);
         ascAct->setCheckable(true);
         ascAct->setChecked(isActiveSortColumn && currentOrder == Qt::AscendingOrder);
         ascAct->setEnabled(ascDescEnabled);
@@ -3663,7 +3658,6 @@ bool MainWindow::AppendSortByEntries(QMenu *menu)
         {
             ascAct->setToolTip(mismatchTooltip);
         }
-        group->addAction(ascAct);
         connect(ascAct, &QAction::triggered, this, [this, keys]() {
             const int idx = FindColumnIndexByKeys(keys);
             if (idx < 0 || mTableView == nullptr)
@@ -3673,7 +3667,7 @@ bool MainWindow::AppendSortByEntries(QMenu *menu)
             mTableView->sortByColumn(idx, Qt::AscendingOrder);
         });
 
-        QAction *descAct = colMenu->addAction(tr("Descending"));
+        QAction *descAct = menu->addAction(descText);
         descAct->setCheckable(true);
         descAct->setChecked(isActiveSortColumn && currentOrder == Qt::DescendingOrder);
         descAct->setEnabled(ascDescEnabled);
@@ -3681,7 +3675,6 @@ bool MainWindow::AppendSortByEntries(QMenu *menu)
         {
             descAct->setToolTip(mismatchTooltip);
         }
-        group->addAction(descAct);
         connect(descAct, &QAction::triggered, this, [this, keys]() {
             const int idx = FindColumnIndexByKeys(keys);
             if (idx < 0 || mTableView == nullptr)
@@ -3691,38 +3684,16 @@ bool MainWindow::AppendSortByEntries(QMenu *menu)
             mTableView->sortByColumn(idx, Qt::DescendingOrder);
         });
 
-        QAction *noneAct = colMenu->addAction(tr("None"));
-        noneAct->setCheckable(true);
-        // Checked when this column is *not* the active sort
-        // column: the column carries no sort, so "None" is the
-        // resting radio state. On the active sort column, "None"
-        // sits unchecked and a click clears the sort.
-        noneAct->setChecked(!isActiveSortColumn);
-        group->addAction(noneAct);
-        connect(noneAct, &QAction::triggered, this, [this, keys]() {
-            // Route through `actionClearSort` when this column is
-            // the live sort column so the toolbar plain button,
-            // top-of-menu Clear Sort, status-bar indicator and
-            // header right-click all share one enable-state /
-            // trigger source (`UpdateSortStatus`). On any other
-            // column, "None" is already the resting radio state
-            // so the click is a structural no-op.
-            if (mSortFilterProxyModel == nullptr || ui == nullptr || ui->actionClearSort == nullptr)
-            {
-                return;
-            }
-            const int idx = FindColumnIndexByKeys(keys);
-            if (idx < 0)
-            {
-                return;
-            }
-            if (mSortFilterProxyModel->SortColumn() == idx)
-            {
-                ui->actionClearSort->trigger();
-            }
-        });
-
         addedAny = true;
+    }
+
+    if (addedAny)
+    {
+        // QMenu hides per-action tooltips by default. Enable them
+        // on the host menu so the type-mismatch explanation
+        // surfaces when the user hovers over a disabled row.
+        // Idempotent: harmless to re-set on repeat builds.
+        menu->setToolTipsVisible(true);
     }
 
     return addedAny;

--- a/app/src/main_window.cpp
+++ b/app/src/main_window.cpp
@@ -6427,6 +6427,54 @@ MainWindow::HeaderContextMenu MainWindow::BuildHeaderContextMenu(int logicalColu
         connect(removeAction, &QAction::triggered, this, [this, filterId]() { ClearFilter(filterId); });
     }
 
+    // Sort block: `Sort ascending by "<col>"`, `Sort descending by
+    // "<col>"`, and `Clear sort`. Mirrors the Sort menu entries but
+    // contextualised to the clicked column. Hidden columns are
+    // skipped (production right-clicks always hit a visible
+    // section; the test seam may pass a hidden index, where the
+    // sort indicator wouldn't render anyway).
+    if (thisColumn.visible)
+    {
+        if (!menu->isEmpty())
+        {
+            menu->addSeparator();
+        }
+        const int currentSortColumn =
+            (mSortFilterProxyModel != nullptr) ? mSortFilterProxyModel->SortColumn() : -1;
+        const Qt::SortOrder currentSortOrder =
+            (mSortFilterProxyModel != nullptr) ? mSortFilterProxyModel->SortOrder() : Qt::AscendingOrder;
+
+        QAction *sortAscAction = menu->addAction(tr("Sort ascending by \"%1\"").arg(thisLabel));
+        sortAscAction->setCheckable(true);
+        sortAscAction->setChecked(currentSortColumn == logicalColumn && currentSortOrder == Qt::AscendingOrder);
+        sortAscAction->setEnabled(modelHasRows);
+        connect(sortAscAction, &QAction::triggered, this, [this, keys = thisKeys]() {
+            const int idx = FindColumnIndexByKeys(keys);
+            if (idx < 0 || mTableView == nullptr)
+            {
+                return;
+            }
+            mTableView->sortByColumn(idx, Qt::AscendingOrder);
+        });
+
+        QAction *sortDescAction = menu->addAction(tr("Sort descending by \"%1\"").arg(thisLabel));
+        sortDescAction->setCheckable(true);
+        sortDescAction->setChecked(currentSortColumn == logicalColumn && currentSortOrder == Qt::DescendingOrder);
+        sortDescAction->setEnabled(modelHasRows);
+        connect(sortDescAction, &QAction::triggered, this, [this, keys = thisKeys]() {
+            const int idx = FindColumnIndexByKeys(keys);
+            if (idx < 0 || mTableView == nullptr)
+            {
+                return;
+            }
+            mTableView->sortByColumn(idx, Qt::DescendingOrder);
+        });
+
+        QAction *clearSortAction = menu->addAction(tr("Clear sort"));
+        clearSortAction->setEnabled(currentSortColumn >= 0);
+        connect(clearSortAction, &QAction::triggered, this, &MainWindow::ClearSort);
+    }
+
     // Re-showing hidden columns is intentionally not offered here:
     // the `View` menu already covers it (and is the only escape
     // hatch when *every* column is hidden, since no header section

--- a/app/src/main_window.cpp
+++ b/app/src/main_window.cpp
@@ -33,6 +33,7 @@
 #include <loglib/udp_server_producer.hpp>
 
 #include <QAbstractProxyModel>
+#include <QActionGroup>
 #include <QApplication>
 #include <QCheckBox>
 #include <QCloseEvent>
@@ -3620,10 +3621,49 @@ bool MainWindow::AppendSortByEntries(QMenu *menu)
         // column. Same pattern the Add-filter dropdown uses.
         const auto &keys = columns[i].keys;
 
-        QAction *ascAct = menu->addAction(tr("Sort by \"%1\" ascending").arg(label));
+        // Per-column submenu carrying three radio-checkable
+        // entries (Ascending / Descending / None). The submenu
+        // title is the disambiguated column label wrapped in
+        // quotes for parity with the previous flat-action wording
+        // ("Sort by \"<col>\" ascending").
+        QMenu *colMenu = menu->addMenu(QStringLiteral("\"%1\"").arg(label));
+        // QMenu hides per-action tooltips by default. Enable them
+        // so the type-mismatch explanation surfaces when the user
+        // hovers over a disabled Asc / Desc row.
+        colMenu->setToolTipsVisible(true);
+
+        // Exclusive group so exactly one of the three rows is
+        // checked at all times -- this is the "radio" semantic
+        // the user expects for Asc/Desc/None.
+        auto *group = new QActionGroup(colMenu);
+        group->setExclusive(true);
+
+        const bool isActiveSortColumn = (currentColumn == columnIdx);
+
+        // Disable Asc/Desc when the column's data does not match
+        // its configured `Type` (`presentSlots > matchingSlots`).
+        // The sort comparator dispatches on the configured type,
+        // so a mismatched column produces an order that does not
+        // reflect the on-screen values -- we'd rather refuse than
+        // mislead. Tooltip explains the cause and points at the
+        // diagnostics dialog (the canonical fix for the pin).
+        const auto health = mModel->ColumnHealth(columnIdx);
+        const bool typeMismatch =
+            health.has_value() && health->presentSlots > health->matchingSlots;
+        const bool ascDescEnabled = modelHasRows && !typeMismatch;
+        const QString mismatchTooltip =
+            tr("This column's data does not match its configured type, so sorting is disabled. "
+               "Open Configuration Diagnostics to inspect or change the type.");
+
+        QAction *ascAct = colMenu->addAction(tr("Ascending"));
         ascAct->setCheckable(true);
-        ascAct->setChecked(currentColumn == columnIdx && currentOrder == Qt::AscendingOrder);
-        ascAct->setEnabled(modelHasRows);
+        ascAct->setChecked(isActiveSortColumn && currentOrder == Qt::AscendingOrder);
+        ascAct->setEnabled(ascDescEnabled);
+        if (typeMismatch)
+        {
+            ascAct->setToolTip(mismatchTooltip);
+        }
+        group->addAction(ascAct);
         connect(ascAct, &QAction::triggered, this, [this, keys]() {
             const int idx = FindColumnIndexByKeys(keys);
             if (idx < 0 || mTableView == nullptr)
@@ -3633,10 +3673,15 @@ bool MainWindow::AppendSortByEntries(QMenu *menu)
             mTableView->sortByColumn(idx, Qt::AscendingOrder);
         });
 
-        QAction *descAct = menu->addAction(tr("Sort by \"%1\" descending").arg(label));
+        QAction *descAct = colMenu->addAction(tr("Descending"));
         descAct->setCheckable(true);
-        descAct->setChecked(currentColumn == columnIdx && currentOrder == Qt::DescendingOrder);
-        descAct->setEnabled(modelHasRows);
+        descAct->setChecked(isActiveSortColumn && currentOrder == Qt::DescendingOrder);
+        descAct->setEnabled(ascDescEnabled);
+        if (typeMismatch)
+        {
+            descAct->setToolTip(mismatchTooltip);
+        }
+        group->addAction(descAct);
         connect(descAct, &QAction::triggered, this, [this, keys]() {
             const int idx = FindColumnIndexByKeys(keys);
             if (idx < 0 || mTableView == nullptr)
@@ -3644,6 +3689,37 @@ bool MainWindow::AppendSortByEntries(QMenu *menu)
                 return;
             }
             mTableView->sortByColumn(idx, Qt::DescendingOrder);
+        });
+
+        QAction *noneAct = colMenu->addAction(tr("None"));
+        noneAct->setCheckable(true);
+        // Checked when this column is *not* the active sort
+        // column: the column carries no sort, so "None" is the
+        // resting radio state. On the active sort column, "None"
+        // sits unchecked and a click clears the sort.
+        noneAct->setChecked(!isActiveSortColumn);
+        group->addAction(noneAct);
+        connect(noneAct, &QAction::triggered, this, [this, keys]() {
+            // Route through `actionClearSort` when this column is
+            // the live sort column so the toolbar plain button,
+            // top-of-menu Clear Sort, status-bar indicator and
+            // header right-click all share one enable-state /
+            // trigger source (`UpdateSortStatus`). On any other
+            // column, "None" is already the resting radio state
+            // so the click is a structural no-op.
+            if (mSortFilterProxyModel == nullptr || ui == nullptr || ui->actionClearSort == nullptr)
+            {
+                return;
+            }
+            const int idx = FindColumnIndexByKeys(keys);
+            if (idx < 0)
+            {
+                return;
+            }
+            if (mSortFilterProxyModel->SortColumn() == idx)
+            {
+                ui->actionClearSort->trigger();
+            }
         });
 
         addedAny = true;
@@ -6527,10 +6603,32 @@ MainWindow::HeaderContextMenu MainWindow::BuildHeaderContextMenu(int logicalColu
         const Qt::SortOrder currentSortOrder =
             (mSortFilterProxyModel != nullptr) ? mSortFilterProxyModel->SortOrder() : Qt::AscendingOrder;
 
+        // Same type-mismatch gate the Sort menu submenus apply --
+        // a column whose data does not match its configured type
+        // sorts via the wrong comparator and produces an order
+        // that does not reflect the on-screen values, so refuse
+        // up-front rather than mislead. `BuildHeaderTooltip`
+        // already exposes the diagnostic on the header itself.
+        const auto sortHealth = mModel->ColumnHealth(logicalColumn);
+        const bool sortTypeMismatch =
+            sortHealth.has_value() && sortHealth->presentSlots > sortHealth->matchingSlots;
+        const bool sortAscDescEnabled = modelHasRows && !sortTypeMismatch;
+        const QString sortMismatchTooltip =
+            tr("This column's data does not match its configured type, so sorting is disabled. "
+               "Open Configuration Diagnostics to inspect or change the type.");
+        // QMenu hides per-action tooltips by default. Enable them
+        // so the type-mismatch explanation surfaces when the user
+        // hovers over a disabled Asc / Desc row.
+        menu->setToolTipsVisible(true);
+
         QAction *sortAscAction = menu->addAction(tr("Sort ascending by \"%1\"").arg(thisLabel));
         sortAscAction->setCheckable(true);
         sortAscAction->setChecked(currentSortColumn == logicalColumn && currentSortOrder == Qt::AscendingOrder);
-        sortAscAction->setEnabled(modelHasRows);
+        sortAscAction->setEnabled(sortAscDescEnabled);
+        if (sortTypeMismatch)
+        {
+            sortAscAction->setToolTip(sortMismatchTooltip);
+        }
         connect(sortAscAction, &QAction::triggered, this, [this, keys = thisKeys]() {
             const int idx = FindColumnIndexByKeys(keys);
             if (idx < 0 || mTableView == nullptr)
@@ -6543,7 +6641,11 @@ MainWindow::HeaderContextMenu MainWindow::BuildHeaderContextMenu(int logicalColu
         QAction *sortDescAction = menu->addAction(tr("Sort descending by \"%1\"").arg(thisLabel));
         sortDescAction->setCheckable(true);
         sortDescAction->setChecked(currentSortColumn == logicalColumn && currentSortOrder == Qt::DescendingOrder);
-        sortDescAction->setEnabled(modelHasRows);
+        sortDescAction->setEnabled(sortAscDescEnabled);
+        if (sortTypeMismatch)
+        {
+            sortDescAction->setToolTip(sortMismatchTooltip);
+        }
         connect(sortDescAction, &QAction::triggered, this, [this, keys = thisKeys]() {
             const int idx = FindColumnIndexByKeys(keys);
             if (idx < 0 || mTableView == nullptr)

--- a/app/src/main_window.cpp
+++ b/app/src/main_window.cpp
@@ -766,6 +766,17 @@ MainWindow::MainWindow(ThemeControl *theme, SessionHistoryManager *historyManage
     connect(mModel, &QAbstractItemModel::rowsInserted, this, &MainWindow::UpdateSortStatus);
     connect(mModel, &QAbstractItemModel::rowsRemoved, this, &MainWindow::UpdateSortStatus);
     connect(mModel, &QAbstractItemModel::modelReset, this, &MainWindow::UpdateSortStatus);
+    // Column rename (via Edit Column...) emits `headerDataChanged`
+    // but no `layoutChanged`, so without this hook the status-bar
+    // tooltip would freeze on the previous label until the next
+    // sort/filter event. Filter on `Qt::Horizontal` so vertical
+    // header pings don't waste a refresh.
+    connect(mModel, &QAbstractItemModel::headerDataChanged, this, [this](Qt::Orientation orientation) {
+        if (orientation == Qt::Horizontal)
+        {
+            UpdateSortStatus();
+        }
+    });
 
     mActionToggleFind = new QAction(tr("Find Bar"), this);
     mActionToggleFind->setObjectName(QStringLiteral("actionToggleFind"));
@@ -999,6 +1010,11 @@ MainWindow::MainWindow(ThemeControl *theme, SessionHistoryManager *historyManage
     mClearSortStatusButton->setIcon(QApplication::style()->standardIcon(QStyle::SP_LineEditClearButton));
     mClearSortStatusButton->setText(tr("Clear sort"));
     mClearSortStatusButton->setAccessibleName(tr("Clear column sort"));
+    // Static fallback tooltip so the button advertises its action
+    // even before the first `UpdateSortStatus` populates the
+    // column-aware variant. The dynamic tooltip overrides this
+    // whenever a sort is active.
+    mClearSortStatusButton->setToolTip(tr("Clear the active column sort."));
     mClearSortStatusButton->setFlat(true);
     mClearSortStatusButton->setCursor(Qt::PointingHandCursor);
     mClearSortStatusButton->hide();
@@ -3242,35 +3258,31 @@ void MainWindow::BuildMainToolbar()
     });
     mMainToolbar->addWidget(clearFiltersButton);
 
-    // Sort split button. Face = `actionSortBy`; the action's slot
-    // pops the dropdown so a click on the face surfaces the
-    // per-column shortcut instead of opening a (non-existent)
-    // generic sort editor. Dropdown = the same `Sort by "<col>"
-    // ascending` / `... descending` checkable rows the top-level
-    // Sort menu produces, minus the leading Clear-sort row (the
-    // toolbar has a dedicated plain Clear-sort button next to
-    // this split button, so a duplicate would be redundant).
+    // Sort dropdown button. Sort has no useful generic editor
+    // like filters do (the per-column choice *is* the action),
+    // so the entire button face opens the per-column dropdown
+    // rather than splitting click-vs-arrow as the Add-filter
+    // button does. `InstantPopup` makes the whole button surface
+    // open the menu and suppresses default-action triggering, so
+    // we don't need a face-click → `showMenu()` lambda (which
+    // would otherwise capture a raw `QToolButton*` and dangle if
+    // `BuildMainToolbar` ever ran twice).
     //
-    // `MenuButtonPopup` (matching the Add-filter button) keeps
-    // the arrow visible as a discoverable affordance; the click
-    // on the face triggers `actionSortBy`, which our slot reroutes
-    // into `showMenu()` to open the dropdown.
+    // The menu carries the same `Sort by "<col>" ascending` /
+    // `... descending` checkable rows the top-level Sort menu
+    // produces, minus the leading Clear-sort row -- the toolbar
+    // has a dedicated plain Clear-sort button next to this one,
+    // so a duplicate dropdown entry would be redundant.
     auto *sortByButton = new QToolButton(mMainToolbar);
     sortByButton->setObjectName(QStringLiteral("sortBySplitButton"));
     sortByButton->setDefaultAction(ui->actionSortBy);
-    sortByButton->setPopupMode(QToolButton::MenuButtonPopup);
+    sortByButton->setPopupMode(QToolButton::InstantPopup);
     sortByButton->setIconSize(toolbarIconSize);
     sortByButton->setToolButtonStyle(Qt::ToolButtonIconOnly);
     auto *sortByMenu = new QMenu(sortByButton);
     sortByMenu->setObjectName(QStringLiteral("sortBySplitMenu"));
     sortByButton->setMenu(sortByMenu);
     connect(sortByMenu, &QMenu::aboutToShow, this, [this, sortByMenu]() { RebuildSortByMenu(sortByMenu); });
-    // Route the face's `actionSortBy` trigger into `showMenu()` so
-    // a face click opens the per-column dropdown. Connect on the
-    // button (not the action) so the menu pops at the button's
-    // position; triggering the action programmatically would not
-    // anchor the popup.
-    connect(ui->actionSortBy, &QAction::triggered, sortByButton, [sortByButton]() { sortByButton->showMenu(); });
     mMainToolbar->addWidget(sortByButton);
 
     // Clear-sort plain action. Sort is single-column, so a per-X
@@ -3552,6 +3564,15 @@ void MainWindow::ClearSort()
     // hides the sorted column) and the post-load rebuild paths,
     // so the proxy / header / configuration stay in lockstep
     // through one well-trodden code path.
+    //
+    // No-op safe: `LogFilterModel::sort(-1, ...)` short-circuits
+    // when no sort is active, so a stray call never emits
+    // `layoutChanged` (and `UpdateSortStatus` is therefore not
+    // re-fired). All five surfaces gate on `actionClearSort`'s
+    // enabled state, which `UpdateSortStatus` ties to the live
+    // sort, so this branch is unreachable in production -- the
+    // guard exists for the test seam and any future programmatic
+    // caller.
     mTableView->sortByColumn(-1, Qt::AscendingOrder);
 }
 
@@ -6532,9 +6553,15 @@ MainWindow::HeaderContextMenu MainWindow::BuildHeaderContextMenu(int logicalColu
             mTableView->sortByColumn(idx, Qt::DescendingOrder);
         });
 
+        // Route through `actionClearSort` so the header menu, the
+        // top-level Sort menu, the toolbar plain button, and the
+        // status-bar indicator all share one enable-state source
+        // (`UpdateSortStatus`). Re-using the action here also
+        // means a future shortcut / icon assignment shows up on
+        // this entry without extra wiring.
         QAction *clearSortAction = menu->addAction(tr("Clear sort"));
-        clearSortAction->setEnabled(currentSortColumn >= 0);
-        connect(clearSortAction, &QAction::triggered, this, &MainWindow::ClearSort);
+        clearSortAction->setEnabled(ui->actionClearSort != nullptr && ui->actionClearSort->isEnabled());
+        connect(clearSortAction, &QAction::triggered, ui->actionClearSort, &QAction::trigger);
     }
 
     // Re-showing hidden columns is intentionally not offered here:

--- a/app/src/main_window.cpp
+++ b/app/src/main_window.cpp
@@ -637,6 +637,23 @@ MainWindow::MainWindow(ThemeControl *theme, SessionHistoryManager *historyManage
     connect(ui->actionClearAllFilters, &QAction::triggered, this, &MainWindow::ClearAllFilters);
     ui->actionClearAllFilters->setDisabled(true);
 
+    // Sort affordances. The bare `actionSortBy` is the split
+    // button's face -- triggering it programmatically opens the
+    // toolbar dropdown (sort has no useful generic editor like
+    // filters do, so the face routes straight to the per-column
+    // menu). `actionClearSort` is shared by the top-level Sort
+    // menu, the toolbar plain button, and the status-bar
+    // indicator; all three trigger the same slot through the
+    // single-source-of-truth action.
+    connect(ui->actionClearSort, &QAction::triggered, this, &MainWindow::ClearSort);
+    ui->actionClearSort->setDisabled(true);
+    // `menuSort->aboutToShow` rebuilds the per-column entries on
+    // every open, same idiom as `menuView` / the filter dropdowns.
+    if (ui->menuSort != nullptr)
+    {
+        connect(ui->menuSort, &QMenu::aboutToShow, this, &MainWindow::RebuildSortMenu);
+    }
+
     // Stream toolbar; hidden until a live-tail stream is opened. The
     // same actions are also in the Stream menu.
     mStreamToolbar = addToolBar(tr("Stream"));
@@ -733,6 +750,22 @@ MainWindow::MainWindow(ThemeControl *theme, SessionHistoryManager *historyManage
     connect(mSortFilterProxyModel, &QAbstractItemModel::rowsRemoved, this, &MainWindow::UpdateRowsShownStatus);
     connect(mSortFilterProxyModel, &QAbstractItemModel::modelReset, this, &MainWindow::UpdateRowsShownStatus);
     connect(mSortFilterProxyModel, &QAbstractItemModel::layoutChanged, this, &MainWindow::UpdateRowsShownStatus);
+
+    // Sort indicator: keep `actionClearSort` enabled state and the
+    // status-bar Clear-sort button in lockstep with the proxy's
+    // sort. `layoutChanged` fires on every sort permutation, so a
+    // single hook covers user-driven `sortByColumn` calls
+    // (header click, menu, dropdown, programmatic `ClearSort`)
+    // and the deferred-restore path (`ApplyDeferredSortFromConfig`
+    // calls `sortByColumn` which emits the same signal). Source
+    // row signals trigger the same slot so the indicator hides
+    // when the model goes empty -- mirroring the rows-shown
+    // status logic.
+    connect(mSortFilterProxyModel, &QAbstractItemModel::layoutChanged, this, &MainWindow::UpdateSortStatus);
+    connect(mSortFilterProxyModel, &QAbstractItemModel::modelReset, this, &MainWindow::UpdateSortStatus);
+    connect(mModel, &QAbstractItemModel::rowsInserted, this, &MainWindow::UpdateSortStatus);
+    connect(mModel, &QAbstractItemModel::rowsRemoved, this, &MainWindow::UpdateSortStatus);
+    connect(mModel, &QAbstractItemModel::modelReset, this, &MainWindow::UpdateSortStatus);
 
     mActionToggleFind = new QAction(tr("Find Bar"), this);
     mActionToggleFind->setObjectName(QStringLiteral("actionToggleFind"));
@@ -3445,6 +3478,195 @@ void MainWindow::RebuildClearFiltersMenu(QMenu *menu)
         act->setObjectName(filterId);
         connect(act, &QAction::triggered, this, [this, filterId]() { ClearFilter(filterId); });
     }
+}
+
+void MainWindow::ClearSort()
+{
+    if (mTableView == nullptr)
+    {
+        return;
+    }
+    // Same call shape used by `SetColumnVisible` (when the user
+    // hides the sorted column) and the post-load rebuild paths,
+    // so the proxy / header / configuration stay in lockstep
+    // through one well-trodden code path.
+    mTableView->sortByColumn(-1, Qt::AscendingOrder);
+}
+
+bool MainWindow::AppendSortByEntries(QMenu *menu)
+{
+    if (menu == nullptr || mModel == nullptr || mSortFilterProxyModel == nullptr)
+    {
+        return false;
+    }
+
+    const auto &columns = mModel->Configuration().columns;
+    if (columns.empty())
+    {
+        return false;
+    }
+
+    // `sortByColumn` would be a structural no-op when the model
+    // has no rows -- the proxy still updates its sort column /
+    // order, but no permutation is visible. Disable the entries
+    // up-front to mirror Add-filter's "model has rows" gate; the
+    // header click already short-circuits in this state.
+    const bool modelHasRows = mModel->rowCount() > 0;
+    const int currentColumn = mSortFilterProxyModel->SortColumn();
+    const Qt::SortOrder currentOrder = mSortFilterProxyModel->SortOrder();
+
+    // Header-disambiguated labels (`name` vs `name [user|id]`),
+    // same helper the View / Add-filter / Clear-filters menus use.
+    const std::vector<QString> labels = BuildAllColumnMenuLabels();
+
+    bool addedAny = false;
+    for (size_t i = 0; i < columns.size(); ++i)
+    {
+        // Hidden columns are skipped to mirror Add-filter and the
+        // header right-click. Re-show is delegated to the View
+        // menu, same as for filtering.
+        if (!columns[i].visible)
+        {
+            continue;
+        }
+        const QString &label = labels[i];
+        const int columnIdx = static_cast<int>(i);
+
+        // Capture stable `keys` so a column reorder landing
+        // between menu build and click still hits the right
+        // column. Same pattern the Add-filter dropdown uses.
+        const auto &keys = columns[i].keys;
+
+        QAction *ascAct = menu->addAction(tr("Sort by \"%1\" ascending").arg(label));
+        ascAct->setCheckable(true);
+        ascAct->setChecked(currentColumn == columnIdx && currentOrder == Qt::AscendingOrder);
+        ascAct->setEnabled(modelHasRows);
+        connect(ascAct, &QAction::triggered, this, [this, keys]() {
+            const int idx = FindColumnIndexByKeys(keys);
+            if (idx < 0 || mTableView == nullptr)
+            {
+                return;
+            }
+            mTableView->sortByColumn(idx, Qt::AscendingOrder);
+        });
+
+        QAction *descAct = menu->addAction(tr("Sort by \"%1\" descending").arg(label));
+        descAct->setCheckable(true);
+        descAct->setChecked(currentColumn == columnIdx && currentOrder == Qt::DescendingOrder);
+        descAct->setEnabled(modelHasRows);
+        connect(descAct, &QAction::triggered, this, [this, keys]() {
+            const int idx = FindColumnIndexByKeys(keys);
+            if (idx < 0 || mTableView == nullptr)
+            {
+                return;
+            }
+            mTableView->sortByColumn(idx, Qt::DescendingOrder);
+        });
+
+        addedAny = true;
+    }
+
+    return addedAny;
+}
+
+void MainWindow::RebuildSortMenu()
+{
+    QMenu *menu = ui->menuSort;
+    if (menu == nullptr)
+    {
+        return;
+    }
+    // Refresh the action's enable state up-front so the entry
+    // looks right whether the rebuild produces per-column rows
+    // or not. `UpdateSortStatus` is the same wiring that drives
+    // the toolbar plain button + status-bar indicator.
+    UpdateSortStatus();
+
+    menu->clear();
+    // `actionClearSort` is the .ui-declared first child of
+    // `menuSort`; re-add it (the `clear()` above strips action
+    // attachments without destroying the action itself) so the
+    // top-of-menu Clear entry survives the rebuild.
+    menu->addAction(ui->actionClearSort);
+    menu->addSeparator();
+
+    if (mModel == nullptr || mModel->Configuration().columns.empty())
+    {
+        QAction *placeholder = menu->addAction(tr("(no columns yet)"));
+        placeholder->setEnabled(false);
+        return;
+    }
+
+    if (!AppendSortByEntries(menu))
+    {
+        // Every column hidden -- legal end state. Surface the
+        // condition explicitly so the user understands why the
+        // menu is otherwise empty (and where to re-show columns).
+        // Same wording as `RebuildAddFilterMenu`.
+        QAction *placeholder = menu->addAction(tr("(every column is hidden – use View menu to show one)"));
+        placeholder->setEnabled(false);
+    }
+}
+
+void MainWindow::RebuildSortByMenu(QMenu *menu)
+{
+    if (menu == nullptr)
+    {
+        return;
+    }
+    menu->clear();
+
+    if (mModel == nullptr || mModel->Configuration().columns.empty())
+    {
+        QAction *placeholder = menu->addAction(tr("(no columns yet)"));
+        placeholder->setEnabled(false);
+        return;
+    }
+
+    if (!AppendSortByEntries(menu))
+    {
+        QAction *placeholder = menu->addAction(tr("(every column is hidden – use View menu to show one)"));
+        placeholder->setEnabled(false);
+    }
+}
+
+void MainWindow::UpdateSortStatus()
+{
+    const int sortColumn =
+        (mSortFilterProxyModel != nullptr) ? mSortFilterProxyModel->SortColumn() : -1;
+    const int sourceRows = (mModel != nullptr) ? mModel->rowCount() : 0;
+    const bool sortActive = sortColumn >= 0;
+
+    if (ui != nullptr && ui->actionClearSort != nullptr)
+    {
+        ui->actionClearSort->setEnabled(sortActive);
+    }
+
+    if (mClearSortStatusButton == nullptr)
+    {
+        return;
+    }
+    if (sourceRows <= 0 || !sortActive)
+    {
+        mClearSortStatusButton->hide();
+        return;
+    }
+
+    // Tooltip names the live column so a rename / reorder shows
+    // through. `BuildAllColumnMenuLabels` disambiguates duplicate
+    // headers via `[keys]` so the tooltip is unambiguous even on
+    // configurations with header collisions.
+    const std::vector<QString> labels = BuildAllColumnMenuLabels();
+    QString columnLabel = (sortColumn < static_cast<int>(labels.size()))
+                              ? labels[static_cast<size_t>(sortColumn)]
+                              : tr("(unknown column)");
+    const QString directionWord = (mSortFilterProxyModel->SortOrder() == Qt::DescendingOrder)
+                                      ? tr("descending")
+                                      : tr("ascending");
+    mClearSortStatusButton->setToolTip(
+        tr("Sorted by \"%1\" (%2) - click to clear.").arg(columnLabel, directionWord)
+    );
+    mClearSortStatusButton->show();
 }
 
 void MainWindow::changeEvent(QEvent *event)

--- a/app/src/main_window.ui
+++ b/app/src/main_window.ui
@@ -211,13 +211,13 @@
   </action>
   <action name="actionSortBy">
    <property name="text">
-    <string>Sort By...</string>
+    <string>Sort By</string>
    </property>
    <property name="iconText">
     <string>Sort</string>
    </property>
    <property name="toolTip">
-    <string>Pick a column and direction to sort by. Click the arrow for the per-column shortcut menu.</string>
+    <string>Open the per-column sort menu (ascending or descending by any visible column).</string>
    </property>
   </action>
   <action name="actionClearSort">

--- a/app/src/main_window.ui
+++ b/app/src/main_window.ui
@@ -68,6 +68,13 @@
     <addaction name="actionClearAllFilters"/>
     <addaction name="separator"/>
    </widget>
+   <widget class="QMenu" name="menuSort">
+    <property name="title">
+     <string>Sort</string>
+    </property>
+    <addaction name="actionClearSort"/>
+    <addaction name="separator"/>
+   </widget>
    <widget class="QMenu" name="menuStream">
     <property name="title">
      <string>Stream</string>
@@ -86,6 +93,7 @@
    <addaction name="menuEdit"/>
    <addaction name="menuView"/>
    <addaction name="menuFilters"/>
+   <addaction name="menuSort"/>
    <addaction name="menuStream"/>
    <addaction name="menuSettings"/>
   </widget>
@@ -199,6 +207,28 @@
    </property>
    <property name="toolTip">
     <string>Remove every active filter rule and show every row. Click the arrow to remove a single filter.</string>
+   </property>
+  </action>
+  <action name="actionSortBy">
+   <property name="text">
+    <string>Sort By...</string>
+   </property>
+   <property name="iconText">
+    <string>Sort</string>
+   </property>
+   <property name="toolTip">
+    <string>Pick a column and direction to sort by. Click the arrow for the per-column shortcut menu.</string>
+   </property>
+  </action>
+  <action name="actionClearSort">
+   <property name="text">
+    <string>Clear Sort</string>
+   </property>
+   <property name="iconText">
+    <string>Clear Sort</string>
+   </property>
+   <property name="toolTip">
+    <string>Drop the active column sort and return rows to file order.</string>
    </property>
   </action>
   <action name="actionPreferences">

--- a/cmake/license_snippets/lucide.txt
+++ b/cmake/license_snippets/lucide.txt
@@ -1,12 +1,13 @@
 Lucide icons -- https://lucide.dev
 ==================================
 
-The 22 SVG files under `resources/icons/` (registered through
+The 24 SVG files under `resources/icons/` (registered through
 `resources/resources.qrc` and rendered by `app/src/icon_loader.cpp`)
 are taken verbatim from the Lucide project's icon set:
 
-    arrow-down-to-line, bookmark, file-clock, folder-open, funnel,
-    funnel-plus, funnel-x, panel-right-open, pause, radio-tower,
+    arrow-down-to-line, arrow-down-up, bookmark, circle-x,
+    file-clock, folder-open, funnel, funnel-plus, funnel-x,
+    panel-right-open, pause, radio-tower,
     search, settings-2, square-play, square,
     gauge (level-column header indicator),
     level-trace (chevron-right), level-debug (bug),

--- a/doc/README.md
+++ b/doc/README.md
@@ -215,7 +215,11 @@ You can persist a customized column layout and filter set via [configurations](#
 
 ## Navigating the Table
 
-- **Sorting**: click a column header to sort ascending/descending. Click again to toggle direction. The initial load is unsorted (records appear in file order).
+- **Sorting**: click a column header to sort ascending/descending. Click again to toggle direction; click a third time to clear the sort. The initial load is unsorted (records appear in file order). The same sort can also be installed and cleared from four other surfaces, all of which stay in lock-step:
+  - The top-level **Sort** menu lists every visible column twice (`Sort by "<col>" ascending` / `... descending`); the active sort is shown as a checked entry. The first row is **Clear Sort**, enabled only while a sort is active.
+  - The main toolbar carries a **Sort** split button (the dropdown mirrors the menu's per-column entries) and a plain **Clear Sort** button next to it.
+  - **Right-clicking a column header** offers `Sort ascending by "<col>"`, `Sort descending by "<col>"`, and `Clear sort` (gated on whether a sort is active) alongside the existing Hide / Edit column / Add filter entries.
+  - The status bar shows a **Clear sort** indicator while a sort is active; clicking it has the same effect as the menu / toolbar entry.
 - **Column resizing**: drag the column header dividers. The last column stretches automatically to fill remaining space.
 - **Smooth scrolling** is enabled by default (per-pixel) both vertically and horizontally.
 - **Alternating row colors** improve readability on dense logs. The table respects the application's light/dark palette.

--- a/doc/README.md
+++ b/doc/README.md
@@ -215,11 +215,11 @@ You can persist a customized column layout and filter set via [configurations](#
 
 ## Navigating the Table
 
-- **Sorting**: click a column header to sort ascending/descending. Click again to toggle direction; click a third time to clear the sort. The initial load is unsorted (records appear in file order). The same sort can also be installed and cleared from four other surfaces, all of which stay in lock-step:
-  - The top-level **Sort** menu lists every visible column twice (`Sort by "<col>" ascending` / `... descending`); the active sort is shown as a checked entry. The first row is **Clear Sort**, enabled only while a sort is active.
-  - The main toolbar carries a **Sort** split button (the dropdown mirrors the menu's per-column entries) and a plain **Clear Sort** button next to it.
-  - **Right-clicking a column header** offers `Sort ascending by "<col>"`, `Sort descending by "<col>"`, and `Clear sort` (gated on whether a sort is active) alongside the existing Hide / Edit column / Add filter entries.
-  - The status bar shows a **Clear sort** indicator while a sort is active; clicking it has the same effect as the menu / toolbar entry.
+- **Sorting**: click a column header to sort ascending, again to flip direction, a third time to clear. The initial load is unsorted (records appear in file order). The same sort is available from four other surfaces, all kept in lock-step:
+  - The **Sort** menu lists every visible column twice (`▲ "<col>"` / `▼ "<col>"`) with the active sort checked. The first row is **Clear Sort**.
+  - The main toolbar carries a **Sort** split button (mirroring the menu) and a plain **Clear Sort** button next to it.
+  - **Right-clicking a column header** offers `Sort ascending by "<col>"`, `Sort descending by "<col>"`, and `Clear sort`.
+  - The status bar shows a **Clear sort** indicator while a sort is active.
 - **Column resizing**: drag the column header dividers. The last column stretches automatically to fill remaining space.
 - **Smooth scrolling** is enabled by default (per-pixel) both vertically and horizontally.
 - **Alternating row colors** improve readability on dense logs. The table respects the application's light/dark palette.

--- a/resources/icons/arrow-down-up.svg
+++ b/resources/icons/arrow-down-up.svg
@@ -1,0 +1,16 @@
+<svg
+  xmlns="http://www.w3.org/2000/svg"
+  width="24"
+  height="24"
+  viewBox="0 0 24 24"
+  fill="none"
+  stroke="currentColor"
+  stroke-width="2"
+  stroke-linecap="round"
+  stroke-linejoin="round"
+>
+  <path d="m3 16 4 4 4-4" />
+  <path d="M7 20V4" />
+  <path d="m21 8-4-4-4 4" />
+  <path d="M17 4v16" />
+</svg>

--- a/resources/icons/circle-x.svg
+++ b/resources/icons/circle-x.svg
@@ -1,0 +1,15 @@
+<svg
+  xmlns="http://www.w3.org/2000/svg"
+  width="24"
+  height="24"
+  viewBox="0 0 24 24"
+  fill="none"
+  stroke="currentColor"
+  stroke-width="2"
+  stroke-linecap="round"
+  stroke-linejoin="round"
+>
+  <circle cx="12" cy="12" r="10" />
+  <path d="m15 9-6 6" />
+  <path d="m9 9 6 6" />
+</svg>

--- a/resources/resources.qrc
+++ b/resources/resources.qrc
@@ -21,7 +21,9 @@
              load-time by `icon_loader::MakeThemedIcon` so a single
              asset works for Light and Dark themes. -->
         <file>icons/arrow-down-to-line.svg</file>
+        <file>icons/arrow-down-up.svg</file>
         <file>icons/bookmark.svg</file>
+        <file>icons/circle-x.svg</file>
         <file>icons/file-clock.svg</file>
         <file>icons/folder-open.svg</file>
         <file>icons/funnel.svg</file>

--- a/test/app/src/main_window_test.cpp
+++ b/test/app/src/main_window_test.cpp
@@ -12456,11 +12456,12 @@ private slots:
         // NOLINTEND(clang-analyzer-core.CallAndMessage)
     }
 
-    // The Sort dropdown lists every *visible* column with two
-    // entries (`Sort by "<col>" ascending` and `... descending`).
-    // Verifies the population, the per-column doubling, and the
+    // The Sort dropdown lists every *visible* column as a
+    // per-column submenu (titled `"<col>"`) carrying three
+    // radio-checkable entries: `Ascending`, `Descending`, `None`.
+    // Verifies the population, the per-column triple, and the
     // hidden-column filter (toggling a column hidden must drop
-    // its entries on the next open, mirroring the Add-filter
+    // its submenu on the next open, mirroring the Add-filter
     // dropdown).
     void TestSortByDropdownListsVisibleColumns()
     {
@@ -12475,32 +12476,35 @@ private slots:
         // NOLINTBEGIN(clang-analyzer-core.CallAndMessage): prior QVERIFY2 aborts on null.
         emit menu->aboutToShow();
 
-        QStringList entryTexts;
-        for (const QAction *act : menu->actions())
+        const QList<QAction *> entries = menu->actions();
+        QVERIFY2(!entries.isEmpty(), "dropdown must list at least one column after streaming a fixture");
+        int submenuCount = 0;
+        for (const QAction *act : entries)
         {
-            entryTexts.append(act != nullptr ? act->text() : QStringLiteral("<null>"));
-        }
-        QVERIFY2(!entryTexts.isEmpty(), "dropdown must list at least one column after streaming a fixture");
-        int ascCount = 0;
-        int descCount = 0;
-        for (const QString &text : entryTexts)
-        {
+            QVERIFY2(act != nullptr, "dropdown entry must not be null");
+            const QMenu *colMenu = act->menu();
             QVERIFY2(
-                text.startsWith(QStringLiteral("Sort by ")),
-                "every dropdown entry must follow the `Sort by \"<col>\" ...` shape"
+                colMenu != nullptr,
+                "every dropdown entry must be a per-column submenu"
             );
-            if (text.endsWith(QStringLiteral("ascending")))
+            QVERIFY2(
+                act->text().startsWith(QStringLiteral("\"")) && act->text().endsWith(QStringLiteral("\"")),
+                "submenu title must be the column label wrapped in quotes"
+            );
+            const QList<QAction *> colActions = colMenu->actions();
+            QCOMPARE(colActions.size(), 3);
+            QCOMPARE(colActions[0]->text(), QStringLiteral("Ascending"));
+            QCOMPARE(colActions[1]->text(), QStringLiteral("Descending"));
+            QCOMPARE(colActions[2]->text(), QStringLiteral("None"));
+            for (const QAction *sub : colActions)
             {
-                ++ascCount;
+                QVERIFY2(sub->isCheckable(), "Asc / Desc / None entries must be checkable for the radio shape");
             }
-            else if (text.endsWith(QStringLiteral("descending")))
-            {
-                ++descCount;
-            }
+            ++submenuCount;
         }
-        QVERIFY2(ascCount > 0 && ascCount == descCount, "every column must contribute both an Asc and a Desc entry");
+        QVERIFY2(submenuCount > 0, "fixture must yield at least one column submenu");
 
-        // Hide the `msg` column and re-open: its entries must
+        // Hide the `msg` column and re-open: its submenu must
         // drop. Cross-checks the visible-only filter shared with
         // the Add-filter dropdown.
         auto *model = mWindow->Model();
@@ -12519,8 +12523,8 @@ private slots:
         // NOLINTEND(clang-analyzer-core.CallAndMessage)
     }
 
-    // Triggering a `Sort by "<col>" ascending|descending` dropdown
-    // entry installs the matching sort on the proxy. Pinned so a
+    // Triggering the `Descending` row in a column's submenu
+    // installs the matching sort on the proxy. Pinned so a
     // refactor that changes the `sortByColumn` plumbing would trip
     // here, replicating the `TestAddFilterDropdownTriggerPreselectsColumn`
     // contract for the sort entry point.
@@ -12534,17 +12538,27 @@ private slots:
         // NOLINTBEGIN(clang-analyzer-core.CallAndMessage): prior QVERIFY2 aborts on null.
         emit menu->aboutToShow();
 
-        QAction *categoryDesc = nullptr;
+        QMenu *categoryMenu = nullptr;
         for (QAction *act : menu->actions())
         {
-            if (act != nullptr && act->text().contains(QStringLiteral("\"category\"")) &&
-                act->text().endsWith(QStringLiteral("descending")))
+            if (act != nullptr && act->text().contains(QStringLiteral("\"category\"")) && act->menu() != nullptr)
             {
-                categoryDesc = act;
+                categoryMenu = act->menu();
                 break;
             }
         }
-        QVERIFY2(categoryDesc != nullptr, "dropdown must offer a descending entry for the `category` column");
+        QVERIFY2(categoryMenu != nullptr, "dropdown must offer a submenu for the `category` column");
+
+        QAction *categoryDesc = nullptr;
+        for (QAction *sub : categoryMenu->actions())
+        {
+            if (sub != nullptr && sub->text() == QStringLiteral("Descending"))
+            {
+                categoryDesc = sub;
+                break;
+            }
+        }
+        QVERIFY2(categoryDesc != nullptr, "category submenu must offer a Descending entry");
 
         categoryDesc->trigger();
         QCoreApplication::processEvents();
@@ -12556,8 +12570,11 @@ private slots:
 
     // `RebuildSortMenu` is hooked to `menuSort->aboutToShow`. The
     // top of the menu must always carry `actionClearSort` followed
-    // by a separator, then per-column Asc/Desc entries. Active
-    // sort is reflected via checkable check state.
+    // by a separator, then one per-column submenu (titled
+    // `"<col>"`) with three radio-checkable entries (Ascending /
+    // Descending / None). Active sort is reflected via the radio
+    // check state inside the matching column's submenu; columns
+    // not carrying the sort show `None` checked.
     void TestSortMenuShapeAndCheckmarks()
     {
         const int categoryCol = StreamFixtureForColumnTests();
@@ -12575,36 +12592,78 @@ private slots:
 
         emit menu->aboutToShow();
         const QList<QAction *> entries = menu->actions();
-        QVERIFY2(entries.size() >= 3, "Sort menu must have Clear + separator + at least one column entry");
+        QVERIFY2(entries.size() >= 3, "Sort menu must have Clear + separator + at least one column submenu");
         QCOMPARE(entries[0]->objectName(), QStringLiteral("actionClearSort"));
         QVERIFY2(entries[1]->isSeparator(), "second slot must be the separator");
         QVERIFY2(entries[0]->isEnabled(), "actionClearSort must be enabled while a sort is active");
 
-        // Walk the per-column rows and find the `category` Asc/Desc
-        // pair. Asc must be checked, Desc unchecked.
-        QAction *ascCategory = nullptr;
-        QAction *descCategory = nullptr;
+        // Walk the per-column submenus and find the `category`
+        // submenu. Asc must be checked; Desc and None unchecked.
+        QMenu *categoryMenu = nullptr;
+        QMenu *otherMenu = nullptr;
         for (QAction *act : entries)
         {
-            if (act == nullptr || act->isSeparator())
+            if (act == nullptr || act->isSeparator() || act->menu() == nullptr)
             {
                 continue;
             }
             if (act->text().contains(QStringLiteral("\"category\"")))
             {
-                if (act->text().endsWith(QStringLiteral("ascending")))
-                {
-                    ascCategory = act;
-                }
-                else if (act->text().endsWith(QStringLiteral("descending")))
-                {
-                    descCategory = act;
-                }
+                categoryMenu = act->menu();
+            }
+            else if (otherMenu == nullptr)
+            {
+                otherMenu = act->menu();
             }
         }
-        QVERIFY2(ascCategory != nullptr && descCategory != nullptr, "menu must carry both `category` entries");
+        QVERIFY2(categoryMenu != nullptr, "menu must carry a `category` submenu");
+
+        QAction *ascCategory = nullptr;
+        QAction *descCategory = nullptr;
+        QAction *noneCategory = nullptr;
+        for (QAction *sub : categoryMenu->actions())
+        {
+            if (sub == nullptr)
+            {
+                continue;
+            }
+            if (sub->text() == QStringLiteral("Ascending"))
+            {
+                ascCategory = sub;
+            }
+            else if (sub->text() == QStringLiteral("Descending"))
+            {
+                descCategory = sub;
+            }
+            else if (sub->text() == QStringLiteral("None"))
+            {
+                noneCategory = sub;
+            }
+        }
+        QVERIFY2(
+            ascCategory != nullptr && descCategory != nullptr && noneCategory != nullptr,
+            "category submenu must carry Ascending, Descending, and None entries"
+        );
         QVERIFY2(ascCategory->isChecked(), "active asc-sort entry must be checked");
         QVERIFY2(!descCategory->isChecked(), "non-active desc-sort entry must be unchecked");
+        QVERIFY2(!noneCategory->isChecked(), "None must be unchecked on the active sort column");
+
+        // Non-active columns show `None` as the resting radio
+        // check, so the radio shape is honest end-to-end.
+        if (otherMenu != nullptr)
+        {
+            QAction *otherNone = nullptr;
+            for (QAction *sub : otherMenu->actions())
+            {
+                if (sub != nullptr && sub->text() == QStringLiteral("None"))
+                {
+                    otherNone = sub;
+                    break;
+                }
+            }
+            QVERIFY2(otherNone != nullptr, "every column submenu must carry a None entry");
+            QVERIFY2(otherNone->isChecked(), "None must be checked on columns that are not the active sort");
+        }
         // NOLINTEND(clang-analyzer-core.CallAndMessage)
     }
 
@@ -12800,6 +12859,228 @@ private slots:
             sortActions[2]->text().contains(QStringLiteral("every column is hidden")),
             "placeholder must explain why the menu has no per-column entries"
         );
+        // NOLINTEND(clang-analyzer-core.CallAndMessage)
+    }
+
+    // A column whose data does not match its configured `Type`
+    // (`presentSlots > matchingSlots`) sorts via the wrong
+    // comparator and produces an order that does not reflect
+    // the on-screen values. The Sort submenus must therefore
+    // disable Asc / Desc on such columns; `None` stays enabled
+    // (it is a no-op for non-sorted columns and a clear for the
+    // active one). A tooltip on each disabled row points the
+    // user at Configuration Diagnostics so the cause is
+    // discoverable. Type-clean columns must keep both rows
+    // enabled in the same menu so the test pins both sides of
+    // the gate.
+    void TestSortSubmenuDisablesAscDescOnTypeMismatch()
+    {
+        const int categoryCol = StreamFixtureForColumnTests();
+        QVERIFY2(categoryCol >= 0, "fixture must expose `category` column");
+        auto *model = mWindow->Model();
+        const int msgCol = ColumnByHeader(*model, QStringLiteral("msg"));
+        QVERIFY2(msgCol >= 0, "fixture must expose `msg` column");
+
+        // Pin `msg` (string-only) to `Integer` to force a
+        // type mismatch and re-snapshot health. Same pattern as
+        // `TestColumnHealthFlagsMismatchedType`.
+        model->ConfigurationManager().SetColumnAutoDetect(static_cast<size_t>(msgCol), false);
+        model->ConfigurationManager().SetColumnType(
+            static_cast<size_t>(msgCol), loglib::LogConfiguration::Type::Integer
+        );
+        model->RefreshColumnHealth();
+        QCoreApplication::processEvents();
+
+        const auto msgHealth = model->ColumnHealth(msgCol);
+        QVERIFY2(msgHealth.has_value(), "ColumnHealth must yield a snapshot after Refresh");
+        // NOLINTNEXTLINE(bugprone-unchecked-optional-access): asserted above.
+        QVERIFY2(
+            msgHealth->presentSlots > msgHealth->matchingSlots,
+            "fixture precondition: msg column must report a type mismatch after the Integer pin"
+        );
+
+        auto *splitMenu = mWindow->findChild<QMenu *>(QStringLiteral("sortBySplitMenu"));
+        QVERIFY2(splitMenu != nullptr, "sort split menu must exist");
+        // NOLINTBEGIN(clang-analyzer-core.CallAndMessage): prior QVERIFY2 aborts on null.
+        emit splitMenu->aboutToShow();
+
+        QMenu *msgSubmenu = nullptr;
+        QMenu *categorySubmenu = nullptr;
+        for (QAction *act : splitMenu->actions())
+        {
+            if (act == nullptr || act->menu() == nullptr)
+            {
+                continue;
+            }
+            if (act->text().contains(QStringLiteral("\"msg\"")))
+            {
+                msgSubmenu = act->menu();
+            }
+            else if (act->text().contains(QStringLiteral("\"category\"")))
+            {
+                categorySubmenu = act->menu();
+            }
+        }
+        QVERIFY2(msgSubmenu != nullptr, "sort dropdown must carry a submenu for the mismatched `msg` column");
+        QVERIFY2(
+            categorySubmenu != nullptr,
+            "sort dropdown must carry a submenu for the type-clean `category` column (control)"
+        );
+
+        const auto findSubAction = [](QMenu *m, const QString &text) -> QAction * {
+            for (QAction *sub : m->actions())
+            {
+                if (sub != nullptr && sub->text() == text)
+                {
+                    return sub;
+                }
+            }
+            return nullptr;
+        };
+
+        QAction *msgAsc = findSubAction(msgSubmenu, QStringLiteral("Ascending"));
+        QAction *msgDesc = findSubAction(msgSubmenu, QStringLiteral("Descending"));
+        QAction *msgNone = findSubAction(msgSubmenu, QStringLiteral("None"));
+        QVERIFY2(
+            msgAsc != nullptr && msgDesc != nullptr && msgNone != nullptr,
+            "msg submenu must carry Ascending / Descending / None"
+        );
+        QVERIFY2(!msgAsc->isEnabled(), "Ascending must be disabled on a type-mismatched column");
+        QVERIFY2(!msgDesc->isEnabled(), "Descending must be disabled on a type-mismatched column");
+        QVERIFY2(msgNone->isEnabled(), "None must stay enabled on a type-mismatched column");
+        QVERIFY2(
+            msgAsc->toolTip().contains(QStringLiteral("does not match")),
+            "disabled Ascending row must explain the type-mismatch cause via tooltip"
+        );
+        QVERIFY2(
+            msgDesc->toolTip().contains(QStringLiteral("does not match")),
+            "disabled Descending row must explain the type-mismatch cause via tooltip"
+        );
+        QVERIFY2(msgSubmenu->toolTipsVisible(), "submenu must opt into per-action tooltips");
+
+        QAction *categoryAsc = findSubAction(categorySubmenu, QStringLiteral("Ascending"));
+        QAction *categoryDesc = findSubAction(categorySubmenu, QStringLiteral("Descending"));
+        QVERIFY2(
+            categoryAsc != nullptr && categoryDesc != nullptr,
+            "category submenu must carry Asc / Desc (control)"
+        );
+        QVERIFY2(categoryAsc->isEnabled(), "Asc must remain enabled on a type-clean column");
+        QVERIFY2(categoryDesc->isEnabled(), "Desc must remain enabled on a type-clean column");
+
+        // Top-level Sort menu must carry the same gate. The
+        // shared `AppendSortByEntries` core feeds both surfaces,
+        // but pinning here protects against a future split.
+        auto *sortMenu = mWindow->findChild<QMenu *>(QStringLiteral("menuSort"));
+        QVERIFY2(sortMenu != nullptr, "Sort menu must exist");
+        emit sortMenu->aboutToShow();
+        QMenu *sortMsgSubmenu = nullptr;
+        for (QAction *act : sortMenu->actions())
+        {
+            if (act != nullptr && act->menu() != nullptr && act->text().contains(QStringLiteral("\"msg\"")))
+            {
+                sortMsgSubmenu = act->menu();
+                break;
+            }
+        }
+        QVERIFY2(sortMsgSubmenu != nullptr, "top-level Sort menu must also carry the msg submenu");
+        QAction *sortMsgAsc = findSubAction(sortMsgSubmenu, QStringLiteral("Ascending"));
+        QAction *sortMsgDesc = findSubAction(sortMsgSubmenu, QStringLiteral("Descending"));
+        QVERIFY2(
+            sortMsgAsc != nullptr && sortMsgDesc != nullptr,
+            "top-level Sort menu msg submenu must carry Asc / Desc"
+        );
+        QVERIFY2(!sortMsgAsc->isEnabled(), "top-level Sort menu Asc must be disabled on mismatch");
+        QVERIFY2(!sortMsgDesc->isEnabled(), "top-level Sort menu Desc must be disabled on mismatch");
+        // NOLINTEND(clang-analyzer-core.CallAndMessage)
+    }
+
+    // The header right-click menu's Sort block mirrors the same
+    // type-mismatch gate the Sort submenus apply, so a user who
+    // right-clicks a flagged column header sees Asc / Desc
+    // disabled with the same diagnostic tooltip. Pinned because
+    // the right-click sort block has its own action-creation
+    // path (not shared with `AppendSortByEntries`), so a future
+    // refactor that converges them must not silently drop the
+    // gate on either side.
+    void TestHeaderContextMenuDisablesSortOnTypeMismatch()
+    {
+        const int categoryCol = StreamFixtureForColumnTests();
+        QVERIFY2(categoryCol >= 0, "fixture must expose `category` column");
+        auto *model = mWindow->Model();
+        const int msgCol = ColumnByHeader(*model, QStringLiteral("msg"));
+        QVERIFY2(msgCol >= 0, "fixture must expose `msg` column");
+
+        model->ConfigurationManager().SetColumnAutoDetect(static_cast<size_t>(msgCol), false);
+        model->ConfigurationManager().SetColumnType(
+            static_cast<size_t>(msgCol), loglib::LogConfiguration::Type::Integer
+        );
+        model->RefreshColumnHealth();
+        QCoreApplication::processEvents();
+
+        auto built = mWindow->BuildHeaderContextMenu(msgCol, nullptr);
+        QVERIFY2(built.menu != nullptr, "BuildHeaderContextMenu must return a menu");
+        // NOLINTBEGIN(clang-analyzer-core.CallAndMessage): prior QVERIFY2 aborts on null.
+        QScopeGuard freeMenu([&built]() { built.menu->deleteLater(); });
+
+        QAction *asc = nullptr;
+        QAction *desc = nullptr;
+        for (QAction *act : built.menu->actions())
+        {
+            if (act == nullptr || act->isSeparator())
+            {
+                continue;
+            }
+            if (act->text().startsWith(QStringLiteral("Sort ascending")))
+            {
+                asc = act;
+            }
+            else if (act->text().startsWith(QStringLiteral("Sort descending")))
+            {
+                desc = act;
+            }
+        }
+        QVERIFY2(asc != nullptr && desc != nullptr, "header menu must include Sort asc/desc entries");
+        QVERIFY2(!asc->isEnabled(), "header right-click Sort ascending must be disabled on a type-mismatched column");
+        QVERIFY2(!desc->isEnabled(), "header right-click Sort descending must be disabled on a type-mismatched column");
+        QVERIFY2(
+            asc->toolTip().contains(QStringLiteral("does not match")),
+            "disabled header Sort ascending must explain the type-mismatch cause via tooltip"
+        );
+        QVERIFY2(
+            desc->toolTip().contains(QStringLiteral("does not match")),
+            "disabled header Sort descending must explain the type-mismatch cause via tooltip"
+        );
+        QVERIFY2(built.menu->toolTipsVisible(), "header menu must opt into per-action tooltips");
+
+        // Control: a type-clean column keeps Asc / Desc enabled
+        // on the same right-click path.
+        auto controlBuilt = mWindow->BuildHeaderContextMenu(categoryCol, nullptr);
+        QVERIFY2(controlBuilt.menu != nullptr, "BuildHeaderContextMenu must return a menu");
+        QScopeGuard freeControl([&controlBuilt]() { controlBuilt.menu->deleteLater(); });
+
+        QAction *controlAsc = nullptr;
+        QAction *controlDesc = nullptr;
+        for (QAction *act : controlBuilt.menu->actions())
+        {
+            if (act == nullptr || act->isSeparator())
+            {
+                continue;
+            }
+            if (act->text().startsWith(QStringLiteral("Sort ascending")))
+            {
+                controlAsc = act;
+            }
+            else if (act->text().startsWith(QStringLiteral("Sort descending")))
+            {
+                controlDesc = act;
+            }
+        }
+        QVERIFY2(
+            controlAsc != nullptr && controlDesc != nullptr,
+            "header menu on a type-clean column must include Sort asc/desc entries"
+        );
+        QVERIFY2(controlAsc->isEnabled(), "Sort ascending must stay enabled on a type-clean column");
+        QVERIFY2(controlDesc->isEnabled(), "Sort descending must stay enabled on a type-clean column");
         // NOLINTEND(clang-analyzer-core.CallAndMessage)
     }
 

--- a/test/app/src/main_window_test.cpp
+++ b/test/app/src/main_window_test.cpp
@@ -12430,18 +12430,21 @@ private slots:
         // NOLINTEND(clang-analyzer-core.CallAndMessage)
     }
 
-    // Shape contract for the Sort split button: `MenuButtonPopup`
-    // `QToolButton` whose default action is the bare `actionSortBy`
-    // (a face click programmatically pops the dropdown -- sort has
-    // no generic editor like filters do) and whose dropdown menu
-    // carries the `sortBySplitMenu` objectName. Mirrors
-    // `TestAddFilterSplitButtonShape`.
+    // Shape contract for the Sort dropdown button: `InstantPopup`
+    // `QToolButton` whose entire face opens the per-column menu
+    // (sort has no useful generic editor, so the click-vs-arrow
+    // split the Add-filter button uses would be redundant), with
+    // `actionSortBy` as its default action for icon/tooltip
+    // propagation, and whose popup menu carries the
+    // `sortBySplitMenu` objectName. Mirrors
+    // `TestAddFilterSplitButtonShape` but pins the simpler
+    // single-target popup mode.
     void TestSortBySplitButtonShape()
     {
         auto *button = mWindow->findChild<QToolButton *>(QStringLiteral("sortBySplitButton"));
         QVERIFY2(button != nullptr, "primary toolbar must host the sort split button");
         // NOLINTBEGIN(clang-analyzer-core.CallAndMessage): prior QVERIFY2 aborts on null.
-        QCOMPARE(button->popupMode(), QToolButton::MenuButtonPopup);
+        QCOMPARE(button->popupMode(), QToolButton::InstantPopup);
 
         const QAction *defaultAction = button->defaultAction();
         QVERIFY2(defaultAction != nullptr, "split button must have a default action");
@@ -12461,8 +12464,11 @@ private slots:
     // dropdown).
     void TestSortByDropdownListsVisibleColumns()
     {
-        const int levelCol = StreamFixtureForColumnTests();
-        QVERIFY2(levelCol >= 0, "fixture must produce columns");
+        // `StreamFixtureForColumnTests` returns the `category`
+        // column index despite its historical name; bind to the
+        // honest variable name to keep the test self-documenting.
+        const int categoryCol = StreamFixtureForColumnTests();
+        QVERIFY2(categoryCol >= 0, "fixture must produce columns");
 
         auto *menu = mWindow->findChild<QMenu *>(QStringLiteral("sortBySplitMenu"));
         QVERIFY2(menu != nullptr, "sort dropdown must exist");
@@ -12520,10 +12526,7 @@ private slots:
     // contract for the sort entry point.
     void TestSortByDropdownTriggerSortsByColumn()
     {
-        const int levelCol = StreamFixtureForColumnTests();
-        QVERIFY2(levelCol >= 0, "fixture must produce columns");
-        auto *model = mWindow->Model();
-        const int categoryCol = ColumnByHeader(*model, QStringLiteral("category"));
+        const int categoryCol = StreamFixtureForColumnTests();
         QVERIFY2(categoryCol >= 0, "fixture must expose `category` column");
 
         auto *menu = mWindow->findChild<QMenu *>(QStringLiteral("sortBySplitMenu"));
@@ -12557,10 +12560,7 @@ private slots:
     // sort is reflected via checkable check state.
     void TestSortMenuShapeAndCheckmarks()
     {
-        const int levelCol = StreamFixtureForColumnTests();
-        QVERIFY2(levelCol >= 0, "fixture must produce columns");
-        auto *model = mWindow->Model();
-        const int categoryCol = ColumnByHeader(*model, QStringLiteral("category"));
+        const int categoryCol = StreamFixtureForColumnTests();
         QVERIFY2(categoryCol >= 0, "fixture must expose `category` column");
 
         auto *menu = mWindow->findChild<QMenu *>(QStringLiteral("menuSort"));
@@ -12614,10 +12614,7 @@ private slots:
     // shape, contextualised to the right-clicked column.
     void TestHeaderContextMenuSortEntries()
     {
-        const int levelCol = StreamFixtureForColumnTests();
-        QVERIFY2(levelCol >= 0, "fixture must produce columns");
-        auto *model = mWindow->Model();
-        const int categoryCol = ColumnByHeader(*model, QStringLiteral("category"));
+        const int categoryCol = StreamFixtureForColumnTests();
         QVERIFY2(categoryCol >= 0, "fixture must expose `category` column");
 
         // Without a sort, Clear sort is disabled and neither
@@ -12625,6 +12622,9 @@ private slots:
         auto built = mWindow->BuildHeaderContextMenu(categoryCol, nullptr);
         QVERIFY2(built.menu != nullptr, "BuildHeaderContextMenu must return a menu");
         // NOLINTBEGIN(clang-analyzer-core.CallAndMessage): prior QVERIFY2 aborts on null.
+        // `QScopeGuard` covers both the happy path and any
+        // QVERIFY2-driven early return; reset it once we want to
+        // build a second menu so we don't double-delete.
         QScopeGuard freeMenu1([&built]() { built.menu->deleteLater(); });
 
         QAction *clearSortNoSort = nullptr;
@@ -12655,8 +12655,6 @@ private slots:
         );
         QVERIFY2(!clearSortNoSort->isEnabled(), "Clear sort must be disabled when no sort is active");
         QVERIFY2(!ascNoSort->isChecked() && !descNoSort->isChecked(), "neither direction is checked without a sort");
-        freeMenu1.dismiss();
-        built.menu->deleteLater();
 
         // With a desc sort on `category`, the matching entry is
         // checked and Clear sort is enabled.
@@ -12709,10 +12707,7 @@ private slots:
     // status-button behaviour.
     void TestClearSortStatusButtonVisibilityFollowsSort()
     {
-        const int levelCol = StreamFixtureForColumnTests();
-        QVERIFY2(levelCol >= 0, "fixture must produce columns");
-        auto *model = mWindow->Model();
-        const int categoryCol = ColumnByHeader(*model, QStringLiteral("category"));
+        const int categoryCol = StreamFixtureForColumnTests();
         QVERIFY2(categoryCol >= 0, "fixture must expose `category` column");
 
         auto *button = mWindow->findChild<QPushButton *>(QStringLiteral("clearSortStatusButton"));
@@ -12737,10 +12732,7 @@ private slots:
     // column. Mirrors `actionClearAllFilters`'s gating.
     void TestActionClearSortEnableStateFollowsSort()
     {
-        const int levelCol = StreamFixtureForColumnTests();
-        QVERIFY2(levelCol >= 0, "fixture must produce columns");
-        auto *model = mWindow->Model();
-        const int categoryCol = ColumnByHeader(*model, QStringLiteral("category"));
+        const int categoryCol = StreamFixtureForColumnTests();
         QVERIFY2(categoryCol >= 0, "fixture must expose `category` column");
 
         auto *action = mWindow->findChild<QAction *>(QStringLiteral("actionClearSort"));
@@ -12755,6 +12747,104 @@ private slots:
         mWindow->findChild<LogTableView *>()->sortByColumn(-1, Qt::AscendingOrder);
         QCoreApplication::processEvents();
         QVERIFY2(!action->isEnabled(), "actionClearSort must disable again after a clear");
+        // NOLINTEND(clang-analyzer-core.CallAndMessage)
+    }
+
+    // Hiding every visible column must surface the
+    // `(every column is hidden ...)` placeholder in both the
+    // top-level Sort menu (after the Clear-sort entry +
+    // separator) and the toolbar dropdown. Pins the
+    // `AppendSortByEntries == false` branch so a future change
+    // to the visibility-filter doesn't silently leave the menus
+    // empty.
+    void TestSortDropdownPlaceholderWhenAllColumnsHidden()
+    {
+        const int categoryCol = StreamFixtureForColumnTests();
+        QVERIFY2(categoryCol >= 0, "fixture must expose `category` column");
+        auto *model = mWindow->Model();
+        const int msgCol = ColumnByHeader(*model, QStringLiteral("msg"));
+        QVERIFY2(msgCol >= 0, "fixture must expose `msg` column");
+
+        // Hide every visible column. `SetColumnVisible` clears
+        // the active sort if the hidden column was the sorted
+        // one, so `actionClearSort` need not be enabled here.
+        mWindow->SetColumnVisible(categoryCol, false);
+        mWindow->SetColumnVisible(msgCol, false);
+        QCoreApplication::processEvents();
+
+        // Toolbar dropdown: a single placeholder, disabled.
+        auto *splitMenu = mWindow->findChild<QMenu *>(QStringLiteral("sortBySplitMenu"));
+        QVERIFY2(splitMenu != nullptr, "sort split menu must exist");
+        // NOLINTBEGIN(clang-analyzer-core.CallAndMessage): prior QVERIFY2 aborts on null.
+        emit splitMenu->aboutToShow();
+        const QList<QAction *> splitActions = splitMenu->actions();
+        QCOMPARE(splitActions.size(), 1);
+        QVERIFY2(splitActions[0] != nullptr, "placeholder action must be present");
+        QVERIFY2(!splitActions[0]->isEnabled(), "placeholder must be disabled");
+        QVERIFY2(
+            splitActions[0]->text().contains(QStringLiteral("every column is hidden")),
+            "placeholder must explain why the dropdown is empty"
+        );
+
+        // Top-level Sort menu: Clear-sort + separator +
+        // placeholder.
+        auto *sortMenu = mWindow->findChild<QMenu *>(QStringLiteral("menuSort"));
+        QVERIFY2(sortMenu != nullptr, "Sort menu must exist");
+        emit sortMenu->aboutToShow();
+        const QList<QAction *> sortActions = sortMenu->actions();
+        QCOMPARE(sortActions.size(), 3);
+        QCOMPARE(sortActions[0]->objectName(), QStringLiteral("actionClearSort"));
+        QVERIFY2(sortActions[1]->isSeparator(), "second slot must be the separator");
+        QVERIFY2(!sortActions[2]->isEnabled(), "placeholder must be disabled");
+        QVERIFY2(
+            sortActions[2]->text().contains(QStringLiteral("every column is hidden")),
+            "placeholder must explain why the menu has no per-column entries"
+        );
+        // NOLINTEND(clang-analyzer-core.CallAndMessage)
+    }
+
+    // The status-bar tooltip must rebuild when the sorted
+    // column's header is renamed via `NotifyColumnEdited` -- a
+    // path that emits `headerDataChanged` but no `layoutChanged`,
+    // so without the dedicated hook the tooltip would freeze on
+    // the previous label until the next sort / filter event.
+    void TestSortStatusTooltipUpdatesOnColumnRename()
+    {
+        const int categoryCol = StreamFixtureForColumnTests();
+        QVERIFY2(categoryCol >= 0, "fixture must expose `category` column");
+
+        // Sort so the status-bar button surfaces; its tooltip
+        // resolves the live column label.
+        mWindow->findChild<LogTableView *>()->sortByColumn(categoryCol, Qt::AscendingOrder);
+        QCoreApplication::processEvents();
+
+        auto *button = mWindow->findChild<QPushButton *>(QStringLiteral("clearSortStatusButton"));
+        QVERIFY2(button != nullptr, "status bar must host the clear-sort indicator");
+        // NOLINTBEGIN(clang-analyzer-core.CallAndMessage): prior QVERIFY2 aborts on null.
+        QVERIFY2(!button->isHidden(), "indicator must surface while a sort is active");
+        QVERIFY2(
+            button->toolTip().contains(QStringLiteral("\"category\"")),
+            "initial tooltip must name the sorted column"
+        );
+
+        // Rename the column header and emit the same
+        // `NotifyColumnEdited` the column editor would fire.
+        // The tooltip refresh hangs off `headerDataChanged`, so
+        // the status-bar text must catch the new label without
+        // any sort / filter event in between.
+        auto *model = mWindow->Model();
+        model->ConfigurationManager().SetColumnHeader(static_cast<size_t>(categoryCol), std::string("renamed-cat"));
+        model->NotifyColumnEdited(categoryCol);
+        QCoreApplication::processEvents();
+
+        QVERIFY2(
+            button->toolTip().contains(QStringLiteral("\"renamed-cat\"")),
+            "tooltip must reflect the renamed column without waiting for a sort/filter event"
+        );
+        QVERIFY2(
+            !button->toolTip().contains(QStringLiteral("\"category\"")),
+            "tooltip must not still carry the stale column label"
+        );
         // NOLINTEND(clang-analyzer-core.CallAndMessage)
     }
 
@@ -16504,6 +16594,23 @@ private slots:
         QCOMPARE(restoredFilter->SortColumn(), categoryCol);
         QCOMPARE(restoredFilter->SortOrder(), Qt::DescendingOrder);
         QCOMPARE(restored->Model()->rowCount(), fixtureLines.size());
+
+        // The deferred sort reaches `UpdateSortStatus` indirectly
+        // via the `layoutChanged` it issues, so the status-bar
+        // indicator and `actionClearSort` must mirror the
+        // restored sort once streaming settles. Pinned so a future
+        // refactor of the deferred-restore plumbing can't silently
+        // strand the status-bar / menu state out of sync with the
+        // proxy.
+        auto *restoredClearSortAction = restored->findChild<QAction *>(QStringLiteral("actionClearSort"));
+        QVERIFY2(restoredClearSortAction != nullptr, "restored window must own actionClearSort");
+        // NOLINTNEXTLINE(clang-analyzer-core.CallAndMessage): prior QVERIFY2 aborts on null.
+        QVERIFY2(restoredClearSortAction->isEnabled(), "actionClearSort must be enabled after deferred restore");
+        auto *restoredClearSortButton =
+            restored->findChild<QPushButton *>(QStringLiteral("clearSortStatusButton"));
+        QVERIFY2(restoredClearSortButton != nullptr, "restored window must own clearSortStatusButton");
+        // NOLINTNEXTLINE(clang-analyzer-core.CallAndMessage): prior QVERIFY2 aborts on null.
+        QVERIFY2(!restoredClearSortButton->isHidden(), "status-bar Clear-sort indicator must surface after restore");
     }
 
     // Recent Sessions submenu rebuild on `aboutToShow`. Asserts:

--- a/test/app/src/main_window_test.cpp
+++ b/test/app/src/main_window_test.cpp
@@ -6250,16 +6250,22 @@ private slots:
         const QScopeGuard menuDeleter([&built]() { built.menu->deleteLater(); });
 
         const QList<QAction *> topActions = built.menu->actions();
-        QCOMPARE(topActions.size(), 5);
+        QCOMPARE(topActions.size(), 9);
 
-        // Hide → Edit column → separator → Add filter on ... → filter submenu.
+        // Hide -> Edit column -> separator -> Add filter on ... ->
+        // filter submenu -> separator -> Sort asc -> Sort desc ->
+        // Clear sort. The trailing sort block sits after the
+        // filter block so the column-mutation actions group above
+        // the row-projection actions.
         QVERIFY2(topActions[0]->text().startsWith("Hide"), "first action must be Hide");
         QVERIFY2(topActions[1]->text().startsWith("Edit column"), "second action must be Edit column ...");
         QVERIFY2(topActions[2]->isSeparator(), "third action must be a separator");
         QVERIFY2(topActions[3]->text().startsWith("Add filter on"), "fourth action must be Add filter on ...");
-        // Last non-separator is the filter submenu; its title is the
-        // filter's display value, not a fixed string.
         QVERIFY2(!topActions[4]->isSeparator(), "fifth action must be the filter submenu");
+        QVERIFY2(topActions[5]->isSeparator(), "sixth action must be the sort-block separator");
+        QVERIFY2(topActions[6]->text().startsWith("Sort ascending"), "seventh action must be Sort ascending");
+        QVERIFY2(topActions[7]->text().startsWith("Sort descending"), "eighth action must be Sort descending");
+        QCOMPARE(topActions[8]->text(), QStringLiteral("Clear sort"));
     }
 
     // With zero rows, Add-filter and per-filter Edit must be
@@ -11917,6 +11923,8 @@ private slots:
             QStringLiteral("__sep"),
             QStringLiteral("__widget"), // addFilterSplitButton
             QStringLiteral("__widget"), // clearFiltersSplitButton
+            QStringLiteral("__widget"), // sortBySplitButton
+            QStringLiteral("actionClearSort"),
             QStringLiteral("__sep"),
             QStringLiteral("actionToggleFind"),
             QStringLiteral("actionToggleRecordDetails"),

--- a/test/app/src/main_window_test.cpp
+++ b/test/app/src/main_window_test.cpp
@@ -12456,13 +12456,13 @@ private slots:
         // NOLINTEND(clang-analyzer-core.CallAndMessage)
     }
 
-    // The Sort dropdown lists every *visible* column as a
-    // per-column submenu (titled `"<col>"`) carrying three
-    // radio-checkable entries: `Ascending`, `Descending`, `None`.
-    // Verifies the population, the per-column triple, and the
-    // hidden-column filter (toggling a column hidden must drop
-    // its submenu on the next open, mirroring the Add-filter
-    // dropdown).
+    // The Sort dropdown lists every *visible* column as two flat
+    // checkable rows: an asc row prefixed with the U+25B2 (▲)
+    // glyph and a desc row prefixed with U+25BC (▼), followed by
+    // the disambiguated column label in quotes. Verifies the
+    // population, the per-column doubling, and the hidden-column
+    // filter (toggling a column hidden must drop its rows on the
+    // next open, mirroring the Add-filter dropdown).
     void TestSortByDropdownListsVisibleColumns()
     {
         // `StreamFixtureForColumnTests` returns the `category`
@@ -12478,35 +12478,40 @@ private slots:
 
         const QList<QAction *> entries = menu->actions();
         QVERIFY2(!entries.isEmpty(), "dropdown must list at least one column after streaming a fixture");
-        int submenuCount = 0;
+        int ascCount = 0;
+        int descCount = 0;
         for (const QAction *act : entries)
         {
             QVERIFY2(act != nullptr, "dropdown entry must not be null");
-            const QMenu *colMenu = act->menu();
+            QVERIFY2(act->menu() == nullptr, "flat entries must not carry submenus");
+            QVERIFY2(act->isCheckable(), "every dropdown row must be checkable");
+            const QString text = act->text();
             QVERIFY2(
-                colMenu != nullptr,
-                "every dropdown entry must be a per-column submenu"
+                text.contains(QStringLiteral("\"")),
+                "every dropdown row must carry the column label in quotes"
             );
             QVERIFY2(
-                act->text().startsWith(QStringLiteral("\"")) && act->text().endsWith(QStringLiteral("\"")),
-                "submenu title must be the column label wrapped in quotes"
+                !text.contains(QStringLiteral("Sort by")),
+                "row text is just glyph + quoted column name; the host menu carries the verb"
             );
-            const QList<QAction *> colActions = colMenu->actions();
-            QCOMPARE(colActions.size(), 3);
-            QCOMPARE(colActions[0]->text(), QStringLiteral("Ascending"));
-            QCOMPARE(colActions[1]->text(), QStringLiteral("Descending"));
-            QCOMPARE(colActions[2]->text(), QStringLiteral("None"));
-            for (const QAction *sub : colActions)
+            if (text.startsWith(QString::fromUtf8(u8"\u25B2")))
             {
-                QVERIFY2(sub->isCheckable(), "Asc / Desc / None entries must be checkable for the radio shape");
+                ++ascCount;
             }
-            ++submenuCount;
+            else if (text.startsWith(QString::fromUtf8(u8"\u25BC")))
+            {
+                ++descCount;
+            }
+            else
+            {
+                QFAIL("every dropdown row must start with the asc / desc triangle glyph");
+            }
         }
-        QVERIFY2(submenuCount > 0, "fixture must yield at least one column submenu");
+        QVERIFY2(ascCount > 0 && ascCount == descCount, "every column must contribute both an Asc and a Desc row");
 
-        // Hide the `msg` column and re-open: its submenu must
-        // drop. Cross-checks the visible-only filter shared with
-        // the Add-filter dropdown.
+        // Hide the `msg` column and re-open: its rows must drop.
+        // Cross-checks the visible-only filter shared with the
+        // Add-filter dropdown.
         auto *model = mWindow->Model();
         const int msgCol = ColumnByHeader(*model, QStringLiteral("msg"));
         QVERIFY2(msgCol >= 0, "fixture must expose `msg` column");
@@ -12523,11 +12528,11 @@ private slots:
         // NOLINTEND(clang-analyzer-core.CallAndMessage)
     }
 
-    // Triggering the `Descending` row in a column's submenu
-    // installs the matching sort on the proxy. Pinned so a
-    // refactor that changes the `sortByColumn` plumbing would trip
-    // here, replicating the `TestAddFilterDropdownTriggerPreselectsColumn`
-    // contract for the sort entry point.
+    // Triggering a desc row installs the matching sort on the
+    // proxy. Pinned so a refactor that changes the
+    // `sortByColumn` plumbing would trip here, replicating the
+    // `TestAddFilterDropdownTriggerPreselectsColumn` contract
+    // for the sort entry point.
     void TestSortByDropdownTriggerSortsByColumn()
     {
         const int categoryCol = StreamFixtureForColumnTests();
@@ -12538,27 +12543,17 @@ private slots:
         // NOLINTBEGIN(clang-analyzer-core.CallAndMessage): prior QVERIFY2 aborts on null.
         emit menu->aboutToShow();
 
-        QMenu *categoryMenu = nullptr;
+        QAction *categoryDesc = nullptr;
         for (QAction *act : menu->actions())
         {
-            if (act != nullptr && act->text().contains(QStringLiteral("\"category\"")) && act->menu() != nullptr)
+            if (act != nullptr && act->text().contains(QStringLiteral("\"category\"")) &&
+                act->text().startsWith(QString::fromUtf8(u8"\u25BC")))
             {
-                categoryMenu = act->menu();
+                categoryDesc = act;
                 break;
             }
         }
-        QVERIFY2(categoryMenu != nullptr, "dropdown must offer a submenu for the `category` column");
-
-        QAction *categoryDesc = nullptr;
-        for (QAction *sub : categoryMenu->actions())
-        {
-            if (sub != nullptr && sub->text() == QStringLiteral("Descending"))
-            {
-                categoryDesc = sub;
-                break;
-            }
-        }
-        QVERIFY2(categoryDesc != nullptr, "category submenu must offer a Descending entry");
+        QVERIFY2(categoryDesc != nullptr, "dropdown must offer a desc row for the `category` column");
 
         categoryDesc->trigger();
         QCoreApplication::processEvents();
@@ -12570,11 +12565,10 @@ private slots:
 
     // `RebuildSortMenu` is hooked to `menuSort->aboutToShow`. The
     // top of the menu must always carry `actionClearSort` followed
-    // by a separator, then one per-column submenu (titled
-    // `"<col>"`) with three radio-checkable entries (Ascending /
-    // Descending / None). Active sort is reflected via the radio
-    // check state inside the matching column's submenu; columns
-    // not carrying the sort show `None` checked.
+    // by a separator, then two flat checkable rows per visible
+    // column (▲ asc, ▼ desc). Sort is single-column /
+    // single-direction, so at most one row across the menu is
+    // ever checked at a time.
     void TestSortMenuShapeAndCheckmarks()
     {
         const int categoryCol = StreamFixtureForColumnTests();
@@ -12592,78 +12586,43 @@ private slots:
 
         emit menu->aboutToShow();
         const QList<QAction *> entries = menu->actions();
-        QVERIFY2(entries.size() >= 3, "Sort menu must have Clear + separator + at least one column submenu");
+        QVERIFY2(entries.size() >= 3, "Sort menu must have Clear + separator + at least one column row");
         QCOMPARE(entries[0]->objectName(), QStringLiteral("actionClearSort"));
         QVERIFY2(entries[1]->isSeparator(), "second slot must be the separator");
         QVERIFY2(entries[0]->isEnabled(), "actionClearSort must be enabled while a sort is active");
 
-        // Walk the per-column submenus and find the `category`
-        // submenu. Asc must be checked; Desc and None unchecked.
-        QMenu *categoryMenu = nullptr;
-        QMenu *otherMenu = nullptr;
+        // Walk the per-column rows and find the `category` Asc /
+        // Desc pair. Asc must be checked, Desc unchecked.
+        QAction *ascCategory = nullptr;
+        QAction *descCategory = nullptr;
+        int totalChecked = 0;
         for (QAction *act : entries)
         {
-            if (act == nullptr || act->isSeparator() || act->menu() == nullptr)
+            if (act == nullptr || act->isSeparator() || act->objectName() == QStringLiteral("actionClearSort"))
             {
                 continue;
+            }
+            QVERIFY2(act->menu() == nullptr, "Sort menu rows must be flat (no submenus)");
+            if (act->isChecked())
+            {
+                ++totalChecked;
             }
             if (act->text().contains(QStringLiteral("\"category\"")))
             {
-                categoryMenu = act->menu();
-            }
-            else if (otherMenu == nullptr)
-            {
-                otherMenu = act->menu();
-            }
-        }
-        QVERIFY2(categoryMenu != nullptr, "menu must carry a `category` submenu");
-
-        QAction *ascCategory = nullptr;
-        QAction *descCategory = nullptr;
-        QAction *noneCategory = nullptr;
-        for (QAction *sub : categoryMenu->actions())
-        {
-            if (sub == nullptr)
-            {
-                continue;
-            }
-            if (sub->text() == QStringLiteral("Ascending"))
-            {
-                ascCategory = sub;
-            }
-            else if (sub->text() == QStringLiteral("Descending"))
-            {
-                descCategory = sub;
-            }
-            else if (sub->text() == QStringLiteral("None"))
-            {
-                noneCategory = sub;
-            }
-        }
-        QVERIFY2(
-            ascCategory != nullptr && descCategory != nullptr && noneCategory != nullptr,
-            "category submenu must carry Ascending, Descending, and None entries"
-        );
-        QVERIFY2(ascCategory->isChecked(), "active asc-sort entry must be checked");
-        QVERIFY2(!descCategory->isChecked(), "non-active desc-sort entry must be unchecked");
-        QVERIFY2(!noneCategory->isChecked(), "None must be unchecked on the active sort column");
-
-        // Non-active columns show `None` as the resting radio
-        // check, so the radio shape is honest end-to-end.
-        if (otherMenu != nullptr)
-        {
-            QAction *otherNone = nullptr;
-            for (QAction *sub : otherMenu->actions())
-            {
-                if (sub != nullptr && sub->text() == QStringLiteral("None"))
+                if (act->text().startsWith(QString::fromUtf8(u8"\u25B2")))
                 {
-                    otherNone = sub;
-                    break;
+                    ascCategory = act;
+                }
+                else if (act->text().startsWith(QString::fromUtf8(u8"\u25BC")))
+                {
+                    descCategory = act;
                 }
             }
-            QVERIFY2(otherNone != nullptr, "every column submenu must carry a None entry");
-            QVERIFY2(otherNone->isChecked(), "None must be checked on columns that are not the active sort");
         }
+        QVERIFY2(ascCategory != nullptr && descCategory != nullptr, "menu must carry both `category` rows");
+        QVERIFY2(ascCategory->isChecked(), "active asc-sort row must be checked");
+        QVERIFY2(!descCategory->isChecked(), "non-active desc-sort row must be unchecked");
+        QCOMPARE(totalChecked, 1);
         // NOLINTEND(clang-analyzer-core.CallAndMessage)
     }
 
@@ -12865,15 +12824,13 @@ private slots:
     // A column whose data does not match its configured `Type`
     // (`presentSlots > matchingSlots`) sorts via the wrong
     // comparator and produces an order that does not reflect
-    // the on-screen values. The Sort submenus must therefore
-    // disable Asc / Desc on such columns; `None` stays enabled
-    // (it is a no-op for non-sorted columns and a clear for the
-    // active one). A tooltip on each disabled row points the
-    // user at Configuration Diagnostics so the cause is
-    // discoverable. Type-clean columns must keep both rows
-    // enabled in the same menu so the test pins both sides of
-    // the gate.
-    void TestSortSubmenuDisablesAscDescOnTypeMismatch()
+    // the on-screen values. The Sort menu must therefore
+    // disable both Asc and Desc rows on such columns. A tooltip
+    // on each disabled row points the user at Configuration
+    // Diagnostics so the cause is discoverable. Type-clean
+    // columns must keep both rows enabled in the same menu so
+    // the test pins both sides of the gate.
+    void TestSortMenuDisablesAscDescOnTypeMismatch()
     {
         const int categoryCol = StreamFixtureForColumnTests();
         QVERIFY2(categoryCol >= 0, "fixture must expose `category` column");
@@ -12899,73 +12856,47 @@ private slots:
             "fixture precondition: msg column must report a type mismatch after the Integer pin"
         );
 
+        const auto findRow = [](QMenu *menu, const QString &columnQuoted, const QString &glyph) -> QAction * {
+            for (QAction *act : menu->actions())
+            {
+                if (act != nullptr && act->text().contains(columnQuoted) && act->text().startsWith(glyph))
+                {
+                    return act;
+                }
+            }
+            return nullptr;
+        };
+        const QString ascGlyph = QString::fromUtf8(u8"\u25B2");
+        const QString descGlyph = QString::fromUtf8(u8"\u25BC");
+
         auto *splitMenu = mWindow->findChild<QMenu *>(QStringLiteral("sortBySplitMenu"));
         QVERIFY2(splitMenu != nullptr, "sort split menu must exist");
         // NOLINTBEGIN(clang-analyzer-core.CallAndMessage): prior QVERIFY2 aborts on null.
         emit splitMenu->aboutToShow();
 
-        QMenu *msgSubmenu = nullptr;
-        QMenu *categorySubmenu = nullptr;
-        for (QAction *act : splitMenu->actions())
-        {
-            if (act == nullptr || act->menu() == nullptr)
-            {
-                continue;
-            }
-            if (act->text().contains(QStringLiteral("\"msg\"")))
-            {
-                msgSubmenu = act->menu();
-            }
-            else if (act->text().contains(QStringLiteral("\"category\"")))
-            {
-                categorySubmenu = act->menu();
-            }
-        }
-        QVERIFY2(msgSubmenu != nullptr, "sort dropdown must carry a submenu for the mismatched `msg` column");
-        QVERIFY2(
-            categorySubmenu != nullptr,
-            "sort dropdown must carry a submenu for the type-clean `category` column (control)"
-        );
-
-        const auto findSubAction = [](QMenu *m, const QString &text) -> QAction * {
-            for (QAction *sub : m->actions())
-            {
-                if (sub != nullptr && sub->text() == text)
-                {
-                    return sub;
-                }
-            }
-            return nullptr;
-        };
-
-        QAction *msgAsc = findSubAction(msgSubmenu, QStringLiteral("Ascending"));
-        QAction *msgDesc = findSubAction(msgSubmenu, QStringLiteral("Descending"));
-        QAction *msgNone = findSubAction(msgSubmenu, QStringLiteral("None"));
-        QVERIFY2(
-            msgAsc != nullptr && msgDesc != nullptr && msgNone != nullptr,
-            "msg submenu must carry Ascending / Descending / None"
-        );
-        QVERIFY2(!msgAsc->isEnabled(), "Ascending must be disabled on a type-mismatched column");
-        QVERIFY2(!msgDesc->isEnabled(), "Descending must be disabled on a type-mismatched column");
-        QVERIFY2(msgNone->isEnabled(), "None must stay enabled on a type-mismatched column");
+        QAction *msgAsc = findRow(splitMenu, QStringLiteral("\"msg\""), ascGlyph);
+        QAction *msgDesc = findRow(splitMenu, QStringLiteral("\"msg\""), descGlyph);
+        QVERIFY2(msgAsc != nullptr && msgDesc != nullptr, "sort dropdown must carry msg asc/desc rows");
+        QVERIFY2(!msgAsc->isEnabled(), "asc row must be disabled on a type-mismatched column");
+        QVERIFY2(!msgDesc->isEnabled(), "desc row must be disabled on a type-mismatched column");
         QVERIFY2(
             msgAsc->toolTip().contains(QStringLiteral("does not match")),
-            "disabled Ascending row must explain the type-mismatch cause via tooltip"
+            "disabled asc row must explain the type-mismatch cause via tooltip"
         );
         QVERIFY2(
             msgDesc->toolTip().contains(QStringLiteral("does not match")),
-            "disabled Descending row must explain the type-mismatch cause via tooltip"
+            "disabled desc row must explain the type-mismatch cause via tooltip"
         );
-        QVERIFY2(msgSubmenu->toolTipsVisible(), "submenu must opt into per-action tooltips");
+        QVERIFY2(splitMenu->toolTipsVisible(), "sort dropdown must opt into per-action tooltips");
 
-        QAction *categoryAsc = findSubAction(categorySubmenu, QStringLiteral("Ascending"));
-        QAction *categoryDesc = findSubAction(categorySubmenu, QStringLiteral("Descending"));
+        QAction *categoryAsc = findRow(splitMenu, QStringLiteral("\"category\""), ascGlyph);
+        QAction *categoryDesc = findRow(splitMenu, QStringLiteral("\"category\""), descGlyph);
         QVERIFY2(
             categoryAsc != nullptr && categoryDesc != nullptr,
-            "category submenu must carry Asc / Desc (control)"
+            "sort dropdown must carry category asc/desc rows (control)"
         );
-        QVERIFY2(categoryAsc->isEnabled(), "Asc must remain enabled on a type-clean column");
-        QVERIFY2(categoryDesc->isEnabled(), "Desc must remain enabled on a type-clean column");
+        QVERIFY2(categoryAsc->isEnabled(), "asc must remain enabled on a type-clean column");
+        QVERIFY2(categoryDesc->isEnabled(), "desc must remain enabled on a type-clean column");
 
         // Top-level Sort menu must carry the same gate. The
         // shared `AppendSortByEntries` core feeds both surfaces,
@@ -12973,29 +12904,19 @@ private slots:
         auto *sortMenu = mWindow->findChild<QMenu *>(QStringLiteral("menuSort"));
         QVERIFY2(sortMenu != nullptr, "Sort menu must exist");
         emit sortMenu->aboutToShow();
-        QMenu *sortMsgSubmenu = nullptr;
-        for (QAction *act : sortMenu->actions())
-        {
-            if (act != nullptr && act->menu() != nullptr && act->text().contains(QStringLiteral("\"msg\"")))
-            {
-                sortMsgSubmenu = act->menu();
-                break;
-            }
-        }
-        QVERIFY2(sortMsgSubmenu != nullptr, "top-level Sort menu must also carry the msg submenu");
-        QAction *sortMsgAsc = findSubAction(sortMsgSubmenu, QStringLiteral("Ascending"));
-        QAction *sortMsgDesc = findSubAction(sortMsgSubmenu, QStringLiteral("Descending"));
+        QAction *sortMsgAsc = findRow(sortMenu, QStringLiteral("\"msg\""), ascGlyph);
+        QAction *sortMsgDesc = findRow(sortMenu, QStringLiteral("\"msg\""), descGlyph);
         QVERIFY2(
             sortMsgAsc != nullptr && sortMsgDesc != nullptr,
-            "top-level Sort menu msg submenu must carry Asc / Desc"
+            "top-level Sort menu must also carry the msg asc/desc rows"
         );
-        QVERIFY2(!sortMsgAsc->isEnabled(), "top-level Sort menu Asc must be disabled on mismatch");
-        QVERIFY2(!sortMsgDesc->isEnabled(), "top-level Sort menu Desc must be disabled on mismatch");
+        QVERIFY2(!sortMsgAsc->isEnabled(), "top-level Sort menu asc must be disabled on mismatch");
+        QVERIFY2(!sortMsgDesc->isEnabled(), "top-level Sort menu desc must be disabled on mismatch");
         // NOLINTEND(clang-analyzer-core.CallAndMessage)
     }
 
     // The header right-click menu's Sort block mirrors the same
-    // type-mismatch gate the Sort submenus apply, so a user who
+    // type-mismatch gate the Sort menu applies, so a user who
     // right-clicks a flagged column header sees Asc / Desc
     // disabled with the same diagnostic tooltip. Pinned because
     // the right-click sort block has its own action-creation

--- a/test/app/src/main_window_test.cpp
+++ b/test/app/src/main_window_test.cpp
@@ -12574,8 +12574,8 @@ private slots:
 
         // Walk the per-column rows and find the `category` Asc /
         // Desc pair. Asc must be checked, Desc unchecked.
-        QAction *ascCategory = nullptr;
-        QAction *descCategory = nullptr;
+        const QAction *ascCategory = nullptr;
+        const QAction *descCategory = nullptr;
         int totalChecked = 0;
         for (QAction *act : entries)
         {
@@ -12624,7 +12624,7 @@ private slots:
         // NOLINTBEGIN(clang-analyzer-core.CallAndMessage): prior QVERIFY2 aborts on null.
         // `QScopeGuard` covers any QVERIFY2-driven early
         // return; reset before building a second menu.
-        QScopeGuard freeMenu1([&built]() { built.menu->deleteLater(); });
+        const QScopeGuard freeMenu1([&built]() { built.menu->deleteLater(); });
 
         const auto findSortBlock = [](QMenu *menu) -> std::tuple<QAction *, QAction *, QAction *> {
             QAction *clearSort = nullptr;
@@ -12666,7 +12666,7 @@ private slots:
         QCoreApplication::processEvents();
         auto built2 = mWindow->BuildHeaderContextMenu(categoryCol, nullptr);
         QVERIFY2(built2.menu != nullptr, "BuildHeaderContextMenu must return a menu");
-        QScopeGuard freeMenu2([&built2]() { built2.menu->deleteLater(); });
+        const QScopeGuard freeMenu2([&built2]() { built2.menu->deleteLater(); });
 
         auto [clearSortActive, ascActive, descActive] = findSortBlock(built2.menu);
         QVERIFY2(
@@ -12871,8 +12871,8 @@ private slots:
         // NOLINTBEGIN(clang-analyzer-core.CallAndMessage): prior QVERIFY2 aborts on null.
         emit splitMenu->aboutToShow();
 
-        QAction *msgAsc = findRow(splitMenu, QStringLiteral("\"msg\""), ascGlyph);
-        QAction *msgDesc = findRow(splitMenu, QStringLiteral("\"msg\""), descGlyph);
+        const QAction *msgAsc = findRow(splitMenu, QStringLiteral("\"msg\""), ascGlyph);
+        const QAction *msgDesc = findRow(splitMenu, QStringLiteral("\"msg\""), descGlyph);
         QVERIFY2(msgAsc != nullptr && msgDesc != nullptr, "sort dropdown must carry msg asc/desc rows");
         QVERIFY2(!msgAsc->isEnabled(), "asc row must be disabled on a type-mismatched column");
         QVERIFY2(!msgDesc->isEnabled(), "desc row must be disabled on a type-mismatched column");
@@ -12886,8 +12886,8 @@ private slots:
         );
         QVERIFY2(splitMenu->toolTipsVisible(), "sort dropdown must opt into per-action tooltips");
 
-        QAction *categoryAsc = findRow(splitMenu, QStringLiteral("\"category\""), ascGlyph);
-        QAction *categoryDesc = findRow(splitMenu, QStringLiteral("\"category\""), descGlyph);
+        const QAction *categoryAsc = findRow(splitMenu, QStringLiteral("\"category\""), ascGlyph);
+        const QAction *categoryDesc = findRow(splitMenu, QStringLiteral("\"category\""), descGlyph);
         QVERIFY2(
             categoryAsc != nullptr && categoryDesc != nullptr,
             "sort dropdown must carry category asc/desc rows (control)"
@@ -12901,8 +12901,8 @@ private slots:
         auto *sortMenu = mWindow->findChild<QMenu *>(QStringLiteral("menuSort"));
         QVERIFY2(sortMenu != nullptr, "Sort menu must exist");
         emit sortMenu->aboutToShow();
-        QAction *sortMsgAsc = findRow(sortMenu, QStringLiteral("\"msg\""), ascGlyph);
-        QAction *sortMsgDesc = findRow(sortMenu, QStringLiteral("\"msg\""), descGlyph);
+        const QAction *sortMsgAsc = findRow(sortMenu, QStringLiteral("\"msg\""), ascGlyph);
+        const QAction *sortMsgDesc = findRow(sortMenu, QStringLiteral("\"msg\""), descGlyph);
         QVERIFY2(
             sortMsgAsc != nullptr && sortMsgDesc != nullptr, "top-level Sort menu must also carry the msg asc/desc rows"
         );
@@ -12932,10 +12932,10 @@ private slots:
         auto built = mWindow->BuildHeaderContextMenu(msgCol, nullptr);
         QVERIFY2(built.menu != nullptr, "BuildHeaderContextMenu must return a menu");
         // NOLINTBEGIN(clang-analyzer-core.CallAndMessage): prior QVERIFY2 aborts on null.
-        QScopeGuard freeMenu([&built]() { built.menu->deleteLater(); });
+        const QScopeGuard freeMenu([&built]() { built.menu->deleteLater(); });
 
-        QAction *asc = nullptr;
-        QAction *desc = nullptr;
+        const QAction *asc = nullptr;
+        const QAction *desc = nullptr;
         for (QAction *act : built.menu->actions())
         {
             if (act == nullptr || act->isSeparator())
@@ -12968,10 +12968,10 @@ private slots:
         // on the same right-click path.
         auto controlBuilt = mWindow->BuildHeaderContextMenu(categoryCol, nullptr);
         QVERIFY2(controlBuilt.menu != nullptr, "BuildHeaderContextMenu must return a menu");
-        QScopeGuard freeControl([&controlBuilt]() { controlBuilt.menu->deleteLater(); });
+        const QScopeGuard freeControl([&controlBuilt]() { controlBuilt.menu->deleteLater(); });
 
-        QAction *controlAsc = nullptr;
-        QAction *controlDesc = nullptr;
+        const QAction *controlAsc = nullptr;
+        const QAction *controlDesc = nullptr;
         for (QAction *act : controlBuilt.menu->actions())
         {
             if (act == nullptr || act->isSeparator())

--- a/test/app/src/main_window_test.cpp
+++ b/test/app/src/main_window_test.cpp
@@ -12489,10 +12489,7 @@ private slots:
             QVERIFY2(act->menu() == nullptr, "flat entries must not carry submenus");
             QVERIFY2(act->isCheckable(), "every dropdown row must be checkable");
             const QString text = act->text();
-            QVERIFY2(
-                text.contains(QStringLiteral("\"")),
-                "every dropdown row must carry the column label in quotes"
-            );
+            QVERIFY2(text.contains(QStringLiteral("\"")), "every dropdown row must carry the column label in quotes");
             QVERIFY2(
                 !text.contains(QStringLiteral("Sort by")),
                 "row text is just glyph + quoted column name; the host menu carries the verb"
@@ -12652,8 +12649,7 @@ private slots:
         // build a second menu so we don't double-delete.
         QScopeGuard freeMenu1([&built]() { built.menu->deleteLater(); });
 
-        const auto findSortBlock =
-            [](QMenu *menu) -> std::tuple<QAction *, QAction *, QAction *> {
+        const auto findSortBlock = [](QMenu *menu) -> std::tuple<QAction *, QAction *, QAction *> {
             QAction *clearSort = nullptr;
             QAction *asc = nullptr;
             QAction *desc = nullptr;
@@ -12684,9 +12680,7 @@ private slots:
             clearSortNoSort != nullptr && ascNoSort != nullptr && descNoSort != nullptr,
             "header menu must always include the Sort block"
         );
-        QVERIFY2(
-            !clearSortNoSort->isEnabled(), "shared actionClearSort must be disabled when no sort is active"
-        );
+        QVERIFY2(!clearSortNoSort->isEnabled(), "shared actionClearSort must be disabled when no sort is active");
         QVERIFY2(!ascNoSort->isChecked() && !descNoSort->isChecked(), "neither direction is checked without a sort");
 
         // With a desc sort on `category`, the matching entry is
@@ -12946,8 +12940,7 @@ private slots:
         QAction *sortMsgAsc = findRow(sortMenu, QStringLiteral("\"msg\""), ascGlyph);
         QAction *sortMsgDesc = findRow(sortMenu, QStringLiteral("\"msg\""), descGlyph);
         QVERIFY2(
-            sortMsgAsc != nullptr && sortMsgDesc != nullptr,
-            "top-level Sort menu must also carry the msg asc/desc rows"
+            sortMsgAsc != nullptr && sortMsgDesc != nullptr, "top-level Sort menu must also carry the msg asc/desc rows"
         );
         QVERIFY2(!sortMsgAsc->isEnabled(), "top-level Sort menu asc must be disabled on mismatch");
         QVERIFY2(!sortMsgDesc->isEnabled(), "top-level Sort menu desc must be disabled on mismatch");
@@ -13064,8 +13057,7 @@ private slots:
         // NOLINTBEGIN(clang-analyzer-core.CallAndMessage): prior QVERIFY2 aborts on null.
         QVERIFY2(!button->isHidden(), "indicator must surface while a sort is active");
         QVERIFY2(
-            button->toolTip().contains(QStringLiteral("\"category\"")),
-            "initial tooltip must name the sorted column"
+            button->toolTip().contains(QStringLiteral("\"category\"")), "initial tooltip must name the sorted column"
         );
 
         // Rename the column header and emit the same
@@ -16847,8 +16839,7 @@ private slots:
         QVERIFY2(restoredClearSortAction != nullptr, "restored window must own actionClearSort");
         // NOLINTNEXTLINE(clang-analyzer-core.CallAndMessage): prior QVERIFY2 aborts on null.
         QVERIFY2(restoredClearSortAction->isEnabled(), "actionClearSort must be enabled after deferred restore");
-        auto *restoredClearSortButton =
-            restored->findChild<QPushButton *>(QStringLiteral("clearSortStatusButton"));
+        auto *restoredClearSortButton = restored->findChild<QPushButton *>(QStringLiteral("clearSortStatusButton"));
         QVERIFY2(restoredClearSortButton != nullptr, "restored window must own clearSortStatusButton");
         // NOLINTNEXTLINE(clang-analyzer-core.CallAndMessage): prior QVERIFY2 aborts on null.
         QVERIFY2(!restoredClearSortButton->isHidden(), "status-bar Clear-sort indicator must surface after restore");

--- a/test/app/src/main_window_test.cpp
+++ b/test/app/src/main_window_test.cpp
@@ -6252,11 +6252,10 @@ private slots:
         const QList<QAction *> topActions = built.menu->actions();
         QCOMPARE(topActions.size(), 9);
 
-        // Hide -> Edit column -> separator -> Add filter on ... ->
-        // filter submenu -> separator -> Sort asc -> Sort desc ->
-        // Clear sort. The trailing sort block sits after the
-        // filter block so the column-mutation actions group above
-        // the row-projection actions.
+        // Order: Hide, Edit column, separator, Add filter on,
+        // filter submenu, separator, Sort asc, Sort desc,
+        // Clear sort. Sort sits after filter so column-
+        // mutation actions group above row-projection ones.
         QVERIFY2(topActions[0]->text().startsWith("Hide"), "first action must be Hide");
         QVERIFY2(topActions[1]->text().startsWith("Edit column"), "second action must be Edit column ...");
         QVERIFY2(topActions[2]->isSeparator(), "third action must be a separator");
@@ -12433,15 +12432,9 @@ private slots:
         // NOLINTEND(clang-analyzer-core.CallAndMessage)
     }
 
-    // Shape contract for the Sort dropdown button: `InstantPopup`
-    // `QToolButton` whose entire face opens the per-column menu
-    // (sort has no useful generic editor, so the click-vs-arrow
-    // split the Add-filter button uses would be redundant), with
-    // `actionSortBy` as its default action for icon/tooltip
-    // propagation, and whose popup menu carries the
-    // `sortBySplitMenu` objectName. Mirrors
-    // `TestAddFilterSplitButtonShape` but pins the simpler
-    // single-target popup mode.
+    // Shape of the Sort dropdown button: `InstantPopup`
+    // `QToolButton` with `actionSortBy` as its default action
+    // and a popup menu named `sortBySplitMenu`.
     void TestSortBySplitButtonShape()
     {
         auto *button = mWindow->findChild<QToolButton *>(QStringLiteral("sortBySplitButton"));
@@ -12459,18 +12452,14 @@ private slots:
         // NOLINTEND(clang-analyzer-core.CallAndMessage)
     }
 
-    // The Sort dropdown lists every *visible* column as two flat
-    // checkable rows: an asc row prefixed with the U+25B2 (▲)
-    // glyph and a desc row prefixed with U+25BC (▼), followed by
-    // the disambiguated column label in quotes. Verifies the
-    // population, the per-column doubling, and the hidden-column
-    // filter (toggling a column hidden must drop its rows on the
-    // next open, mirroring the Add-filter dropdown).
+    // The Sort dropdown lists every visible column as two
+    // checkable rows: ▲ asc and ▼ desc, each followed by the
+    // disambiguated column label in quotes. Hiding a column
+    // drops its rows on the next open.
     void TestSortByDropdownListsVisibleColumns()
     {
-        // `StreamFixtureForColumnTests` returns the `category`
-        // column index despite its historical name; bind to the
-        // honest variable name to keep the test self-documenting.
+        // The fixture helper returns the `category` column
+        // index; bind to a clearer name.
         const int categoryCol = StreamFixtureForColumnTests();
         QVERIFY2(categoryCol >= 0, "fixture must produce columns");
 
@@ -12509,9 +12498,7 @@ private slots:
         }
         QVERIFY2(ascCount > 0 && ascCount == descCount, "every column must contribute both an Asc and a Desc row");
 
-        // Hide the `msg` column and re-open: its rows must drop.
-        // Cross-checks the visible-only filter shared with the
-        // Add-filter dropdown.
+        // Hide `msg` and re-open: its rows must drop.
         auto *model = mWindow->Model();
         const int msgCol = ColumnByHeader(*model, QStringLiteral("msg"));
         QVERIFY2(msgCol >= 0, "fixture must expose `msg` column");
@@ -12529,10 +12516,7 @@ private slots:
     }
 
     // Triggering a desc row installs the matching sort on the
-    // proxy. Pinned so a refactor that changes the
-    // `sortByColumn` plumbing would trip here, replicating the
-    // `TestAddFilterDropdownTriggerPreselectsColumn` contract
-    // for the sort entry point.
+    // proxy.
     void TestSortByDropdownTriggerSortsByColumn()
     {
         const int categoryCol = StreamFixtureForColumnTests();
@@ -12563,12 +12547,10 @@ private slots:
         // NOLINTEND(clang-analyzer-core.CallAndMessage)
     }
 
-    // `RebuildSortMenu` is hooked to `menuSort->aboutToShow`. The
-    // top of the menu must always carry `actionClearSort` followed
-    // by a separator, then two flat checkable rows per visible
-    // column (▲ asc, ▼ desc). Sort is single-column /
-    // single-direction, so at most one row across the menu is
-    // ever checked at a time.
+    // The Sort menu must lead with `actionClearSort` + a
+    // separator, then two checkable rows (▲ asc, ▼ desc) per
+    // visible column. Sort is single-column / single-direction,
+    // so at most one row is ever checked.
     void TestSortMenuShapeAndCheckmarks()
     {
         const int categoryCol = StreamFixtureForColumnTests();
@@ -12578,9 +12560,8 @@ private slots:
         QVERIFY2(menu != nullptr, "Sort menu must exist");
         // NOLINTBEGIN(clang-analyzer-core.CallAndMessage): prior QVERIFY2 aborts on null.
 
-        // Sort the proxy so a checked entry exists; Asc on
-        // `category`. The aboutToShow rebuild reads the live
-        // proxy state.
+        // Asc-sort `category` so the rebuild has a checked
+        // entry to mark.
         mWindow->findChild<LogTableView *>()->sortByColumn(categoryCol, Qt::AscendingOrder);
         QCoreApplication::processEvents();
 
@@ -12626,27 +12607,23 @@ private slots:
         // NOLINTEND(clang-analyzer-core.CallAndMessage)
     }
 
-    // Header right-click menu on a sorted column must mark the
-    // matching `Sort ascending|descending by "<col>"` entry checked,
-    // and the shared `actionClearSort` re-attached at the tail
-    // must follow its global enabled state (driven by
-    // `UpdateSortStatus`). Mirrors the Sort menu shape,
-    // contextualised to the right-clicked column.
+    // Header right-click on a sorted column must mark the
+    // matching Sort asc/desc entry as checked, and the shared
+    // `actionClearSort` must reflect its global enabled state.
     void TestHeaderContextMenuSortEntries()
     {
         const int categoryCol = StreamFixtureForColumnTests();
         QVERIFY2(categoryCol >= 0, "fixture must expose `category` column");
 
-        // Without a sort, the shared `actionClearSort` is disabled
-        // and neither direction is checked. Identify the Clear
-        // entry by `objectName` so a future label tweak doesn't
-        // need a test edit.
+        // Without a sort, the shared `actionClearSort` is
+        // disabled and neither direction is checked. Identify
+        // the Clear entry by `objectName` so a future label
+        // tweak doesn't need a test edit.
         auto built = mWindow->BuildHeaderContextMenu(categoryCol, nullptr);
         QVERIFY2(built.menu != nullptr, "BuildHeaderContextMenu must return a menu");
         // NOLINTBEGIN(clang-analyzer-core.CallAndMessage): prior QVERIFY2 aborts on null.
-        // `QScopeGuard` covers both the happy path and any
-        // QVERIFY2-driven early return; reset it once we want to
-        // build a second menu so we don't double-delete.
+        // `QScopeGuard` covers any QVERIFY2-driven early
+        // return; reset before building a second menu.
         QScopeGuard freeMenu1([&built]() { built.menu->deleteLater(); });
 
         const auto findSortBlock = [](QMenu *menu) -> std::tuple<QAction *, QAction *, QAction *> {
@@ -12701,8 +12678,8 @@ private slots:
         QVERIFY2(descActive->isChecked(), "active desc entry must be checked");
 
         // The same `actionClearSort` instance is reused across
-        // every Sort surface; verify pointer identity so a future
-        // accidental clone trips the test.
+        // every Sort surface; verify pointer identity so an
+        // accidental clone would trip the test.
         auto *globalClearSort = mWindow->findChild<QAction *>(QStringLiteral("actionClearSort"));
         QCOMPARE(clearSortActive, globalClearSort);
 
@@ -12731,8 +12708,8 @@ private slots:
         QCoreApplication::processEvents();
         QVERIFY2(!button->isHidden(), "indicator must surface when a sort becomes active");
 
-        // Click the button -- it triggers `actionClearSort` and
-        // the next `layoutChanged` must hide it again.
+        // Clicking triggers `actionClearSort`; the next
+        // `layoutChanged` must hide the indicator again.
         button->click();
         QCoreApplication::processEvents();
         QCOMPARE(mWindow->FilterModel()->SortColumn(), -1);
@@ -12762,16 +12739,12 @@ private slots:
         // NOLINTEND(clang-analyzer-core.CallAndMessage)
     }
 
-    // The toolbar's plain Clear-Sort button is the
-    // auto-generated `QToolButton` `QToolBar::addAction(...)`
-    // emits for `actionClearSort`. It has no `objectName` of its
-    // own, so resolve it via `widgetForAction` and pin its
-    // enable + click contract. This is the fifth Clear-sort
-    // surface (alongside menu / split-menu / right-click /
-    // status-bar) and was previously the only one without
-    // direct coverage -- without this test a refactor that
-    // accidentally dropped `addAction(actionClearSort)` from the
-    // toolbar would only trip the toolbar-layout test.
+    // The toolbar's plain Clear-Sort button is the auto-
+    // generated `QToolButton` from `addAction`. Resolve it via
+    // `widgetForAction` and pin its enable + click contract -
+    // without this test a refactor dropping
+    // `addAction(actionClearSort)` would only trip the
+    // toolbar-layout test.
     void TestToolbarClearSortButtonTriggersClear()
     {
         const int categoryCol = StreamFixtureForColumnTests();
@@ -12801,13 +12774,9 @@ private slots:
         // NOLINTEND(clang-analyzer-core.CallAndMessage)
     }
 
-    // Hiding every visible column must surface the
-    // `(every column is hidden ...)` placeholder in both the
-    // top-level Sort menu (after the Clear-sort entry +
-    // separator) and the toolbar dropdown. Pins the
-    // `AppendSortByEntries == false` branch so a future change
-    // to the visibility-filter doesn't silently leave the menus
-    // empty.
+    // When every column is hidden both Sort surfaces must
+    // surface the `(every column is hidden ...)` placeholder,
+    // not leave the menu empty.
     void TestSortDropdownPlaceholderWhenAllColumnsHidden()
     {
         const int categoryCol = StreamFixtureForColumnTests();
@@ -12816,9 +12785,8 @@ private slots:
         const int msgCol = ColumnByHeader(*model, QStringLiteral("msg"));
         QVERIFY2(msgCol >= 0, "fixture must expose `msg` column");
 
-        // Hide every visible column. `SetColumnVisible` clears
-        // the active sort if the hidden column was the sorted
-        // one, so `actionClearSort` need not be enabled here.
+        // Hide every visible column. `SetColumnVisible`
+        // clears the sort if the sorted column gets hidden.
         mWindow->SetColumnVisible(categoryCol, false);
         mWindow->SetColumnVisible(msgCol, false);
         QCoreApplication::processEvents();
@@ -12854,15 +12822,11 @@ private slots:
         // NOLINTEND(clang-analyzer-core.CallAndMessage)
     }
 
-    // A column whose data does not match its configured `Type`
-    // (`presentSlots > matchingSlots`) sorts via the wrong
-    // comparator and produces an order that does not reflect
-    // the on-screen values. The Sort menu must therefore
-    // disable both Asc and Desc rows on such columns. A tooltip
-    // on each disabled row points the user at Configuration
-    // Diagnostics so the cause is discoverable. Type-clean
-    // columns must keep both rows enabled in the same menu so
-    // the test pins both sides of the gate.
+    // Columns whose data doesn't match their configured type
+    // sort via the wrong comparator, so the Sort menu must
+    // disable both Asc and Desc on them and surface a tooltip
+    // pointing at Configuration Diagnostics. Type-clean
+    // columns stay enabled (control).
     void TestSortMenuDisablesAscDescOnTypeMismatch()
     {
         const int categoryCol = StreamFixtureForColumnTests();
@@ -12931,9 +12895,9 @@ private slots:
         QVERIFY2(categoryAsc->isEnabled(), "asc must remain enabled on a type-clean column");
         QVERIFY2(categoryDesc->isEnabled(), "desc must remain enabled on a type-clean column");
 
-        // Top-level Sort menu must carry the same gate. The
-        // shared `AppendSortByEntries` core feeds both surfaces,
-        // but pinning here protects against a future split.
+        // Top-level Sort menu carries the same gate (shared
+        // core, but pin both surfaces in case of a future
+        // split).
         auto *sortMenu = mWindow->findChild<QMenu *>(QStringLiteral("menuSort"));
         QVERIFY2(sortMenu != nullptr, "Sort menu must exist");
         emit sortMenu->aboutToShow();
@@ -12947,14 +12911,9 @@ private slots:
         // NOLINTEND(clang-analyzer-core.CallAndMessage)
     }
 
-    // The header right-click menu's Sort block mirrors the same
-    // type-mismatch gate the Sort menu applies, so a user who
-    // right-clicks a flagged column header sees Asc / Desc
-    // disabled with the same diagnostic tooltip. Pinned because
-    // the right-click sort block has its own action-creation
-    // path (not shared with `AppendSortByEntries`), so a future
-    // refactor that converges them must not silently drop the
-    // gate on either side.
+    // Header right-click must apply the same type-mismatch
+    // gate as the Sort menu. The right-click path doesn't
+    // share `AppendSortByEntries`, so pin it independently.
     void TestHeaderContextMenuDisablesSortOnTypeMismatch()
     {
         const int categoryCol = StreamFixtureForColumnTests();
@@ -13038,10 +12997,10 @@ private slots:
     }
 
     // The status-bar tooltip must rebuild when the sorted
-    // column's header is renamed via `NotifyColumnEdited` -- a
-    // path that emits `headerDataChanged` but no `layoutChanged`,
-    // so without the dedicated hook the tooltip would freeze on
-    // the previous label until the next sort / filter event.
+    // column is renamed - `NotifyColumnEdited` emits only
+    // `headerDataChanged`, so without the dedicated hook the
+    // tooltip would freeze on the old label until the next
+    // sort / filter event.
     void TestSortStatusTooltipUpdatesOnColumnRename()
     {
         const int categoryCol = StreamFixtureForColumnTests();
@@ -13060,11 +13019,10 @@ private slots:
             button->toolTip().contains(QStringLiteral("\"category\"")), "initial tooltip must name the sorted column"
         );
 
-        // Rename the column header and emit the same
+        // Rename the column and emit the same
         // `NotifyColumnEdited` the column editor would fire.
-        // The tooltip refresh hangs off `headerDataChanged`, so
-        // the status-bar text must catch the new label without
-        // any sort / filter event in between.
+        // The tooltip must catch the new label without any
+        // sort / filter event in between.
         auto *model = mWindow->Model();
         model->ConfigurationManager().SetColumnHeader(static_cast<size_t>(categoryCol), std::string("renamed-cat"));
         model->NotifyColumnEdited(categoryCol);
@@ -16828,13 +16786,10 @@ private slots:
         QCOMPARE(restoredFilter->SortOrder(), Qt::DescendingOrder);
         QCOMPARE(restored->Model()->rowCount(), fixtureLines.size());
 
-        // The deferred sort reaches `UpdateSortStatus` indirectly
-        // via the `layoutChanged` it issues, so the status-bar
-        // indicator and `actionClearSort` must mirror the
-        // restored sort once streaming settles. Pinned so a future
-        // refactor of the deferred-restore plumbing can't silently
-        // strand the status-bar / menu state out of sync with the
-        // proxy.
+        // The deferred sort reaches `UpdateSortStatus` via
+        // the `layoutChanged` it issues. Pin the status-bar
+        // indicator and `actionClearSort` to mirror the
+        // restored sort once streaming settles.
         auto *restoredClearSortAction = restored->findChild<QAction *>(QStringLiteral("actionClearSort"));
         QVERIFY2(restoredClearSortAction != nullptr, "restored window must own actionClearSort");
         // NOLINTNEXTLINE(clang-analyzer-core.CallAndMessage): prior QVERIFY2 aborts on null.

--- a/test/app/src/main_window_test.cpp
+++ b/test/app/src/main_window_test.cpp
@@ -6265,7 +6265,10 @@ private slots:
         QVERIFY2(topActions[5]->isSeparator(), "sixth action must be the sort-block separator");
         QVERIFY2(topActions[6]->text().startsWith("Sort ascending"), "seventh action must be Sort ascending");
         QVERIFY2(topActions[7]->text().startsWith("Sort descending"), "eighth action must be Sort descending");
-        QCOMPARE(topActions[8]->text(), QStringLiteral("Clear sort"));
+        // The trailing Clear-sort entry is the shared
+        // `actionClearSort` re-attached; pin by `objectName` so the
+        // entry's text can evolve in the .ui without a test edit.
+        QCOMPARE(topActions[8]->objectName(), QStringLiteral("actionClearSort"));
     }
 
     // With zero rows, Add-filter and per-filter Edit must be
@@ -12628,15 +12631,19 @@ private slots:
 
     // Header right-click menu on a sorted column must mark the
     // matching `Sort ascending|descending by "<col>"` entry checked,
-    // and `Clear sort` must be enabled. Mirrors the Sort menu
-    // shape, contextualised to the right-clicked column.
+    // and the shared `actionClearSort` re-attached at the tail
+    // must follow its global enabled state (driven by
+    // `UpdateSortStatus`). Mirrors the Sort menu shape,
+    // contextualised to the right-clicked column.
     void TestHeaderContextMenuSortEntries()
     {
         const int categoryCol = StreamFixtureForColumnTests();
         QVERIFY2(categoryCol >= 0, "fixture must expose `category` column");
 
-        // Without a sort, Clear sort is disabled and neither
-        // direction is checked.
+        // Without a sort, the shared `actionClearSort` is disabled
+        // and neither direction is checked. Identify the Clear
+        // entry by `objectName` so a future label tweak doesn't
+        // need a test edit.
         auto built = mWindow->BuildHeaderContextMenu(categoryCol, nullptr);
         QVERIFY2(built.menu != nullptr, "BuildHeaderContextMenu must return a menu");
         // NOLINTBEGIN(clang-analyzer-core.CallAndMessage): prior QVERIFY2 aborts on null.
@@ -12645,74 +12652,67 @@ private slots:
         // build a second menu so we don't double-delete.
         QScopeGuard freeMenu1([&built]() { built.menu->deleteLater(); });
 
-        QAction *clearSortNoSort = nullptr;
-        QAction *ascNoSort = nullptr;
-        QAction *descNoSort = nullptr;
-        for (QAction *act : built.menu->actions())
-        {
-            if (act == nullptr || act->isSeparator())
+        const auto findSortBlock =
+            [](QMenu *menu) -> std::tuple<QAction *, QAction *, QAction *> {
+            QAction *clearSort = nullptr;
+            QAction *asc = nullptr;
+            QAction *desc = nullptr;
+            for (QAction *act : menu->actions())
             {
-                continue;
+                if (act == nullptr || act->isSeparator())
+                {
+                    continue;
+                }
+                if (act->objectName() == QStringLiteral("actionClearSort"))
+                {
+                    clearSort = act;
+                }
+                else if (act->text().startsWith(QStringLiteral("Sort ascending")))
+                {
+                    asc = act;
+                }
+                else if (act->text().startsWith(QStringLiteral("Sort descending")))
+                {
+                    desc = act;
+                }
             }
-            if (act->text() == QStringLiteral("Clear sort"))
-            {
-                clearSortNoSort = act;
-            }
-            else if (act->text().startsWith(QStringLiteral("Sort ascending")))
-            {
-                ascNoSort = act;
-            }
-            else if (act->text().startsWith(QStringLiteral("Sort descending")))
-            {
-                descNoSort = act;
-            }
-        }
+            return {clearSort, asc, desc};
+        };
+
+        auto [clearSortNoSort, ascNoSort, descNoSort] = findSortBlock(built.menu);
         QVERIFY2(
             clearSortNoSort != nullptr && ascNoSort != nullptr && descNoSort != nullptr,
             "header menu must always include the Sort block"
         );
-        QVERIFY2(!clearSortNoSort->isEnabled(), "Clear sort must be disabled when no sort is active");
+        QVERIFY2(
+            !clearSortNoSort->isEnabled(), "shared actionClearSort must be disabled when no sort is active"
+        );
         QVERIFY2(!ascNoSort->isChecked() && !descNoSort->isChecked(), "neither direction is checked without a sort");
 
         // With a desc sort on `category`, the matching entry is
-        // checked and Clear sort is enabled.
+        // checked and the shared `actionClearSort` is enabled.
         mWindow->findChild<LogTableView *>()->sortByColumn(categoryCol, Qt::DescendingOrder);
         QCoreApplication::processEvents();
         auto built2 = mWindow->BuildHeaderContextMenu(categoryCol, nullptr);
         QVERIFY2(built2.menu != nullptr, "BuildHeaderContextMenu must return a menu");
         QScopeGuard freeMenu2([&built2]() { built2.menu->deleteLater(); });
 
-        QAction *clearSortActive = nullptr;
-        QAction *ascActive = nullptr;
-        QAction *descActive = nullptr;
-        for (QAction *act : built2.menu->actions())
-        {
-            if (act == nullptr || act->isSeparator())
-            {
-                continue;
-            }
-            if (act->text() == QStringLiteral("Clear sort"))
-            {
-                clearSortActive = act;
-            }
-            else if (act->text().startsWith(QStringLiteral("Sort ascending")))
-            {
-                ascActive = act;
-            }
-            else if (act->text().startsWith(QStringLiteral("Sort descending")))
-            {
-                descActive = act;
-            }
-        }
+        auto [clearSortActive, ascActive, descActive] = findSortBlock(built2.menu);
         QVERIFY2(
             clearSortActive != nullptr && ascActive != nullptr && descActive != nullptr,
             "header menu must always include the Sort block"
         );
-        QVERIFY2(clearSortActive->isEnabled(), "Clear sort must be enabled when a sort is active");
+        QVERIFY2(clearSortActive->isEnabled(), "shared actionClearSort must be enabled when a sort is active");
         QVERIFY2(!ascActive->isChecked(), "non-active asc entry must be unchecked under a desc sort");
         QVERIFY2(descActive->isChecked(), "active desc entry must be checked");
 
-        // Triggering Clear sort must drop the proxy's sort.
+        // The same `actionClearSort` instance is reused across
+        // every Sort surface; verify pointer identity so a future
+        // accidental clone trips the test.
+        auto *globalClearSort = mWindow->findChild<QAction *>(QStringLiteral("actionClearSort"));
+        QCOMPARE(clearSortActive, globalClearSort);
+
+        // Triggering the entry drops the proxy's sort.
         clearSortActive->trigger();
         QCoreApplication::processEvents();
         QCOMPARE(mWindow->FilterModel()->SortColumn(), -1);
@@ -12765,6 +12765,45 @@ private slots:
         mWindow->findChild<LogTableView *>()->sortByColumn(-1, Qt::AscendingOrder);
         QCoreApplication::processEvents();
         QVERIFY2(!action->isEnabled(), "actionClearSort must disable again after a clear");
+        // NOLINTEND(clang-analyzer-core.CallAndMessage)
+    }
+
+    // The toolbar's plain Clear-Sort button is the
+    // auto-generated `QToolButton` `QToolBar::addAction(...)`
+    // emits for `actionClearSort`. It has no `objectName` of its
+    // own, so resolve it via `widgetForAction` and pin its
+    // enable + click contract. This is the fifth Clear-sort
+    // surface (alongside menu / split-menu / right-click /
+    // status-bar) and was previously the only one without
+    // direct coverage -- without this test a refactor that
+    // accidentally dropped `addAction(actionClearSort)` from the
+    // toolbar would only trip the toolbar-layout test.
+    void TestToolbarClearSortButtonTriggersClear()
+    {
+        const int categoryCol = StreamFixtureForColumnTests();
+        QVERIFY2(categoryCol >= 0, "fixture must expose `category` column");
+
+        auto *toolbar = mWindow->findChild<QToolBar *>(QStringLiteral("mainToolbar"));
+        QVERIFY2(toolbar != nullptr, "main toolbar must exist");
+        // NOLINTBEGIN(clang-analyzer-core.CallAndMessage): prior QVERIFY2 aborts on null.
+        auto *action = mWindow->findChild<QAction *>(QStringLiteral("actionClearSort"));
+        QVERIFY2(action != nullptr, "actionClearSort must exist");
+        auto *button = qobject_cast<QToolButton *>(toolbar->widgetForAction(action));
+        QVERIFY2(button != nullptr, "toolbar must host a plain Clear-Sort button for actionClearSort");
+
+        // Idle: action disabled -> button disabled.
+        QVERIFY2(!button->isEnabled(), "toolbar Clear-Sort button must follow the action's disabled state");
+
+        // Install a sort; the button must enable.
+        mWindow->findChild<LogTableView *>()->sortByColumn(categoryCol, Qt::AscendingOrder);
+        QCoreApplication::processEvents();
+        QVERIFY2(button->isEnabled(), "toolbar Clear-Sort button must enable while a sort is active");
+
+        // Click drops the proxy sort and re-disables the button.
+        button->click();
+        QCoreApplication::processEvents();
+        QCOMPARE(mWindow->FilterModel()->SortColumn(), -1);
+        QVERIFY2(!button->isEnabled(), "toolbar Clear-Sort button must re-disable after the sort is cleared");
         // NOLINTEND(clang-analyzer-core.CallAndMessage)
     }
 

--- a/test/app/src/main_window_test.cpp
+++ b/test/app/src/main_window_test.cpp
@@ -12577,7 +12577,7 @@ private slots:
         const QAction *ascCategory = nullptr;
         const QAction *descCategory = nullptr;
         int totalChecked = 0;
-        for (QAction *act : entries)
+        for (const QAction *act : entries)
         {
             if (act == nullptr || act->isSeparator() || act->objectName() == QStringLiteral("actionClearSort"))
             {
@@ -12936,7 +12936,7 @@ private slots:
 
         const QAction *asc = nullptr;
         const QAction *desc = nullptr;
-        for (QAction *act : built.menu->actions())
+        for (const QAction *act : built.menu->actions())
         {
             if (act == nullptr || act->isSeparator())
             {
@@ -12972,7 +12972,7 @@ private slots:
 
         const QAction *controlAsc = nullptr;
         const QAction *controlDesc = nullptr;
-        for (QAction *act : controlBuilt.menu->actions())
+        for (const QAction *act : controlBuilt.menu->actions())
         {
             if (act == nullptr || act->isSeparator())
             {

--- a/test/app/src/main_window_test.cpp
+++ b/test/app/src/main_window_test.cpp
@@ -12430,6 +12430,334 @@ private slots:
         // NOLINTEND(clang-analyzer-core.CallAndMessage)
     }
 
+    // Shape contract for the Sort split button: `MenuButtonPopup`
+    // `QToolButton` whose default action is the bare `actionSortBy`
+    // (a face click programmatically pops the dropdown -- sort has
+    // no generic editor like filters do) and whose dropdown menu
+    // carries the `sortBySplitMenu` objectName. Mirrors
+    // `TestAddFilterSplitButtonShape`.
+    void TestSortBySplitButtonShape()
+    {
+        auto *button = mWindow->findChild<QToolButton *>(QStringLiteral("sortBySplitButton"));
+        QVERIFY2(button != nullptr, "primary toolbar must host the sort split button");
+        // NOLINTBEGIN(clang-analyzer-core.CallAndMessage): prior QVERIFY2 aborts on null.
+        QCOMPARE(button->popupMode(), QToolButton::MenuButtonPopup);
+
+        const QAction *defaultAction = button->defaultAction();
+        QVERIFY2(defaultAction != nullptr, "split button must have a default action");
+        QCOMPARE(defaultAction->objectName(), QStringLiteral("actionSortBy"));
+
+        const QMenu *menu = button->menu();
+        QVERIFY2(menu != nullptr, "split button must have a popup menu");
+        QCOMPARE(menu->objectName(), QStringLiteral("sortBySplitMenu"));
+        // NOLINTEND(clang-analyzer-core.CallAndMessage)
+    }
+
+    // The Sort dropdown lists every *visible* column with two
+    // entries (`Sort by "<col>" ascending` and `... descending`).
+    // Verifies the population, the per-column doubling, and the
+    // hidden-column filter (toggling a column hidden must drop
+    // its entries on the next open, mirroring the Add-filter
+    // dropdown).
+    void TestSortByDropdownListsVisibleColumns()
+    {
+        const int levelCol = StreamFixtureForColumnTests();
+        QVERIFY2(levelCol >= 0, "fixture must produce columns");
+
+        auto *menu = mWindow->findChild<QMenu *>(QStringLiteral("sortBySplitMenu"));
+        QVERIFY2(menu != nullptr, "sort dropdown must exist");
+        // NOLINTBEGIN(clang-analyzer-core.CallAndMessage): prior QVERIFY2 aborts on null.
+        emit menu->aboutToShow();
+
+        QStringList entryTexts;
+        for (const QAction *act : menu->actions())
+        {
+            entryTexts.append(act != nullptr ? act->text() : QStringLiteral("<null>"));
+        }
+        QVERIFY2(!entryTexts.isEmpty(), "dropdown must list at least one column after streaming a fixture");
+        int ascCount = 0;
+        int descCount = 0;
+        for (const QString &text : entryTexts)
+        {
+            QVERIFY2(
+                text.startsWith(QStringLiteral("Sort by ")),
+                "every dropdown entry must follow the `Sort by \"<col>\" ...` shape"
+            );
+            if (text.endsWith(QStringLiteral("ascending")))
+            {
+                ++ascCount;
+            }
+            else if (text.endsWith(QStringLiteral("descending")))
+            {
+                ++descCount;
+            }
+        }
+        QVERIFY2(ascCount > 0 && ascCount == descCount, "every column must contribute both an Asc and a Desc entry");
+
+        // Hide the `msg` column and re-open: its entries must
+        // drop. Cross-checks the visible-only filter shared with
+        // the Add-filter dropdown.
+        auto *model = mWindow->Model();
+        const int msgCol = ColumnByHeader(*model, QStringLiteral("msg"));
+        QVERIFY2(msgCol >= 0, "fixture must expose `msg` column");
+        mWindow->SetColumnVisible(msgCol, false);
+        emit menu->aboutToShow();
+
+        for (const QAction *act : menu->actions())
+        {
+            QVERIFY2(
+                !act->text().contains(QStringLiteral("\"msg\"")),
+                "hidden column must not surface in the dropdown after hide"
+            );
+        }
+        // NOLINTEND(clang-analyzer-core.CallAndMessage)
+    }
+
+    // Triggering a `Sort by "<col>" ascending|descending` dropdown
+    // entry installs the matching sort on the proxy. Pinned so a
+    // refactor that changes the `sortByColumn` plumbing would trip
+    // here, replicating the `TestAddFilterDropdownTriggerPreselectsColumn`
+    // contract for the sort entry point.
+    void TestSortByDropdownTriggerSortsByColumn()
+    {
+        const int levelCol = StreamFixtureForColumnTests();
+        QVERIFY2(levelCol >= 0, "fixture must produce columns");
+        auto *model = mWindow->Model();
+        const int categoryCol = ColumnByHeader(*model, QStringLiteral("category"));
+        QVERIFY2(categoryCol >= 0, "fixture must expose `category` column");
+
+        auto *menu = mWindow->findChild<QMenu *>(QStringLiteral("sortBySplitMenu"));
+        QVERIFY2(menu != nullptr, "sort dropdown must exist");
+        // NOLINTBEGIN(clang-analyzer-core.CallAndMessage): prior QVERIFY2 aborts on null.
+        emit menu->aboutToShow();
+
+        QAction *categoryDesc = nullptr;
+        for (QAction *act : menu->actions())
+        {
+            if (act != nullptr && act->text().contains(QStringLiteral("\"category\"")) &&
+                act->text().endsWith(QStringLiteral("descending")))
+            {
+                categoryDesc = act;
+                break;
+            }
+        }
+        QVERIFY2(categoryDesc != nullptr, "dropdown must offer a descending entry for the `category` column");
+
+        categoryDesc->trigger();
+        QCoreApplication::processEvents();
+
+        QCOMPARE(mWindow->FilterModel()->SortColumn(), categoryCol);
+        QCOMPARE(mWindow->FilterModel()->SortOrder(), Qt::DescendingOrder);
+        // NOLINTEND(clang-analyzer-core.CallAndMessage)
+    }
+
+    // `RebuildSortMenu` is hooked to `menuSort->aboutToShow`. The
+    // top of the menu must always carry `actionClearSort` followed
+    // by a separator, then per-column Asc/Desc entries. Active
+    // sort is reflected via checkable check state.
+    void TestSortMenuShapeAndCheckmarks()
+    {
+        const int levelCol = StreamFixtureForColumnTests();
+        QVERIFY2(levelCol >= 0, "fixture must produce columns");
+        auto *model = mWindow->Model();
+        const int categoryCol = ColumnByHeader(*model, QStringLiteral("category"));
+        QVERIFY2(categoryCol >= 0, "fixture must expose `category` column");
+
+        auto *menu = mWindow->findChild<QMenu *>(QStringLiteral("menuSort"));
+        QVERIFY2(menu != nullptr, "Sort menu must exist");
+        // NOLINTBEGIN(clang-analyzer-core.CallAndMessage): prior QVERIFY2 aborts on null.
+
+        // Sort the proxy so a checked entry exists; Asc on
+        // `category`. The aboutToShow rebuild reads the live
+        // proxy state.
+        mWindow->findChild<LogTableView *>()->sortByColumn(categoryCol, Qt::AscendingOrder);
+        QCoreApplication::processEvents();
+
+        emit menu->aboutToShow();
+        const QList<QAction *> entries = menu->actions();
+        QVERIFY2(entries.size() >= 3, "Sort menu must have Clear + separator + at least one column entry");
+        QCOMPARE(entries[0]->objectName(), QStringLiteral("actionClearSort"));
+        QVERIFY2(entries[1]->isSeparator(), "second slot must be the separator");
+        QVERIFY2(entries[0]->isEnabled(), "actionClearSort must be enabled while a sort is active");
+
+        // Walk the per-column rows and find the `category` Asc/Desc
+        // pair. Asc must be checked, Desc unchecked.
+        QAction *ascCategory = nullptr;
+        QAction *descCategory = nullptr;
+        for (QAction *act : entries)
+        {
+            if (act == nullptr || act->isSeparator())
+            {
+                continue;
+            }
+            if (act->text().contains(QStringLiteral("\"category\"")))
+            {
+                if (act->text().endsWith(QStringLiteral("ascending")))
+                {
+                    ascCategory = act;
+                }
+                else if (act->text().endsWith(QStringLiteral("descending")))
+                {
+                    descCategory = act;
+                }
+            }
+        }
+        QVERIFY2(ascCategory != nullptr && descCategory != nullptr, "menu must carry both `category` entries");
+        QVERIFY2(ascCategory->isChecked(), "active asc-sort entry must be checked");
+        QVERIFY2(!descCategory->isChecked(), "non-active desc-sort entry must be unchecked");
+        // NOLINTEND(clang-analyzer-core.CallAndMessage)
+    }
+
+    // Header right-click menu on a sorted column must mark the
+    // matching `Sort ascending|descending by "<col>"` entry checked,
+    // and `Clear sort` must be enabled. Mirrors the Sort menu
+    // shape, contextualised to the right-clicked column.
+    void TestHeaderContextMenuSortEntries()
+    {
+        const int levelCol = StreamFixtureForColumnTests();
+        QVERIFY2(levelCol >= 0, "fixture must produce columns");
+        auto *model = mWindow->Model();
+        const int categoryCol = ColumnByHeader(*model, QStringLiteral("category"));
+        QVERIFY2(categoryCol >= 0, "fixture must expose `category` column");
+
+        // Without a sort, Clear sort is disabled and neither
+        // direction is checked.
+        auto built = mWindow->BuildHeaderContextMenu(categoryCol, nullptr);
+        QVERIFY2(built.menu != nullptr, "BuildHeaderContextMenu must return a menu");
+        // NOLINTBEGIN(clang-analyzer-core.CallAndMessage): prior QVERIFY2 aborts on null.
+        QScopeGuard freeMenu1([&built]() { built.menu->deleteLater(); });
+
+        QAction *clearSortNoSort = nullptr;
+        QAction *ascNoSort = nullptr;
+        QAction *descNoSort = nullptr;
+        for (QAction *act : built.menu->actions())
+        {
+            if (act == nullptr || act->isSeparator())
+            {
+                continue;
+            }
+            if (act->text() == QStringLiteral("Clear sort"))
+            {
+                clearSortNoSort = act;
+            }
+            else if (act->text().startsWith(QStringLiteral("Sort ascending")))
+            {
+                ascNoSort = act;
+            }
+            else if (act->text().startsWith(QStringLiteral("Sort descending")))
+            {
+                descNoSort = act;
+            }
+        }
+        QVERIFY2(
+            clearSortNoSort != nullptr && ascNoSort != nullptr && descNoSort != nullptr,
+            "header menu must always include the Sort block"
+        );
+        QVERIFY2(!clearSortNoSort->isEnabled(), "Clear sort must be disabled when no sort is active");
+        QVERIFY2(!ascNoSort->isChecked() && !descNoSort->isChecked(), "neither direction is checked without a sort");
+        freeMenu1.dismiss();
+        built.menu->deleteLater();
+
+        // With a desc sort on `category`, the matching entry is
+        // checked and Clear sort is enabled.
+        mWindow->findChild<LogTableView *>()->sortByColumn(categoryCol, Qt::DescendingOrder);
+        QCoreApplication::processEvents();
+        auto built2 = mWindow->BuildHeaderContextMenu(categoryCol, nullptr);
+        QVERIFY2(built2.menu != nullptr, "BuildHeaderContextMenu must return a menu");
+        QScopeGuard freeMenu2([&built2]() { built2.menu->deleteLater(); });
+
+        QAction *clearSortActive = nullptr;
+        QAction *ascActive = nullptr;
+        QAction *descActive = nullptr;
+        for (QAction *act : built2.menu->actions())
+        {
+            if (act == nullptr || act->isSeparator())
+            {
+                continue;
+            }
+            if (act->text() == QStringLiteral("Clear sort"))
+            {
+                clearSortActive = act;
+            }
+            else if (act->text().startsWith(QStringLiteral("Sort ascending")))
+            {
+                ascActive = act;
+            }
+            else if (act->text().startsWith(QStringLiteral("Sort descending")))
+            {
+                descActive = act;
+            }
+        }
+        QVERIFY2(
+            clearSortActive != nullptr && ascActive != nullptr && descActive != nullptr,
+            "header menu must always include the Sort block"
+        );
+        QVERIFY2(clearSortActive->isEnabled(), "Clear sort must be enabled when a sort is active");
+        QVERIFY2(!ascActive->isChecked(), "non-active asc entry must be unchecked under a desc sort");
+        QVERIFY2(descActive->isChecked(), "active desc entry must be checked");
+
+        // Triggering Clear sort must drop the proxy's sort.
+        clearSortActive->trigger();
+        QCoreApplication::processEvents();
+        QCOMPARE(mWindow->FilterModel()->SortColumn(), -1);
+        // NOLINTEND(clang-analyzer-core.CallAndMessage)
+    }
+
+    // Status-bar Clear-sort indicator must be hidden by default,
+    // surface when a sort is installed, and hide again when the
+    // sort is dropped. Mirrors the existing Clear-filters
+    // status-button behaviour.
+    void TestClearSortStatusButtonVisibilityFollowsSort()
+    {
+        const int levelCol = StreamFixtureForColumnTests();
+        QVERIFY2(levelCol >= 0, "fixture must produce columns");
+        auto *model = mWindow->Model();
+        const int categoryCol = ColumnByHeader(*model, QStringLiteral("category"));
+        QVERIFY2(categoryCol >= 0, "fixture must expose `category` column");
+
+        auto *button = mWindow->findChild<QPushButton *>(QStringLiteral("clearSortStatusButton"));
+        QVERIFY2(button != nullptr, "status bar must host the clear-sort indicator");
+        // NOLINTBEGIN(clang-analyzer-core.CallAndMessage): prior QVERIFY2 aborts on null.
+        QVERIFY2(button->isHidden(), "indicator must be hidden when no sort is active");
+
+        mWindow->findChild<LogTableView *>()->sortByColumn(categoryCol, Qt::AscendingOrder);
+        QCoreApplication::processEvents();
+        QVERIFY2(!button->isHidden(), "indicator must surface when a sort becomes active");
+
+        // Click the button -- it triggers `actionClearSort` and
+        // the next `layoutChanged` must hide it again.
+        button->click();
+        QCoreApplication::processEvents();
+        QCOMPARE(mWindow->FilterModel()->SortColumn(), -1);
+        QVERIFY2(button->isHidden(), "indicator must hide again after a clear");
+        // NOLINTEND(clang-analyzer-core.CallAndMessage)
+    }
+
+    // `actionClearSort` enable state must follow the proxy's sort
+    // column. Mirrors `actionClearAllFilters`'s gating.
+    void TestActionClearSortEnableStateFollowsSort()
+    {
+        const int levelCol = StreamFixtureForColumnTests();
+        QVERIFY2(levelCol >= 0, "fixture must produce columns");
+        auto *model = mWindow->Model();
+        const int categoryCol = ColumnByHeader(*model, QStringLiteral("category"));
+        QVERIFY2(categoryCol >= 0, "fixture must expose `category` column");
+
+        auto *action = mWindow->findChild<QAction *>(QStringLiteral("actionClearSort"));
+        QVERIFY2(action != nullptr, "actionClearSort must exist");
+        // NOLINTBEGIN(clang-analyzer-core.CallAndMessage): prior QVERIFY2 aborts on null.
+        QVERIFY2(!action->isEnabled(), "actionClearSort must start disabled");
+
+        mWindow->findChild<LogTableView *>()->sortByColumn(categoryCol, Qt::DescendingOrder);
+        QCoreApplication::processEvents();
+        QVERIFY2(action->isEnabled(), "actionClearSort must enable while a sort is active");
+
+        mWindow->findChild<LogTableView *>()->sortByColumn(-1, Qt::AscendingOrder);
+        QCoreApplication::processEvents();
+        QVERIFY2(!action->isEnabled(), "actionClearSort must disable again after a clear");
+        // NOLINTEND(clang-analyzer-core.CallAndMessage)
+    }
+
     // Item 1: `RebuildViewMenu` re-adds the primary toolbar's
     // `toggleViewAction` on every menu open. Without this the user
     // who hid the toolbar would have no discoverable way to bring


### PR DESCRIPTION
Five lock-stepped Sort surfaces -- a new top-level **Sort** menu, a **Sort** split-button + plain **Clear Sort** action on the primary toolbar, an `actionClearSort` indicator on the status bar, and a sort block on the column-header right-click menu -- all routed through a single shared `actionClearSort` slot and a shared `AppendSortByEntries` core. `MainWindow::ClearSort` is the one programmatic entry point; everything else either reuses `ui->actionClearSort` directly (so the enable state, tooltip, icon, and any future shortcut propagate once) or routes through `LogTableView::sortByColumn` so the proxy, header indicator, and persisted configuration always stay in lockstep.

## Why

Sort was the one row-projection action with zero discoverability outside the column header itself -- a user who didn't know that clicking a header sorts had no entry point at all, and a user who *did* know still had no way to clear a sort short of click-cycling the same header back to the unsorted state (which the prior `QHeaderView` contract didn't even surface in `doc/README.md`). Every comparable tool (VS Code, IntelliJ run console, DBeaver, the existing log-analysis competitors) ships a primary-toolbar Sort button and a menu entry alongside the click-the-header path; landing them here puts our Sort affordances on the same shelf the rest of the GUI-polish branches built out (Add Filter / Clear Filters split buttons in #56, the rows-shown / filter-active status indicators in #55, the column-header funnel in #57).

The status-bar `Clear sort` indicator is the smaller half of the same conversation: a filter that's hiding rows now surfaces a `Clear filters` button next to the `n of m shown` label (#55), and a sort that's reordering rows deserves the same one-click escape hatch -- "where did my chronological order go?" was the second-most-common confusion in dense scrolling, right after "where did my rows go?".

The reason every surface routes through one shared `actionClearSort` is the lesson the filter branches taught us: when "Clear sort" lives as five independently-built `QAction`s, casing drifts (`Clear Sort` vs `Clear sort`), enable state desyncs, and a future shortcut / icon change has to be applied five times. Re-attaching the `.ui` action across menus is free in Qt; the menu owns the layout, not the `QAction`. The new tests pin pointer identity with `findChild<QAction *>("actionClearSort")` so an accidental clone trips immediately.

The `▲` / `▼` triangle glyphs the menu rows are prefixed with are the same Unicode code-points `QHeaderView` paints as its sort indicator, so the menu reads as a direct mirror of what the column header would show -- a translator can rename `"Sort"` and the quoted column label, but the glyphs are hoisted to `static constexpr QChar` so the visual cue can't drift.

The type-mismatch gate is the only behavioural addition rather than a chrome rearrangement: a column whose data doesn't match its configured `Column::type` (already surfaced by the warning triangle in the header and the diagnostics dialog) sorts via the wrong comparator and produces an order that doesn't reflect the on-screen values. Refusing up-front and pointing the user at *Configuration Diagnostics* via the disabled row's tooltip is the same shape the existing filter editor uses when a column health check fails.

## What changed

**Menu / action / resource scaffolding (`app/src/main_window.ui`, `resources/resources.qrc`, `cmake/license_snippets/lucide.txt`).** New top-level `menuSort` slotted between `menuFilters` and `menuStream`, carrying `actionClearSort` + a separator (the per-column rows are appended live on `aboutToShow`). Two new `actionSortBy` (split-button face) and `actionClearSort` actions, both tagged with `iconText` so they degrade to text in `Qt::ToolButtonTextOnly` mode. Two new Lucide SVGs (`arrow-down-up.svg`, `circle-x.svg`) under `resources/icons/`, registered in `resources.qrc` and credited in the Lucide license snippet (icon count goes 22 -> 24).

**`MainWindow::ClearSort` slot (`app/src/main_window.cpp`).** One-liner that calls `mTableView->sortByColumn(-1, Qt::AscendingOrder)` -- the same code path `SetColumnVisible` and the post-load rebuild use, so proxy / header / config stay in lockstep through one well-trodden route. No-op safe when no sort is active (every UI surface already gates on `actionClearSort`'s enabled state, so the guard is for the test seam and any future programmatic caller).

**Sort menu rebuild (`MainWindow::RebuildSortMenu` / `RebuildSortByMenu` / `AppendSortByEntries` / `AppendSortEntriesOrPlaceholder`).** `RebuildSortMenu` is hooked to `menuSort->aboutToShow` and rebuilds the menu on every open: re-attach `actionClearSort`, separator, then the per-column rows. `RebuildSortByMenu` is hooked to the toolbar split-button's dropdown and skips the Clear-sort prelude (the toolbar has its own dedicated Clear-Sort button next to the dropdown). Both delegate to the shared `AppendSortEntriesOrPlaceholder`, which delegates to `AppendSortByEntries` and falls back to `(no columns yet)` / `(every column is hidden ...)` placeholders (same wording the existing `RebuildAddFilterMenu` uses).

`AppendSortByEntries` emits two checkable rows per *visible* column: `▲ "<col>"` and `▼ "<col>"`, where `<col>` is the disambiguated `BuildAllColumnMenuLabels` output (so two `level` columns surface as `"level [user|id]"`). The triangle glyphs are `static constexpr QChar(u'\u25B2')` / `QChar(u'\u25BC')` -- intentionally outside `tr()` so a translator can't accidentally swap them. Check state mirrors `LogFilterModel::SortColumn()` / `SortOrder()`; sort is single-column / single-direction so at most one row across the menu is ever checked (the radio invariant the prior per-column `QActionGroup` exploration would have enforced).

Each row captures the column's stable `keys` and re-resolves via `FindColumnIndexByKeys` at trigger time, so a column reorder landing between menu build and click still hits the right column (same idiom the filter actions use). Rows are disabled when the model has zero rows (a sort would be a structural no-op but the action would still appear available) or when the column's `ColumnHealth` reports `presentSlots > matchingSlots`; the disabled row carries a tooltip explaining the type-mismatch cause and pointing at Configuration Diagnostics. `setToolTipsVisible(true)` is set on the host menu so the tooltip surfaces on hover (`QMenu` hides per-action tooltips by default).

**`BuildMainToolbar` extensions (`app/src/main_window.cpp`).** Two new entries right after the Clear Filters split button:

- `sortBySplitButton` (`QToolButton::InstantPopup`) -- the *whole face* opens the per-column dropdown (sort has no generic editor like filters do, so a click-vs-arrow split would be redundant). `setDefaultAction(actionSortBy)` is kept so the button inherits the icon, tooltip, and accessible name, but the action's `triggered` signal is unused. `MenuButtonPopup` was the initial shape and was switched to `InstantPopup` during code review to drop a face-click lambda that captured a raw `QToolButton *` and would have dangled if `BuildMainToolbar` were ever re-run.
- `actionClearSort` plain `addAction` -- a per-X dropdown would only ever hold one entry (sort is single-column), so the honest shape is a plain button next to the dropdown rather than a degenerate split button. Enable state is driven by `UpdateSortStatus` in lockstep with `LogFilterModel::SortColumn()`.

Both actions are tagged for `RefreshThemedIcons` so palette / DPR / theme flips re-tint the new glyphs alongside the existing toolbar entries (Sort = `arrow-down-up`, Clear Sort = `circle-x`).

**Status-bar `mClearSortStatusButton` (`app/src/main_window.cpp`, `app/include/main_window.hpp`).** Allocated next to `mClearFiltersStatusButton` in the status bar. Same shape: flat / clickable, hidden by default, click routes through `actionClearSort->trigger()` so all five surfaces share the single slot. Tooltip names the live column and direction (`Sorted by "<col>" (ascending) - click to clear.`) so a rename / reorder shows through.

`UpdateSortStatus` is the single source of truth for both the action's enable state and the button's visibility. Visible iff `LogFilterModel::SortColumn() >= 0` and the source has rows; hidden otherwise. Wired to `LogFilterModel::layoutChanged` and source `rowsInserted` / `rowsRemoved` / `modelReset` (the indicator must hide when the model goes empty), plus a horizontal `headerDataChanged` lambda that re-runs `UpdateSortStatus` only when the rename touches the currently-sorted column (the `BuildAllColumnMenuLabels` rebuild is the only non-trivial work on the path, so the gate keeps every column rename from triggering it). A trailing `UpdateSortStatus()` call at the end of the constructor settles the initial state -- the signal hooks subscribe before the status-bar button is allocated, so the first batch of `layoutChanged` events from `RestoreWindowChrome` would otherwise no-op against a `nullptr`.

**Header right-click sort block (`MainWindow::BuildHeaderContextMenu`, `app/src/main_window.cpp`).** A new block sits after the existing Filter block (separator + three entries): `Sort ascending by "<col>"`, `Sort descending by "<col>"`, and the shared `actionClearSort` re-attached. Each Asc/Desc action captures the column's stable `keys` and re-resolves via `FindColumnIndexByKeys` at trigger time, mirrors the type-mismatch gate (`ColumnHealth::presentSlots > matchingSlots` disables both with the diagnostics-pointing tooltip), and the host menu opts into per-action tooltips via `setToolTipsVisible(true)`. Hidden columns skip the block in the same shape the existing filter block uses (production right-clicks always hit a visible section, but the gate matches the rest of the file).

The Clear entry is the exact same `ui->actionClearSort` instance reused across every Sort surface -- the host menu is built fresh per right-click and `deleteLater`d on dismiss, so re-attaching is safe.

**`doc/README.md`.** The "Sorting" bullet in the *Navigating the Table* section expands to call out all five surfaces (top-level menu, toolbar split + Clear Sort, header right-click block, status-bar indicator) and documents the third-click clear behaviour `QHeaderView` already provided but the existing bullet didn't mention.

**Tests (`test/app/src/main_window_test.cpp`, +634 lines).** 11 new cases pinning the contract end-to-end:

- `TestSortBySplitButtonShape` -- `InstantPopup`, default action `objectName`, dropdown menu `objectName`.
- `TestSortByDropdownListsVisibleColumns` -- exactly one Asc + one Desc entry per visible column, each prefixed with the right triangle glyph and carrying the quoted column label; hiding a column drops both of its rows on the next `aboutToShow`.
- `TestSortByDropdownTriggerSortsByColumn` -- triggering a Desc entry installs the matching `SortColumn` / `SortOrder` on the proxy.
- `TestSortMenuShapeAndCheckmarks` -- the top-level Sort menu always leads with `actionClearSort` + separator; the active sort lights up exactly one matching checkable row (radio invariant).
- `TestHeaderContextMenuSortEntries` -- header right-click exposes Asc / Desc / Clear sort; the matching direction is checked under an active sort; the Clear entry is the same `actionClearSort` instance (`QCOMPARE` against `findChild<QAction *>("actionClearSort")`); triggering it drops the proxy's sort.
- `TestClearSortStatusButtonVisibilityFollowsSort` -- status-bar indicator hidden by default, surfaces with a sort, hides again on clear; clicking it triggers `actionClearSort`.
- `TestActionClearSortEnableStateFollowsSort` -- the action's enable state mirrors `SortColumn() >= 0` through install / clear.
- `TestToolbarClearSortButtonTriggersClear` -- the auto-generated `QToolButton` from `toolbar->widgetForAction(actionClearSort)` follows the action's enabled state and, on click, drops the proxy sort. Pins the previously-uncovered fifth Clear-sort surface.
- `TestSortDropdownPlaceholderWhenAllColumnsHidden` -- when every column is hidden, both the toolbar dropdown and the top-level Sort menu surface the `(every column is hidden ...)` placeholder rather than an empty menu.
- `TestSortMenuDisablesAscDescOnTypeMismatch` -- after pinning `msg` (string-only) to `Integer` to force a mismatch and refreshing health, both the toolbar dropdown and the top-level Sort menu disable both directions on `msg`, carry the diagnostics-pointing tooltip, and leave the type-clean `category` column alone (control).
- `TestHeaderContextMenuDisablesSortOnTypeMismatch` -- same gate exercised through the right-click path (independent code, so pinned separately).
- `TestSortStatusTooltipUpdatesOnColumnRename` -- a rename of the sorted column emits `headerDataChanged`; the status-bar tooltip catches the new label without waiting for a sort / filter event.
- `TestRestoreLastSessionDefersSortUntilStreamingFinishes` is extended: after a deferred-sort restore, `actionClearSort` is enabled and the status-bar indicator is visible (pins that the deferred restore reaches `UpdateSortStatus` via the trailing `layoutChanged`).
- `TestHeaderContextMenuActionOrdering` and `TestMainToolbarActionsInOrder` are updated to reflect the new Sort block in the header menu and the `sortBySplitButton` + `actionClearSort` entries in the toolbar.

**Code review fixups (`95c2842`, `2e99789`, `5e6086e`, `d490934`).** A trailing sweep that:

- Switches the Sort dropdown from `MenuButtonPopup` to `InstantPopup` (drops the dangling-lambda risk and removes the click-vs-arrow ambiguity).
- Routes the header right-click Clear entry through `actionClearSort` instead of synthesising a duplicate `QAction` (drops the `Clear Sort` / `Clear sort` casing drift and earns shortcut / icon propagation for free across all five surfaces).
- Adds the horizontal `headerDataChanged` lambda so the status-bar tooltip stays in lock-step on column rename (with the matching `TestSortStatusTooltipUpdatesOnColumnRename`).
- Hoists the `▲` / `▼` glyphs out of `tr()` into `static constexpr QChar` constants so a translator can't accidentally swap them.
- Tightens the `headerDataChanged` lambda to its full 3-arg signature and skips the `UpdateSortStatus` rebuild on horizontal pings that don't touch the sorted column.
- Drops the misleading `…` ellipsis from `actionSortBy` (no dialog opens), rewrites its tooltip for the new whole-face popup, and seeds `mClearSortStatusButton` with a static fallback tooltip until `UpdateSortStatus` writes the column-aware variant.
- `run-clang-tidy` + `pre-commit` sweep over the new / heavily-modified TUs (`main_window.hpp`, `main_window.cpp`, `main_window_test.cpp`).

## Test plan

- [x] `ctest -LE benchmark` green locally on Windows + MSVC + Release + IPO (354 / 354 offscreen, including the 11 new cases).
- [x] `run-clang-tidy` over `main_window.cpp` and `main_window_test.cpp` reports zero warnings on the new code.
- [x] Manual smoke: open a JSON Lines log -- click a column header -- column sorts ascending; click again -- descending; click again -- sort clears (the new third-click behaviour `doc/README.md` now documents).
- [x] Manual smoke: open the new **Sort** menu -- *Clear Sort* is disabled, every visible column appears twice (`▲ "<col>"` / `▼ "<col>"`). Pick a row -- column sorts and the same row lights up on next open. Pick *Clear Sort* -- sort drops, Clear-sort disables again.
- [x] Manual smoke: click the toolbar Sort split button -- per-column dropdown opens; click an entry -- column sorts. The plain Clear Sort button next to it enables; click it -- sort drops.
- [x] Manual smoke: right-click a column header -- the menu carries the new Sort block after the existing Filter block (`Sort ascending`, `Sort descending`, `Clear sort`). The matching direction is checked under an active sort.
- [x] Manual smoke: apply a sort -- the status-bar `Clear sort` button surfaces with a tooltip naming the column and direction. Rename the sorted column via the column editor -- the tooltip updates immediately. Click the indicator -- sort drops, indicator hides.
- [x] Manual smoke: pin a string column (`msg`) to `Integer` via Configuration Diagnostics -- the column's Asc / Desc rows in the Sort menu, toolbar dropdown, and header right-click all disable and carry the diagnostics-pointing tooltip. Reset the column type -- rows re-enable.
- [x] Manual smoke: hide every column via the View menu -- the Sort menu and toolbar dropdown both surface the `(every column is hidden ...)` placeholder rather than an empty menu.
- [x] Manual smoke: save a session with a sort active, restart the app, restore the session -- the proxy carries the same sort, `actionClearSort` is enabled, and the status-bar indicator is visible.
- [x] CI: `build-linux`, `build-macos`, `build-windows`, `clang-ci (asan-ubsan / tsan / coverage)`, `pre-commit`, CodeQL all green on this PR.