### PR TITLE
GUI polish: floating jump-to-tail pill

### DIFF
--- a/app/CMakeLists.txt
+++ b/app/CMakeLists.txt
@@ -30,6 +30,8 @@ set(PROJECT_SOURCES
     include/find_dock.hpp
     src/icon_loader.cpp
     include/icon_loader.hpp
+    src/jump_to_tail_pill.cpp
+    include/jump_to_tail_pill.hpp
     src/level_cell_delegate.cpp
     include/level_cell_delegate.hpp
     src/parse_errors_dock.cpp

--- a/app/include/jump_to_tail_pill.hpp
+++ b/app/include/jump_to_tail_pill.hpp
@@ -46,6 +46,14 @@ public:
     /// Displayed text caps at "999+" so a runaway live tail does
     /// not stretch the pill across the viewport. The cap is purely
     /// cosmetic; callers may pass any non-negative count.
+    ///
+    /// Emits `contentSizeChanged` after every text update -- the
+    /// rebuilt label changes the pill's `sizeHint`, and the host
+    /// has to re-anchor the pill to the viewport edge whether the
+    /// count grew or shrank. Without that signal a count that
+    /// crosses the "999+" boundary the wrong way (e.g. user clears
+    /// some rows and we drop back below the cap) would leave the
+    /// pill drifting off-centre until the next viewport resize.
     void SetCount(int count);
 
     /// Update which way the arrow points. Idempotent. The icon is
@@ -66,6 +74,15 @@ public:
     {
         return mCount;
     }
+
+signals:
+    /// The pill's `sizeHint` may have changed because the rendered
+    /// text was rebuilt (count grew, shrank, or crossed the
+    /// `999+` cap boundary). The host (`LogTableView`) listens
+    /// and re-runs `PositionTailPill` so the pill stays centred
+    /// against the viewport edge regardless of which direction
+    /// the size moved.
+    void contentSizeChanged();
 
 protected:
     /// Re-tint the arrow icon and re-apply the rounded-pill QSS

--- a/app/include/jump_to_tail_pill.hpp
+++ b/app/include/jump_to_tail_pill.hpp
@@ -6,113 +6,74 @@ class QEvent;
 class QGraphicsOpacityEffect;
 class QPropertyAnimation;
 
-/// Floating "* N new lines" pill rendered on top of the log table
-/// viewport. Surfaces the reading-position preservation that
-/// `LogTableView::SaveAnchorIfShouldPreserve` /
-/// `RestoreAnchorIfSaved` already perform: when the user has
-/// scrolled away from the tail edge and new rows arrive, the pill
-/// fades in with a running count; a click jumps to the newest row
-/// and (in live-tail sessions) re-engages Follow newest.
+/// Floating "N new lines" pill (Slack / YouTube pattern) shown on
+/// the log table viewport. When the user has scrolled away from
+/// the tail and new rows arrive, the pill fades in with a running
+/// count; clicking it jumps to the newest row.
 ///
-/// Owned by `LogTableView` and parented to its viewport so it
-/// floats over the rows without being clipped by the grid. The
-/// arrow direction follows the configured `TailEdge` -- "down"
-/// for `Bottom` (default append-at-bottom), "up" for `Top`
-/// (newest-first) -- and the host repositions the pill near the
-/// matching viewport edge.
-///
-/// Pattern: YouTube comments / Slack "* N new messages" pill.
+/// Owned by `LogTableView` and parented to its viewport. The arrow
+/// direction tracks the configured `TailEdge` (Down for Bottom, Up
+/// for Top); the host repositions the pill near that edge.
 class JumpToTailPill : public QToolButton
 {
     Q_OBJECT
 
 public:
-    /// Which way the arrow glyph points. `Down` matches
-    /// `LogTableView::TailEdge::Bottom`; `Up` matches `Top`.
     enum class ArrowDirection
     {
-        Down,
-        Up,
+        Down, ///< matches `LogTableView::TailEdge::Bottom`
+        Up,   ///< matches `LogTableView::TailEdge::Top`
     };
 
     explicit JumpToTailPill(QWidget *parent);
 
-    /// Update the displayed count and drive the fade animation.
-    /// `count <= 0` fades the pill out (and hides it once the
-    /// animation finishes); a positive count fades it in. The
-    /// host (`LogTableView`) feeds the running tally; this widget
-    /// is purely a renderer and emits `clicked` on press.
-    ///
-    /// Displayed text caps at "999+" so a runaway live tail does
-    /// not stretch the pill across the viewport. The cap is purely
-    /// cosmetic; callers may pass any non-negative count.
-    ///
-    /// Emits `contentSizeChanged` after every text update -- the
-    /// rebuilt label changes the pill's `sizeHint`, and the host
-    /// has to re-anchor the pill to the viewport edge whether the
-    /// count grew or shrank. Without that signal a count that
-    /// crosses the "999+" boundary the wrong way (e.g. user clears
-    /// some rows and we drop back below the cap) would leave the
-    /// pill drifting off-centre until the next viewport resize.
+    /// Set the displayed count and fade in / out. Positive counts
+    /// fade in; `<= 0` fades out and hides. Text caps at "999+" to
+    /// bound the pill width. Emits `contentSizeChanged` so the
+    /// host can re-anchor when `sizeHint` shifts (count growth,
+    /// shrink, or crossing the cap).
     void SetCount(int count);
 
-    /// Update which way the arrow points. Idempotent. The icon is
-    /// re-tinted from the *button's* palette (not the parent's),
-    /// so a theme switch reaching the pill via `changeEvent`
-    /// refreshes the glyph correctly.
+    /// Set the arrow direction. Idempotent. The icon is re-tinted
+    /// from this widget's palette so theme changes refresh it.
     void SetArrowDirection(ArrowDirection direction);
 
-    /// Current rendered direction (read by tests and by
-    /// `LogTableView::PositionTailPill` for edge selection).
     [[nodiscard]] ArrowDirection Direction() const noexcept
     {
         return mDirection;
     }
 
-    /// Current count last fed to `SetCount`. Read by tests.
     [[nodiscard]] int Count() const noexcept
     {
         return mCount;
     }
 
 signals:
-    /// The pill's `sizeHint` may have changed because the rendered
-    /// text was rebuilt (count grew, shrank, or crossed the
-    /// `999+` cap boundary). The host (`LogTableView`) listens
-    /// and re-runs `PositionTailPill` so the pill stays centred
-    /// against the viewport edge regardless of which direction
-    /// the size moved.
+    /// Rendered text changed and the pill's `sizeHint` may have
+    /// moved (in either direction). The host re-runs
+    /// `PositionTailPill` so the pill stays centred at the edge.
     void contentSizeChanged();
 
 protected:
-    /// Re-tint the arrow icon and re-apply the rounded-pill QSS
-    /// whenever the palette / style flips so the pill tracks
-    /// Light <-> Dark theme switches without restart.
+    /// Re-tint the icon and re-apply the QSS on palette / style
+    /// changes so the pill tracks theme switches without restart.
     void changeEvent(QEvent *event) override;
 
 private:
-    /// Rebuild the displayed text from `mCount` (e.g. "↓ 3 new
-    /// lines" / "↑ 1 new line" / "↓ 999+ new lines"). Pure
-    /// formatter; no side effects beyond `setText`.
+    /// Rebuild the visible text and accessible name from `mCount`.
     void RebuildText();
 
-    /// Re-rasterise the arrow icon at the current palette's
-    /// `HighlightedText` colour so the glyph reads as foreground
-    /// on the pill's `Highlight` background. Called from
-    /// `SetArrowDirection`, `changeEvent`, and after the first
-    /// `show()` so the device-pixel-ratio matches.
+    /// Re-rasterise the arrow icon in the current `HighlightedText`
+    /// colour at the current device pixel ratio.
     void RefreshIcon();
 
-    /// Apply the rounded-pill QSS (background = `Highlight`,
-    /// foreground = `HighlightedText`, `border-radius = h/2`).
-    /// Pulled out so `changeEvent(PaletteChange)` can re-run it.
+    /// Apply the rounded-pill QSS resolved against the current
+    /// palette. Pulled out so `changeEvent` can re-run it.
     void ApplyStyleSheet();
 
-    /// Run the fade-in / fade-out animation. Sets `setVisible`
-    /// at the appropriate ends so the hidden pill doesn't intercept
-    /// hover events. Idempotent; re-targeting an in-flight
-    /// animation just retargets the QPropertyAnimation's end
-    /// value rather than chaining a new one.
+    /// Run the fade animation, retargeting any in-flight run so a
+    /// fade-in interrupted by a fade-out (or vice versa) stays
+    /// smooth.
     void FadeTo(qreal endOpacity);
 
     QGraphicsOpacityEffect *mOpacity = nullptr;
@@ -120,15 +81,11 @@ private:
     int mCount = 0;
     ArrowDirection mDirection = ArrowDirection::Down;
 
-    /// Re-entrancy guard for `ApplyStyleSheet` / `RefreshIcon`.
-    /// `setStyleSheet` synchronously emits both `StyleChange` and
-    /// `PaletteChange` on the widget on Qt 6 (the QSS system
-    /// re-resolves palette roles), so a `changeEvent` that
-    /// dispatches to `ApplyStyleSheet` from either branch would
-    /// recurse forever -- this crashed the test suite with a
-    /// stack overflow during construction. The flag short-circuits
-    /// the recursive call without dropping the *external*
-    /// theme-switch refresh path (which arrives outside any
-    /// `setStyleSheet` of ours).
+    /// Re-entrancy guard. On Qt 6, `setStyleSheet` synchronously
+    /// emits `StyleChange` / `PaletteChange`, which would route
+    /// back into `ApplyStyleSheet` and recurse forever (this
+    /// crashed the test suite during construction). External
+    /// theme switches arrive outside our `setStyleSheet`, so the
+    /// guard is clear and the refresh still runs.
     bool mApplyingPalette = false;
 };

--- a/app/include/jump_to_tail_pill.hpp
+++ b/app/include/jump_to_tail_pill.hpp
@@ -102,4 +102,16 @@ private:
     QPropertyAnimation *mFade = nullptr;
     int mCount = 0;
     ArrowDirection mDirection = ArrowDirection::Down;
+
+    /// Re-entrancy guard for `ApplyStyleSheet` / `RefreshIcon`.
+    /// `setStyleSheet` synchronously emits both `StyleChange` and
+    /// `PaletteChange` on the widget on Qt 6 (the QSS system
+    /// re-resolves palette roles), so a `changeEvent` that
+    /// dispatches to `ApplyStyleSheet` from either branch would
+    /// recurse forever -- this crashed the test suite with a
+    /// stack overflow during construction. The flag short-circuits
+    /// the recursive call without dropping the *external*
+    /// theme-switch refresh path (which arrives outside any
+    /// `setStyleSheet` of ours).
+    bool mApplyingPalette = false;
 };

--- a/app/include/jump_to_tail_pill.hpp
+++ b/app/include/jump_to_tail_pill.hpp
@@ -1,0 +1,105 @@
+#pragma once
+
+#include <QToolButton>
+
+class QEvent;
+class QGraphicsOpacityEffect;
+class QPropertyAnimation;
+
+/// Floating "* N new lines" pill rendered on top of the log table
+/// viewport. Surfaces the reading-position preservation that
+/// `LogTableView::SaveAnchorIfShouldPreserve` /
+/// `RestoreAnchorIfSaved` already perform: when the user has
+/// scrolled away from the tail edge and new rows arrive, the pill
+/// fades in with a running count; a click jumps to the newest row
+/// and (in live-tail sessions) re-engages Follow newest.
+///
+/// Owned by `LogTableView` and parented to its viewport so it
+/// floats over the rows without being clipped by the grid. The
+/// arrow direction follows the configured `TailEdge` -- "down"
+/// for `Bottom` (default append-at-bottom), "up" for `Top`
+/// (newest-first) -- and the host repositions the pill near the
+/// matching viewport edge.
+///
+/// Pattern: YouTube comments / Slack "* N new messages" pill.
+class JumpToTailPill : public QToolButton
+{
+    Q_OBJECT
+
+public:
+    /// Which way the arrow glyph points. `Down` matches
+    /// `LogTableView::TailEdge::Bottom`; `Up` matches `Top`.
+    enum class ArrowDirection
+    {
+        Down,
+        Up,
+    };
+
+    explicit JumpToTailPill(QWidget *parent);
+
+    /// Update the displayed count and drive the fade animation.
+    /// `count <= 0` fades the pill out (and hides it once the
+    /// animation finishes); a positive count fades it in. The
+    /// host (`LogTableView`) feeds the running tally; this widget
+    /// is purely a renderer and emits `clicked` on press.
+    ///
+    /// Displayed text caps at "999+" so a runaway live tail does
+    /// not stretch the pill across the viewport. The cap is purely
+    /// cosmetic; callers may pass any non-negative count.
+    void SetCount(int count);
+
+    /// Update which way the arrow points. Idempotent. The icon is
+    /// re-tinted from the *button's* palette (not the parent's),
+    /// so a theme switch reaching the pill via `changeEvent`
+    /// refreshes the glyph correctly.
+    void SetArrowDirection(ArrowDirection direction);
+
+    /// Current rendered direction (read by tests and by
+    /// `LogTableView::PositionTailPill` for edge selection).
+    [[nodiscard]] ArrowDirection Direction() const noexcept
+    {
+        return mDirection;
+    }
+
+    /// Current count last fed to `SetCount`. Read by tests.
+    [[nodiscard]] int Count() const noexcept
+    {
+        return mCount;
+    }
+
+protected:
+    /// Re-tint the arrow icon and re-apply the rounded-pill QSS
+    /// whenever the palette / style flips so the pill tracks
+    /// Light <-> Dark theme switches without restart.
+    void changeEvent(QEvent *event) override;
+
+private:
+    /// Rebuild the displayed text from `mCount` (e.g. "↓ 3 new
+    /// lines" / "↑ 1 new line" / "↓ 999+ new lines"). Pure
+    /// formatter; no side effects beyond `setText`.
+    void RebuildText();
+
+    /// Re-rasterise the arrow icon at the current palette's
+    /// `HighlightedText` colour so the glyph reads as foreground
+    /// on the pill's `Highlight` background. Called from
+    /// `SetArrowDirection`, `changeEvent`, and after the first
+    /// `show()` so the device-pixel-ratio matches.
+    void RefreshIcon();
+
+    /// Apply the rounded-pill QSS (background = `Highlight`,
+    /// foreground = `HighlightedText`, `border-radius = h/2`).
+    /// Pulled out so `changeEvent(PaletteChange)` can re-run it.
+    void ApplyStyleSheet();
+
+    /// Run the fade-in / fade-out animation. Sets `setVisible`
+    /// at the appropriate ends so the hidden pill doesn't intercept
+    /// hover events. Idempotent; re-targeting an in-flight
+    /// animation just retargets the QPropertyAnimation's end
+    /// value rather than chaining a new one.
+    void FadeTo(qreal endOpacity);
+
+    QGraphicsOpacityEffect *mOpacity = nullptr;
+    QPropertyAnimation *mFade = nullptr;
+    int mCount = 0;
+    ArrowDirection mDirection = ArrowDirection::Down;
+};

--- a/app/include/log_table_view.hpp
+++ b/app/include/log_table_view.hpp
@@ -1,12 +1,14 @@
 #pragma once
 
 #include "anchor_manager.hpp"
+#include "jump_to_tail_pill.hpp"
 
 #include <QHeaderView>
 #include <QItemSelectionModel>
 #include <QList>
 #include <QMetaObject>
 #include <QPersistentModelIndex>
+#include <QPointer>
 #include <QStyleOptionHeader>
 #include <QTableView>
 
@@ -107,12 +109,24 @@ signals:
     /// filter as `userScrolledAwayFromTail`.
     void userScrolledToTail();
 
+    /// User clicked the floating "jump to newest" pill. Forwarded
+    /// to `MainWindow`, which performs the proxy-aware scroll and
+    /// (in live-tail sessions) re-engages Follow newest. The view
+    /// itself stays ignorant of proxies and the Follow action.
+    void jumpToTailRequested();
+
 protected:
     /// Draws the empty-state shortcuts card when the model has no rows.
     void paintEvent(QPaintEvent *event) override;
 
     /// Mark the next `valueChanged` as user-initiated.
     void wheelEvent(QWheelEvent *event) override;
+
+    /// Filters viewport resize events so the floating pill stays
+    /// glued to the tail-side edge of the visible area without the
+    /// view having to subclass the viewport. Installed in
+    /// `LogTableView::LogTableView`.
+    bool eventFilter(QObject *watched, QEvent *event) override;
 
 private:
     void OnVerticalScrollValueChanged(int value);
@@ -132,6 +146,19 @@ private:
 
     void SaveAnchorIfShouldPreserve();
     void RestoreAnchorIfSaved();
+
+    /// Re-place `mTailPill` at the tail-side edge of the
+    /// viewport, centred horizontally. Called from the viewport
+    /// resize hook and from `SetTailEdge` (when the edge flips).
+    /// No-op when the pill is absent.
+    void PositionTailPill();
+
+    /// Centralised reset: zero the pending-new-rows counter and
+    /// fade the pill out. Called when the user / a programmatic
+    /// edge change lands the viewport back at the tail, when a
+    /// new model is attached, on `modelReset`, and on session
+    /// boundaries that drop the table contents.
+    void ResetPendingNewRows();
 
     TailEdge mTailEdge = TailEdge::Bottom;
 
@@ -164,4 +191,30 @@ private:
     /// Non-owning. Wired by `MainWindow`; null on standalone test
     /// fixtures. Anchor slots null-check before dereferencing.
     AnchorManager *mAnchors = nullptr;
+
+    /// Floating "* N new lines" pill parented to the viewport.
+    /// `QPointer` so a viewport teardown (Qt destroys the
+    /// viewport when the view is destroyed) zeroes the pointer
+    /// before our own destructor runs, sparing the slot wiring a
+    /// dangling deref. Visibility / count are driven by
+    /// `OnRowsInserted`, `OnVerticalScrollValueChanged`, and the
+    /// `modelReset` hook.
+    QPointer<JumpToTailPill> mTailPill;
+
+    /// Running count of rows appended while the user was scrolled
+    /// away from the tail edge. Reset to 0 whenever the viewport
+    /// returns to the tail edge or the model is wiped.
+    int mPendingNewRows = 0;
+
+#ifdef LOGAPP_BUILD_TESTING
+public:
+    [[nodiscard]] JumpToTailPill *TailPillForTest() const noexcept
+    {
+        return mTailPill;
+    }
+    [[nodiscard]] int PendingNewRowsForTest() const noexcept
+    {
+        return mPendingNewRows;
+    }
+#endif
 };

--- a/app/include/log_table_view.hpp
+++ b/app/include/log_table_view.hpp
@@ -78,6 +78,30 @@ public:
     /// chain down to `LogModel`; empty when no `LogModel` is reachable.
     [[nodiscard]] std::vector<AnchorManager::Key> AnchorKeysForSelection() const;
 
+    /// Suppress `mPendingNewRows` accumulation. While suppressed,
+    /// `OnRowsInserted` skips the count update and the pill stays
+    /// hidden, regardless of `mAtTailEdge`. `MainWindow` toggles
+    /// this on / off in lockstep with `actionFollowTail` so the
+    /// pill never flashes during the at-tail-with-Follow-engaged
+    /// steady state where Qt's signal ordering can briefly drop
+    /// `mAtTailEdge` between the layout update and the
+    /// `JumpToNewestRow` scroll-back. Clearing the suppression
+    /// also resets any tally accumulated while suppression was
+    /// off, so a transient un-suppress + re-suppress can't leak
+    /// a stale count once the steady-state path resumes.
+    void SetPendingNewRowsSuppressed(bool suppressed);
+
+    /// Acknowledge any "* N new lines" announcement: zero the
+    /// running counter and fade the pill out. Called by
+    /// `MainWindow`'s pill-click handler so a click whose scroll
+    /// happens to land short of the visual tail (custom sort
+    /// where the source-newest row is in the middle of the
+    /// proxy, or filtered-newest fallback that snaps to the
+    /// proxy tail without crossing `maximum`) still clears the
+    /// announcement -- the user explicitly asked to be caught
+    /// up.
+    void AcknowledgePendingNewRows();
+
 public slots:
     void CopySelectedRowsToClipboard();
 
@@ -218,10 +242,26 @@ private:
     /// `modelReset` hook.
     QPointer<JumpToTailPill> mTailPill;
 
-    /// Running count of rows appended while the user was scrolled
-    /// away from the tail edge. Reset to 0 whenever the viewport
-    /// returns to the tail edge or the model is wiped.
+    /// Running count of *visible* (post-filter) rows that
+    /// arrived while the user was scrolled away from the tail
+    /// edge. Reset to 0 whenever the viewport returns to the
+    /// tail edge, the model is wiped, or `MainWindow` flips
+    /// suppression on for the Follow-newest steady state.
+    /// Counts proxy rows, not source rows, because that's what
+    /// the user sees and what the pill click navigates to.
     int mPendingNewRows = 0;
+
+    /// True while `MainWindow` has Follow newest engaged. The
+    /// view-side flag suppresses `mPendingNewRows` accumulation
+    /// outright -- it doesn't simulate "user is at tail" because
+    /// `mAtTailEdge` is also consumed by the anchor / signal
+    /// state machines that have their own correctness depending
+    /// on the scrollbar's actual position. Belt-and-braces: even
+    /// if Qt's signal ordering briefly drops `mAtTailEdge` to
+    /// false between a row insert's geometry update and the
+    /// `JumpToNewestRow` scroll-back, the suppression flag keeps
+    /// `OnRowsInserted` from incrementing the tally.
+    bool mPendingNewRowsSuppressed = false;
 
 #ifdef LOGAPP_BUILD_TESTING
 public:
@@ -232,6 +272,10 @@ public:
     [[nodiscard]] int PendingNewRowsForTest() const noexcept
     {
         return mPendingNewRows;
+    }
+    [[nodiscard]] bool PendingNewRowsSuppressedForTest() const noexcept
+    {
+        return mPendingNewRowsSuppressed;
     }
     /// `mAtTailEdge` is the at-tail-edge flag the scroll-edge state
     /// machine maintains. The `OnVerticalScrollRangeChanged` listener

--- a/app/include/log_table_view.hpp
+++ b/app/include/log_table_view.hpp
@@ -57,8 +57,14 @@ public:
     /// preservation path -- see `userScrolledAwayFromTail`).
     void setModel(QAbstractItemModel *model) override;
 
-    /// Switch which scrollbar edge is treated as the tail. Idempotent;
-    /// re-evaluates `mAtTailEdge` against the current position.
+    /// Switch which scrollbar edge is treated as the tail.
+    /// **Always** re-evaluates `mAtTailEdge` against the current
+    /// scrollbar position, even when `edge == mTailEdge` -- callers
+    /// (and tests) rely on the re-seed side effect to recover from a
+    /// preceding programmatic scrollbar mutation that the
+    /// `valueChanged`-driven state machine silently absorbed. Do not
+    /// short-circuit on `edge == mTailEdge` without also providing a
+    /// separate re-seed seam.
     void SetTailEdge(TailEdge edge);
 
     [[nodiscard]] TailEdge GetTailEdge() const noexcept;
@@ -130,6 +136,17 @@ protected:
 
 private:
     void OnVerticalScrollValueChanged(int value);
+
+    /// Re-evaluate `mAtTailEdge` when the scrollbar's range changes
+    /// (typically because new rows grew `maximum`). Without this, a
+    /// user sitting at the previous tail can drift below it silently:
+    /// `valueChanged` never fires (the value didn't move), but
+    /// `value < newMax` now -- so `mAtTailEdge` would stay stuck at
+    /// `true` and `OnRowsInserted` would keep skipping the count.
+    /// Transitions are flag-only here: a range change is not a user
+    /// scroll, so the `userScrolled*` signals stay silent (Follow
+    /// newest must not be toggled by a layout event).
+    void OnVerticalScrollRangeChanged(int min, int max);
 
     /// Reading-position preservation hooks (chat-app pattern). Around
     /// each structural change we snapshot the topmost visible row and
@@ -215,6 +232,17 @@ public:
     [[nodiscard]] int PendingNewRowsForTest() const noexcept
     {
         return mPendingNewRows;
+    }
+    /// `mAtTailEdge` is the at-tail-edge flag the scroll-edge state
+    /// machine maintains. The `OnVerticalScrollRangeChanged` listener
+    /// refreshes it when row inserts grow the range without moving
+    /// the value; this seam lets the corresponding regression test
+    /// observe the transition without round-tripping through
+    /// `OnRowsInserted` (which Qt's view machinery can re-reset
+    /// before the test gets a chance to read it).
+    [[nodiscard]] bool AtTailEdgeForTest() const noexcept
+    {
+        return mAtTailEdge;
     }
 #endif
 };

--- a/app/include/log_table_view.hpp
+++ b/app/include/log_table_view.hpp
@@ -57,14 +57,11 @@ public:
     /// preservation path -- see `userScrolledAwayFromTail`).
     void setModel(QAbstractItemModel *model) override;
 
-    /// Switch which scrollbar edge is treated as the tail.
-    /// **Always** re-evaluates `mAtTailEdge` against the current
-    /// scrollbar position, even when `edge == mTailEdge` -- callers
-    /// (and tests) rely on the re-seed side effect to recover from a
-    /// preceding programmatic scrollbar mutation that the
-    /// `valueChanged`-driven state machine silently absorbed. Do not
-    /// short-circuit on `edge == mTailEdge` without also providing a
-    /// separate re-seed seam.
+    /// Switch which scrollbar edge is treated as the tail. Always
+    /// re-evaluates `mAtTailEdge` against the current scrollbar
+    /// position, even when `edge == mTailEdge`: callers rely on the
+    /// re-seed to recover from preceding programmatic scrollbar
+    /// mutations that the `valueChanged` state machine ignored.
     void SetTailEdge(TailEdge edge);
 
     [[nodiscard]] TailEdge GetTailEdge() const noexcept;
@@ -78,28 +75,20 @@ public:
     /// chain down to `LogModel`; empty when no `LogModel` is reachable.
     [[nodiscard]] std::vector<AnchorManager::Key> AnchorKeysForSelection() const;
 
-    /// Suppress `mPendingNewRows` accumulation. While suppressed,
-    /// `OnRowsInserted` skips the count update and the pill stays
-    /// hidden, regardless of `mAtTailEdge`. `MainWindow` toggles
-    /// this on / off in lockstep with `actionFollowTail` so the
-    /// pill never flashes during the at-tail-with-Follow-engaged
-    /// steady state where Qt's signal ordering can briefly drop
-    /// `mAtTailEdge` between the layout update and the
-    /// `JumpToNewestRow` scroll-back. Clearing the suppression
-    /// also resets any tally accumulated while suppression was
-    /// off, so a transient un-suppress + re-suppress can't leak
-    /// a stale count once the steady-state path resumes.
+    /// Suppress pending-new-rows counting. `MainWindow` mirrors
+    /// `actionFollowTail` into this flag so the pill never flashes
+    /// during the at-tail-with-Follow-engaged steady state, where
+    /// Qt's signal ordering can briefly drop `mAtTailEdge` between
+    /// the row insert and the follow-up scroll-back. Engaging
+    /// suppression also clears any pending tally.
     void SetPendingNewRowsSuppressed(bool suppressed);
 
-    /// Acknowledge any "* N new lines" announcement: zero the
-    /// running counter and fade the pill out. Called by
-    /// `MainWindow`'s pill-click handler so a click whose scroll
-    /// happens to land short of the visual tail (custom sort
-    /// where the source-newest row is in the middle of the
-    /// proxy, or filtered-newest fallback that snaps to the
-    /// proxy tail without crossing `maximum`) still clears the
-    /// announcement -- the user explicitly asked to be caught
-    /// up.
+    /// Zero the running counter and fade the pill out. Called from
+    /// the pill-click handler so the announcement clears even when
+    /// the resulting scroll lands short of the visual tail (custom
+    /// sort placing source-newest in the middle of the proxy, or
+    /// the filtered fallback snapping to the proxy tail without
+    /// crossing `maximum`).
     void AcknowledgePendingNewRows();
 
 public slots:
@@ -140,9 +129,8 @@ signals:
     void userScrolledToTail();
 
     /// User clicked the floating "jump to newest" pill. Forwarded
-    /// to `MainWindow`, which performs the proxy-aware scroll and
-    /// (in live-tail sessions) re-engages Follow newest. The view
-    /// itself stays ignorant of proxies and the Follow action.
+    /// to `MainWindow`, which owns the proxy-aware scroll and the
+    /// Follow re-engage; the view stays ignorant of both.
     void jumpToTailRequested();
 
 protected:
@@ -152,24 +140,20 @@ protected:
     /// Mark the next `valueChanged` as user-initiated.
     void wheelEvent(QWheelEvent *event) override;
 
-    /// Filters viewport resize events so the floating pill stays
-    /// glued to the tail-side edge of the visible area without the
-    /// view having to subclass the viewport. Installed in
-    /// `LogTableView::LogTableView`.
+    /// Watches the viewport for resize events so the floating pill
+    /// stays glued to the tail-side edge without subclassing the
+    /// viewport.
     bool eventFilter(QObject *watched, QEvent *event) override;
 
 private:
     void OnVerticalScrollValueChanged(int value);
 
-    /// Re-evaluate `mAtTailEdge` when the scrollbar's range changes
-    /// (typically because new rows grew `maximum`). Without this, a
-    /// user sitting at the previous tail can drift below it silently:
-    /// `valueChanged` never fires (the value didn't move), but
-    /// `value < newMax` now -- so `mAtTailEdge` would stay stuck at
-    /// `true` and `OnRowsInserted` would keep skipping the count.
-    /// Transitions are flag-only here: a range change is not a user
-    /// scroll, so the `userScrolled*` signals stay silent (Follow
-    /// newest must not be toggled by a layout event).
+    /// Refresh `mAtTailEdge` when the scrollbar range changes
+    /// (typically a row insert growing `maximum` without moving
+    /// `value`). Without this, a user at the previous tail would
+    /// silently drift below it and the pill counter would never
+    /// arm. Flag-only: a range change is not a user scroll, so the
+    /// `userScrolled*` signals must stay silent.
     void OnVerticalScrollRangeChanged(int min, int max);
 
     /// Reading-position preservation hooks (chat-app pattern). Around
@@ -188,17 +172,13 @@ private:
     void SaveAnchorIfShouldPreserve();
     void RestoreAnchorIfSaved();
 
-    /// Re-place `mTailPill` at the tail-side edge of the
-    /// viewport, centred horizontally. Called from the viewport
-    /// resize hook and from `SetTailEdge` (when the edge flips).
-    /// No-op when the pill is absent.
+    /// Re-place `mTailPill` against the tail-side viewport edge,
+    /// centred horizontally. No-op when the pill is absent.
     void PositionTailPill();
 
-    /// Centralised reset: zero the pending-new-rows counter and
-    /// fade the pill out. Called when the user / a programmatic
-    /// edge change lands the viewport back at the tail, when a
-    /// new model is attached, on `modelReset`, and on session
-    /// boundaries that drop the table contents.
+    /// Zero the pending-new-rows counter and fade the pill out.
+    /// Called on tail-edge landings, `setModel`, `modelReset`, and
+    /// suppression engagement.
     void ResetPendingNewRows();
 
     TailEdge mTailEdge = TailEdge::Bottom;
@@ -233,34 +213,22 @@ private:
     /// fixtures. Anchor slots null-check before dereferencing.
     AnchorManager *mAnchors = nullptr;
 
-    /// Floating "* N new lines" pill parented to the viewport.
-    /// `QPointer` so a viewport teardown (Qt destroys the
-    /// viewport when the view is destroyed) zeroes the pointer
-    /// before our own destructor runs, sparing the slot wiring a
-    /// dangling deref. Visibility / count are driven by
-    /// `OnRowsInserted`, `OnVerticalScrollValueChanged`, and the
-    /// `modelReset` hook.
+    /// Floating "N new lines" pill parented to the viewport.
+    /// `QPointer` so a viewport teardown zeroes the pointer before
+    /// our destructor runs.
     QPointer<JumpToTailPill> mTailPill;
 
-    /// Running count of *visible* (post-filter) rows that
-    /// arrived while the user was scrolled away from the tail
-    /// edge. Reset to 0 whenever the viewport returns to the
-    /// tail edge, the model is wiped, or `MainWindow` flips
-    /// suppression on for the Follow-newest steady state.
-    /// Counts proxy rows, not source rows, because that's what
-    /// the user sees and what the pill click navigates to.
+    /// Running count of *visible* (post-filter) rows that arrived
+    /// while the user was scrolled away from the tail. Reset on
+    /// any tail-edge landing, on model swap, or when suppression
+    /// engages.
     int mPendingNewRows = 0;
 
-    /// True while `MainWindow` has Follow newest engaged. The
-    /// view-side flag suppresses `mPendingNewRows` accumulation
-    /// outright -- it doesn't simulate "user is at tail" because
-    /// `mAtTailEdge` is also consumed by the anchor / signal
-    /// state machines that have their own correctness depending
-    /// on the scrollbar's actual position. Belt-and-braces: even
-    /// if Qt's signal ordering briefly drops `mAtTailEdge` to
-    /// false between a row insert's geometry update and the
-    /// `JumpToNewestRow` scroll-back, the suppression flag keeps
-    /// `OnRowsInserted` from incrementing the tally.
+    /// Mirror of `actionFollowTail`. While set, `OnRowsInserted`
+    /// short-circuits even if `mAtTailEdge` momentarily drops to
+    /// false between an insert's geometry pass and the follow-up
+    /// scroll-back. Kept separate from `mAtTailEdge` because that
+    /// flag also feeds the anchor / signal state machines.
     bool mPendingNewRowsSuppressed = false;
 
 #ifdef LOGAPP_BUILD_TESTING
@@ -277,13 +245,10 @@ public:
     {
         return mPendingNewRowsSuppressed;
     }
-    /// `mAtTailEdge` is the at-tail-edge flag the scroll-edge state
-    /// machine maintains. The `OnVerticalScrollRangeChanged` listener
-    /// refreshes it when row inserts grow the range without moving
-    /// the value; this seam lets the corresponding regression test
-    /// observe the transition without round-tripping through
-    /// `OnRowsInserted` (which Qt's view machinery can re-reset
-    /// before the test gets a chance to read it).
+    /// Direct seam over `mAtTailEdge` so the `rangeChanged`
+    /// regression test can observe the transition without
+    /// round-tripping through `OnRowsInserted` (which the view
+    /// machinery can re-reset before the test reads it).
     [[nodiscard]] bool AtTailEdgeForTest() const noexcept
     {
         return mAtTailEdge;

--- a/app/include/main_window.hpp
+++ b/app/include/main_window.hpp
@@ -395,8 +395,8 @@ public:
         OpenRecentSession(uuid);
     }
 
-    /// Test-only forwarder to the `JumpToNewestRow` private helper
-    /// so the filtered-newest-row fallback can be exercised without
+    /// Test seam for the `JumpToNewestRow` private helper; lets
+    /// the filtered-newest-row fallback be exercised without
     /// synthesising a real pill click.
     void JumpToNewestRowForTest()
     {
@@ -966,39 +966,25 @@ private:
     /// session mode.
     void UpdateStreamToolbarVisibility();
 
-    /// Scroll to the newest row when Follow tail is on; mapped
-    /// through the proxy chain so the scroll lands correctly
-    /// under a sort. Thin gate that defers the actual scroll to
-    /// `JumpToNewestRow` -- which also applies the
-    /// filtered-newest fallback below, so under live-tail +
-    /// Follow with a filter excluding the source-newest line we
-    /// now scroll to the *visible* newest line instead of
-    /// silently doing nothing.
+    /// Scroll to the newest row when Follow newest is on. Thin
+    /// gate that forwards to `JumpToNewestRow`, which is what
+    /// actually handles the proxy chain and the filtered fallback.
     void ScrollToNewestRowIfFollowing();
 
-    /// Unconditional version of the above: scroll to the newest
-    /// row through the proxy chain, regardless of session mode or
-    /// `actionFollowTail`. Used by the "jump to newest" pill,
-    /// which is a user-driven "catch me up" command rather than
-    /// part of the streaming-policy state machine. Safe to call
-    /// with no rows / no source attached (early-returns).
+    /// Scroll to the newest row through the proxy chain, ignoring
+    /// session mode / `actionFollowTail`. Used by the pill click
+    /// ("catch me up") rather than the streaming-policy state
+    /// machine. Safe to call with no rows.
     ///
-    /// Three-stage target resolution:
-    ///   1. Map the source-newest row (by line id) through the
-    ///      proxy chain. Lands on the absolute newest line when
-    ///      it survives any active filter; correct under custom
-    ///      column sorts too.
-    ///   2. If stage 1 returns an invalid index (source-newest
-    ///      is filtered out), walk source rows backwards up to
-    ///      `JUMP_FALLBACK_WALK_LIMIT` and pick the first one
-    ///      that maps through. Preserves "newest by line id"
-    ///      under combined sort + filter where the proxy's
-    ///      visual top/bottom is not the newest line.
-    ///   3. If the walk also yields nothing, snap to the proxy's
-    ///      visual tail so the pill click always moves the
-    ///      viewport. Tail edge picked from
-    ///      `LogTableView::GetTailEdge()` (the single source of
-    ///      truth for the view's orientation).
+    /// Target resolution:
+    ///   1. Map the source-newest row through the proxy chain.
+    ///      Correct under custom column sorts.
+    ///   2. If filtered out, walk source rows backwards up to
+    ///      `JUMP_FALLBACK_WALK_LIMIT` and take the first that
+    ///      survives the proxy.
+    ///   3. If nothing visible, snap to the proxy's visual tail
+    ///      (`LogTableView::GetTailEdge()`) so the click always
+    ///      moves the viewport.
     void JumpToNewestRow();
 
     /// Re-apply the persisted retention cap to the model.

--- a/app/include/main_window.hpp
+++ b/app/include/main_window.hpp
@@ -394,6 +394,14 @@ public:
     {
         OpenRecentSession(uuid);
     }
+
+    /// Test-only forwarder to the `JumpToNewestRow` private helper
+    /// so the filtered-newest-row fallback can be exercised without
+    /// synthesising a real pill click.
+    void JumpToNewestRowForTest()
+    {
+        JumpToNewestRow();
+    }
 #endif
 
 protected:

--- a/app/include/main_window.hpp
+++ b/app/include/main_window.hpp
@@ -966,9 +966,14 @@ private:
     /// session mode.
     void UpdateStreamToolbarVisibility();
 
-    /// Scroll to the newest row when Follow tail is on; mapped through
-    /// the proxy chain so the scroll lands correctly under a sort.
-    /// Thin gate that defers the actual scroll to `JumpToNewestRow`.
+    /// Scroll to the newest row when Follow tail is on; mapped
+    /// through the proxy chain so the scroll lands correctly
+    /// under a sort. Thin gate that defers the actual scroll to
+    /// `JumpToNewestRow` -- which also applies the
+    /// filtered-newest fallback below, so under live-tail +
+    /// Follow with a filter excluding the source-newest line we
+    /// now scroll to the *visible* newest line instead of
+    /// silently doing nothing.
     void ScrollToNewestRowIfFollowing();
 
     /// Unconditional version of the above: scroll to the newest
@@ -977,6 +982,23 @@ private:
     /// which is a user-driven "catch me up" command rather than
     /// part of the streaming-policy state machine. Safe to call
     /// with no rows / no source attached (early-returns).
+    ///
+    /// Three-stage target resolution:
+    ///   1. Map the source-newest row (by line id) through the
+    ///      proxy chain. Lands on the absolute newest line when
+    ///      it survives any active filter; correct under custom
+    ///      column sorts too.
+    ///   2. If stage 1 returns an invalid index (source-newest
+    ///      is filtered out), walk source rows backwards up to
+    ///      `JUMP_FALLBACK_WALK_LIMIT` and pick the first one
+    ///      that maps through. Preserves "newest by line id"
+    ///      under combined sort + filter where the proxy's
+    ///      visual top/bottom is not the newest line.
+    ///   3. If the walk also yields nothing, snap to the proxy's
+    ///      visual tail so the pill click always moves the
+    ///      viewport. Tail edge picked from
+    ///      `LogTableView::GetTailEdge()` (the single source of
+    ///      truth for the view's orientation).
     void JumpToNewestRow();
 
     /// Re-apply the persisted retention cap to the model.

--- a/app/include/main_window.hpp
+++ b/app/include/main_window.hpp
@@ -960,7 +960,16 @@ private:
 
     /// Scroll to the newest row when Follow tail is on; mapped through
     /// the proxy chain so the scroll lands correctly under a sort.
+    /// Thin gate that defers the actual scroll to `JumpToNewestRow`.
     void ScrollToNewestRowIfFollowing();
+
+    /// Unconditional version of the above: scroll to the newest
+    /// row through the proxy chain, regardless of session mode or
+    /// `actionFollowTail`. Used by the "jump to newest" pill,
+    /// which is a user-driven "catch me up" command rather than
+    /// part of the streaming-policy state machine. Safe to call
+    /// with no rows / no source attached (early-returns).
+    void JumpToNewestRow();
 
     /// Re-apply the persisted retention cap to the model.
     void ApplyStreamingRetention();

--- a/app/src/jump_to_tail_pill.cpp
+++ b/app/src/jump_to_tail_pill.cpp
@@ -11,6 +11,7 @@
 #include <QPalette>
 #include <QPixmap>
 #include <QPropertyAnimation>
+#include <QScopeGuard>
 #include <QSize>
 #include <QString>
 #include <QStringLiteral>
@@ -140,13 +141,25 @@ void JumpToTailPill::changeEvent(QEvent *event)
     switch (event->type())
     {
     case QEvent::PaletteChange:
-    case QEvent::StyleChange:
     case QEvent::ApplicationPaletteChange:
-        // Re-apply both: the QSS reads palette role names but Qt
-        // caches the resolved stylesheet, and the icon was tinted
-        // against the previous palette colour.
-        ApplyStyleSheet();
-        RefreshIcon();
+        // Theme switches reach us via palette swaps (Light <->
+        // Dark, custom themes). The QSS literal hex strings are
+        // resolved against the *previous* palette, so re-apply
+        // and re-tint the glyph.
+        //
+        // The `mApplyingPalette` guard breaks the implicit
+        // recursion: `setStyleSheet` synchronously emits
+        // `PaletteChange` / `StyleChange` on the widget on Qt 6
+        // (the QSS resolver re-binds palette roles), and routing
+        // those back into `ApplyStyleSheet` recurses forever
+        // (stack overflow). A genuine external theme switch
+        // arrives outside our `setStyleSheet` call, so the
+        // guard is clear and the refresh runs.
+        if (!mApplyingPalette)
+        {
+            ApplyStyleSheet();
+            RefreshIcon();
+        }
         break;
     default:
         break;
@@ -209,6 +222,15 @@ void JumpToTailPill::RefreshIcon()
 
 void JumpToTailPill::ApplyStyleSheet()
 {
+    if (mApplyingPalette)
+    {
+        // Defensive: caller already holds the guard. Skip rather
+        // than thrash the QSS twice.
+        return;
+    }
+    mApplyingPalette = true;
+    const auto guardRelease = qScopeGuard([this]() { mApplyingPalette = false; });
+
     // Pill height is driven by the QSS padding plus the icon /
     // font metric; computing `border-radius` from a measured
     // height would require a sizeHint round-trip after every

--- a/app/src/jump_to_tail_pill.cpp
+++ b/app/src/jump_to_tail_pill.cpp
@@ -18,36 +18,25 @@
 
 namespace
 {
-/// SVG asset reused from the `actionFollowTail` toolbar icon. A
-/// single asset works for both directions: the `Up` variant is the
-/// same pixmap rotated 180 degrees via `QTransform`.
+/// Reused from the Follow-tail toolbar action. The Up variant is
+/// the same pixmap rotated 180 degrees.
 constexpr auto ARROW_SVG_PATH = ":/icons/arrow-down-to-line.svg";
 
-/// Logical-pixel edge length for the arrow glyph. The pill's row
-/// height is driven by the text font metrics; this size matches a
-/// typical body line height so the glyph reads as part of the
-/// text run rather than as an oversized adornment.
+/// Logical-pixel edge length for the arrow, sized to match the
+/// surrounding text line height.
 constexpr int ARROW_ICON_PX = 14;
 
-/// Fade duration; matches the Find bar's match-count debounce
-/// envelope so two animation timescales don't visibly compete.
-/// Long enough to read as "appearing", short enough that a fast
-/// typist / streaming session doesn't see lingering animation.
+/// Fade duration. Long enough to read as "appearing", short enough
+/// not to linger over a fast typist / streaming session.
 constexpr int FADE_DURATION_MS = 150;
 
-/// Cap on the literal value rendered in the pill before we switch
-/// to "999+". The pill is informational; the user only needs to
-/// know "a lot". Choosing a 3-digit cap also keeps the pill width
-/// bounded across locales (grouped digits, RTL, etc.) so the
-/// auto-positioning helper in the host view doesn't have to
-/// repaint a wider pill mid-stream.
+/// Cap on the displayed count before switching to "999+". Keeps
+/// the pill width bounded across locales.
 constexpr int DISPLAYED_COUNT_CAP = 999;
 
-/// HSL lightness threshold that splits "this background needs to
-/// be darkened for hover contrast" from "this background needs
-/// to be lightened". Mid-grey by definition; named so the
-/// theme-branching helper in `ApplyStyleSheet` reads as a policy
-/// rather than a magic number.
+/// HSL lightness split point for the hover-contrast branch: below
+/// is treated as a dark theme (lighten on hover), above as light
+/// (darken on hover).
 constexpr qreal LIGHTNESS_DARK_THEME_THRESHOLD = 0.5;
 } // namespace
 
@@ -56,32 +45,22 @@ JumpToTailPill::JumpToTailPill(QWidget *parent)
 {
     setObjectName(QStringLiteral("jumpToTailPill"));
     setCursor(Qt::PointingHandCursor);
-    // `Qt::TabFocus` so keyboard-only users can land on the pill
-    // and activate it with `Space` / `Enter` (`QAbstractButton`
-    // wires those automatically). `Qt::NoFocus` would have
-    // stranded screen-reader / switch-control users; the click
-    // affordance is otherwise mouse-only.
+    // `Qt::TabFocus` keeps the pill reachable for keyboard /
+    // screen-reader / switch-control users (`Space` / `Enter`
+    // activate it via QAbstractButton).
     setFocusPolicy(Qt::TabFocus);
-    // Icon + text laid out side by side so the arrow visually
-    // leads the count. `ToolButtonTextBesideIcon` honours QSS
-    // padding consistently across platforms; the
-    // `ToolButtonFollowStyle` default leaves the layout up to the
-    // platform theme and on some Windows styles strips the icon
-    // entirely.
+    // `TextBesideIcon` honours QSS padding consistently across
+    // platforms; the platform default can strip the icon on some
+    // Windows styles.
     setToolButtonStyle(Qt::ToolButtonTextBesideIcon);
     setAutoRaise(false);
-    // Accessible description carries the *action*; the accessible
-    // name is rebuilt with the running count by `RebuildText` so
-    // screen readers announce "Jump to newest row, 5 new lines"
-    // and follow live updates. Without the per-count refresh,
-    // assistive tech would see only "Jump to newest row" with no
-    // running tally -- the visible label's count would never
-    // reach the user.
+    // `accessibleDescription` carries the action; the running
+    // count goes into `accessibleName`, which `RebuildText`
+    // refreshes (Qt's AT bridge prefers `accessibleName` over the
+    // visible `text`, so without the refresh the count never
+    // reaches assistive tech).
     setAccessibleDescription(tr("Jump to the newest row and re-engage Follow newest if streaming."));
 
-    // Opacity effect on the widget itself; `setVisible(false)` at
-    // the end of the fade-out so the hidden pill stops absorbing
-    // hover events and accessibility tree walks.
     mOpacity = new QGraphicsOpacityEffect(this);
     mOpacity->setOpacity(0.0);
     setGraphicsEffect(mOpacity);
@@ -90,9 +69,8 @@ JumpToTailPill::JumpToTailPill(QWidget *parent)
     mFade->setDuration(FADE_DURATION_MS);
     mFade->setEasingCurve(QEasingCurve::OutQuad);
     connect(mFade, &QPropertyAnimation::finished, this, [this]() {
-        // Once fully transparent, drop visibility so the widget is
-        // out of the input + accessibility tree. Re-shown by
-        // `FadeTo(1.0)` before the next animation starts.
+        // Drop visibility once fully transparent so the hidden
+        // pill leaves the input + accessibility tree.
         if (mOpacity->opacity() <= 0.0)
         {
             QToolButton::setVisible(false);
@@ -103,7 +81,6 @@ JumpToTailPill::JumpToTailPill(QWidget *parent)
     RefreshIcon();
     RebuildText();
 
-    // Pill is hidden + transparent until `SetCount(>0)` arms it.
     QToolButton::setVisible(false);
 }
 
@@ -116,20 +93,16 @@ void JumpToTailPill::SetCount(int count)
     }
     mCount = sanitised;
     RebuildText();
-    // Notify the host *after* `RebuildText` has updated the label
-    // so a `PositionTailPill` triggered by this signal sees the
-    // new sizeHint. Two-direction repositioning is critical for
-    // counts that cross the "999+" cap (label width changes by
-    // more than a digit's worth) and for shrinking counts that
-    // would otherwise leave the pill stuck off-centre against the
-    // viewport edge.
+    // Emit after `RebuildText` so a listener-driven
+    // `PositionTailPill` sees the new sizeHint. Needed in both
+    // directions: growth, shrink, and crossing the "999+" cap.
     emit contentSizeChanged();
 
     if (mCount > 0)
     {
-        // Must `show()` before the fade starts: a widget with
-        // `visible == false` does not paint its graphics effect,
-        // so animating opacity while hidden is a no-op visually.
+        // Must `show()` before fading: a hidden widget does not
+        // paint its graphics effect, so animating opacity is a
+        // no-op visually.
         if (!isVisible())
         {
             QToolButton::setVisible(true);
@@ -164,19 +137,12 @@ void JumpToTailPill::changeEvent(QEvent *event)
     {
     case QEvent::PaletteChange:
     case QEvent::ApplicationPaletteChange:
-        // Theme switches reach us via palette swaps (Light <->
-        // Dark, custom themes). The QSS literal hex strings are
-        // resolved against the *previous* palette, so re-apply
-        // and re-tint the glyph.
-        //
-        // The `mApplyingPalette` guard breaks the implicit
-        // recursion: `setStyleSheet` synchronously emits
-        // `PaletteChange` / `StyleChange` on the widget on Qt 6
-        // (the QSS resolver re-binds palette roles), and routing
-        // those back into `ApplyStyleSheet` recurses forever
-        // (stack overflow). A genuine external theme switch
-        // arrives outside our `setStyleSheet` call, so the
-        // guard is clear and the refresh runs.
+        // Re-resolve QSS / icon against the new palette on theme
+        // switches. The `mApplyingPalette` guard breaks the
+        // recursion that Qt 6 induces when `setStyleSheet`
+        // synchronously re-emits `PaletteChange`; an external
+        // theme switch arrives outside our `setStyleSheet`, so
+        // the guard is clear and the refresh runs.
         if (!mApplyingPalette)
         {
             ApplyStyleSheet();
@@ -190,36 +156,16 @@ void JumpToTailPill::changeEvent(QEvent *event)
 
 void JumpToTailPill::RebuildText()
 {
-    // Leading glyph mirrors the icon direction so screen-readers
-    // and copy-paste of the accessible text still convey "down"
-    // / "up"; the icon is purely visual.
+    // Leading glyph mirrors the icon direction so screen readers
+    // and copy-paste of the accessible text still convey up/down.
     const QString arrow = (mDirection == ArrowDirection::Down) ? QStringLiteral("\u2193") : QStringLiteral("\u2191");
 
-    // Two branches:
-    //
-    //   * Past the display cap we render `"%1+ new lines"` -- a
-    //     bounded literal whose `+` suffix is a math/notation
-    //     glyph used identically across locales. The catalog
-    //     entry is a separate string (one `%1`, plural-agnostic)
-    //     so translators don't have to puzzle over what `%n`
-    //     means against a capped-and-bounded number.
-    //   * Below the cap we use `tr("%n new lines", ..., mCount)`.
-    //     `%n` opts the source string into Qt's plural-aware
-    //     translation: `lupdate` emits both singular and plural
-    //     slots so locales with multiple plural forms (Polish,
-    //     Russian, Arabic, ...) can pick the right one. The
-    //     English source still reads "new lines" in the singular
-    //     slot too -- intentional: the 150 ms fade-in would
-    //     flicker between "1 new line" and "2 new lines" on
-    //     every batch boundary and that visual jitter is more
-    //     distracting than the technically-incorrect plural for
-    //     count == 1. Locales that need a true singular form can
-    //     override in the catalog without us touching the
-    //     code.
-    //
-    // Arrow glyph is prepended outside `tr` so translators get
-    // a clean message string and don't have to babysit the
-    // direction marker.
+    // Below the cap we use `%n` for plural-aware translation; past
+    // the cap the count is bounded so a plural-agnostic `%1+`
+    // string is clearer for translators. The English "new lines"
+    // also covers count == 1: a 150 ms fade between "1 new line"
+    // and "2 new lines" would flicker. Locales with strict plural
+    // rules can still override in the catalog.
     QString message;
     if (mCount > DISPLAYED_COUNT_CAP)
     {
@@ -231,27 +177,14 @@ void JumpToTailPill::RebuildText()
     }
     setText(QStringLiteral("%1 %2").arg(arrow, message));
 
-    // Live-update the accessible name so screen readers (NVDA,
-    // VoiceOver, Narrator) announce the current count when focus
-    // lands on the pill or when AT polls for state changes.
-    // Without this refresh the static "Jump to newest row" set
-    // in the ctor would mask every count update -- Qt's
-    // accessibility bridge prefers `accessibleName` over the
-    // visible `text` property, so the running count would never
-    // reach AT users.
+    // Refresh the accessible name so AT users hear the running
+    // count, not just the static action label.
     if (mCount > 0)
     {
-        // Two-arg `tr` so translators get the count as a plain
-        // `%1` rather than wrestling with `%n` plurality on the
-        // accessible name (the visible label already covers
-        // plural-correctness; AT prosody is more forgiving).
         setAccessibleName(tr("Jump to newest row, %1 new lines available").arg(mCount));
     }
     else
     {
-        // Idle accessible name for the brief windows when the
-        // pill is technically still in the tree (fade-out in
-        // flight) but conceptually empty.
         setAccessibleName(tr("Jump to newest row"));
     }
 }
@@ -264,9 +197,8 @@ void JumpToTailPill::RefreshIcon()
     QPixmap pix = icon_loader::MakeThemedPixmap(QLatin1String(ARROW_SVG_PATH), tint, ARROW_ICON_PX, dpr);
     if (pix.isNull())
     {
-        // Missing asset -- fall through to text-only. Same
-        // degradation policy as the rest of the icon-loader call
-        // sites (toolbar, headers).
+        // Missing asset: degrade to text-only (same policy as the
+        // other icon-loader call sites).
         setIcon(QIcon());
         setIconSize(QSize(ARROW_ICON_PX, ARROW_ICON_PX));
         return;
@@ -274,10 +206,8 @@ void JumpToTailPill::RefreshIcon()
 
     if (mDirection == ArrowDirection::Up)
     {
-        // Vertical flip: the source asset is "down to line"; the
-        // 180-degree rotation produces an "up from line" glyph
-        // that reads correctly when the tail is at the top of the
-        // viewport (newest-first mode).
+        // Rotate the "down to line" source to "up from line" for
+        // newest-first mode.
         const QTransform xform = QTransform().rotate(180);
         pix = pix.transformed(xform, Qt::SmoothTransformation);
     }
@@ -290,15 +220,10 @@ void JumpToTailPill::RefreshIcon()
 
 void JumpToTailPill::ApplyStyleSheet()
 {
-    // The only caller that could re-enter is `changeEvent`, and
-    // it already gates on `!mApplyingPalette`, so reaching this
-    // branch means a future caller forgot the gate. Assert in
-    // debug builds (a noisy failure beats a silent skip masking
-    // the wiring bug) but keep the early-return in release as a
-    // stack-overflow firewall: the synchronous `PaletteChange`
-    // that Qt 6 emits inside `setStyleSheet` would otherwise
-    // recurse without bound -- see the header doc on
-    // `mApplyingPalette`.
+    // Hitting this branch means a future caller forgot the
+    // `mApplyingPalette` gate; assert in debug builds and keep
+    // the early-return as a release-mode stack-overflow firewall
+    // (see header doc on `mApplyingPalette`).
     Q_ASSERT_X(
         !mApplyingPalette,
         "JumpToTailPill::ApplyStyleSheet",
@@ -311,43 +236,28 @@ void JumpToTailPill::ApplyStyleSheet()
     mApplyingPalette = true;
     const auto guardRelease = qScopeGuard([this]() { mApplyingPalette = false; });
 
-    // Pill height is driven by the QSS padding plus the icon /
-    // font metric; computing `border-radius` from a measured
-    // height would require a sizeHint round-trip after every
-    // theme change. A generous fixed radius reads as "pill" at
-    // every realistic font size and still rounds the corners
-    // correctly even when the widget is shorter than 2*r.
+    // A generous fixed radius reads as "pill" at every realistic
+    // font size and avoids a sizeHint round-trip on every theme
+    // change.
     constexpr int RADIUS_PX = 12;
     constexpr int PADDING_VERTICAL_PX = 6;
     constexpr int PADDING_HORIZONTAL_PX = 12;
 
-    // Resolve palette roles once so a theme switch picks up the
-    // new colour names; the QSS itself uses literal hex (Qt does
-    // not resolve `palette(...)` references on every role).
     const QColor bg = palette().color(QPalette::Active, QPalette::Highlight);
     const QColor fg = palette().color(QPalette::Active, QPalette::HighlightedText);
 
-    // Hover / pressed must visibly contrast against `bg` on every
-    // theme. `QColor::darker(N)` divides HSV `V` -- on a dark
-    // theme that pulls the hover *into* the surrounding black,
-    // making the pill almost vanish on hover. Branch on the
-    // background's perceived lightness so the adjustment goes
-    // toward more contrast in either direction:
-    //   * light theme (typical `Highlight` ~ vivid blue,
-    //     lightness > 0.5) -> darken on hover.
-    //   * dark theme (typical `Highlight` ~ dim blue,
-    //     lightness <= 0.5) -> lighten on hover.
-    // Same factor (~10% / ~25%) on both sides so the feedback
-    // intensity matches across themes.
+    // `QColor::darker` on a dark-theme highlight would pull the
+    // hover *into* the surrounding black, hiding the pill on
+    // hover. Branch on perceived lightness so the adjustment
+    // always increases contrast: lighten on dark themes, darken
+    // on light ones.
     const auto adjustForContrast = [](const QColor &c, int factor) {
         return c.lightnessF() < LIGHTNESS_DARK_THEME_THRESHOLD ? c.lighter(factor) : c.darker(factor);
     };
     const QColor hoverBg = adjustForContrast(bg, 110);
     const QColor pressedBg = adjustForContrast(bg, 125);
-    // Focus ring: a subtle outline that reads against both the
-    // pill's `bg` and the surrounding viewport. Reusing
-    // `HighlightedText` for the outline keeps the colour in lock-
-    // step with the foreground glyph.
+    // Reuse `HighlightedText` for the focus ring so it tracks the
+    // foreground glyph through theme changes.
     const QColor focusRing = fg;
 
     const QString sheet = QStringLiteral("QToolButton#jumpToTailPill {"
@@ -369,15 +279,9 @@ void JumpToTailPill::ApplyStyleSheet()
                               .arg(hoverBg.name(QColor::HexRgb))
                               .arg(pressedBg.name(QColor::HexRgb))
                               .arg(focusRing.name(QColor::HexRgb));
-    // Idempotent fast-path: identical sheets are common when
-    // `changeEvent(PaletteChange)` fires from a Qt internal that
-    // didn't actually move any of our tracked roles (e.g. a font
-    // metrics change). Skipping the `setStyleSheet` call avoids
-    // a synchronous QSS re-resolve (which would re-emit
-    // `PaletteChange` and `StyleChange` -- the original recursion
-    // we have to guard against). The `mApplyingPalette` guard
-    // remains the firewall; this branch keeps the common case
-    // out of the firewall path entirely.
+    // Skip the no-op `setStyleSheet`: a synchronous re-resolve
+    // would re-emit `PaletteChange` / `StyleChange` and bounce
+    // through the recursion guard for no reason.
     if (sheet == styleSheet())
     {
         return;
@@ -387,10 +291,9 @@ void JumpToTailPill::ApplyStyleSheet()
 
 void JumpToTailPill::FadeTo(qreal endOpacity)
 {
-    // Retarget any in-flight animation rather than chaining. Qt
-    // restarts the QPropertyAnimation from the *current* opacity,
-    // so a fade-in interrupted by a fade-out (or vice versa) is
-    // smooth instead of jumping to the prior endpoint.
+    // Retarget any in-flight animation so a fade-in interrupted
+    // by a fade-out (or vice versa) stays smooth instead of
+    // snapping to the previous endpoint.
     if (mFade->state() == QAbstractAnimation::Running)
     {
         mFade->stop();

--- a/app/src/jump_to_tail_pill.cpp
+++ b/app/src/jump_to_tail_pill.cpp
@@ -4,7 +4,6 @@
 
 #include <QEasingCurve>
 #include <QEvent>
-#include <QFontMetrics>
 #include <QGraphicsOpacityEffect>
 #include <QIcon>
 #include <QLatin1String>
@@ -43,6 +42,13 @@ constexpr int FADE_DURATION_MS = 150;
 /// auto-positioning helper in the host view doesn't have to
 /// repaint a wider pill mid-stream.
 constexpr int DISPLAYED_COUNT_CAP = 999;
+
+/// HSL lightness threshold that splits "this background needs to
+/// be darkened for hover contrast" from "this background needs
+/// to be lightened". Mid-grey by definition; named so the
+/// theme-branching helper in `ApplyStyleSheet` reads as a policy
+/// rather than a magic number.
+constexpr qreal LIGHTNESS_DARK_THEME_THRESHOLD = 0.5;
 } // namespace
 
 JumpToTailPill::JumpToTailPill(QWidget *parent)
@@ -50,7 +56,12 @@ JumpToTailPill::JumpToTailPill(QWidget *parent)
 {
     setObjectName(QStringLiteral("jumpToTailPill"));
     setCursor(Qt::PointingHandCursor);
-    setFocusPolicy(Qt::NoFocus);
+    // `Qt::TabFocus` so keyboard-only users can land on the pill
+    // and activate it with `Space` / `Enter` (`QAbstractButton`
+    // wires those automatically). `Qt::NoFocus` would have
+    // stranded screen-reader / switch-control users; the click
+    // affordance is otherwise mouse-only.
+    setFocusPolicy(Qt::TabFocus);
     // Icon + text laid out side by side so the arrow visually
     // leads the count. `ToolButtonTextBesideIcon` honours QSS
     // padding consistently across platforms; the
@@ -59,10 +70,13 @@ JumpToTailPill::JumpToTailPill(QWidget *parent)
     // entirely.
     setToolButtonStyle(Qt::ToolButtonTextBesideIcon);
     setAutoRaise(false);
-    // Accessible name reads to screen readers without the running
-    // count, which the live text already carries; the description
-    // adds the action so the affordance reads as a verb.
-    setAccessibleName(tr("Jump to newest row"));
+    // Accessible description carries the *action*; the accessible
+    // name is rebuilt with the running count by `RebuildText` so
+    // screen readers announce "Jump to newest row, 5 new lines"
+    // and follow live updates. Without the per-count refresh,
+    // assistive tech would see only "Jump to newest row" with no
+    // running tally -- the visible label's count would never
+    // reach the user.
     setAccessibleDescription(tr("Jump to the newest row and re-engage Follow newest if streaming."));
 
     // Opacity effect on the widget itself; `setVisible(false)` at
@@ -102,6 +116,14 @@ void JumpToTailPill::SetCount(int count)
     }
     mCount = sanitised;
     RebuildText();
+    // Notify the host *after* `RebuildText` has updated the label
+    // so a `PositionTailPill` triggered by this signal sees the
+    // new sizeHint. Two-direction repositioning is critical for
+    // counts that cross the "999+" cap (label width changes by
+    // more than a digit's worth) and for shrinking counts that
+    // would otherwise leave the pill stuck off-centre against the
+    // viewport edge.
+    emit contentSizeChanged();
 
     if (mCount > 0)
     {
@@ -209,6 +231,30 @@ void JumpToTailPill::RebuildText()
         message = tr("%n new lines", "jump-to-tail pill running count", mCount);
     }
     setText(QStringLiteral("%1 %2").arg(arrow, message));
+
+    // Live-update the accessible name so screen readers (NVDA,
+    // VoiceOver, Narrator) announce the current count when focus
+    // lands on the pill or when AT polls for state changes.
+    // Without this refresh the static "Jump to newest row" set
+    // in the ctor would mask every count update -- Qt's
+    // accessibility bridge prefers `accessibleName` over the
+    // visible `text` property, so the running count would never
+    // reach AT users.
+    if (mCount > 0)
+    {
+        // Two-arg `tr` so translators get the count as a plain
+        // `%1` rather than wrestling with `%n` plurality on the
+        // accessible name (the visible label already covers
+        // plural-correctness; AT prosody is more forgiving).
+        setAccessibleName(tr("Jump to newest row, %1 new lines available").arg(mCount));
+    }
+    else
+    {
+        // Idle accessible name for the brief windows when the
+        // pill is technically still in the tree (fade-out in
+        // flight) but conceptually empty.
+        setAccessibleName(tr("Jump to newest row"));
+    }
 }
 
 void JumpToTailPill::RefreshIcon()
@@ -281,11 +327,29 @@ void JumpToTailPill::ApplyStyleSheet()
     // not resolve `palette(...)` references on every role).
     const QColor bg = palette().color(QPalette::Active, QPalette::Highlight);
     const QColor fg = palette().color(QPalette::Active, QPalette::HighlightedText);
-    // Slightly darker hover; `QColor::darker(110)` keeps the hue
-    // and pushes the lightness ~10% down -- works on light AND
-    // dark themes without bespoke per-mode tints.
-    const QColor hoverBg = bg.darker(110);
-    const QColor pressedBg = bg.darker(125);
+
+    // Hover / pressed must visibly contrast against `bg` on every
+    // theme. `QColor::darker(N)` divides HSV `V` -- on a dark
+    // theme that pulls the hover *into* the surrounding black,
+    // making the pill almost vanish on hover. Branch on the
+    // background's perceived lightness so the adjustment goes
+    // toward more contrast in either direction:
+    //   * light theme (typical `Highlight` ~ vivid blue,
+    //     lightness > 0.5) -> darken on hover.
+    //   * dark theme (typical `Highlight` ~ dim blue,
+    //     lightness <= 0.5) -> lighten on hover.
+    // Same factor (~10% / ~25%) on both sides so the feedback
+    // intensity matches across themes.
+    const auto adjustForContrast = [](const QColor &c, int factor) {
+        return c.lightnessF() < LIGHTNESS_DARK_THEME_THRESHOLD ? c.lighter(factor) : c.darker(factor);
+    };
+    const QColor hoverBg = adjustForContrast(bg, 110);
+    const QColor pressedBg = adjustForContrast(bg, 125);
+    // Focus ring: a subtle outline that reads against both the
+    // pill's `bg` and the surrounding viewport. Reusing
+    // `HighlightedText` for the outline keeps the colour in lock-
+    // step with the foreground glyph.
+    const QColor focusRing = fg;
 
     const QString sheet = QStringLiteral(
                               "QToolButton#jumpToTailPill {"
@@ -298,6 +362,7 @@ void JumpToTailPill::ApplyStyleSheet()
                               "}"
                               "QToolButton#jumpToTailPill:hover { background-color: %6; }"
                               "QToolButton#jumpToTailPill:pressed { background-color: %7; }"
+                              "QToolButton#jumpToTailPill:focus { outline: 2px solid %8; }"
     )
                               .arg(bg.name(QColor::HexRgb))
                               .arg(fg.name(QColor::HexRgb))
@@ -305,7 +370,21 @@ void JumpToTailPill::ApplyStyleSheet()
                               .arg(PADDING_VERTICAL_PX)
                               .arg(PADDING_HORIZONTAL_PX)
                               .arg(hoverBg.name(QColor::HexRgb))
-                              .arg(pressedBg.name(QColor::HexRgb));
+                              .arg(pressedBg.name(QColor::HexRgb))
+                              .arg(focusRing.name(QColor::HexRgb));
+    // Idempotent fast-path: identical sheets are common when
+    // `changeEvent(PaletteChange)` fires from a Qt internal that
+    // didn't actually move any of our tracked roles (e.g. a font
+    // metrics change). Skipping the `setStyleSheet` call avoids
+    // a synchronous QSS re-resolve (which would re-emit
+    // `PaletteChange` and `StyleChange` -- the original recursion
+    // we have to guard against). The `mApplyingPalette` guard
+    // remains the firewall; this branch keeps the common case
+    // out of the firewall path entirely.
+    if (sheet == styleSheet())
+    {
+        return;
+    }
     setStyleSheet(sheet);
 }
 

--- a/app/src/jump_to_tail_pill.cpp
+++ b/app/src/jump_to_tail_pill.cpp
@@ -1,0 +1,268 @@
+#include "jump_to_tail_pill.hpp"
+
+#include "icon_loader.hpp"
+
+#include <QEasingCurve>
+#include <QEvent>
+#include <QFontMetrics>
+#include <QGraphicsOpacityEffect>
+#include <QIcon>
+#include <QLatin1String>
+#include <QPalette>
+#include <QPixmap>
+#include <QPropertyAnimation>
+#include <QSize>
+#include <QString>
+#include <QStringLiteral>
+#include <QTransform>
+
+namespace
+{
+/// SVG asset reused from the `actionFollowTail` toolbar icon. A
+/// single asset works for both directions: the `Up` variant is the
+/// same pixmap rotated 180 degrees via `QTransform`.
+constexpr auto ARROW_SVG_PATH = ":/icons/arrow-down-to-line.svg";
+
+/// Logical-pixel edge length for the arrow glyph. The pill's row
+/// height is driven by the text font metrics; this size matches a
+/// typical body line height so the glyph reads as part of the
+/// text run rather than as an oversized adornment.
+constexpr int ARROW_ICON_PX = 14;
+
+/// Fade duration; matches the Find bar's match-count debounce
+/// envelope so two animation timescales don't visibly compete.
+/// Long enough to read as "appearing", short enough that a fast
+/// typist / streaming session doesn't see lingering animation.
+constexpr int FADE_DURATION_MS = 150;
+
+/// Cap on the literal value rendered in the pill before we switch
+/// to "999+". The pill is informational; the user only needs to
+/// know "a lot". Choosing a 3-digit cap also keeps the pill width
+/// bounded across locales (grouped digits, RTL, etc.) so the
+/// auto-positioning helper in the host view doesn't have to
+/// repaint a wider pill mid-stream.
+constexpr int DISPLAYED_COUNT_CAP = 999;
+} // namespace
+
+JumpToTailPill::JumpToTailPill(QWidget *parent)
+    : QToolButton(parent)
+{
+    setObjectName(QStringLiteral("jumpToTailPill"));
+    setCursor(Qt::PointingHandCursor);
+    setFocusPolicy(Qt::NoFocus);
+    // Icon + text laid out side by side so the arrow visually
+    // leads the count. `ToolButtonTextBesideIcon` honours QSS
+    // padding consistently across platforms; the
+    // `ToolButtonFollowStyle` default leaves the layout up to the
+    // platform theme and on some Windows styles strips the icon
+    // entirely.
+    setToolButtonStyle(Qt::ToolButtonTextBesideIcon);
+    setAutoRaise(false);
+    // Accessible name reads to screen readers without the running
+    // count, which the live text already carries; the description
+    // adds the action so the affordance reads as a verb.
+    setAccessibleName(tr("Jump to newest row"));
+    setAccessibleDescription(tr("Jump to the newest row and re-engage Follow newest if streaming."));
+
+    // Opacity effect on the widget itself; `setVisible(false)` at
+    // the end of the fade-out so the hidden pill stops absorbing
+    // hover events and accessibility tree walks.
+    mOpacity = new QGraphicsOpacityEffect(this);
+    mOpacity->setOpacity(0.0);
+    setGraphicsEffect(mOpacity);
+
+    mFade = new QPropertyAnimation(mOpacity, "opacity", this);
+    mFade->setDuration(FADE_DURATION_MS);
+    mFade->setEasingCurve(QEasingCurve::OutQuad);
+    connect(mFade, &QPropertyAnimation::finished, this, [this]() {
+        // Once fully transparent, drop visibility so the widget is
+        // out of the input + accessibility tree. Re-shown by
+        // `FadeTo(1.0)` before the next animation starts.
+        if (mOpacity->opacity() <= 0.0)
+        {
+            QToolButton::setVisible(false);
+        }
+    });
+
+    ApplyStyleSheet();
+    RefreshIcon();
+    RebuildText();
+
+    // Pill is hidden + transparent until `SetCount(>0)` arms it.
+    QToolButton::setVisible(false);
+}
+
+void JumpToTailPill::SetCount(int count)
+{
+    const int sanitised = count < 0 ? 0 : count;
+    if (sanitised == mCount)
+    {
+        return;
+    }
+    mCount = sanitised;
+    RebuildText();
+
+    if (mCount > 0)
+    {
+        // Must `show()` before the fade starts: a widget with
+        // `visible == false` does not paint its graphics effect,
+        // so animating opacity while hidden is a no-op visually.
+        if (!isVisible())
+        {
+            QToolButton::setVisible(true);
+        }
+        FadeTo(1.0);
+    }
+    else
+    {
+        FadeTo(0.0);
+    }
+}
+
+void JumpToTailPill::SetArrowDirection(ArrowDirection direction)
+{
+    if (direction == mDirection)
+    {
+        return;
+    }
+    mDirection = direction;
+    RefreshIcon();
+    RebuildText();
+}
+
+void JumpToTailPill::changeEvent(QEvent *event)
+{
+    QToolButton::changeEvent(event);
+    if (event == nullptr)
+    {
+        return;
+    }
+    switch (event->type())
+    {
+    case QEvent::PaletteChange:
+    case QEvent::StyleChange:
+    case QEvent::ApplicationPaletteChange:
+        // Re-apply both: the QSS reads palette role names but Qt
+        // caches the resolved stylesheet, and the icon was tinted
+        // against the previous palette colour.
+        ApplyStyleSheet();
+        RefreshIcon();
+        break;
+    default:
+        break;
+    }
+}
+
+void JumpToTailPill::RebuildText()
+{
+    // Leading glyph mirrors the icon direction so screen-readers
+    // and copy-paste of the accessible text still convey "down"
+    // / "up"; the icon is purely visual.
+    const QString arrow =
+        (mDirection == ArrowDirection::Down) ? QStringLiteral("\u2193") : QStringLiteral("\u2191");
+
+    const int shown = mCount > DISPLAYED_COUNT_CAP ? DISPLAYED_COUNT_CAP : mCount;
+    const QString countStr =
+        mCount > DISPLAYED_COUNT_CAP ? tr("%1+").arg(shown) : QString::number(shown);
+
+    // Always use the plural form. The pill is only visible for
+    // counts >= 1; a literal "1 new line" would technically be
+    // more correct but the singular flashes for one frame on every
+    // batch boundary and reads as noise. The translator can still
+    // override via `%Ln` if a target language needs different
+    // pluralisation.
+    const QString text = tr("%1 %2 new lines").arg(arrow, countStr);
+    setText(text);
+}
+
+void JumpToTailPill::RefreshIcon()
+{
+    const QColor tint = palette().color(QPalette::Active, QPalette::HighlightedText);
+    const qreal dpr = devicePixelRatioF() > 0.0 ? devicePixelRatioF() : 1.0;
+
+    QPixmap pix = icon_loader::MakeThemedPixmap(QLatin1String(ARROW_SVG_PATH), tint, ARROW_ICON_PX, dpr);
+    if (pix.isNull())
+    {
+        // Missing asset -- fall through to text-only. Same
+        // degradation policy as the rest of the icon-loader call
+        // sites (toolbar, headers).
+        setIcon(QIcon());
+        setIconSize(QSize(ARROW_ICON_PX, ARROW_ICON_PX));
+        return;
+    }
+
+    if (mDirection == ArrowDirection::Up)
+    {
+        // Vertical flip: the source asset is "down to line"; the
+        // 180-degree rotation produces an "up from line" glyph
+        // that reads correctly when the tail is at the top of the
+        // viewport (newest-first mode).
+        const QTransform xform = QTransform().rotate(180);
+        pix = pix.transformed(xform, Qt::SmoothTransformation);
+    }
+
+    QIcon icon;
+    icon.addPixmap(pix);
+    setIcon(icon);
+    setIconSize(QSize(ARROW_ICON_PX, ARROW_ICON_PX));
+}
+
+void JumpToTailPill::ApplyStyleSheet()
+{
+    // Pill height is driven by the QSS padding plus the icon /
+    // font metric; computing `border-radius` from a measured
+    // height would require a sizeHint round-trip after every
+    // theme change. A generous fixed radius reads as "pill" at
+    // every realistic font size and still rounds the corners
+    // correctly even when the widget is shorter than 2*r.
+    constexpr int RADIUS_PX = 12;
+    constexpr int PADDING_VERTICAL_PX = 6;
+    constexpr int PADDING_HORIZONTAL_PX = 12;
+
+    // Resolve palette roles once so a theme switch picks up the
+    // new colour names; the QSS itself uses literal hex (Qt does
+    // not resolve `palette(...)` references on every role).
+    const QColor bg = palette().color(QPalette::Active, QPalette::Highlight);
+    const QColor fg = palette().color(QPalette::Active, QPalette::HighlightedText);
+    // Slightly darker hover; `QColor::darker(110)` keeps the hue
+    // and pushes the lightness ~10% down -- works on light AND
+    // dark themes without bespoke per-mode tints.
+    const QColor hoverBg = bg.darker(110);
+    const QColor pressedBg = bg.darker(125);
+
+    const QString sheet = QStringLiteral(
+                              "QToolButton#jumpToTailPill {"
+                              "  background-color: %1;"
+                              "  color: %2;"
+                              "  border: none;"
+                              "  border-radius: %3px;"
+                              "  padding: %4px %5px;"
+                              "  font-weight: 600;"
+                              "}"
+                              "QToolButton#jumpToTailPill:hover { background-color: %6; }"
+                              "QToolButton#jumpToTailPill:pressed { background-color: %7; }"
+    )
+                              .arg(bg.name(QColor::HexRgb))
+                              .arg(fg.name(QColor::HexRgb))
+                              .arg(RADIUS_PX)
+                              .arg(PADDING_VERTICAL_PX)
+                              .arg(PADDING_HORIZONTAL_PX)
+                              .arg(hoverBg.name(QColor::HexRgb))
+                              .arg(pressedBg.name(QColor::HexRgb));
+    setStyleSheet(sheet);
+}
+
+void JumpToTailPill::FadeTo(qreal endOpacity)
+{
+    // Retarget any in-flight animation rather than chaining. Qt
+    // restarts the QPropertyAnimation from the *current* opacity,
+    // so a fade-in interrupted by a fade-out (or vice versa) is
+    // smooth instead of jumping to the prior endpoint.
+    if (mFade->state() == QAbstractAnimation::Running)
+    {
+        mFade->stop();
+    }
+    mFade->setStartValue(mOpacity->opacity());
+    mFade->setEndValue(endOpacity);
+    mFade->start();
+}

--- a/app/src/jump_to_tail_pill.cpp
+++ b/app/src/jump_to_tail_pill.cpp
@@ -174,23 +174,41 @@ void JumpToTailPill::RebuildText()
     const QString arrow =
         (mDirection == ArrowDirection::Down) ? QStringLiteral("\u2193") : QStringLiteral("\u2191");
 
-    const int shown = mCount > DISPLAYED_COUNT_CAP ? DISPLAYED_COUNT_CAP : mCount;
-    // `QStringLiteral` rather than `tr()`: the "+" cap suffix is not
-    // localisable (it is a math/notation symbol used identically
-    // across languages), and a separate `tr("%1+")` entry would
-    // clutter every `.ts` catalog with a single-character
-    // pseudo-string for translators to puzzle over.
-    const QString countStr =
-        mCount > DISPLAYED_COUNT_CAP ? QStringLiteral("%1+").arg(shown) : QString::number(shown);
-
-    // Always use the plural form. The pill is only visible for
-    // counts >= 1; a literal "1 new line" would technically be
-    // more correct but the singular flashes for one frame on every
-    // batch boundary and reads as noise. The translator can still
-    // override via `%Ln` if a target language needs different
-    // pluralisation.
-    const QString text = tr("%1 %2 new lines").arg(arrow, countStr);
-    setText(text);
+    // Two branches:
+    //
+    //   * Past the display cap we render `"%1+ new lines"` -- a
+    //     bounded literal whose `+` suffix is a math/notation
+    //     glyph used identically across locales. The catalog
+    //     entry is a separate string (one `%1`, plural-agnostic)
+    //     so translators don't have to puzzle over what `%n`
+    //     means against a capped-and-bounded number.
+    //   * Below the cap we use `tr("%n new lines", ..., mCount)`.
+    //     `%n` opts the source string into Qt's plural-aware
+    //     translation: `lupdate` emits both singular and plural
+    //     slots so locales with multiple plural forms (Polish,
+    //     Russian, Arabic, ...) can pick the right one. The
+    //     English source still reads "new lines" in the singular
+    //     slot too -- intentional: the 150 ms fade-in would
+    //     flicker between "1 new line" and "2 new lines" on
+    //     every batch boundary and that visual jitter is more
+    //     distracting than the technically-incorrect plural for
+    //     count == 1. Locales that need a true singular form can
+    //     override in the catalog without us touching the
+    //     code.
+    //
+    // Arrow glyph is prepended outside `tr` so translators get
+    // a clean message string and don't have to babysit the
+    // direction marker.
+    QString message;
+    if (mCount > DISPLAYED_COUNT_CAP)
+    {
+        message = tr("%1+ new lines").arg(DISPLAYED_COUNT_CAP);
+    }
+    else
+    {
+        message = tr("%n new lines", "jump-to-tail pill running count", mCount);
+    }
+    setText(QStringLiteral("%1 %2").arg(arrow, message));
 }
 
 void JumpToTailPill::RefreshIcon()
@@ -227,10 +245,22 @@ void JumpToTailPill::RefreshIcon()
 
 void JumpToTailPill::ApplyStyleSheet()
 {
+    // The only caller that could re-enter is `changeEvent`, and
+    // it already gates on `!mApplyingPalette`, so reaching this
+    // branch means a future caller forgot the gate. Assert in
+    // debug builds (a noisy failure beats a silent skip masking
+    // the wiring bug) but keep the early-return in release as a
+    // stack-overflow firewall: the synchronous `PaletteChange`
+    // that Qt 6 emits inside `setStyleSheet` would otherwise
+    // recurse without bound -- see the header doc on
+    // `mApplyingPalette`.
+    Q_ASSERT_X(
+        !mApplyingPalette,
+        "JumpToTailPill::ApplyStyleSheet",
+        "re-entered while the QSS apply is in flight; recursive caller must gate on mApplyingPalette"
+    );
     if (mApplyingPalette)
     {
-        // Defensive: caller already holds the guard. Skip rather
-        // than thrash the QSS twice.
         return;
     }
     mApplyingPalette = true;

--- a/app/src/jump_to_tail_pill.cpp
+++ b/app/src/jump_to_tail_pill.cpp
@@ -193,8 +193,7 @@ void JumpToTailPill::RebuildText()
     // Leading glyph mirrors the icon direction so screen-readers
     // and copy-paste of the accessible text still convey "down"
     // / "up"; the icon is purely visual.
-    const QString arrow =
-        (mDirection == ArrowDirection::Down) ? QStringLiteral("\u2193") : QStringLiteral("\u2191");
+    const QString arrow = (mDirection == ArrowDirection::Down) ? QStringLiteral("\u2193") : QStringLiteral("\u2191");
 
     // Two branches:
     //
@@ -351,19 +350,17 @@ void JumpToTailPill::ApplyStyleSheet()
     // step with the foreground glyph.
     const QColor focusRing = fg;
 
-    const QString sheet = QStringLiteral(
-                              "QToolButton#jumpToTailPill {"
-                              "  background-color: %1;"
-                              "  color: %2;"
-                              "  border: none;"
-                              "  border-radius: %3px;"
-                              "  padding: %4px %5px;"
-                              "  font-weight: 600;"
-                              "}"
-                              "QToolButton#jumpToTailPill:hover { background-color: %6; }"
-                              "QToolButton#jumpToTailPill:pressed { background-color: %7; }"
-                              "QToolButton#jumpToTailPill:focus { outline: 2px solid %8; }"
-    )
+    const QString sheet = QStringLiteral("QToolButton#jumpToTailPill {"
+                                         "  background-color: %1;"
+                                         "  color: %2;"
+                                         "  border: none;"
+                                         "  border-radius: %3px;"
+                                         "  padding: %4px %5px;"
+                                         "  font-weight: 600;"
+                                         "}"
+                                         "QToolButton#jumpToTailPill:hover { background-color: %6; }"
+                                         "QToolButton#jumpToTailPill:pressed { background-color: %7; }"
+                                         "QToolButton#jumpToTailPill:focus { outline: 2px solid %8; }")
                               .arg(bg.name(QColor::HexRgb))
                               .arg(fg.name(QColor::HexRgb))
                               .arg(RADIUS_PX)

--- a/app/src/jump_to_tail_pill.cpp
+++ b/app/src/jump_to_tail_pill.cpp
@@ -175,8 +175,13 @@ void JumpToTailPill::RebuildText()
         (mDirection == ArrowDirection::Down) ? QStringLiteral("\u2193") : QStringLiteral("\u2191");
 
     const int shown = mCount > DISPLAYED_COUNT_CAP ? DISPLAYED_COUNT_CAP : mCount;
+    // `QStringLiteral` rather than `tr()`: the "+" cap suffix is not
+    // localisable (it is a math/notation symbol used identically
+    // across languages), and a separate `tr("%1+")` entry would
+    // clutter every `.ts` catalog with a single-character
+    // pseudo-string for translators to puzzle over.
     const QString countStr =
-        mCount > DISPLAYED_COUNT_CAP ? tr("%1+").arg(shown) : QString::number(shown);
+        mCount > DISPLAYED_COUNT_CAP ? QStringLiteral("%1+").arg(shown) : QString::number(shown);
 
     // Always use the plural form. The pill is only visible for
     // counts >= 1; a literal "1 new line" would technically be

--- a/app/src/log_table_view.cpp
+++ b/app/src/log_table_view.cpp
@@ -103,14 +103,24 @@ LogTableView::LogTableView(QWidget *parent)
         mTailEdge == TailEdge::Top ? JumpToTailPill::ArrowDirection::Up : JumpToTailPill::ArrowDirection::Down
     );
     connect(mTailPill, &QToolButton::clicked, this, [this]() {
-        // The host is responsible for the actual scroll; we only
-        // surface the intent. The reset of `mPendingNewRows` /
-        // pill visibility is driven by the resulting tail-edge
-        // transition inside `OnVerticalScrollValueChanged`, so
-        // the pill correctly stays hidden whether the host
-        // accepts or ignores the request.
+        // The host is responsible for the actual scroll. The
+        // reset of `mPendingNewRows` / pill visibility is driven
+        // by the resulting tail-edge transition inside
+        // `OnVerticalScrollValueChanged` *when* the scroll
+        // actually lands at the tail; `MainWindow`'s click
+        // handler also calls `AcknowledgePendingNewRows` so
+        // clicks whose scroll lands short of the visual tail
+        // (custom sort + filter mapping the source-newest row
+        // into the middle of the proxy) still clear the
+        // announcement.
         emit jumpToTailRequested();
     });
+    // Pill `sizeHint` changes (count growth, shrink, "999+" cap
+    // crossing) require a re-anchor against the viewport edge;
+    // `OnRowsInserted` only handles the growth path. The signal
+    // covers the shrink + cap-crossing paths so the pill never
+    // drifts off-centre.
+    connect(mTailPill, &JumpToTailPill::contentSizeChanged, this, &LogTableView::PositionTailPill);
 
     // The pill is glued to the tail-side edge of the viewport; an
     // event filter on the viewport drives the reposition without
@@ -487,11 +497,27 @@ void LogTableView::OnRowsInserted(const QModelIndex &parent, int first, int last
     RestoreAnchorIfSaved();
 
     // Surface the new arrivals to the user via the floating pill
-    // when they're not currently watching the tail edge. The
-    // pill stays hidden in the at-tail case because the user is
-    // (or, in live-tail, is being auto-scrolled to) the newest
-    // row already.
-    if (mAtTailEdge || mTailPill == nullptr)
+    // when they're *not* currently watching the tail edge AND
+    // Follow newest is disengaged. The pill stays hidden when:
+    //
+    //   * `mAtTailEdge` -- user is already at the visual tail,
+    //     no catch-up affordance needed.
+    //   * `mPendingNewRowsSuppressed` -- live-tail Follow newest
+    //     is engaged. Qt's signal ordering can briefly drop
+    //     `mAtTailEdge` to false between the row insert's
+    //     geometry pass (which grows `maximum`) and the
+    //     subsequent `JumpToNewestRow` scroll-back, which would
+    //     cause a 1-frame pill flash on every batch in the
+    //     steady-state Follow path. The suppression flag keeps
+    //     this hot path silent regardless of signal ordering
+    //     across Qt versions.
+    //
+    // The batch size below counts *visible* rows (the slot is
+    // wired to the outermost proxy in the chain), so a filter
+    // that swallows a source batch produces no count update --
+    // which matches the user's mental model of "rows you missed
+    // since you scrolled away".
+    if (mAtTailEdge || mPendingNewRowsSuppressed || mTailPill == nullptr)
     {
         return;
     }
@@ -502,6 +528,10 @@ void LogTableView::OnRowsInserted(const QModelIndex &parent, int first, int last
     }
     mPendingNewRows += batch;
     mTailPill->SetCount(mPendingNewRows);
+    // Direct call here covers the typical "count grew" case
+    // before the user can perceive the new sizeHint; the
+    // `contentSizeChanged` signal also drives the same helper,
+    // so this is belt-and-braces for the most common path.
     PositionTailPill();
 }
 
@@ -597,7 +627,15 @@ void LogTableView::PositionTailPill()
     mTailPill->adjustSize();
     const QSize pillSize = mTailPill->size();
     const QRect vpRect = vp->rect();
-    const int x = vpRect.left() + ((vpRect.width() - pillSize.width()) / 2);
+    // Centre horizontally, but clamp so a viewport narrower than
+    // the pill doesn't push the pill off the left edge (negative
+    // `x`) or the right edge. The clamp produces "left-aligned"
+    // behaviour in that pathological case rather than a partial
+    // bleed -- still a degraded layout, but at least the click
+    // target is fully inside the viewport.
+    const int rawX = vpRect.left() + ((vpRect.width() - pillSize.width()) / 2);
+    const int maxX = vpRect.right() - pillSize.width() + 1;
+    const int x = std::max(vpRect.left(), std::min(rawX, maxX));
     int y = 0;
     if (mTailEdge == TailEdge::Bottom)
     {
@@ -613,6 +651,31 @@ void LogTableView::PositionTailPill()
     }
     mTailPill->move(x, y);
     mTailPill->raise();
+}
+
+void LogTableView::SetPendingNewRowsSuppressed(bool suppressed)
+{
+    if (suppressed == mPendingNewRowsSuppressed)
+    {
+        return;
+    }
+    mPendingNewRowsSuppressed = suppressed;
+    // Engaging suppression also drops any tally accumulated
+    // before the flip -- otherwise a "user scrolled away, rows
+    // pile up, user re-engages Follow newest" sequence would
+    // freeze the pre-flip count visible until the next at-tail
+    // landing. The pill click and the Follow-on toggle both
+    // imply the user has acknowledged whatever announcement was
+    // showing.
+    if (suppressed)
+    {
+        ResetPendingNewRows();
+    }
+}
+
+void LogTableView::AcknowledgePendingNewRows()
+{
+    ResetPendingNewRows();
 }
 
 void LogTableView::ResetPendingNewRows()

--- a/app/src/log_table_view.cpp
+++ b/app/src/log_table_view.cpp
@@ -612,7 +612,7 @@ void LogTableView::PositionTailPill()
     {
         return;
     }
-    QWidget *vp = viewport();
+    const QWidget *vp = viewport();
     if (vp == nullptr)
     {
         return;

--- a/app/src/log_table_view.cpp
+++ b/app/src/log_table_view.cpp
@@ -220,9 +220,7 @@ void LogTableView::setModel(QAbstractItemModel *model)
     // tally is by definition stale. Listening here also covers
     // the `clearAllFilters` -> proxy reset path, which never
     // emits `rowsRemoved`.
-    mModelConnections.append(
-        connect(model, &QAbstractItemModel::modelReset, this, &LogTableView::ResetPendingNewRows)
-    );
+    mModelConnections.append(connect(model, &QAbstractItemModel::modelReset, this, &LogTableView::ResetPendingNewRows));
 }
 
 void LogTableView::keyPressEvent(QKeyEvent *event)

--- a/app/src/log_table_view.cpp
+++ b/app/src/log_table_view.cpp
@@ -78,6 +78,12 @@ LogTableView::LogTableView(QWidget *parent)
     // clamping, our anchor restore) cannot disengage Follow newest.
     connect(vbar, &QAbstractSlider::valueChanged, this, &LogTableView::OnVerticalScrollValueChanged);
 
+    // Range changes fire when row inserts grow `maximum` without
+    // moving `value`. `OnVerticalScrollRangeChanged` keeps the
+    // at-tail flag fresh in that path so a user who is at the tail
+    // with Follow off does not silently drift behind the newest row.
+    connect(vbar, &QAbstractSlider::rangeChanged, this, &LogTableView::OnVerticalScrollRangeChanged);
+
     // `actionTriggered` covers every user-initiated scrollbar action
     // (arrow / track clicks, Page Up / Down, Home / End, drag, wheel
     // on the scrollbar) and fires synchronously before the resulting
@@ -115,8 +121,11 @@ LogTableView::LogTableView(QWidget *parent)
 void LogTableView::SetTailEdge(TailEdge edge)
 {
     mTailEdge = edge;
-    // Re-seed against the current scroll position so a flip from one
-    // edge to the other does not register as a user transition.
+    // Re-seed against the current scroll position. Runs even when
+    // `edge == mTailEdge` (no flip): production callers and tests
+    // rely on this to absorb a preceding programmatic scrollbar
+    // mutation that `OnVerticalScrollValueChanged` silently
+    // transitioned -- see the header doc on `SetTailEdge`.
     mAtTailEdge = ComputeAtTailEdge(verticalScrollBar()->value());
 
     // Mirror the edge on the pill: arrow direction follows the
@@ -415,6 +424,38 @@ void LogTableView::OnVerticalScrollValueChanged(int value)
     }
 }
 
+void LogTableView::OnVerticalScrollRangeChanged(int /*min*/, int /*max*/)
+{
+    // A row insert that grew `maximum` triggers this without a
+    // corresponding `valueChanged` (the value didn't move). Without
+    // re-evaluating the at-tail flag, a user sitting at the previous
+    // tail would silently fall behind: `mAtTailEdge` would stay
+    // stuck at `true` and `OnRowsInserted` would keep skipping the
+    // count for every subsequent batch. Resolve only the flag here;
+    // the `userScrolled*` signals stay silent because a layout
+    // change is not a user scroll (and we must not toggle Follow
+    // newest off as a side effect of new rows arriving).
+    const int value = verticalScrollBar()->value();
+    const bool atTailEdge = ComputeAtTailEdge(value);
+    if (atTailEdge == mAtTailEdge)
+    {
+        return;
+    }
+    mAtTailEdge = atTailEdge;
+    if (atTailEdge)
+    {
+        // Drifted *into* the tail by a layout change (rare: rows
+        // removed shrinking the range past `value`). Clear any
+        // pending tally so the pill matches the new state.
+        ResetPendingNewRows();
+    }
+    // Transition *off* tail: do not reset, do not emit. The next
+    // `rowsInserted` will increment from zero -- we accept losing
+    // the count for the in-flight batch (whose insert is what grew
+    // the range) because we have no reliable way to attribute its
+    // rows after the fact.
+}
+
 void LogTableView::OnRowsAboutToBeInserted(const QModelIndex &parent, int /*first*/, int /*last*/)
 {
     if (parent.isValid())
@@ -563,7 +604,15 @@ void LogTableView::PositionTailPill()
 
 void LogTableView::ResetPendingNewRows()
 {
-    if (mPendingNewRows == 0 && (mTailPill == nullptr || !mTailPill->isVisible()))
+    // `isHidden()` reflects the explicit `setVisible(false)` the pill
+    // ctor / fade-out lambda issue; `isVisible()` would additionally
+    // require every ancestor to be mapped, which is false under the
+    // offscreen QPA used in CI tests even for a logically-shown pill.
+    // The early-return is a redundant-work guard, not a behaviour
+    // gate: `SetCount(0)` is itself idempotent, so dropping it would
+    // not regress -- but the explicit `isHidden()` check keeps the
+    // intent honest under both production and offscreen runs.
+    if (mPendingNewRows == 0 && (mTailPill == nullptr || mTailPill->isHidden()))
     {
         return;
     }

--- a/app/src/log_table_view.cpp
+++ b/app/src/log_table_view.cpp
@@ -120,6 +120,10 @@ LogTableView::LogTableView(QWidget *parent)
 
 void LogTableView::SetTailEdge(TailEdge edge)
 {
+    // Snapshot the previous edge *before* overwriting so the
+    // "did the orientation actually flip?" question is answerable
+    // below -- the pill-reset gate depends on it.
+    const bool edgeFlipped = (edge != mTailEdge);
     mTailEdge = edge;
     // Re-seed against the current scroll position. Runs even when
     // `edge == mTailEdge` (no flip): production callers and tests
@@ -140,11 +144,20 @@ void LogTableView::SetTailEdge(TailEdge edge)
         PositionTailPill();
     }
 
-    // A tail-edge flip while the pending counter is non-zero
-    // would leave the pill stranded showing a tally that no
-    // longer relates to where the user is reading. Clear it; the
-    // next batch refills the count under the new edge.
-    if (mAtTailEdge)
+    // Clear the pending tally in two cases:
+    //
+    //   * `edgeFlipped`: rows counted against the previous
+    //     orientation (e.g. "↓ 5 new lines" tallied at the bottom)
+    //     no longer relate to where the user is reading after the
+    //     flip ("↑ 5" would mislead about both direction *and*
+    //     batch boundary). A mid-scroll flip is the exact scenario
+    //     this branch catches -- gating on `mAtTailEdge` alone
+    //     would skip it (user isn't at either edge), leaving the
+    //     pill stranded with a stale count under the new arrow.
+    //   * `mAtTailEdge`: the re-seed lands the viewport at the
+    //     new tail (no flip, or flip that happened to put us at
+    //     the new edge). User is current; the pill should match.
+    if (edgeFlipped || mAtTailEdge)
     {
         ResetPendingNewRows();
     }

--- a/app/src/log_table_view.cpp
+++ b/app/src/log_table_view.cpp
@@ -1,6 +1,7 @@
 #include "log_table_view.hpp"
 
 #include "anchor_manager.hpp"
+#include "jump_to_tail_pill.hpp"
 #include "shortcut_catalog.hpp"
 
 #include <log_model.hpp>
@@ -9,25 +10,38 @@
 #include <QAbstractProxyModel>
 #include <QApplication>
 #include <QClipboard>
+#include <QEvent>
 #include <QFont>
 #include <QFontMetrics>
 #include <QHeaderView>
 #include <QItemSelectionModel>
 #include <QKeyEvent>
 #include <QMainWindow>
+#include <QObject>
 #include <QPaintEvent>
 #include <QPainter>
 #include <QPalette>
 #include <QPen>
 #include <QPoint>
 #include <QRect>
+#include <QResizeEvent>
 #include <QScrollBar>
 #include <QString>
 #include <QStyleOptionHeader>
 #include <QWheelEvent>
+#include <QWidget>
 
 #include <algorithm>
 #include <utility>
+
+namespace
+{
+/// Logical-pixel margin between the pill's outer edge and the
+/// matching viewport edge. Picked to leave room for the
+/// scrollbar's thumb / arrow indicator on the matching side
+/// without pushing the pill out of the visible band.
+constexpr int PILL_VIEWPORT_MARGIN_PX = 12;
+} // namespace
 
 void LogHeaderView::CenterIconAlignmentForIconOnlySection(QStyleOptionHeader *option)
 {
@@ -70,6 +84,33 @@ LogTableView::LogTableView(QWidget *parent)
     // `valueChanged`, so the flag we set here is still true when the
     // value-change handler runs.
     connect(vbar, &QAbstractSlider::actionTriggered, this, [this](int) { mNextValueChangeIsUser = true; });
+
+    // Floating "jump to newest" pill, parented to the viewport so
+    // it overlays the rows instead of being clipped by the grid.
+    // Hidden by default; `OnRowsInserted` shows it when the user
+    // is scrolled away and rows arrive. The view forwards the
+    // click as `jumpToTailRequested` so `MainWindow` can do the
+    // proxy-aware scroll + Follow re-engage without the view
+    // having to know about those concepts.
+    mTailPill = new JumpToTailPill(viewport());
+    mTailPill->SetArrowDirection(
+        mTailEdge == TailEdge::Top ? JumpToTailPill::ArrowDirection::Up : JumpToTailPill::ArrowDirection::Down
+    );
+    connect(mTailPill, &QToolButton::clicked, this, [this]() {
+        // The host is responsible for the actual scroll; we only
+        // surface the intent. The reset of `mPendingNewRows` /
+        // pill visibility is driven by the resulting tail-edge
+        // transition inside `OnVerticalScrollValueChanged`, so
+        // the pill correctly stays hidden whether the host
+        // accepts or ignores the request.
+        emit jumpToTailRequested();
+    });
+
+    // The pill is glued to the tail-side edge of the viewport; an
+    // event filter on the viewport drives the reposition without
+    // requiring a custom viewport subclass.
+    viewport()->installEventFilter(this);
+    PositionTailPill();
 }
 
 void LogTableView::SetTailEdge(TailEdge edge)
@@ -78,6 +119,27 @@ void LogTableView::SetTailEdge(TailEdge edge)
     // Re-seed against the current scroll position so a flip from one
     // edge to the other does not register as a user transition.
     mAtTailEdge = ComputeAtTailEdge(verticalScrollBar()->value());
+
+    // Mirror the edge on the pill: arrow direction follows the
+    // tail orientation (down for Bottom, up for Top), and the
+    // anchor position flips so the pill stays at the *tail* side
+    // of the viewport rather than visually pointing away from it.
+    if (mTailPill != nullptr)
+    {
+        mTailPill->SetArrowDirection(
+            edge == TailEdge::Top ? JumpToTailPill::ArrowDirection::Up : JumpToTailPill::ArrowDirection::Down
+        );
+        PositionTailPill();
+    }
+
+    // A tail-edge flip while the pending counter is non-zero
+    // would leave the pill stranded showing a tally that no
+    // longer relates to where the user is reading. Clear it; the
+    // next batch refills the count under the new edge.
+    if (mAtTailEdge)
+    {
+        ResetPendingNewRows();
+    }
 }
 
 LogTableView::TailEdge LogTableView::GetTailEdge() const noexcept
@@ -98,6 +160,12 @@ void LogTableView::setModel(QAbstractItemModel *model)
     // new model would be a different beast.
     mPreservedAnchor = QPersistentModelIndex();
     mAnchorIsSaved = false;
+    // Same reasoning for the pending-new-rows counter: a count
+    // accumulated against the old model is meaningless once it
+    // detaches. Hide the pill before the new model attaches so
+    // it can't briefly flash with a stale tally if the new model
+    // already has rows.
+    ResetPendingNewRows();
 
     QTableView::setModel(model);
 
@@ -117,6 +185,13 @@ void LogTableView::setModel(QAbstractItemModel *model)
         connect(model, &QAbstractItemModel::layoutAboutToBeChanged, this, &LogTableView::OnLayoutAboutToBeChanged)
     );
     mModelConnections.append(connect(model, &QAbstractItemModel::layoutChanged, this, &LogTableView::OnLayoutChanged));
+    // `modelReset` zeroes the rowcount; any pending "new lines"
+    // tally is by definition stale. Listening here also covers
+    // the `clearAllFilters` -> proxy reset path, which never
+    // emits `rowsRemoved`.
+    mModelConnections.append(
+        connect(model, &QAbstractItemModel::modelReset, this, &LogTableView::ResetPendingNewRows)
+    );
 }
 
 void LogTableView::keyPressEvent(QKeyEvent *event)
@@ -314,6 +389,17 @@ void LogTableView::OnVerticalScrollValueChanged(int value)
         return;
     }
     mAtTailEdge = atTailEdge;
+    // Any landing at the tail edge -- user OR programmatic --
+    // drops the pending count. This intentionally fires even for
+    // programmatic edges (`scrollTo`, our anchor restore, or the
+    // pill-click scroll routed through `MainWindow`), so the pill
+    // disappears as soon as the user is "caught up" regardless of
+    // who issued the scroll. The user-edge signal emission below
+    // still requires `wasUser` to avoid Follow-newest false toggles.
+    if (atTailEdge)
+    {
+        ResetPendingNewRows();
+    }
     if (!wasUser)
     {
         // Programmatic / layout-driven change: refresh the flag (above)
@@ -339,13 +425,31 @@ void LogTableView::OnRowsAboutToBeInserted(const QModelIndex &parent, int /*firs
     SaveAnchorIfShouldPreserve();
 }
 
-void LogTableView::OnRowsInserted(const QModelIndex &parent, int /*first*/, int /*last*/)
+void LogTableView::OnRowsInserted(const QModelIndex &parent, int first, int last)
 {
     if (parent.isValid())
     {
         return;
     }
     RestoreAnchorIfSaved();
+
+    // Surface the new arrivals to the user via the floating pill
+    // when they're not currently watching the tail edge. The
+    // pill stays hidden in the at-tail case because the user is
+    // (or, in live-tail, is being auto-scrolled to) the newest
+    // row already.
+    if (mAtTailEdge || mTailPill == nullptr)
+    {
+        return;
+    }
+    const int batch = (last >= first) ? (last - first + 1) : 0;
+    if (batch <= 0)
+    {
+        return;
+    }
+    mPendingNewRows += batch;
+    mTailPill->SetCount(mPendingNewRows);
+    PositionTailPill();
 }
 
 void LogTableView::OnLayoutAboutToBeChanged()
@@ -419,6 +523,68 @@ void LogTableView::RestoreAnchorIfSaved()
     // `mNextValueChangeIsUser` stays false here, so this `setValue`
     // is treated as programmatic by `OnVerticalScrollValueChanged`.
     vbar->setValue(vbar->value() + delta);
+}
+
+void LogTableView::PositionTailPill()
+{
+    if (mTailPill == nullptr)
+    {
+        return;
+    }
+    QWidget *vp = viewport();
+    if (vp == nullptr)
+    {
+        return;
+    }
+    // `adjustSize` so the pill knows its current sizeHint *before*
+    // we compute its position; without this, an early call (in
+    // the ctor, before the first show) places the pill at the
+    // initial 0x0 sizeHint and a later `SetCount` resize would
+    // overshoot the margin.
+    mTailPill->adjustSize();
+    const QSize pillSize = mTailPill->size();
+    const QRect vpRect = vp->rect();
+    const int x = vpRect.left() + ((vpRect.width() - pillSize.width()) / 2);
+    int y = 0;
+    if (mTailEdge == TailEdge::Bottom)
+    {
+        // Glue to the bottom; the down-arrow glyph reads as
+        // "rows are accumulating below the viewport".
+        y = vpRect.bottom() - pillSize.height() - PILL_VIEWPORT_MARGIN_PX;
+    }
+    else
+    {
+        // Newest-first: tail is the top; up-arrow at the top
+        // reads as "rows are accumulating above the viewport".
+        y = vpRect.top() + PILL_VIEWPORT_MARGIN_PX;
+    }
+    mTailPill->move(x, y);
+    mTailPill->raise();
+}
+
+void LogTableView::ResetPendingNewRows()
+{
+    if (mPendingNewRows == 0 && (mTailPill == nullptr || !mTailPill->isVisible()))
+    {
+        return;
+    }
+    mPendingNewRows = 0;
+    if (mTailPill != nullptr)
+    {
+        mTailPill->SetCount(0);
+    }
+}
+
+bool LogTableView::eventFilter(QObject *watched, QEvent *event)
+{
+    if (watched == viewport() && event != nullptr && event->type() == QEvent::Resize)
+    {
+        // Re-place the pill on every viewport resize. The filter
+        // returns `false` so the base class still gets to handle
+        // the resize (scroll-area maths, header sizing, ...).
+        PositionTailPill();
+    }
+    return QTableView::eventFilter(watched, event);
 }
 
 void LogTableView::CopySelectedRowsToClipboard()

--- a/app/src/log_table_view.cpp
+++ b/app/src/log_table_view.cpp
@@ -36,10 +36,8 @@
 
 namespace
 {
-/// Logical-pixel margin between the pill's outer edge and the
-/// matching viewport edge. Picked to leave room for the
-/// scrollbar's thumb / arrow indicator on the matching side
-/// without pushing the pill out of the visible band.
+/// Logical-pixel gap between the pill and the tail-side viewport
+/// edge. Leaves room for the scrollbar's thumb / arrow indicator.
 constexpr int PILL_VIEWPORT_MARGIN_PX = 12;
 } // namespace
 
@@ -78,10 +76,10 @@ LogTableView::LogTableView(QWidget *parent)
     // clamping, our anchor restore) cannot disengage Follow newest.
     connect(vbar, &QAbstractSlider::valueChanged, this, &LogTableView::OnVerticalScrollValueChanged);
 
-    // Range changes fire when row inserts grow `maximum` without
-    // moving `value`. `OnVerticalScrollRangeChanged` keeps the
-    // at-tail flag fresh in that path so a user who is at the tail
-    // with Follow off does not silently drift behind the newest row.
+    // Row inserts that grow `maximum` without moving `value` don't
+    // fire `valueChanged`; the range hook keeps `mAtTailEdge`
+    // fresh so a user at the previous tail does not silently fall
+    // behind.
     connect(vbar, &QAbstractSlider::rangeChanged, this, &LogTableView::OnVerticalScrollRangeChanged);
 
     // `actionTriggered` covers every user-initiated scrollbar action
@@ -92,60 +90,37 @@ LogTableView::LogTableView(QWidget *parent)
     connect(vbar, &QAbstractSlider::actionTriggered, this, [this](int) { mNextValueChangeIsUser = true; });
 
     // Floating "jump to newest" pill, parented to the viewport so
-    // it overlays the rows instead of being clipped by the grid.
-    // Hidden by default; `OnRowsInserted` shows it when the user
-    // is scrolled away and rows arrive. The view forwards the
-    // click as `jumpToTailRequested` so `MainWindow` can do the
-    // proxy-aware scroll + Follow re-engage without the view
-    // having to know about those concepts.
+    // it overlays rows without being clipped by the grid. The
+    // view just forwards the click; `MainWindow` owns the
+    // proxy-aware scroll and the Follow re-engage.
     mTailPill = new JumpToTailPill(viewport());
     mTailPill->SetArrowDirection(
         mTailEdge == TailEdge::Top ? JumpToTailPill::ArrowDirection::Up : JumpToTailPill::ArrowDirection::Down
     );
-    connect(mTailPill, &QToolButton::clicked, this, [this]() {
-        // The host is responsible for the actual scroll. The
-        // reset of `mPendingNewRows` / pill visibility is driven
-        // by the resulting tail-edge transition inside
-        // `OnVerticalScrollValueChanged` *when* the scroll
-        // actually lands at the tail; `MainWindow`'s click
-        // handler also calls `AcknowledgePendingNewRows` so
-        // clicks whose scroll lands short of the visual tail
-        // (custom sort + filter mapping the source-newest row
-        // into the middle of the proxy) still clear the
-        // announcement.
-        emit jumpToTailRequested();
-    });
-    // Pill `sizeHint` changes (count growth, shrink, "999+" cap
-    // crossing) require a re-anchor against the viewport edge;
-    // `OnRowsInserted` only handles the growth path. The signal
-    // covers the shrink + cap-crossing paths so the pill never
-    // drifts off-centre.
+    connect(mTailPill, &QToolButton::clicked, this, [this]() { emit jumpToTailRequested(); });
+    // Re-anchor on text-driven sizeHint changes (shrinking counts,
+    // crossing the "999+" cap) -- `OnRowsInserted` only covers the
+    // growth path.
     connect(mTailPill, &JumpToTailPill::contentSizeChanged, this, &LogTableView::PositionTailPill);
 
-    // The pill is glued to the tail-side edge of the viewport; an
-    // event filter on the viewport drives the reposition without
-    // requiring a custom viewport subclass.
+    // Event filter on the viewport drives `PositionTailPill` on
+    // resize without subclassing the viewport.
     viewport()->installEventFilter(this);
 }
 
 void LogTableView::SetTailEdge(TailEdge edge)
 {
-    // Snapshot the previous edge *before* overwriting so the
-    // "did the orientation actually flip?" question is answerable
-    // below -- the pill-reset gate depends on it.
+    // Snapshot before overwriting so the pill-reset gate below can
+    // see whether the orientation actually flipped.
     const bool edgeFlipped = (edge != mTailEdge);
     mTailEdge = edge;
-    // Re-seed against the current scroll position. Runs even when
-    // `edge == mTailEdge` (no flip): production callers and tests
-    // rely on this to absorb a preceding programmatic scrollbar
-    // mutation that `OnVerticalScrollValueChanged` silently
-    // transitioned -- see the header doc on `SetTailEdge`.
+    // Re-seed even when the edge didn't change: production callers
+    // rely on this to absorb preceding programmatic scrollbar
+    // mutations (see the header doc on `SetTailEdge`).
     mAtTailEdge = ComputeAtTailEdge(verticalScrollBar()->value());
 
-    // Mirror the edge on the pill: arrow direction follows the
-    // tail orientation (down for Bottom, up for Top), and the
-    // anchor position flips so the pill stays at the *tail* side
-    // of the viewport rather than visually pointing away from it.
+    // Mirror onto the pill so the arrow points at the tail and the
+    // anchor stays at the matching edge.
     if (mTailPill != nullptr)
     {
         mTailPill->SetArrowDirection(
@@ -154,19 +129,11 @@ void LogTableView::SetTailEdge(TailEdge edge)
         PositionTailPill();
     }
 
-    // Clear the pending tally in two cases:
-    //
-    //   * `edgeFlipped`: rows counted against the previous
-    //     orientation (e.g. "↓ 5 new lines" tallied at the bottom)
-    //     no longer relate to where the user is reading after the
-    //     flip ("↑ 5" would mislead about both direction *and*
-    //     batch boundary). A mid-scroll flip is the exact scenario
-    //     this branch catches -- gating on `mAtTailEdge` alone
-    //     would skip it (user isn't at either edge), leaving the
-    //     pill stranded with a stale count under the new arrow.
-    //   * `mAtTailEdge`: the re-seed lands the viewport at the
-    //     new tail (no flip, or flip that happened to put us at
-    //     the new edge). User is current; the pill should match.
+    // Drop the pending tally when either the orientation flipped
+    // (the count belongs to the old direction) or the re-seed
+    // lands us at the new tail (user is current). Gating on
+    // `mAtTailEdge` alone would strand a mid-scroll flip with a
+    // stale count under the new arrow.
     if (edgeFlipped || mAtTailEdge)
     {
         ResetPendingNewRows();
@@ -191,11 +158,9 @@ void LogTableView::setModel(QAbstractItemModel *model)
     // new model would be a different beast.
     mPreservedAnchor = QPersistentModelIndex();
     mAnchorIsSaved = false;
-    // Same reasoning for the pending-new-rows counter: a count
-    // accumulated against the old model is meaningless once it
-    // detaches. Hide the pill before the new model attaches so
-    // it can't briefly flash with a stale tally if the new model
-    // already has rows.
+    // The pending-new-rows tally belongs to the previous model.
+    // Drop it before the new model attaches so it can't briefly
+    // flash with a stale count if the new model has rows.
     ResetPendingNewRows();
 
     QTableView::setModel(model);
@@ -216,10 +181,9 @@ void LogTableView::setModel(QAbstractItemModel *model)
         connect(model, &QAbstractItemModel::layoutAboutToBeChanged, this, &LogTableView::OnLayoutAboutToBeChanged)
     );
     mModelConnections.append(connect(model, &QAbstractItemModel::layoutChanged, this, &LogTableView::OnLayoutChanged));
-    // `modelReset` zeroes the rowcount; any pending "new lines"
-    // tally is by definition stale. Listening here also covers
-    // the `clearAllFilters` -> proxy reset path, which never
-    // emits `rowsRemoved`.
+    // `modelReset` zeroes the rowcount, so any pending tally is
+    // stale. Also covers the `clearAllFilters` -> proxy reset path,
+    // which never emits `rowsRemoved`.
     mModelConnections.append(connect(model, &QAbstractItemModel::modelReset, this, &LogTableView::ResetPendingNewRows));
 }
 
@@ -418,13 +382,10 @@ void LogTableView::OnVerticalScrollValueChanged(int value)
         return;
     }
     mAtTailEdge = atTailEdge;
-    // Any landing at the tail edge -- user OR programmatic --
-    // drops the pending count. This intentionally fires even for
-    // programmatic edges (`scrollTo`, our anchor restore, or the
-    // pill-click scroll routed through `MainWindow`), so the pill
-    // disappears as soon as the user is "caught up" regardless of
-    // who issued the scroll. The user-edge signal emission below
-    // still requires `wasUser` to avoid Follow-newest false toggles.
+    // Any tail-edge landing (user or programmatic) drops the
+    // pending count so the pill disappears once the user is
+    // caught up. The `wasUser` gate below still guards the
+    // user-edge signals so Follow newest doesn't false-toggle.
     if (atTailEdge)
     {
         ResetPendingNewRows();
@@ -447,15 +408,10 @@ void LogTableView::OnVerticalScrollValueChanged(int value)
 
 void LogTableView::OnVerticalScrollRangeChanged(int /*min*/, int /*max*/)
 {
-    // A row insert that grew `maximum` triggers this without a
-    // corresponding `valueChanged` (the value didn't move). Without
-    // re-evaluating the at-tail flag, a user sitting at the previous
-    // tail would silently fall behind: `mAtTailEdge` would stay
-    // stuck at `true` and `OnRowsInserted` would keep skipping the
-    // count for every subsequent batch. Resolve only the flag here;
-    // the `userScrolled*` signals stay silent because a layout
-    // change is not a user scroll (and we must not toggle Follow
-    // newest off as a side effect of new rows arriving).
+    // Refresh `mAtTailEdge` on range changes without emitting
+    // user-scroll signals (a layout change is not a user scroll;
+    // we must not toggle Follow newest as a side effect of rows
+    // arriving).
     const int value = verticalScrollBar()->value();
     const bool atTailEdge = ComputeAtTailEdge(value);
     if (atTailEdge == mAtTailEdge)
@@ -465,15 +421,13 @@ void LogTableView::OnVerticalScrollRangeChanged(int /*min*/, int /*max*/)
     mAtTailEdge = atTailEdge;
     if (atTailEdge)
     {
-        // Drifted *into* the tail by a layout change (rare: rows
-        // removed shrinking the range past `value`). Clear any
-        // pending tally so the pill matches the new state.
+        // Drifted into the tail because rows removed shrank the
+        // range past `value`. Clear so the pill matches.
         ResetPendingNewRows();
     }
-    // Transition *off* tail: do not reset, do not emit. The next
+    // Transition off tail: don't reset, don't emit. The next
     // `rowsInserted` will increment from zero -- we accept losing
-    // the count for the in-flight batch (whose insert is what grew
-    // the range) because we have no reliable way to attribute its
+    // the in-flight batch's count since we cannot attribute its
     // rows after the fact.
 }
 
@@ -494,27 +448,11 @@ void LogTableView::OnRowsInserted(const QModelIndex &parent, int first, int last
     }
     RestoreAnchorIfSaved();
 
-    // Surface the new arrivals to the user via the floating pill
-    // when they're *not* currently watching the tail edge AND
-    // Follow newest is disengaged. The pill stays hidden when:
-    //
-    //   * `mAtTailEdge` -- user is already at the visual tail,
-    //     no catch-up affordance needed.
-    //   * `mPendingNewRowsSuppressed` -- live-tail Follow newest
-    //     is engaged. Qt's signal ordering can briefly drop
-    //     `mAtTailEdge` to false between the row insert's
-    //     geometry pass (which grows `maximum`) and the
-    //     subsequent `JumpToNewestRow` scroll-back, which would
-    //     cause a 1-frame pill flash on every batch in the
-    //     steady-state Follow path. The suppression flag keeps
-    //     this hot path silent regardless of signal ordering
-    //     across Qt versions.
-    //
-    // The batch size below counts *visible* rows (the slot is
-    // wired to the outermost proxy in the chain), so a filter
-    // that swallows a source batch produces no count update --
-    // which matches the user's mental model of "rows you missed
-    // since you scrolled away".
+    // Add the batch to the pill counter when the user is scrolled
+    // away and Follow newest is off. The slot is wired to the
+    // outermost proxy, so `batch` already excludes filtered rows --
+    // matching the user's mental model of "rows you missed since
+    // you scrolled away".
     if (mAtTailEdge || mPendingNewRowsSuppressed || mTailPill == nullptr)
     {
         return;
@@ -526,10 +464,8 @@ void LogTableView::OnRowsInserted(const QModelIndex &parent, int first, int last
     }
     mPendingNewRows += batch;
     mTailPill->SetCount(mPendingNewRows);
-    // Direct call here covers the typical "count grew" case
-    // before the user can perceive the new sizeHint; the
-    // `contentSizeChanged` signal also drives the same helper,
-    // so this is belt-and-braces for the most common path.
+    // Direct reposition for the common "count grew" path; the
+    // `contentSizeChanged` signal covers the same path too.
     PositionTailPill();
 }
 
@@ -617,34 +553,25 @@ void LogTableView::PositionTailPill()
     {
         return;
     }
-    // `adjustSize` so the pill knows its current sizeHint *before*
-    // we compute its position; without this, an early call (in
-    // the ctor, before the first show) places the pill at the
-    // initial 0x0 sizeHint and a later `SetCount` resize would
-    // overshoot the margin.
+    // `adjustSize` first so we use the current sizeHint; an early
+    // call (pre-`show`) would otherwise place the pill against a
+    // 0x0 size and overshoot later.
     mTailPill->adjustSize();
     const QSize pillSize = mTailPill->size();
     const QRect vpRect = vp->rect();
-    // Centre horizontally, but clamp so a viewport narrower than
-    // the pill doesn't push the pill off the left edge (negative
-    // `x`) or the right edge. The clamp produces "left-aligned"
-    // behaviour in that pathological case rather than a partial
-    // bleed -- still a degraded layout, but at least the click
-    // target is fully inside the viewport.
+    // Centre horizontally, clamped so a viewport narrower than the
+    // pill keeps the click target fully visible (degraded but not
+    // broken).
     const int rawX = vpRect.left() + ((vpRect.width() - pillSize.width()) / 2);
     const int maxX = vpRect.right() - pillSize.width() + 1;
     const int x = std::max(vpRect.left(), std::min(rawX, maxX));
     int y = 0;
     if (mTailEdge == TailEdge::Bottom)
     {
-        // Glue to the bottom; the down-arrow glyph reads as
-        // "rows are accumulating below the viewport".
         y = vpRect.bottom() - pillSize.height() - PILL_VIEWPORT_MARGIN_PX;
     }
     else
     {
-        // Newest-first: tail is the top; up-arrow at the top
-        // reads as "rows are accumulating above the viewport".
         y = vpRect.top() + PILL_VIEWPORT_MARGIN_PX;
     }
     mTailPill->move(x, y);
@@ -658,13 +585,11 @@ void LogTableView::SetPendingNewRowsSuppressed(bool suppressed)
         return;
     }
     mPendingNewRowsSuppressed = suppressed;
-    // Engaging suppression also drops any tally accumulated
-    // before the flip -- otherwise a "user scrolled away, rows
-    // pile up, user re-engages Follow newest" sequence would
-    // freeze the pre-flip count visible until the next at-tail
-    // landing. The pill click and the Follow-on toggle both
-    // imply the user has acknowledged whatever announcement was
-    // showing.
+    // Engaging suppression also drops the pending tally:
+    // toggling Follow newest back on counts as an acknowledgement
+    // of whatever announcement was showing, so the pill should
+    // clear immediately rather than freeze until the next
+    // at-tail landing.
     if (suppressed)
     {
         ResetPendingNewRows();
@@ -678,14 +603,10 @@ void LogTableView::AcknowledgePendingNewRows()
 
 void LogTableView::ResetPendingNewRows()
 {
-    // `isHidden()` reflects the explicit `setVisible(false)` the pill
-    // ctor / fade-out lambda issue; `isVisible()` would additionally
-    // require every ancestor to be mapped, which is false under the
-    // offscreen QPA used in CI tests even for a logically-shown pill.
-    // The early-return is a redundant-work guard, not a behaviour
-    // gate: `SetCount(0)` is itself idempotent, so dropping it would
-    // not regress -- but the explicit `isHidden()` check keeps the
-    // intent honest under both production and offscreen runs.
+    // `isHidden()` instead of `!isVisible()`: under the offscreen
+    // QPA used in CI tests, `isVisible()` is always false even for
+    // a logically-shown pill, so it would mask the redundant-work
+    // guard. `SetCount(0)` is idempotent regardless.
     if (mPendingNewRows == 0 && (mTailPill == nullptr || mTailPill->isHidden()))
     {
         return;
@@ -701,9 +622,9 @@ bool LogTableView::eventFilter(QObject *watched, QEvent *event)
 {
     if (watched == viewport() && event != nullptr && event->type() == QEvent::Resize)
     {
-        // Re-place the pill on every viewport resize. The filter
-        // returns `false` so the base class still gets to handle
-        // the resize (scroll-area maths, header sizing, ...).
+        // Re-place the pill on every viewport resize. We fall
+        // through to the base class so scroll-area maths and
+        // header sizing still run.
         PositionTailPill();
     }
     return QTableView::eventFilter(watched, event);

--- a/app/src/log_table_view.cpp
+++ b/app/src/log_table_view.cpp
@@ -110,7 +110,6 @@ LogTableView::LogTableView(QWidget *parent)
     // event filter on the viewport drives the reposition without
     // requiring a custom viewport subclass.
     viewport()->installEventFilter(this);
-    PositionTailPill();
 }
 
 void LogTableView::SetTailEdge(TailEdge edge)

--- a/app/src/main_window.cpp
+++ b/app/src/main_window.cpp
@@ -3853,15 +3853,36 @@ void MainWindow::JumpToNewestRow()
     {
         return;
     }
-    // Map through both proxy layers so the scroll lands on the correct
-    // visual row under sort / filter / reverse-order.
+    // First attempt: map the source's newest row through the proxy
+    // chain. Under a custom column sort this still lands on the
+    // *actually* newest line (by line id), not just the visual
+    // bottom -- which is the desirable Follow-newest behaviour.
     const QModelIndex sourceIndex = mModel->index(sourceRowCount - 1, 0);
     const QModelIndex midIndex = mRowOrderProxyModel->mapFromSource(sourceIndex);
-    const QModelIndex proxyIndex = mSortFilterProxyModel->mapFromSource(midIndex);
+    QModelIndex proxyIndex = mSortFilterProxyModel->mapFromSource(midIndex);
+
+    // Fallback: when the source's newest row is hidden by an active
+    // filter (very common with live tail + error/level filters), the
+    // mapping above returns an invalid index. A "jump to newest" that
+    // silently does nothing reads as a broken pill, so fall back to
+    // the visible tail -- proxy row 0 in newest-first, last proxy row
+    // otherwise. The user's intent is "catch me up on visible rows",
+    // which this satisfies.
     if (!proxyIndex.isValid())
     {
-        return;
+        const int proxyRowCount = mSortFilterProxyModel->rowCount();
+        if (proxyRowCount <= 0)
+        {
+            return;
+        }
+        const int targetRow = mRowOrderProxyModel->IsReversed() ? 0 : (proxyRowCount - 1);
+        proxyIndex = mSortFilterProxyModel->index(targetRow, 0);
+        if (!proxyIndex.isValid())
+        {
+            return;
+        }
     }
+
     // Newest-first puts the latest row at proxy row 0; tail edge is
     // owned by `ApplyDisplayOrder`.
     const auto position =

--- a/app/src/main_window.cpp
+++ b/app/src/main_window.cpp
@@ -3708,6 +3708,7 @@ bool MainWindow::AppendSortByEntries(QMenu *menu)
         {
             ascAct->setToolTip(mismatchTooltip);
         }
+        // NOLINTNEXTLINE(bugprone-exception-escape) - vector<string> capture copy can technically throw bad_alloc.
         connect(ascAct, &QAction::triggered, this, [this, keys]() {
             const int idx = FindColumnIndexByKeys(keys);
             if (idx < 0 || mTableView == nullptr)
@@ -3725,6 +3726,7 @@ bool MainWindow::AppendSortByEntries(QMenu *menu)
         {
             descAct->setToolTip(mismatchTooltip);
         }
+        // NOLINTNEXTLINE(bugprone-exception-escape) - vector<string> capture copy can technically throw bad_alloc.
         connect(descAct, &QAction::triggered, this, [this, keys]() {
             const int idx = FindColumnIndexByKeys(keys);
             if (idx < 0 || mTableView == nullptr)

--- a/app/src/main_window.cpp
+++ b/app/src/main_window.cpp
@@ -688,19 +688,66 @@ MainWindow::MainWindow(ThemeControl *theme, SessionHistoryManager *historyManage
         }
     });
 
+    // Mirror Follow-newest into the view's pill-suppression flag.
+    // Rationale: in the at-tail-with-Follow-engaged steady state
+    // Qt's signal ordering can briefly drop `mAtTailEdge` to
+    // false between the row-insert geometry pass (which grows
+    // `maximum`) and the subsequent `JumpToNewestRow` scroll-
+    // back. Without suppression the pill would flash on every
+    // batch in the most common live-tail state. The suppression
+    // also resets the running tally, so the user toggling Follow
+    // back on while scrolled away catches them up cleanly --
+    // they explicitly chose the auto-follow policy over the
+    // catch-up affordance.
+    //
+    // `toggled` rather than `triggered` so a programmatic
+    // `setChecked` (e.g. the pill-click handler below, or a
+    // user dragging back to the tail edge) drives the same
+    // suppression update as the user clicking the toolbar
+    // action.
+    connect(ui->actionFollowTail, &QAction::toggled, this, [this](bool checked) {
+        if (mTableView != nullptr)
+        {
+            mTableView->SetPendingNewRowsSuppressed(checked);
+        }
+    });
+    // Seed the suppression flag from the action's initial
+    // checked state. The `.ui` declares `actionFollowTail`
+    // checked by default, but `toggled` only fires on *changes*
+    // -- without this one-shot the view would start out un-
+    // suppressed even though Follow newest is logically engaged
+    // from frame zero, leaking the steady-state flicker we just
+    // wired the connection above to prevent.
+    if (mTableView != nullptr)
+    {
+        mTableView->SetPendingNewRowsSuppressed(ui->actionFollowTail->isChecked());
+    }
+
     // Floating "jump to newest" pill: the view surfaces the
     // click as `jumpToTailRequested`; this slot performs the
-    // proxy-aware scroll and (in live-tail) re-engages Follow
-    // newest. The view stays ignorant of proxies and of the
-    // Follow action -- single source of truth for the policy
-    // sits here, alongside the rest of the scroll-edge wiring.
+    // proxy-aware scroll, acknowledges the announcement, and
+    // (in live-tail) re-engages Follow newest. The view stays
+    // ignorant of proxies and of the Follow action -- single
+    // source of truth for the policy sits here, alongside the
+    // rest of the scroll-edge wiring.
     connect(mTableView, &LogTableView::jumpToTailRequested, this, [this]() {
-        // `JumpToNewestRow` issues a programmatic `scrollTo`,
-        // which lands the viewport at the tail edge. The view's
-        // `OnVerticalScrollValueChanged` zeroes the pending-new-
-        // rows counter on that transition (even for programmatic
-        // scrolls), so the pill fades out without a separate
-        // reset call here.
+        // Acknowledge the announcement *up-front*. The user has
+        // explicitly asked to be caught up; whether the scroll
+        // below lands exactly at the visual tail or slightly
+        // short (custom sort + filter where the source-newest
+        // row is in the middle of the proxy, or the bounded-
+        // walk fallback that snaps to the proxy tail without
+        // crossing `maximum`), the pending tally is stale by
+        // the user's intent. The at-tail-edge path still
+        // re-runs `ResetPendingNewRows`, but it's idempotent.
+        if (mTableView != nullptr)
+        {
+            mTableView->AcknowledgePendingNewRows();
+        }
+        // `JumpToNewestRow` issues a programmatic `scrollTo`
+        // through the proxy chain; the resulting tail-edge
+        // landing is what fades the pill cosmetic-wise (the
+        // count is already zero from the line above).
         JumpToNewestRow();
         // Live-tail sessions auto-disengage Follow newest when
         // the user manually scrolls away; the pill click is the
@@ -3891,9 +3938,15 @@ void MainWindow::JumpToNewestRow()
     // burst" cases without breaking a sweat.
     if (!proxyIndex.isValid())
     {
+        // `JUMP_FALLBACK_WALK_LIMIT` bounds *additional* candidates
+        // inspected after the source-newest first attempt that
+        // already failed above. A 256-row walk covers the typical
+        // "level filter swallows the latest INFO burst" case
+        // without turning the GUI thread into an O(N) scan when
+        // a pathological filter excludes the entire tail.
         constexpr int JUMP_FALLBACK_WALK_LIMIT = 256;
-        const int walkLimit = std::min(sourceRowCount, JUMP_FALLBACK_WALK_LIMIT);
-        for (int offset = 1; offset < walkLimit; ++offset)
+        const int maxOffset = std::min(sourceRowCount - 1, JUMP_FALLBACK_WALK_LIMIT);
+        for (int offset = 1; offset <= maxOffset; ++offset)
         {
             const QModelIndex candidateSource = mModel->index(sourceRowCount - 1 - offset, 0);
             const QModelIndex candidateMid = mRowOrderProxyModel->mapFromSource(candidateSource);
@@ -3915,6 +3968,15 @@ void MainWindow::JumpToNewestRow()
         const int proxyRowCount = mSortFilterProxyModel->rowCount();
         if (proxyRowCount <= 0)
         {
+            // No visible rows at all (every source row filtered
+            // out). There's nothing to scroll to, so clear any
+            // stale pill announcement -- "newest visible row"
+            // is the empty set, the tally is by definition
+            // meaningless until rows reappear.
+            if (mTableView != nullptr)
+            {
+                mTableView->AcknowledgePendingNewRows();
+            }
             return;
         }
         const int targetRow = tailIsTop ? 0 : (proxyRowCount - 1);

--- a/app/src/main_window.cpp
+++ b/app/src/main_window.cpp
@@ -689,72 +689,44 @@ MainWindow::MainWindow(ThemeControl *theme, SessionHistoryManager *historyManage
     });
 
     // Mirror Follow-newest into the view's pill-suppression flag.
-    // Rationale: in the at-tail-with-Follow-engaged steady state
-    // Qt's signal ordering can briefly drop `mAtTailEdge` to
-    // false between the row-insert geometry pass (which grows
-    // `maximum`) and the subsequent `JumpToNewestRow` scroll-
-    // back. Without suppression the pill would flash on every
-    // batch in the most common live-tail state. The suppression
-    // also resets the running tally, so the user toggling Follow
-    // back on while scrolled away catches them up cleanly --
-    // they explicitly chose the auto-follow policy over the
-    // catch-up affordance.
-    //
-    // `toggled` rather than `triggered` so a programmatic
-    // `setChecked` (e.g. the pill-click handler below, or a
-    // user dragging back to the tail edge) drives the same
-    // suppression update as the user clicking the toolbar
-    // action.
+    // Without this, Qt's signal ordering during a row insert can
+    // briefly drop `mAtTailEdge` between the geometry pass and the
+    // follow-up scroll-back, flashing the pill in the most common
+    // live-tail steady state. `toggled` (not `triggered`) so a
+    // programmatic `setChecked` from the pill-click handler below
+    // takes the same path as a user toolbar click.
     connect(ui->actionFollowTail, &QAction::toggled, this, [this](bool checked) {
         if (mTableView != nullptr)
         {
             mTableView->SetPendingNewRowsSuppressed(checked);
         }
     });
-    // Seed the suppression flag from the action's initial
-    // checked state. The `.ui` declares `actionFollowTail`
-    // checked by default, but `toggled` only fires on *changes*
-    // -- without this one-shot the view would start out un-
-    // suppressed even though Follow newest is logically engaged
-    // from frame zero, leaking the steady-state flicker we just
-    // wired the connection above to prevent.
+    // Seed from the action's initial checked state: the `.ui`
+    // declares Follow on by default but `toggled` only fires on
+    // changes, so without this one-shot the view would start
+    // un-suppressed.
     if (mTableView != nullptr)
     {
         mTableView->SetPendingNewRowsSuppressed(ui->actionFollowTail->isChecked());
     }
 
-    // Floating "jump to newest" pill: the view surfaces the
-    // click as `jumpToTailRequested`; this slot performs the
-    // proxy-aware scroll, acknowledges the announcement, and
-    // (in live-tail) re-engages Follow newest. The view stays
-    // ignorant of proxies and of the Follow action -- single
-    // source of truth for the policy sits here, alongside the
-    // rest of the scroll-edge wiring.
+    // Pill click: acknowledge, scroll, and re-engage Follow newest
+    // in live-tail. Keeping the policy here means the view stays
+    // ignorant of proxies and the Follow action.
     connect(mTableView, &LogTableView::jumpToTailRequested, this, [this]() {
-        // Acknowledge the announcement *up-front*. The user has
-        // explicitly asked to be caught up; whether the scroll
-        // below lands exactly at the visual tail or slightly
-        // short (custom sort + filter where the source-newest
-        // row is in the middle of the proxy, or the bounded-
-        // walk fallback that snaps to the proxy tail without
-        // crossing `maximum`), the pending tally is stale by
-        // the user's intent. The at-tail-edge path still
-        // re-runs `ResetPendingNewRows`, but it's idempotent.
+        // Acknowledge up-front so the count clears even when the
+        // scroll below lands short of the visual tail (custom
+        // sort placing source-newest in the middle of the proxy,
+        // or the bounded-walk fallback snapping to the proxy tail
+        // without crossing `maximum`).
         if (mTableView != nullptr)
         {
             mTableView->AcknowledgePendingNewRows();
         }
-        // `JumpToNewestRow` issues a programmatic `scrollTo`
-        // through the proxy chain; the resulting tail-edge
-        // landing is what fades the pill cosmetic-wise (the
-        // count is already zero from the line above).
         JumpToNewestRow();
-        // Live-tail sessions auto-disengage Follow newest when
-        // the user manually scrolls away; the pill click is the
-        // user's explicit "catch me up" command, so re-engage
-        // unconditionally on the same gate the scroll-back path
-        // uses. Outside live-tail there is no Follow notion, so
-        // the action is left alone.
+        // The pill click is an explicit "catch me up" command, so
+        // unconditionally re-engage Follow in live tail (a manual
+        // scroll-away would otherwise have disengaged it).
         if (IsLiveTailSession() && !ui->actionFollowTail->isChecked())
         {
             ui->actionFollowTail->setChecked(true);
@@ -3903,49 +3875,25 @@ void MainWindow::JumpToNewestRow()
         return;
     }
 
-    // Single source of truth for "which visual edge is the tail".
-    // `RowOrderProxyModel::IsReversed()` and
-    // `LogTableView::GetTailEdge()` are both kept in lockstep by
-    // `ApplyDisplayOrder`, but the *view* is what the user sees --
-    // if the two ever drift, we prefer the view's answer so the
-    // scroll lands at the visual edge the user is staring at.
+    // Use the view's tail edge as the single source of truth.
+    // `RowOrderProxyModel::IsReversed()` is kept in lockstep with
+    // it, but the view is what the user actually sees.
     const bool tailIsTop = (mTableView->GetTailEdge() == LogTableView::TailEdge::Top);
 
-    // First attempt: map the source's newest row (by line id)
-    // through the proxy chain. Under a custom column sort this
-    // still lands on the *actually* newest line, not just the
-    // visual top/bottom -- the desirable Follow-newest behaviour.
+    // Stage 1: map source-newest through the proxy chain. Lands
+    // on the absolute newest line under sort + filter when it
+    // survives the filter.
     const QModelIndex sourceIndex = mModel->index(sourceRowCount - 1, 0);
     const QModelIndex midIndex = mRowOrderProxyModel->mapFromSource(sourceIndex);
     QModelIndex proxyIndex = mSortFilterProxyModel->mapFromSource(midIndex);
 
-    // Fallback: when the source's newest row is hidden by an
-    // active filter (very common with live tail + error/level
-    // filters), the mapping above returns an invalid index.
-    //
-    // Walk source rows backwards from newest until we find one
-    // that survives the proxy chain (or run out). This preserves
-    // the "newest-by-line-id" semantics even under a *combined*
-    // sort + filter, where the proxy's visual top/bottom is
-    // sorted-by-column rather than by recency and would not be
-    // the "newest visible line".
-    //
-    // The walk is bounded by `JUMP_FALLBACK_WALK_LIMIT` so a
-    // pathological filter that excludes the entire tail does not
-    // turn an O(1) jump into an O(N) scan on the GUI thread. Past
-    // the limit we accept the visual tail as a best-effort target
-    // -- the user's intent at that point is "show me *some*
-    // visible row near the end", and a 256-row walk has already
-    // covered the typical "level filter eats the latest INFO
-    // burst" cases without breaking a sweat.
+    // Stage 2: source-newest is filtered out (common under live
+    // tail with a level/error filter). Walk backwards from newest
+    // and take the first source row that survives the proxy. The
+    // walk is bounded so a filter excluding the entire tail can't
+    // turn an O(1) jump into an O(N) GUI-thread scan.
     if (!proxyIndex.isValid())
     {
-        // `JUMP_FALLBACK_WALK_LIMIT` bounds *additional* candidates
-        // inspected after the source-newest first attempt that
-        // already failed above. A 256-row walk covers the typical
-        // "level filter swallows the latest INFO burst" case
-        // without turning the GUI thread into an O(N) scan when
-        // a pathological filter excludes the entire tail.
         constexpr int JUMP_FALLBACK_WALK_LIMIT = 256;
         const int maxOffset = std::min(sourceRowCount - 1, JUMP_FALLBACK_WALK_LIMIT);
         for (int offset = 1; offset <= maxOffset; ++offset)
@@ -3961,20 +3909,15 @@ void MainWindow::JumpToNewestRow()
         }
     }
 
-    // Final fallback: the bounded walk found nothing visible (or
-    // the source has fewer rows than we walked). Snap to the
-    // proxy's visual tail so the pill click still moves the
-    // viewport rather than silently doing nothing.
+    // Stage 3: snap to the proxy's visual tail so the pill click
+    // always moves the viewport instead of silently doing nothing.
     if (!proxyIndex.isValid())
     {
         const int proxyRowCount = mSortFilterProxyModel->rowCount();
         if (proxyRowCount <= 0)
         {
-            // No visible rows at all (every source row filtered
-            // out). There's nothing to scroll to, so clear any
-            // stale pill announcement -- "newest visible row"
-            // is the empty set, the tally is by definition
-            // meaningless until rows reappear.
+            // Nothing visible to scroll to. Clear the pending
+            // announcement -- it can't refer to any row.
             if (mTableView != nullptr)
             {
                 mTableView->AcknowledgePendingNewRows();

--- a/app/src/main_window.cpp
+++ b/app/src/main_window.cpp
@@ -688,6 +688,32 @@ MainWindow::MainWindow(ThemeControl *theme, SessionHistoryManager *historyManage
         }
     });
 
+    // Floating "jump to newest" pill: the view surfaces the
+    // click as `jumpToTailRequested`; this slot performs the
+    // proxy-aware scroll and (in live-tail) re-engages Follow
+    // newest. The view stays ignorant of proxies and of the
+    // Follow action -- single source of truth for the policy
+    // sits here, alongside the rest of the scroll-edge wiring.
+    connect(mTableView, &LogTableView::jumpToTailRequested, this, [this]() {
+        // `JumpToNewestRow` issues a programmatic `scrollTo`,
+        // which lands the viewport at the tail edge. The view's
+        // `OnVerticalScrollValueChanged` zeroes the pending-new-
+        // rows counter on that transition (even for programmatic
+        // scrolls), so the pill fades out without a separate
+        // reset call here.
+        JumpToNewestRow();
+        // Live-tail sessions auto-disengage Follow newest when
+        // the user manually scrolls away; the pill click is the
+        // user's explicit "catch me up" command, so re-engage
+        // unconditionally on the same gate the scroll-back path
+        // uses. Outside live-tail there is no Follow notion, so
+        // the action is left alone.
+        if (IsLiveTailSession() && !ui->actionFollowTail->isChecked())
+        {
+            ui->actionFollowTail->setChecked(true);
+        }
+    });
+
     // Find bar lives in a dockable host so the user can float / dock
     // it and the layout round-trips through `saveState`. The hosted
     // `FindRecordWidget` keeps the same slots, so existing wiring
@@ -3809,6 +3835,16 @@ void MainWindow::ScrollToNewestRowIfFollowing()
         return;
     }
     if (!ui->actionFollowTail->isChecked())
+    {
+        return;
+    }
+    JumpToNewestRow();
+}
+
+void MainWindow::JumpToNewestRow()
+{
+    if (mModel == nullptr || mRowOrderProxyModel == nullptr || mSortFilterProxyModel == nullptr ||
+        mTableView == nullptr)
     {
         return;
     }

--- a/app/src/main_window.cpp
+++ b/app/src/main_window.cpp
@@ -3853,21 +3853,63 @@ void MainWindow::JumpToNewestRow()
     {
         return;
     }
-    // First attempt: map the source's newest row through the proxy
-    // chain. Under a custom column sort this still lands on the
-    // *actually* newest line (by line id), not just the visual
-    // bottom -- which is the desirable Follow-newest behaviour.
+
+    // Single source of truth for "which visual edge is the tail".
+    // `RowOrderProxyModel::IsReversed()` and
+    // `LogTableView::GetTailEdge()` are both kept in lockstep by
+    // `ApplyDisplayOrder`, but the *view* is what the user sees --
+    // if the two ever drift, we prefer the view's answer so the
+    // scroll lands at the visual edge the user is staring at.
+    const bool tailIsTop = (mTableView->GetTailEdge() == LogTableView::TailEdge::Top);
+
+    // First attempt: map the source's newest row (by line id)
+    // through the proxy chain. Under a custom column sort this
+    // still lands on the *actually* newest line, not just the
+    // visual top/bottom -- the desirable Follow-newest behaviour.
     const QModelIndex sourceIndex = mModel->index(sourceRowCount - 1, 0);
     const QModelIndex midIndex = mRowOrderProxyModel->mapFromSource(sourceIndex);
     QModelIndex proxyIndex = mSortFilterProxyModel->mapFromSource(midIndex);
 
-    // Fallback: when the source's newest row is hidden by an active
-    // filter (very common with live tail + error/level filters), the
-    // mapping above returns an invalid index. A "jump to newest" that
-    // silently does nothing reads as a broken pill, so fall back to
-    // the visible tail -- proxy row 0 in newest-first, last proxy row
-    // otherwise. The user's intent is "catch me up on visible rows",
-    // which this satisfies.
+    // Fallback: when the source's newest row is hidden by an
+    // active filter (very common with live tail + error/level
+    // filters), the mapping above returns an invalid index.
+    //
+    // Walk source rows backwards from newest until we find one
+    // that survives the proxy chain (or run out). This preserves
+    // the "newest-by-line-id" semantics even under a *combined*
+    // sort + filter, where the proxy's visual top/bottom is
+    // sorted-by-column rather than by recency and would not be
+    // the "newest visible line".
+    //
+    // The walk is bounded by `JUMP_FALLBACK_WALK_LIMIT` so a
+    // pathological filter that excludes the entire tail does not
+    // turn an O(1) jump into an O(N) scan on the GUI thread. Past
+    // the limit we accept the visual tail as a best-effort target
+    // -- the user's intent at that point is "show me *some*
+    // visible row near the end", and a 256-row walk has already
+    // covered the typical "level filter eats the latest INFO
+    // burst" cases without breaking a sweat.
+    if (!proxyIndex.isValid())
+    {
+        constexpr int JUMP_FALLBACK_WALK_LIMIT = 256;
+        const int walkLimit = std::min(sourceRowCount, JUMP_FALLBACK_WALK_LIMIT);
+        for (int offset = 1; offset < walkLimit; ++offset)
+        {
+            const QModelIndex candidateSource = mModel->index(sourceRowCount - 1 - offset, 0);
+            const QModelIndex candidateMid = mRowOrderProxyModel->mapFromSource(candidateSource);
+            const QModelIndex candidateProxy = mSortFilterProxyModel->mapFromSource(candidateMid);
+            if (candidateProxy.isValid())
+            {
+                proxyIndex = candidateProxy;
+                break;
+            }
+        }
+    }
+
+    // Final fallback: the bounded walk found nothing visible (or
+    // the source has fewer rows than we walked). Snap to the
+    // proxy's visual tail so the pill click still moves the
+    // viewport rather than silently doing nothing.
     if (!proxyIndex.isValid())
     {
         const int proxyRowCount = mSortFilterProxyModel->rowCount();
@@ -3875,7 +3917,7 @@ void MainWindow::JumpToNewestRow()
         {
             return;
         }
-        const int targetRow = mRowOrderProxyModel->IsReversed() ? 0 : (proxyRowCount - 1);
+        const int targetRow = tailIsTop ? 0 : (proxyRowCount - 1);
         proxyIndex = mSortFilterProxyModel->index(targetRow, 0);
         if (!proxyIndex.isValid())
         {
@@ -3883,10 +3925,7 @@ void MainWindow::JumpToNewestRow()
         }
     }
 
-    // Newest-first puts the latest row at proxy row 0; tail edge is
-    // owned by `ApplyDisplayOrder`.
-    const auto position =
-        mRowOrderProxyModel->IsReversed() ? QAbstractItemView::PositionAtTop : QAbstractItemView::PositionAtBottom;
+    const auto position = tailIsTop ? QAbstractItemView::PositionAtTop : QAbstractItemView::PositionAtBottom;
     mTableView->scrollTo(proxyIndex, position);
 }
 

--- a/test/app/src/main_window_test.cpp
+++ b/test/app/src/main_window_test.cpp
@@ -2923,16 +2923,29 @@ private slots:
     // Clicking the pill emits `jumpToTailRequested` and the
     // host-side wiring (`MainWindow` -> `JumpToNewestRow`) scrolls
     // back to tail, which zeroes the counter via the same edge
-    // transition path. Verifies both the signal emission and the
-    // round-trip reset.
+    // transition path AND re-engages Follow newest. Verifies the
+    // signal emission, the round-trip reset, and the Follow gate
+    // (the headline behaviour the click is supposed to drive in a
+    // live-tail session -- if Follow does not re-engage, the next
+    // batch would push the user behind the tail again immediately).
     void TestJumpToTailPillClickJumpsAndResets()
     {
         auto *tableView = mWindow->findChild<LogTableView *>();
         auto *model = mWindow->findChild<LogModel *>();
+        QAction *followAction = FindActionByObjectName(mWindow, QStringLiteral("actionFollowTail"));
         QVERIFY(tableView != nullptr);
         QVERIFY(model != nullptr);
+        QVERIFY(followAction != nullptr);
         JumpToTailPill *pill = tableView->TailPillForTest();
         QVERIFY(pill != nullptr);
+
+        // `IsLiveTailSession()` gates the Follow re-engage on the
+        // pill-click path; without this seam call the host slot
+        // would see `Idle` and skip the re-engage even though the
+        // model is in streaming mode. Production wires the session
+        // mode through `OpenLogStream`; tests opt in explicitly.
+        auto restore = qScopeGuard([this]() { mWindow->SetSessionModeForTest(MainWindow::TestSessionMode::Idle); });
+        mWindow->SetSessionModeForTest(MainWindow::TestSessionMode::LiveTail);
 
         loglib::StreamLineSource &streamSource = BeginSyntheticStreamSession(*model);
         QtStreamingLogSink *sink = model->Sink();
@@ -2943,12 +2956,28 @@ private slots:
         sink->OnBatch(MakeSyntheticBatch(streamSource, keys, valueKey, 1, 40, /*declareNewKey=*/true));
         QCoreApplication::processEvents();
 
+        // Follow newest defaults to on in live-tail; pin the
+        // assumption so the scroll-away assertion below is
+        // meaningful (a scroll-away on a Follow-off action would
+        // not toggle anything, masking a missing re-engage).
+        followAction->setEnabled(true);
+        followAction->setChecked(true);
+
         QScrollBar *vbar = tableView->verticalScrollBar();
         vbar->setRange(0, 1000);
         vbar->setValue(vbar->maximum());
         tableView->SetTailEdge(LogTableView::TailEdge::Bottom);
         vbar->triggerAction(QAbstractSlider::SliderToMinimum);
         QCoreApplication::processEvents();
+
+        // The scroll-away path is the production trigger for Follow
+        // disengaging; sanity-check the wiring fired before we test
+        // the re-engage path below. If this fails the rest of the
+        // assertions are meaningless.
+        QVERIFY2(
+            !followAction->isChecked(),
+            "scroll-away must disengage Follow newest before the click test exercises re-engage"
+        );
 
         sink->OnBatch(MakeSyntheticBatch(streamSource, keys, valueKey, 41, 6, /*declareNewKey=*/false));
         QCoreApplication::processEvents();
@@ -2971,6 +3000,11 @@ private slots:
         // `ResetPendingNewRows`, so the counter is zero again.
         QCOMPARE(tableView->PendingNewRowsForTest(), 0);
         QCOMPARE(pill->Count(), 0);
+        // The headline behaviour: Follow newest is back on so the
+        // next batch keeps the user at the tail. The pill click is
+        // the user's "catch me up" command, not "show me the tail
+        // once and then immediately fall behind again".
+        QVERIFY2(followAction->isChecked(), "pill click must re-engage Follow newest in a live-tail session");
 
         model->EndStreaming(false);
     }
@@ -2994,6 +3028,155 @@ private slots:
 
         tableView->SetTailEdge(LogTableView::TailEdge::Bottom);
         QCOMPARE(pill->Direction(), JumpToTailPill::ArrowDirection::Down);
+    }
+
+    // `JumpToNewestRow` used to bail when the source's newest row
+    // was filtered out: it mapped `source[rowCount - 1]` through the
+    // proxy chain, got an invalid index, and returned without
+    // scrolling. The pill click would then do nothing -- a "dead"
+    // affordance under any filter that excludes the newest line, a
+    // very common case in a live tail with a level/error filter
+    // installed. The fallback added in `JumpToNewestRow` scrolls to
+    // the visual tail of the proxy (proxy row 0 in newest-first,
+    // last proxy row otherwise) when the source-newest mapping
+    // fails, so the click always moves the viewport.
+    //
+    // Setup: push lines 1..30 with `value=1..30`, install a
+    // `NumericRangeRowPredicate` that excludes `value >= 26`, scroll
+    // the bar off tail, and invoke `JumpToNewestRow` directly via
+    // the test seam. The assertion is that the scrollbar reached
+    // the new (filter-shrunk) maximum -- under the old code the
+    // call early-returned and the value stayed put.
+    void TestJumpToNewestRowFallbackToVisualTailWhenFiltered()
+    {
+        auto *model = mWindow->findChild<LogModel *>();
+        auto *tableView = mWindow->findChild<LogTableView *>();
+        LogFilterModel *filterModel = mWindow->FilterModel();
+        QVERIFY(model != nullptr);
+        QVERIFY(tableView != nullptr);
+        QVERIFY(filterModel != nullptr);
+
+        loglib::StreamLineSource &streamSource = BeginSyntheticStreamSession(*model);
+        QtStreamingLogSink *sink = model->Sink();
+        QVERIFY(sink != nullptr);
+        loglib::KeyIndex &keys = sink->Keys();
+        const loglib::KeyId valueKey = keys.GetOrInsert(std::string("value"));
+
+        sink->OnBatch(MakeSyntheticBatch(streamSource, keys, valueKey, 1, 30, /*declareNewKey=*/true));
+        QCoreApplication::processEvents();
+        QCOMPARE(model->rowCount(), 30);
+
+        const int valueCol = ColumnByHeader(*model, QStringLiteral("value"));
+        QVERIFY2(valueCol >= 0, "MakeSyntheticBatch must produce a 'value' column for the filter to target");
+
+        // `value < 26` keeps source rows 1..25; rows 26..30 are
+        // filtered out. The source's *newest* row (value=30) is in
+        // the excluded set -- this is the bug condition.
+        {
+            std::vector<loglib::RowPredicate> rules;
+            rules.emplace_back(
+                std::in_place_type<loglib::NumericRangeRowPredicate>,
+                static_cast<size_t>(valueCol),
+                std::optional<double>{},
+                std::optional<double>{25.5}
+            );
+            filterModel->SetFilterRules(std::move(rules));
+        }
+        QCoreApplication::processEvents();
+        QCOMPARE(model->rowCount(), 30);
+        QCOMPARE(filterModel->rowCount(), 25);
+
+        // Park the scrollbar away from the tail. `setRange` + a
+        // mid-range `setValue` mirrors the production "user scrolled
+        // up" state without needing a real wheel/key event for this
+        // test; we are exercising `JumpToNewestRow`'s mapping path,
+        // not the scroll-edge state machine.
+        QScrollBar *vbar = tableView->verticalScrollBar();
+        vbar->setRange(0, 1000);
+        vbar->setValue(0);
+        const int valueBefore = vbar->value();
+        QCOMPARE(valueBefore, 0);
+
+        mWindow->JumpToNewestRowForTest();
+        QCoreApplication::processEvents();
+
+        // Under the old code this stayed at 0 (the call early-
+        // returned because `mapFromSource(source row 29)` was
+        // invalid). With the fallback we land at the proxy's
+        // visual tail -- which `scrollTo(..., AtBottom)` resolves
+        // to the scrollbar's `maximum()`.
+        QVERIFY2(
+            vbar->value() > valueBefore,
+            qPrintable(QStringLiteral("scrollbar must move toward the visual tail when the newest source row is "
+                                      "filtered out; value stayed at %1")
+                           .arg(vbar->value()))
+        );
+
+        model->EndStreaming(false);
+    }
+
+    // `OnVerticalScrollValueChanged` keeps `mAtTailEdge` fresh only
+    // when the scrollbar `value` changes. A row insert that grows
+    // `maximum` (without moving `value`) used to leave the flag
+    // stale: a user sitting at the previous tail with Follow off
+    // would silently fall behind, and every subsequent
+    // `OnRowsInserted` would skip the count because `mAtTailEdge`
+    // was stuck at `true`. The `rangeChanged` listener added in
+    // `LogTableView::ctor` re-evaluates the flag on every range
+    // change.
+    //
+    // Drives `setRange` directly (the production trigger is a
+    // model row insert that the QTableView translates into a
+    // `setRange` on the scrollbar) and asserts the flag flipped
+    // without any `userScrolled*` emission -- a layout change is
+    // not a user scroll and must not toggle Follow newest.
+    //
+    // Uses `AtTailEdgeForTest()` to observe the transition directly
+    // rather than routing through a row insert: under the offscreen
+    // QPA, the view's geometry pass after a row insert can call
+    // `setRange(0, 0)` again (no real viewport), which would
+    // immediately re-flip the flag and mask the bug under test.
+    // The seam pins the *moment* the listener fires.
+    void TestRangeChangeFreshensAtTailFlag()
+    {
+        auto *tableView = mWindow->findChild<LogTableView *>();
+        QVERIFY(tableView != nullptr);
+
+        QScrollBar *vbar = tableView->verticalScrollBar();
+        vbar->setRange(0, 0);
+        vbar->setValue(0);
+        tableView->SetTailEdge(LogTableView::TailEdge::Bottom);
+        QVERIFY2(tableView->AtTailEdgeForTest(), "empty range + value 0 must be at-tail after re-seed");
+
+        const QSignalSpy awaySpy(tableView, &LogTableView::userScrolledAwayFromTail);
+        const QSignalSpy toSpy(tableView, &LogTableView::userScrolledToTail);
+        QVERIFY(awaySpy.isValid());
+        QVERIFY(toSpy.isValid());
+
+        // Grow the range without moving `value` -- the exact
+        // condition that left the flag stale before the fix. The
+        // `rangeChanged` listener must flip `mAtTailEdge` to false.
+        vbar->setRange(0, 500);
+        QVERIFY2(
+            !tableView->AtTailEdgeForTest(),
+            "rangeChanged growing max must flip mAtTailEdge to false when value < newMax"
+        );
+
+        // The inverse: shrinking the range back so `value >= max`
+        // again must transition the flag back to true via the same
+        // listener (covers the rare "rows removed past value"
+        // branch of `OnVerticalScrollRangeChanged`).
+        vbar->setRange(0, 0);
+        QVERIFY2(
+            tableView->AtTailEdgeForTest(), "rangeChanged shrinking max back below value must restore at-tail"
+        );
+
+        // Neither transition is a user scroll -- the Follow-newest
+        // wiring would auto-disengage / re-engage on a stray
+        // emission, which is the exact regression the silent
+        // branch inside `OnVerticalScrollRangeChanged` prevents.
+        QCOMPARE(awaySpy.count(), 0);
+        QCOMPARE(toSpy.count(), 0);
     }
 
     // Alternating row colours stay off on the log table regardless

--- a/test/app/src/main_window_test.cpp
+++ b/test/app/src/main_window_test.cpp
@@ -3030,6 +3030,87 @@ private slots:
         QCOMPARE(pill->Direction(), JumpToTailPill::ArrowDirection::Down);
     }
 
+    // Regression: flipping the tail edge while the user is
+    // mid-scroll (not at either edge) used to leave the pill
+    // stranded with a stale count under the new arrow glyph.
+    // `SetTailEdge` gated the reset on `mAtTailEdge` -- which is
+    // false for a mid-scroll viewport in both orientations -- so
+    // a tally accumulated under `Bottom` (e.g. "↓ 5 new lines",
+    // 5 rows arrived below) would survive a flip to `Top` and
+    // render as "↑ 5 new lines" against the new orientation,
+    // misattributing both direction *and* batch boundary.
+    //
+    // The fix gates the reset on the *orientation flip* itself
+    // (`edge != mTailEdge`) in addition to the `mAtTailEdge`
+    // re-seed case. This test pins the flip-resets-tally contract
+    // by driving the exact mid-scroll-flip scenario and asserting
+    // the pending counter is zero afterwards.
+    void TestJumpToTailPillResetsOnEdgeFlipMidScroll()
+    {
+        auto *tableView = mWindow->findChild<LogTableView *>();
+        auto *model = mWindow->findChild<LogModel *>();
+        QVERIFY(tableView != nullptr);
+        QVERIFY(model != nullptr);
+        JumpToTailPill *pill = tableView->TailPillForTest();
+        QVERIFY(pill != nullptr);
+
+        loglib::StreamLineSource &streamSource = BeginSyntheticStreamSession(*model);
+        QtStreamingLogSink *sink = model->Sink();
+        QVERIFY(sink != nullptr);
+        loglib::KeyIndex &keys = sink->Keys();
+        const loglib::KeyId valueKey = keys.GetOrInsert(std::string("value"));
+
+        sink->OnBatch(MakeSyntheticBatch(streamSource, keys, valueKey, 1, 30, /*declareNewKey=*/true));
+        QCoreApplication::processEvents();
+
+        // Park at the (Bottom) tail, scroll away to flip
+        // `mAtTailEdge` to false, then take a batch so the pill
+        // accumulates a count. After this dance the pill is
+        // showing a non-zero count under `Bottom` orientation.
+        QScrollBar *vbar = tableView->verticalScrollBar();
+        vbar->setRange(0, 1000);
+        vbar->setValue(vbar->maximum());
+        tableView->SetTailEdge(LogTableView::TailEdge::Bottom);
+        vbar->triggerAction(QAbstractSlider::SliderToMinimum);
+        QCoreApplication::processEvents();
+
+        sink->OnBatch(MakeSyntheticBatch(streamSource, keys, valueKey, 31, 5, /*declareNewKey=*/false));
+        QCoreApplication::processEvents();
+        QCOMPARE(tableView->PendingNewRowsForTest(), 5);
+        QCOMPARE(pill->Count(), 5);
+
+        // Park the scrollbar in the middle so neither
+        // `ComputeAtTailEdge(Bottom)` nor `ComputeAtTailEdge(Top)`
+        // returns true -- this is the *exact* condition where the
+        // old gate (`if (mAtTailEdge)`) would skip the reset.
+        // `setRange` is needed because `SliderToMinimum` clamped
+        // the range to whatever Qt's view layout computed; pin it
+        // back so the mid-position math is well-defined.
+        vbar->setRange(0, 1000);
+        vbar->setValue(500);
+        QVERIFY2(
+            !tableView->AtTailEdgeForTest(),
+            "precondition: mid-scroll viewport must not be at the Bottom tail edge before the flip"
+        );
+
+        // The flip. Under the old gate the pending counter
+        // survived this call ("↑ 5 new lines" with 5 counted at
+        // the bottom). Under the fix the orientation flip itself
+        // triggers `ResetPendingNewRows`.
+        tableView->SetTailEdge(LogTableView::TailEdge::Top);
+
+        QCOMPARE(pill->Direction(), JumpToTailPill::ArrowDirection::Up);
+        QVERIFY2(
+            !tableView->AtTailEdgeForTest(),
+            "sanity: mid-scroll viewport must not be at the Top tail edge either, so the at-tail "
+            "branch of the reset gate cannot mask a missing edge-flip branch"
+        );
+        QCOMPARE(tableView->PendingNewRowsForTest(), 0);
+        QCOMPARE(pill->Count(), 0);
+
+        model->EndStreaming(false);
+    }
+
     // `JumpToNewestRow` used to bail when the source's newest row
     // was filtered out: it mapped `source[rowCount - 1]` through the
     // proxy chain, got an invalid index, and returned without

--- a/test/app/src/main_window_test.cpp
+++ b/test/app/src/main_window_test.cpp
@@ -3260,6 +3260,388 @@ private slots:
         QCOMPARE(toSpy.count(), 0);
     }
 
+    // Regression: under live-tail with Follow newest *engaged*,
+    // every batch used to risk a transient pill-flash. The
+    // sequence:
+    //
+    //   1. Source emits `rowsInserted` for the new batch.
+    //   2. `QTableView`'s internal slot (registered before our
+    //      `OnRowsInserted` via `QTableView::setModel`) updates
+    //      geometry, calling `setRange(0, newMax)` on the
+    //      scrollbar.
+    //   3. `rangeChanged` fires synchronously ->
+    //      `OnVerticalScrollRangeChanged` flips `mAtTailEdge` to
+    //      `false` because the value is now < the new max.
+    //   4. *Our* `OnRowsInserted` runs next, sees
+    //      `mAtTailEdge == false`, and bumps the pending tally.
+    //   5. Only then does `lineCountChanged` fire, ->
+    //      `ScrollToNewestRowIfFollowing` -> `JumpToNewestRow`
+    //      scrolls back to tail and resets the tally.
+    //
+    // Steps 4-5 mean the pill briefly accumulates a count even
+    // though the user is at-tail with Follow on -- the most
+    // common live-tail steady state. Whether this flicker is
+    // *visible* depends on whether Qt's animation tick happens
+    // to land between steps 4 and 5; it's brittle either way.
+    // The fix mirrors `actionFollowTail::toggled` into the
+    // view's `mPendingNewRowsSuppressed` flag, so step 4
+    // short-circuits before incrementing.
+    //
+    // Pin: with Follow engaged, no batch should ever push the
+    // pill's count above zero, regardless of signal ordering.
+    void TestJumpToTailPillStaysZeroUnderFollowNewest()
+    {
+        auto *tableView = mWindow->findChild<LogTableView *>();
+        auto *model = mWindow->findChild<LogModel *>();
+        QAction *followAction = FindActionByObjectName(mWindow, QStringLiteral("actionFollowTail"));
+        QVERIFY(tableView != nullptr);
+        QVERIFY(model != nullptr);
+        QVERIFY(followAction != nullptr);
+        JumpToTailPill *pill = tableView->TailPillForTest();
+        QVERIFY(pill != nullptr);
+
+        auto restore = qScopeGuard([this]() { mWindow->SetSessionModeForTest(MainWindow::TestSessionMode::Idle); });
+        mWindow->SetSessionModeForTest(MainWindow::TestSessionMode::LiveTail);
+
+        loglib::StreamLineSource &streamSource = BeginSyntheticStreamSession(*model);
+        QtStreamingLogSink *sink = model->Sink();
+        QVERIFY(sink != nullptr);
+        loglib::KeyIndex &keys = sink->Keys();
+        const loglib::KeyId valueKey = keys.GetOrInsert(std::string("value"));
+
+        // Engage Follow newest and verify the suppression flag
+        // followed via the `actionFollowTail::toggled` mirror.
+        // Suppression must be active *before* the batch arrives,
+        // otherwise the very window we're trying to close (between
+        // `rangeChanged` and `JumpToNewestRow`) would still leak a
+        // count.
+        followAction->setEnabled(true);
+        followAction->setChecked(true);
+        QVERIFY2(
+            tableView->PendingNewRowsSuppressedForTest(),
+            "Follow newest engaging must mirror into the view's pending-new-rows suppression flag"
+        );
+
+        sink->OnBatch(MakeSyntheticBatch(streamSource, keys, valueKey, 1, 25, /*declareNewKey=*/true));
+        QCoreApplication::processEvents();
+        QCOMPARE(model->rowCount(), 25);
+
+        QCOMPARE(tableView->PendingNewRowsForTest(), 0);
+        QCOMPARE(pill->Count(), 0);
+        QVERIFY2(
+            pill->isHidden(), "pill must stay hidden across a batch in the live-tail Follow-newest steady state"
+        );
+
+        // A second batch must also stay silent -- the
+        // suppression flag is sticky, not one-shot.
+        sink->OnBatch(MakeSyntheticBatch(streamSource, keys, valueKey, 26, 13, /*declareNewKey=*/false));
+        QCoreApplication::processEvents();
+        QCOMPARE(tableView->PendingNewRowsForTest(), 0);
+        QCOMPARE(pill->Count(), 0);
+
+        model->EndStreaming(false);
+    }
+
+    // Disengaging Follow newest mid-stream releases suppression so
+    // the pill resumes counting, but a tally already accumulated
+    // by some intervening event (here: a manual `setChecked(true)`
+    // ping that exercises the suppression-flip drain) must not
+    // leak across the toggle. The `SetPendingNewRowsSuppressed`
+    // implementation calls `ResetPendingNewRows` on engage so a
+    // user toggling Follow back on while scrolled away catches
+    // them up cleanly.
+    void TestFollowNewestEngagingClearsPendingTally()
+    {
+        auto *tableView = mWindow->findChild<LogTableView *>();
+        auto *model = mWindow->findChild<LogModel *>();
+        QAction *followAction = FindActionByObjectName(mWindow, QStringLiteral("actionFollowTail"));
+        QVERIFY(tableView != nullptr);
+        QVERIFY(model != nullptr);
+        QVERIFY(followAction != nullptr);
+        JumpToTailPill *pill = tableView->TailPillForTest();
+        QVERIFY(pill != nullptr);
+
+        auto restore = qScopeGuard([this]() { mWindow->SetSessionModeForTest(MainWindow::TestSessionMode::Idle); });
+        mWindow->SetSessionModeForTest(MainWindow::TestSessionMode::LiveTail);
+
+        loglib::StreamLineSource &streamSource = BeginSyntheticStreamSession(*model);
+        QtStreamingLogSink *sink = model->Sink();
+        QVERIFY(sink != nullptr);
+        loglib::KeyIndex &keys = sink->Keys();
+        const loglib::KeyId valueKey = keys.GetOrInsert(std::string("value"));
+
+        // Start with Follow off so the scroll-away + batch path
+        // can accumulate a tally. The pill must surface here
+        // (this is exactly the path `TestJumpToTailPillSurfaces*`
+        // covers, just under a live-tail session).
+        followAction->setEnabled(true);
+        followAction->setChecked(false);
+
+        sink->OnBatch(MakeSyntheticBatch(streamSource, keys, valueKey, 1, 30, /*declareNewKey=*/true));
+        QCoreApplication::processEvents();
+
+        QScrollBar *vbar = tableView->verticalScrollBar();
+        vbar->setRange(0, 1000);
+        vbar->setValue(vbar->maximum());
+        tableView->SetTailEdge(LogTableView::TailEdge::Bottom);
+        vbar->triggerAction(QAbstractSlider::SliderToMinimum);
+        QCoreApplication::processEvents();
+
+        sink->OnBatch(MakeSyntheticBatch(streamSource, keys, valueKey, 31, 4, /*declareNewKey=*/false));
+        QCoreApplication::processEvents();
+        QCOMPARE(tableView->PendingNewRowsForTest(), 4);
+        QCOMPARE(pill->Count(), 4);
+
+        // User toggles Follow newest back on. This should drain
+        // the tally as part of suppression engaging -- semantically
+        // "I trust auto-follow more than the catch-up affordance",
+        // which means the pill announcement is no longer wanted.
+        followAction->setChecked(true);
+
+        QVERIFY2(
+            tableView->PendingNewRowsSuppressedForTest(),
+            "engaging Follow newest must mirror into the view's pending-new-rows suppression flag"
+        );
+        QCOMPARE(tableView->PendingNewRowsForTest(), 0);
+        QCOMPARE(pill->Count(), 0);
+
+        model->EndStreaming(false);
+    }
+
+    // Regression for the "pill click + custom sort" corner case:
+    // when a column sort is active and the source-newest row maps
+    // through the proxy chain to the *middle* of the visible
+    // proxy (not at the visual tail), `JumpToNewestRow`'s
+    // `scrollTo(..., PositionAtBottom)` lands the scrollbar at
+    // some intermediate value -- *not* `maximum()`. Without the
+    // explicit acknowledgement in `MainWindow`'s pill-click
+    // handler, the pill's count would stay non-zero (no at-tail
+    // edge transition fires `ResetPendingNewRows`). That means
+    // the user clicked "catch me up" and the pill *visibly* did
+    // not clear, which reads as a broken affordance.
+    //
+    // Setup: 30 rows, sort by `value` descending. In Bottom
+    // orientation (the default), sorting `value` descending puts
+    // the source-newest row (value=30) at proxy row 0 -- the
+    // visual *top* of the table. `scrollTo(PositionAtBottom)`
+    // can't get the visual top to the visual bottom (there are
+    // no rows above it), so the scroll is a no-op or close to
+    // it; `mAtTailEdge` stays false.
+    //
+    // The pill click must clear the count regardless of where
+    // the scroll lands. `MainWindow::jumpToTailRequested` calls
+    // `AcknowledgePendingNewRows` up-front exactly to handle this
+    // case.
+    void TestJumpToTailPillClickAcknowledgesUnderCustomSort()
+    {
+        auto *tableView = mWindow->findChild<LogTableView *>();
+        auto *model = mWindow->findChild<LogModel *>();
+        QAction *followAction = FindActionByObjectName(mWindow, QStringLiteral("actionFollowTail"));
+        QVERIFY(tableView != nullptr);
+        QVERIFY(model != nullptr);
+        QVERIFY(followAction != nullptr);
+        JumpToTailPill *pill = tableView->TailPillForTest();
+        QVERIFY(pill != nullptr);
+
+        // Static session keeps Follow newest out of the picture
+        // -- the regression is purely about the pill not being
+        // cleared after a click whose scroll lands short of the
+        // visual tail. Live-tail's auto-follow re-engage would
+        // otherwise mask the bug because the Follow toggle drains
+        // the tally as a side effect.
+        auto restore = qScopeGuard([this]() { mWindow->SetSessionModeForTest(MainWindow::TestSessionMode::Idle); });
+        mWindow->SetSessionModeForTest(MainWindow::TestSessionMode::Static);
+
+        loglib::StreamLineSource &streamSource = BeginSyntheticStaticSession(*model);
+        QtStreamingLogSink *sink = model->Sink();
+        QVERIFY(sink != nullptr);
+        loglib::KeyIndex &keys = sink->Keys();
+        const loglib::KeyId valueKey = keys.GetOrInsert(std::string("value"));
+
+        sink->OnBatch(MakeSyntheticBatch(streamSource, keys, valueKey, 1, 30, /*declareNewKey=*/true));
+        QCoreApplication::processEvents();
+
+        // Sort by `value` descending so source row N-1 (value=30)
+        // becomes proxy row 0 -- the visual top under Bottom
+        // orientation. A subsequent `JumpToNewestRow` then maps
+        // source-newest to proxy row 0, calls
+        // `scrollTo(PositionAtBottom)` against it, and the scroll
+        // can't move the row to the visual bottom (the row is
+        // *above* every other visible row), leaving the scrollbar
+        // short of `maximum()`.
+        const int valueCol = ColumnByHeader(*model, QStringLiteral("value"));
+        QVERIFY2(valueCol >= 0, "MakeSyntheticBatch must produce a 'value' column for the sort to target");
+        tableView->sortByColumn(valueCol, Qt::DescendingOrder);
+        QCoreApplication::processEvents();
+
+        // Park scrolled away from the (Bottom) tail and seed a
+        // pending tally via a second batch. The new rows arrive
+        // somewhere in the source order; under the descending sort
+        // they slot in *above* most existing rows, but the pill's
+        // count tracks "rows since I scrolled away" without caring
+        // where they ended up visually.
+        QScrollBar *vbar = tableView->verticalScrollBar();
+        vbar->setRange(0, 1000);
+        vbar->setValue(vbar->maximum());
+        tableView->SetTailEdge(LogTableView::TailEdge::Bottom);
+        vbar->triggerAction(QAbstractSlider::SliderToMinimum);
+        QCoreApplication::processEvents();
+
+        sink->OnBatch(MakeSyntheticBatch(streamSource, keys, valueKey, 31, 8, /*declareNewKey=*/false));
+        QCoreApplication::processEvents();
+        QVERIFY2(
+            tableView->PendingNewRowsForTest() > 0,
+            qPrintable(QStringLiteral("precondition: pill must have non-zero tally before the click; got %1")
+                           .arg(tableView->PendingNewRowsForTest()))
+        );
+
+        // Click the pill. The click handler in `MainWindow`
+        // calls `AcknowledgePendingNewRows()` up-front, before
+        // the proxy-aware scroll, so the count is cleared
+        // regardless of where the scroll actually lands.
+        pill->click();
+        QCoreApplication::processEvents();
+
+        QCOMPARE(tableView->PendingNewRowsForTest(), 0);
+        QCOMPARE(pill->Count(), 0);
+
+        model->EndStreaming(false);
+    }
+
+    // Pill keyboard accessibility: the affordance must be
+    // reachable for keyboard / screen-reader / switch-control
+    // users. `Qt::NoFocus` would have left them with no way to
+    // invoke "jump to newest" through the pill at all
+    // (`Qt::NoFocus` widgets don't accept focus, don't appear in
+    // the tab order, and can't activate via `Space` / `Enter`).
+    // `Qt::TabFocus` is the minimum that makes the click
+    // affordance keyboard-equivalent; pinning the policy here
+    // catches a future regression that loosens / tightens the
+    // policy without considering the AT impact.
+    //
+    // Also pins the live-update accessible name: screen readers
+    // poll `accessibleName`, not the visible button `text`, so
+    // a static "Jump to newest row" name (the pre-fix state)
+    // would silently swallow every count update. Asserting on
+    // the substring keeps the test robust to wording tweaks
+    // while still catching a missing live update.
+    void TestJumpToTailPillAccessibilityContract()
+    {
+        auto *tableView = mWindow->findChild<LogTableView *>();
+        auto *model = mWindow->findChild<LogModel *>();
+        QVERIFY(tableView != nullptr);
+        QVERIFY(model != nullptr);
+        JumpToTailPill *pill = tableView->TailPillForTest();
+        QVERIFY(pill != nullptr);
+
+        QCOMPARE(pill->focusPolicy(), Qt::TabFocus);
+        QVERIFY2(
+            pill->accessibleName().contains(QStringLiteral("Jump to newest row")),
+            "pill accessibleName must reference the action while the count is zero"
+        );
+
+        loglib::StreamLineSource &streamSource = BeginSyntheticStreamSession(*model);
+        QtStreamingLogSink *sink = model->Sink();
+        QVERIFY(sink != nullptr);
+        loglib::KeyIndex &keys = sink->Keys();
+        const loglib::KeyId valueKey = keys.GetOrInsert(std::string("value"));
+
+        sink->OnBatch(MakeSyntheticBatch(streamSource, keys, valueKey, 1, 30, /*declareNewKey=*/true));
+        QCoreApplication::processEvents();
+
+        QScrollBar *vbar = tableView->verticalScrollBar();
+        vbar->setRange(0, 1000);
+        vbar->setValue(vbar->maximum());
+        tableView->SetTailEdge(LogTableView::TailEdge::Bottom);
+        vbar->triggerAction(QAbstractSlider::SliderToMinimum);
+        QCoreApplication::processEvents();
+
+        sink->OnBatch(MakeSyntheticBatch(streamSource, keys, valueKey, 31, 7, /*declareNewKey=*/false));
+        QCoreApplication::processEvents();
+        QCOMPARE(pill->Count(), 7);
+
+        // Live-update path: with a non-zero count, the
+        // accessible name must include the count so screen
+        // readers convey *how many* rows are pending.
+        // Substring match: locales rephrase the sentence (and
+        // some embed `7` differently), the contract is that
+        // the digit is present in the announced name.
+        QVERIFY2(
+            pill->accessibleName().contains(QStringLiteral("7")),
+            qPrintable(QStringLiteral("pill accessibleName must include the running count for AT users; got: %1")
+                           .arg(pill->accessibleName()))
+        );
+
+        model->EndStreaming(false);
+    }
+
+    // Bug #1 corner case + #14 follow-up: when every visible row
+    // is filtered out (proxy rowCount == 0), `JumpToNewestRow`
+    // has nothing to scroll to and used to early-return without
+    // clearing the pill. The acknowledged-on-empty-proxy branch
+    // forwards through `AcknowledgePendingNewRows` so a pending
+    // tally accumulated before the filter was tightened doesn't
+    // linger across the swallow.
+    void TestJumpToNewestRowAcknowledgesWhenProxyEmpty()
+    {
+        auto *tableView = mWindow->findChild<LogTableView *>();
+        auto *model = mWindow->findChild<LogModel *>();
+        LogFilterModel *filterModel = mWindow->FilterModel();
+        QVERIFY(tableView != nullptr);
+        QVERIFY(model != nullptr);
+        QVERIFY(filterModel != nullptr);
+        JumpToTailPill *pill = tableView->TailPillForTest();
+        QVERIFY(pill != nullptr);
+
+        loglib::StreamLineSource &streamSource = BeginSyntheticStreamSession(*model);
+        QtStreamingLogSink *sink = model->Sink();
+        QVERIFY(sink != nullptr);
+        loglib::KeyIndex &keys = sink->Keys();
+        const loglib::KeyId valueKey = keys.GetOrInsert(std::string("value"));
+
+        sink->OnBatch(MakeSyntheticBatch(streamSource, keys, valueKey, 1, 30, /*declareNewKey=*/true));
+        QCoreApplication::processEvents();
+
+        // Park scrolled away and accumulate a pending count.
+        QScrollBar *vbar = tableView->verticalScrollBar();
+        vbar->setRange(0, 1000);
+        vbar->setValue(vbar->maximum());
+        tableView->SetTailEdge(LogTableView::TailEdge::Bottom);
+        vbar->triggerAction(QAbstractSlider::SliderToMinimum);
+        QCoreApplication::processEvents();
+
+        sink->OnBatch(MakeSyntheticBatch(streamSource, keys, valueKey, 31, 4, /*declareNewKey=*/false));
+        QCoreApplication::processEvents();
+        QCOMPARE(pill->Count(), 4);
+
+        // Tighten the filter to swallow every row -- proxy is
+        // now empty. The pre-fix `JumpToNewestRow` would early-
+        // return without clearing the pill in this branch.
+        const int valueCol = ColumnByHeader(*model, QStringLiteral("value"));
+        QVERIFY2(valueCol >= 0, "MakeSyntheticBatch must produce a 'value' column");
+        {
+            std::vector<loglib::RowPredicate> rules;
+            // Range that excludes every value (max < min).
+            rules.emplace_back(
+                std::in_place_type<loglib::NumericRangeRowPredicate>,
+                static_cast<size_t>(valueCol),
+                std::optional<double>{1000.0},
+                std::optional<double>{0.0}
+            );
+            filterModel->SetFilterRules(std::move(rules));
+        }
+        QCoreApplication::processEvents();
+        QCOMPARE(filterModel->rowCount(), 0);
+
+        mWindow->JumpToNewestRowForTest();
+        QCoreApplication::processEvents();
+
+        QCOMPARE(tableView->PendingNewRowsForTest(), 0);
+        QCOMPARE(pill->Count(), 0);
+
+        model->EndStreaming(false);
+    }
+
     // Alternating row colours stay off on the log table regardless
     // of newest-first orientation. Per-level theme colours already
     // partition rows; toggling alternation also used to flicker

--- a/test/app/src/main_window_test.cpp
+++ b/test/app/src/main_window_test.cpp
@@ -2750,7 +2750,7 @@ private slots:
         auto *model = mWindow->findChild<LogModel *>();
         QVERIFY(tableView != nullptr);
         QVERIFY(model != nullptr);
-        JumpToTailPill *pill = tableView->TailPillForTest();
+        const JumpToTailPill *pill = tableView->TailPillForTest();
         QVERIFY(pill != nullptr);
 
         loglib::StreamLineSource &streamSource = BeginSyntheticStreamSession(*model);
@@ -2788,7 +2788,7 @@ private slots:
         auto *model = mWindow->findChild<LogModel *>();
         QVERIFY(tableView != nullptr);
         QVERIFY(model != nullptr);
-        JumpToTailPill *pill = tableView->TailPillForTest();
+        const JumpToTailPill *pill = tableView->TailPillForTest();
         QVERIFY(pill != nullptr);
 
         loglib::StreamLineSource &streamSource = BeginSyntheticStreamSession(*model);
@@ -2842,7 +2842,7 @@ private slots:
         auto *model = mWindow->findChild<LogModel *>();
         QVERIFY(tableView != nullptr);
         QVERIFY(model != nullptr);
-        JumpToTailPill *pill = tableView->TailPillForTest();
+        const JumpToTailPill *pill = tableView->TailPillForTest();
         QVERIFY(pill != nullptr);
 
         loglib::StreamLineSource &streamSource = BeginSyntheticStreamSession(*model);
@@ -2885,7 +2885,7 @@ private slots:
         auto *model = mWindow->findChild<LogModel *>();
         QVERIFY(tableView != nullptr);
         QVERIFY(model != nullptr);
-        JumpToTailPill *pill = tableView->TailPillForTest();
+        const JumpToTailPill *pill = tableView->TailPillForTest();
         QVERIFY(pill != nullptr);
 
         loglib::StreamLineSource &streamSource = BeginSyntheticStreamSession(*model);
@@ -2984,7 +2984,7 @@ private slots:
         QCOMPARE(pill->Count(), 6);
 
         // Subscribe before triggering so the spy can see the emit.
-        QSignalSpy jumpSpy(tableView, &LogTableView::jumpToTailRequested);
+        const QSignalSpy jumpSpy(tableView, &LogTableView::jumpToTailRequested);
         QVERIFY(jumpSpy.isValid());
 
         // `QToolButton::click` triggers the same `clicked` signal a
@@ -3017,7 +3017,7 @@ private slots:
     {
         auto *tableView = mWindow->findChild<LogTableView *>();
         QVERIFY(tableView != nullptr);
-        JumpToTailPill *pill = tableView->TailPillForTest();
+        const JumpToTailPill *pill = tableView->TailPillForTest();
         QVERIFY(pill != nullptr);
 
         QCOMPARE(tableView->GetTailEdge(), LogTableView::TailEdge::Bottom);
@@ -3051,7 +3051,7 @@ private slots:
         auto *model = mWindow->findChild<LogModel *>();
         QVERIFY(tableView != nullptr);
         QVERIFY(model != nullptr);
-        JumpToTailPill *pill = tableView->TailPillForTest();
+        const JumpToTailPill *pill = tableView->TailPillForTest();
         QVERIFY(pill != nullptr);
 
         loglib::StreamLineSource &streamSource = BeginSyntheticStreamSession(*model);
@@ -3295,7 +3295,7 @@ private slots:
         QVERIFY(tableView != nullptr);
         QVERIFY(model != nullptr);
         QVERIFY(followAction != nullptr);
-        JumpToTailPill *pill = tableView->TailPillForTest();
+        const JumpToTailPill *pill = tableView->TailPillForTest();
         QVERIFY(pill != nullptr);
 
         auto restore = qScopeGuard([this]() { mWindow->SetSessionModeForTest(MainWindow::TestSessionMode::Idle); });
@@ -3354,7 +3354,7 @@ private slots:
         QVERIFY(tableView != nullptr);
         QVERIFY(model != nullptr);
         QVERIFY(followAction != nullptr);
-        JumpToTailPill *pill = tableView->TailPillForTest();
+        const JumpToTailPill *pill = tableView->TailPillForTest();
         QVERIFY(pill != nullptr);
 
         auto restore = qScopeGuard([this]() { mWindow->SetSessionModeForTest(MainWindow::TestSessionMode::Idle); });
@@ -3432,7 +3432,7 @@ private slots:
     {
         auto *tableView = mWindow->findChild<LogTableView *>();
         auto *model = mWindow->findChild<LogModel *>();
-        QAction *followAction = FindActionByObjectName(mWindow, QStringLiteral("actionFollowTail"));
+        const QAction *followAction = FindActionByObjectName(mWindow, QStringLiteral("actionFollowTail"));
         QVERIFY(tableView != nullptr);
         QVERIFY(model != nullptr);
         QVERIFY(followAction != nullptr);
@@ -3527,7 +3527,7 @@ private slots:
         auto *model = mWindow->findChild<LogModel *>();
         QVERIFY(tableView != nullptr);
         QVERIFY(model != nullptr);
-        JumpToTailPill *pill = tableView->TailPillForTest();
+        const JumpToTailPill *pill = tableView->TailPillForTest();
         QVERIFY(pill != nullptr);
 
         QCOMPARE(pill->focusPolicy(), Qt::TabFocus);
@@ -3586,7 +3586,7 @@ private slots:
         QVERIFY(tableView != nullptr);
         QVERIFY(model != nullptr);
         QVERIFY(filterModel != nullptr);
-        JumpToTailPill *pill = tableView->TailPillForTest();
+        const JumpToTailPill *pill = tableView->TailPillForTest();
         QVERIFY(pill != nullptr);
 
         loglib::StreamLineSource &streamSource = BeginSyntheticStreamSession(*model);

--- a/test/app/src/main_window_test.cpp
+++ b/test/app/src/main_window_test.cpp
@@ -2714,36 +2714,28 @@ private slots:
         model->EndStreaming(false);
     }
 
-    // The floating "jump to newest" pill is hidden by default on a
-    // fresh idle window: no rows have arrived, the user isn't
-    // scrolled away from anything, and the call-to-action would
-    // distract from the empty-state placeholder. Pins the resting
-    // state so a future change to the pill's construction order
-    // (e.g. visible-then-fade vs hidden-then-show) is caught here.
+    // Pill is hidden on a fresh idle window: no rows, no
+    // scroll-away, nothing to announce. Pins the resting state
+    // so a future change to the construction order is caught.
+    //
+    // Note: this group uses `isHidden()` instead of `!isVisible()`
+    // because under the offscreen QPA the test window is never
+    // mapped, so `isVisible()` is always false. `isHidden()`
+    // reflects the explicit `setVisible(false)` the pill ctor
+    // issues -- the production "would show if mapped" property.
     void TestJumpToTailPillHiddenOnIdle()
     {
         const auto *tableView = mWindow->findChild<LogTableView *>();
         QVERIFY(tableView != nullptr);
         const JumpToTailPill *pill = tableView->TailPillForTest();
         QVERIFY2(pill != nullptr, "log table view must construct the jump-to-tail pill");
-        // `isHidden()` rather than `!isVisible()`: under the
-        // offscreen QPA the test window is never mapped, so
-        // `isVisible()` is always false regardless of state.
-        // `isHidden()` reflects the explicit `setVisible(false)`
-        // the pill ctor issues -- the production "would show if
-        // my parent were mapped" property we actually care
-        // about. Same idiom in the rest of this group.
         QVERIFY2(pill->isHidden(), "pill must be hidden on a fresh idle window");
         QCOMPARE(pill->Count(), 0);
         QCOMPARE(tableView->PendingNewRowsForTest(), 0);
     }
 
-    // While the user is at the tail edge, inserted rows do not
-    // raise the pill: the user is (or, in live-tail with Follow,
-    // is being auto-scrolled to) the newest row already, so a
-    // "catch me up" affordance would be misleading. Drives a
-    // synthetic batch against an at-tail viewport and verifies
-    // the pill stays at zero / hidden.
+    // While the user is at the tail edge, inserted rows must not
+    // raise the pill -- they're already current.
     void TestJumpToTailPillStaysHiddenAtTail()
     {
         auto *tableView = mWindow->findChild<LogTableView *>();
@@ -2759,9 +2751,8 @@ private slots:
         loglib::KeyIndex &keys = sink->Keys();
         const loglib::KeyId valueKey = keys.GetOrInsert(std::string("value"));
 
-        // Verify we start at the tail edge. The default
-        // `TailEdge::Bottom` + empty scrollbar trivially satisfies
-        // `ComputeAtTailEdge`.
+        // Default `TailEdge::Bottom` + empty scrollbar starts us
+        // at the tail edge.
         QVERIFY(tableView->verticalScrollBar()->value() >= tableView->verticalScrollBar()->maximum());
 
         sink->OnBatch(MakeSyntheticBatch(streamSource, keys, valueKey, 1, 10, /*declareNewKey=*/true));
@@ -2775,13 +2766,11 @@ private slots:
         model->EndStreaming(false);
     }
 
-    // After a real user scroll-away from the tail, the next batch
-    // raises the pill and the count reflects the batch size. Uses
-    // the same `triggerAction(SliderToMinimum)` user-scroll
-    // simulation as `TestFollowNewestDisengagesOnScrollbarAction`
-    // so the scroll-edge state machine sees a user-flagged value
-    // change (programmatic `setValue` would be filtered out and
-    // never disengage the at-tail flag).
+    // After a user scroll-away from the tail, the next batch
+    // raises the pill with a matching count. Uses
+    // `triggerAction(SliderToMinimum)` so the scroll-edge state
+    // machine sees a user-flagged change; a plain `setValue`
+    // would be filtered out as programmatic.
     void TestJumpToTailPillSurfacesAfterScrollAway()
     {
         auto *tableView = mWindow->findChild<LogTableView *>();
@@ -2797,45 +2786,34 @@ private slots:
         loglib::KeyIndex &keys = sink->Keys();
         const loglib::KeyId valueKey = keys.GetOrInsert(std::string("value"));
 
-        // Seed with a scrollable amount of rows, then simulate a
-        // user Home press to scroll away from the bottom tail.
+        // Seed scrollable rows, then simulate a user Home press
+        // to scroll away from the bottom tail.
         sink->OnBatch(MakeSyntheticBatch(streamSource, keys, valueKey, 1, 30, /*declareNewKey=*/true));
         QCoreApplication::processEvents();
 
         QScrollBar *vbar = tableView->verticalScrollBar();
         vbar->setRange(0, 1000);
         vbar->setValue(vbar->maximum());
-        // Re-seed the at-tail flag in the view (the previous
-        // programmatic setValue may have transitioned the flag
-        // silently); production code reaches the same state via
-        // `SetTailEdge` after `ApplyDisplayOrder`.
+        // Re-seed the at-tail flag: the prior programmatic
+        // `setValue` may have transitioned it silently. Production
+        // reaches the same state via `SetTailEdge` in
+        // `ApplyDisplayOrder`.
         tableView->SetTailEdge(LogTableView::TailEdge::Bottom);
         vbar->triggerAction(QAbstractSlider::SliderToMinimum);
         QCoreApplication::processEvents();
 
-        // Next batch must surface in the pill.
         sink->OnBatch(MakeSyntheticBatch(streamSource, keys, valueKey, 31, 7, /*declareNewKey=*/false));
         QCoreApplication::processEvents();
 
         QCOMPARE(tableView->PendingNewRowsForTest(), 7);
         QCOMPARE(pill->Count(), 7);
-        // `!isHidden()` rather than `isVisible()`: under the
-        // offscreen QPA the test window is never mapped, so
-        // `isVisible()` returns false even for a pill that has
-        // been explicitly `show()`-n. `isHidden() == false` is
-        // the closest production-equivalent check ("would show
-        // if my parent were mapped"). Same idiom is used by the
-        // earlier `TestJumpToTailPillHiddenOnIdle`'s inverse
-        // (where the ctor explicitly calls `setVisible(false)`,
-        // so `isHidden()` would be true).
         QVERIFY2(!pill->isHidden(), "pill must be un-hidden after a scroll-away + batch");
 
         model->EndStreaming(false);
     }
 
-    // Two consecutive batches accumulate into the running tally
-    // -- the count is "rows since the user scrolled away", not
-    // "rows in the last batch". Pins the additive contract.
+    // The pill count accumulates across batches: it tracks "rows
+    // since you scrolled away", not "rows in the last batch".
     void TestJumpToTailPillAccumulatesAcrossBatches()
     {
         auto *tableView = mWindow->findChild<LogTableView *>();
@@ -2874,11 +2852,8 @@ private slots:
         model->EndStreaming(false);
     }
 
-    // Returning to the tail edge zeroes the counter and the pill
-    // hides. Both the user-edge transition (`SliderToMaximum`
-    // here) and the at-tail flag flip route through
-    // `ResetPendingNewRows`, so a single user scroll back catches
-    // the user up and the pill disappears.
+    // Returning to the tail edge zeroes the counter and hides
+    // the pill: a single user scroll back catches them up.
     void TestJumpToTailPillResetsOnTailReturn()
     {
         auto *tableView = mWindow->findChild<LogTableView *>();
@@ -2908,9 +2883,9 @@ private slots:
         QCoreApplication::processEvents();
         QCOMPARE(pill->Count(), 4);
 
-        // User returns to the tail edge -- `triggerAction` flags
-        // the change as user-initiated, so `OnVerticalScrollValueChanged`
-        // emits `userScrolledToTail` AND drops the pending count.
+        // User returns to the tail. `triggerAction` flags the
+        // change as user-initiated, so `OnVerticalScrollValueChanged`
+        // emits `userScrolledToTail` and drops the pending count.
         vbar->triggerAction(QAbstractSlider::SliderToMaximum);
         QCoreApplication::processEvents();
 
@@ -2920,14 +2895,10 @@ private slots:
         model->EndStreaming(false);
     }
 
-    // Clicking the pill emits `jumpToTailRequested` and the
-    // host-side wiring (`MainWindow` -> `JumpToNewestRow`) scrolls
-    // back to tail, which zeroes the counter via the same edge
-    // transition path AND re-engages Follow newest. Verifies the
-    // signal emission, the round-trip reset, and the Follow gate
-    // (the headline behaviour the click is supposed to drive in a
-    // live-tail session -- if Follow does not re-engage, the next
-    // batch would push the user behind the tail again immediately).
+    // Clicking the pill emits `jumpToTailRequested`, which the
+    // host turns into a scroll back to tail (zeroing the counter)
+    // and a Follow-newest re-engage. Without the re-engage the
+    // next batch would push the user behind the tail again.
     void TestJumpToTailPillClickJumpsAndResets()
     {
         auto *tableView = mWindow->findChild<LogTableView *>();
@@ -2939,11 +2910,9 @@ private slots:
         JumpToTailPill *pill = tableView->TailPillForTest();
         QVERIFY(pill != nullptr);
 
-        // `IsLiveTailSession()` gates the Follow re-engage on the
-        // pill-click path; without this seam call the host slot
-        // would see `Idle` and skip the re-engage even though the
-        // model is in streaming mode. Production wires the session
-        // mode through `OpenLogStream`; tests opt in explicitly.
+        // The host slot gates the Follow re-engage on
+        // `IsLiveTailSession()`; production sets the mode in
+        // `OpenLogStream`, so tests must opt in explicitly.
         auto restore = qScopeGuard([this]() { mWindow->SetSessionModeForTest(MainWindow::TestSessionMode::Idle); });
         mWindow->SetSessionModeForTest(MainWindow::TestSessionMode::LiveTail);
 
@@ -2956,10 +2925,9 @@ private slots:
         sink->OnBatch(MakeSyntheticBatch(streamSource, keys, valueKey, 1, 40, /*declareNewKey=*/true));
         QCoreApplication::processEvents();
 
-        // Follow newest defaults to on in live-tail; pin the
-        // assumption so the scroll-away assertion below is
-        // meaningful (a scroll-away on a Follow-off action would
-        // not toggle anything, masking a missing re-engage).
+        // Pin Follow on so the scroll-away assertion below is
+        // meaningful (Follow already off would mask a missing
+        // re-engage).
         followAction->setEnabled(true);
         followAction->setChecked(true);
 
@@ -2970,10 +2938,8 @@ private slots:
         vbar->triggerAction(QAbstractSlider::SliderToMinimum);
         QCoreApplication::processEvents();
 
-        // The scroll-away path is the production trigger for Follow
-        // disengaging; sanity-check the wiring fired before we test
-        // the re-engage path below. If this fails the rest of the
-        // assertions are meaningless.
+        // Sanity-check the scroll-away disengaged Follow before
+        // we exercise the re-engage path.
         QVERIFY2(
             !followAction->isChecked(),
             "scroll-away must disengage Follow newest before the click test exercises re-engage"
@@ -2983,36 +2949,27 @@ private slots:
         QCoreApplication::processEvents();
         QCOMPARE(pill->Count(), 6);
 
-        // Subscribe before triggering so the spy can see the emit.
         const QSignalSpy jumpSpy(tableView, &LogTableView::jumpToTailRequested);
         QVERIFY(jumpSpy.isValid());
 
-        // `QToolButton::click` triggers the same `clicked` signal a
-        // real mouse-up press would; the pill's lambda re-emits as
-        // `jumpToTailRequested` on the host view.
         pill->click();
         QCoreApplication::processEvents();
 
         QCOMPARE(jumpSpy.count(), 1);
-        // The host slot called `JumpToNewestRow` which issues a
-        // programmatic `scrollTo` back to the bottom -- that
-        // transitions the at-tail flag and invokes
-        // `ResetPendingNewRows`, so the counter is zero again.
+        // `JumpToNewestRow` scrolls back to the bottom; the
+        // at-tail transition fires `ResetPendingNewRows`.
         QCOMPARE(tableView->PendingNewRowsForTest(), 0);
         QCOMPARE(pill->Count(), 0);
-        // The headline behaviour: Follow newest is back on so the
-        // next batch keeps the user at the tail. The pill click is
-        // the user's "catch me up" command, not "show me the tail
-        // once and then immediately fall behind again".
+        // Follow newest must be re-engaged: the pill click is
+        // "catch me up", not "show the tail once and then fall
+        // behind again".
         QVERIFY2(followAction->isChecked(), "pill click must re-engage Follow newest in a live-tail session");
 
         model->EndStreaming(false);
     }
 
-    // `SetTailEdge(Top)` must propagate to the pill's arrow
-    // direction so the glyph reads correctly in newest-first
-    // mode. Default (Bottom) shows a down-arrow; flipping to Top
-    // must switch the rendered direction to Up.
+    // `SetTailEdge(Top)` must flip the pill arrow to Up so the
+    // glyph reads correctly in newest-first mode.
     void TestJumpToTailPillArrowFollowsTailEdge()
     {
         auto *tableView = mWindow->findChild<LogTableView *>();
@@ -3030,21 +2987,11 @@ private slots:
         QCOMPARE(pill->Direction(), JumpToTailPill::ArrowDirection::Down);
     }
 
-    // Regression: flipping the tail edge while the user is
-    // mid-scroll (not at either edge) used to leave the pill
-    // stranded with a stale count under the new arrow glyph.
-    // `SetTailEdge` gated the reset on `mAtTailEdge` -- which is
-    // false for a mid-scroll viewport in both orientations -- so
-    // a tally accumulated under `Bottom` (e.g. "↓ 5 new lines",
-    // 5 rows arrived below) would survive a flip to `Top` and
-    // render as "↑ 5 new lines" against the new orientation,
-    // misattributing both direction *and* batch boundary.
-    //
-    // The fix gates the reset on the *orientation flip* itself
-    // (`edge != mTailEdge`) in addition to the `mAtTailEdge`
-    // re-seed case. This test pins the flip-resets-tally contract
-    // by driving the exact mid-scroll-flip scenario and asserting
-    // the pending counter is zero afterwards.
+    // Regression: a tail-edge flip while the user was mid-scroll
+    // used to leave the pill showing the old direction's tally
+    // under the new arrow ("5 rows below" becoming "5 rows
+    // above"). The fix gates the reset on the orientation flip
+    // itself, not just on `mAtTailEdge`.
     void TestJumpToTailPillResetsOnEdgeFlipMidScroll()
     {
         auto *tableView = mWindow->findChild<LogTableView *>();
@@ -3063,10 +3010,9 @@ private slots:
         sink->OnBatch(MakeSyntheticBatch(streamSource, keys, valueKey, 1, 30, /*declareNewKey=*/true));
         QCoreApplication::processEvents();
 
-        // Park at the (Bottom) tail, scroll away to flip
-        // `mAtTailEdge` to false, then take a batch so the pill
-        // accumulates a count. After this dance the pill is
-        // showing a non-zero count under `Bottom` orientation.
+        // Park at the (Bottom) tail, scroll away, then take a
+        // batch so the pill ends up with a non-zero count under
+        // Bottom orientation.
         QScrollBar *vbar = tableView->verticalScrollBar();
         vbar->setRange(0, 1000);
         vbar->setValue(vbar->maximum());
@@ -3079,13 +3025,11 @@ private slots:
         QCOMPARE(tableView->PendingNewRowsForTest(), 5);
         QCOMPARE(pill->Count(), 5);
 
-        // Park the scrollbar in the middle so neither
-        // `ComputeAtTailEdge(Bottom)` nor `ComputeAtTailEdge(Top)`
-        // returns true -- this is the *exact* condition where the
-        // old gate (`if (mAtTailEdge)`) would skip the reset.
-        // `setRange` is needed because `SliderToMinimum` clamped
-        // the range to whatever Qt's view layout computed; pin it
-        // back so the mid-position math is well-defined.
+        // Park the scrollbar in the middle so neither tail edge
+        // computes as true -- the exact mid-scroll condition
+        // where the old `if (mAtTailEdge)` gate would skip the
+        // reset. `setRange` is needed because `SliderToMinimum`
+        // clamped the range to Qt's computed layout.
         vbar->setRange(0, 1000);
         vbar->setValue(500);
         QVERIFY2(
@@ -3093,10 +3037,6 @@ private slots:
             "precondition: mid-scroll viewport must not be at the Bottom tail edge before the flip"
         );
 
-        // The flip. Under the old gate the pending counter
-        // survived this call ("↑ 5 new lines" with 5 counted at
-        // the bottom). Under the fix the orientation flip itself
-        // triggers `ResetPendingNewRows`.
         tableView->SetTailEdge(LogTableView::TailEdge::Top);
 
         QCOMPARE(pill->Direction(), JumpToTailPill::ArrowDirection::Up);
@@ -3111,23 +3051,16 @@ private slots:
         model->EndStreaming(false);
     }
 
-    // `JumpToNewestRow` used to bail when the source's newest row
-    // was filtered out: it mapped `source[rowCount - 1]` through the
-    // proxy chain, got an invalid index, and returned without
-    // scrolling. The pill click would then do nothing -- a "dead"
-    // affordance under any filter that excludes the newest line, a
-    // very common case in a live tail with a level/error filter
-    // installed. The fallback added in `JumpToNewestRow` scrolls to
-    // the visual tail of the proxy (proxy row 0 in newest-first,
-    // last proxy row otherwise) when the source-newest mapping
-    // fails, so the click always moves the viewport.
+    // `JumpToNewestRow` used to bail (and the pill click do
+    // nothing) when the source's newest row was filtered out --
+    // a common live-tail + level filter case. The fallback now
+    // walks back to the first visible source row and ultimately
+    // snaps to the proxy's visual tail, so the click always
+    // moves the viewport.
     //
-    // Setup: push lines 1..30 with `value=1..30`, install a
-    // `NumericRangeRowPredicate` that excludes `value >= 26`, scroll
-    // the bar off tail, and invoke `JumpToNewestRow` directly via
-    // the test seam. The assertion is that the scrollbar reached
-    // the new (filter-shrunk) maximum -- under the old code the
-    // call early-returned and the value stayed put.
+    // Setup: push values 1..30, exclude `value >= 26`, scroll
+    // off tail, and check that `JumpToNewestRow` advances the
+    // scrollbar (vs. the pre-fix early-return that left it put).
     void TestJumpToNewestRowFallbackToVisualTailWhenFiltered()
     {
         auto *model = mWindow->findChild<LogModel *>();
@@ -3150,9 +3083,8 @@ private slots:
         const int valueCol = ColumnByHeader(*model, QStringLiteral("value"));
         QVERIFY2(valueCol >= 0, "MakeSyntheticBatch must produce a 'value' column for the filter to target");
 
-        // `value < 26` keeps source rows 1..25; rows 26..30 are
-        // filtered out. The source's *newest* row (value=30) is in
-        // the excluded set -- this is the bug condition.
+        // Exclude `value >= 26` so the source-newest row
+        // (value=30) is filtered out -- the bug condition.
         {
             std::vector<loglib::RowPredicate> rules;
             rules.emplace_back(
@@ -3167,11 +3099,10 @@ private slots:
         QCOMPARE(model->rowCount(), 30);
         QCOMPARE(filterModel->rowCount(), 25);
 
-        // Park the scrollbar away from the tail. `setRange` + a
-        // mid-range `setValue` mirrors the production "user scrolled
-        // up" state without needing a real wheel/key event for this
-        // test; we are exercising `JumpToNewestRow`'s mapping path,
-        // not the scroll-edge state machine.
+        // Park the scrollbar off tail; this test exercises
+        // `JumpToNewestRow`'s mapping path, not the scroll-edge
+        // state machine, so a plain `setRange` + `setValue` is
+        // enough.
         QScrollBar *vbar = tableView->verticalScrollBar();
         vbar->setRange(0, 1000);
         vbar->setValue(0);
@@ -3181,11 +3112,9 @@ private slots:
         mWindow->JumpToNewestRowForTest();
         QCoreApplication::processEvents();
 
-        // Under the old code this stayed at 0 (the call early-
-        // returned because `mapFromSource(source row 29)` was
-        // invalid). With the fallback we land at the proxy's
-        // visual tail -- which `scrollTo(..., AtBottom)` resolves
-        // to the scrollbar's `maximum()`.
+        // Pre-fix: stays at 0 (source-newest mapping was
+        // invalid). With the fallback we land near the proxy's
+        // visual tail.
         QVERIFY2(
             vbar->value() > valueBefore,
             qPrintable(QStringLiteral("scrollbar must move toward the visual tail when the newest source row is "
@@ -3196,28 +3125,17 @@ private slots:
         model->EndStreaming(false);
     }
 
-    // `OnVerticalScrollValueChanged` keeps `mAtTailEdge` fresh only
-    // when the scrollbar `value` changes. A row insert that grows
-    // `maximum` (without moving `value`) used to leave the flag
-    // stale: a user sitting at the previous tail with Follow off
-    // would silently fall behind, and every subsequent
-    // `OnRowsInserted` would skip the count because `mAtTailEdge`
-    // was stuck at `true`. The `rangeChanged` listener added in
-    // `LogTableView::ctor` re-evaluates the flag on every range
-    // change.
+    // A row insert that grows `maximum` without moving `value`
+    // used to leave `mAtTailEdge` stale (`OnVerticalScrollValueChanged`
+    // only fires when `value` changes), so a user at the previous
+    // tail would silently drift behind. The `rangeChanged`
+    // listener refreshes the flag without emitting user-scroll
+    // signals (a layout change must not toggle Follow newest).
     //
-    // Drives `setRange` directly (the production trigger is a
-    // model row insert that the QTableView translates into a
-    // `setRange` on the scrollbar) and asserts the flag flipped
-    // without any `userScrolled*` emission -- a layout change is
-    // not a user scroll and must not toggle Follow newest.
-    //
-    // Uses `AtTailEdgeForTest()` to observe the transition directly
-    // rather than routing through a row insert: under the offscreen
-    // QPA, the view's geometry pass after a row insert can call
-    // `setRange(0, 0)` again (no real viewport), which would
-    // immediately re-flip the flag and mask the bug under test.
-    // The seam pins the *moment* the listener fires.
+    // Drives `setRange` directly and observes via
+    // `AtTailEdgeForTest()`: a row insert under the offscreen QPA
+    // can re-call `setRange(0, 0)` during geometry and mask the
+    // bug; the seam pins the moment the listener fires.
     void TestRangeChangeFreshensAtTailFlag()
     {
         auto *tableView = mWindow->findChild<LogTableView *>();
@@ -3234,59 +3152,36 @@ private slots:
         QVERIFY(awaySpy.isValid());
         QVERIFY(toSpy.isValid());
 
-        // Grow the range without moving `value` -- the exact
-        // condition that left the flag stale before the fix. The
-        // `rangeChanged` listener must flip `mAtTailEdge` to false.
+        // Grow the range without moving `value` -- the bug
+        // condition. The listener must flip the flag to false.
         vbar->setRange(0, 500);
         QVERIFY2(
             !tableView->AtTailEdgeForTest(),
             "rangeChanged growing max must flip mAtTailEdge to false when value < newMax"
         );
 
-        // The inverse: shrinking the range back so `value >= max`
-        // again must transition the flag back to true via the same
-        // listener (covers the rare "rows removed past value"
-        // branch of `OnVerticalScrollRangeChanged`).
+        // Shrinking the range back so `value >= max` must restore
+        // the flag (the rare "rows removed past value" branch).
         vbar->setRange(0, 0);
         QVERIFY2(tableView->AtTailEdgeForTest(), "rangeChanged shrinking max back below value must restore at-tail");
 
-        // Neither transition is a user scroll -- the Follow-newest
-        // wiring would auto-disengage / re-engage on a stray
-        // emission, which is the exact regression the silent
-        // branch inside `OnVerticalScrollRangeChanged` prevents.
+        // Neither transition is a user scroll, so no
+        // `userScrolled*` signal must fire (a stray emission
+        // would auto-toggle Follow newest).
         QCOMPARE(awaySpy.count(), 0);
         QCOMPARE(toSpy.count(), 0);
     }
 
-    // Regression: under live-tail with Follow newest *engaged*,
-    // every batch used to risk a transient pill-flash. The
-    // sequence:
+    // Regression: under live-tail with Follow newest engaged,
+    // signal ordering during a row insert (`rangeChanged` ->
+    // `mAtTailEdge` to false -> our `OnRowsInserted` increments
+    // -> `lineCountChanged` -> scroll-back -> reset) used to
+    // briefly leak a count between steps 3 and 5. The fix
+    // mirrors `actionFollowTail` into `mPendingNewRowsSuppressed`
+    // so the increment short-circuits.
     //
-    //   1. Source emits `rowsInserted` for the new batch.
-    //   2. `QTableView`'s internal slot (registered before our
-    //      `OnRowsInserted` via `QTableView::setModel`) updates
-    //      geometry, calling `setRange(0, newMax)` on the
-    //      scrollbar.
-    //   3. `rangeChanged` fires synchronously ->
-    //      `OnVerticalScrollRangeChanged` flips `mAtTailEdge` to
-    //      `false` because the value is now < the new max.
-    //   4. *Our* `OnRowsInserted` runs next, sees
-    //      `mAtTailEdge == false`, and bumps the pending tally.
-    //   5. Only then does `lineCountChanged` fire, ->
-    //      `ScrollToNewestRowIfFollowing` -> `JumpToNewestRow`
-    //      scrolls back to tail and resets the tally.
-    //
-    // Steps 4-5 mean the pill briefly accumulates a count even
-    // though the user is at-tail with Follow on -- the most
-    // common live-tail steady state. Whether this flicker is
-    // *visible* depends on whether Qt's animation tick happens
-    // to land between steps 4 and 5; it's brittle either way.
-    // The fix mirrors `actionFollowTail::toggled` into the
-    // view's `mPendingNewRowsSuppressed` flag, so step 4
-    // short-circuits before incrementing.
-    //
-    // Pin: with Follow engaged, no batch should ever push the
-    // pill's count above zero, regardless of signal ordering.
+    // Pin: with Follow engaged, no batch may push the pill above
+    // zero regardless of signal ordering.
     void TestJumpToTailPillStaysZeroUnderFollowNewest()
     {
         auto *tableView = mWindow->findChild<LogTableView *>();
@@ -3308,11 +3203,9 @@ private slots:
         const loglib::KeyId valueKey = keys.GetOrInsert(std::string("value"));
 
         // Engage Follow newest and verify the suppression flag
-        // followed via the `actionFollowTail::toggled` mirror.
-        // Suppression must be active *before* the batch arrives,
-        // otherwise the very window we're trying to close (between
-        // `rangeChanged` and `JumpToNewestRow`) would still leak a
-        // count.
+        // followed. Suppression must be active *before* the
+        // batch arrives or the window we're closing would still
+        // leak a count.
         followAction->setEnabled(true);
         followAction->setChecked(true);
         QVERIFY2(
@@ -3338,14 +3231,9 @@ private slots:
         model->EndStreaming(false);
     }
 
-    // Disengaging Follow newest mid-stream releases suppression so
-    // the pill resumes counting, but a tally already accumulated
-    // by some intervening event (here: a manual `setChecked(true)`
-    // ping that exercises the suppression-flip drain) must not
-    // leak across the toggle. The `SetPendingNewRowsSuppressed`
-    // implementation calls `ResetPendingNewRows` on engage so a
-    // user toggling Follow back on while scrolled away catches
-    // them up cleanly.
+    // Toggling Follow newest back on while scrolled away with a
+    // pending tally must drain the count -- engaging suppression
+    // implies the user has acknowledged the announcement.
     void TestFollowNewestEngagingClearsPendingTally()
     {
         auto *tableView = mWindow->findChild<LogTableView *>();
@@ -3367,9 +3255,8 @@ private slots:
         const loglib::KeyId valueKey = keys.GetOrInsert(std::string("value"));
 
         // Start with Follow off so the scroll-away + batch path
-        // can accumulate a tally. The pill must surface here
-        // (this is exactly the path `TestJumpToTailPillSurfaces*`
-        // covers, just under a live-tail session).
+        // accumulates a tally (same path as
+        // `TestJumpToTailPillSurfaces*`, just under live-tail).
         followAction->setEnabled(true);
         followAction->setChecked(false);
 
@@ -3388,10 +3275,9 @@ private slots:
         QCOMPARE(tableView->PendingNewRowsForTest(), 4);
         QCOMPARE(pill->Count(), 4);
 
-        // User toggles Follow newest back on. This should drain
-        // the tally as part of suppression engaging -- semantically
-        // "I trust auto-follow more than the catch-up affordance",
-        // which means the pill announcement is no longer wanted.
+        // Toggle Follow back on. Engaging suppression must drain
+        // the tally: "I trust auto-follow more than the catch-up
+        // affordance".
         followAction->setChecked(true);
 
         QVERIFY2(
@@ -3404,30 +3290,13 @@ private slots:
         model->EndStreaming(false);
     }
 
-    // Regression for the "pill click + custom sort" corner case:
-    // when a column sort is active and the source-newest row maps
-    // through the proxy chain to the *middle* of the visible
-    // proxy (not at the visual tail), `JumpToNewestRow`'s
-    // `scrollTo(..., PositionAtBottom)` lands the scrollbar at
-    // some intermediate value -- *not* `maximum()`. Without the
-    // explicit acknowledgement in `MainWindow`'s pill-click
-    // handler, the pill's count would stay non-zero (no at-tail
-    // edge transition fires `ResetPendingNewRows`). That means
-    // the user clicked "catch me up" and the pill *visibly* did
-    // not clear, which reads as a broken affordance.
-    //
-    // Setup: 30 rows, sort by `value` descending. In Bottom
-    // orientation (the default), sorting `value` descending puts
-    // the source-newest row (value=30) at proxy row 0 -- the
-    // visual *top* of the table. `scrollTo(PositionAtBottom)`
-    // can't get the visual top to the visual bottom (there are
-    // no rows above it), so the scroll is a no-op or close to
-    // it; `mAtTailEdge` stays false.
-    //
-    // The pill click must clear the count regardless of where
-    // the scroll lands. `MainWindow::jumpToTailRequested` calls
-    // `AcknowledgePendingNewRows` up-front exactly to handle this
-    // case.
+    // Regression: under a custom sort the pill-click scroll can
+    // land short of the visual tail (the source-newest row sits
+    // in the middle of the proxy), so `mAtTailEdge` never
+    // transitions and `ResetPendingNewRows` would not fire. The
+    // host's `jumpToTailRequested` handler now acknowledges
+    // up-front so the count clears regardless of where the
+    // scroll lands.
     void TestJumpToTailPillClickAcknowledgesUnderCustomSort()
     {
         auto *tableView = mWindow->findChild<LogTableView *>();
@@ -3439,12 +3308,9 @@ private slots:
         JumpToTailPill *pill = tableView->TailPillForTest();
         QVERIFY(pill != nullptr);
 
-        // Static session keeps Follow newest out of the picture
-        // -- the regression is purely about the pill not being
-        // cleared after a click whose scroll lands short of the
-        // visual tail. Live-tail's auto-follow re-engage would
-        // otherwise mask the bug because the Follow toggle drains
-        // the tally as a side effect.
+        // Static session keeps Follow newest out of the picture:
+        // live-tail's auto re-engage would drain the tally as a
+        // side effect and mask the regression.
         auto restore = qScopeGuard([this]() { mWindow->SetSessionModeForTest(MainWindow::TestSessionMode::Idle); });
         mWindow->SetSessionModeForTest(MainWindow::TestSessionMode::Static);
 
@@ -3457,25 +3323,19 @@ private slots:
         sink->OnBatch(MakeSyntheticBatch(streamSource, keys, valueKey, 1, 30, /*declareNewKey=*/true));
         QCoreApplication::processEvents();
 
-        // Sort by `value` descending so source row N-1 (value=30)
-        // becomes proxy row 0 -- the visual top under Bottom
-        // orientation. A subsequent `JumpToNewestRow` then maps
-        // source-newest to proxy row 0, calls
-        // `scrollTo(PositionAtBottom)` against it, and the scroll
-        // can't move the row to the visual bottom (the row is
-        // *above* every other visible row), leaving the scrollbar
-        // short of `maximum()`.
+        // Sort descending so source-newest (value=30) lands at
+        // proxy row 0 -- the visual top under Bottom orientation.
+        // `JumpToNewestRow`'s `scrollTo(PositionAtBottom)` then
+        // can't move that row to the visual bottom, leaving the
+        // scrollbar short of `maximum()`.
         const int valueCol = ColumnByHeader(*model, QStringLiteral("value"));
         QVERIFY2(valueCol >= 0, "MakeSyntheticBatch must produce a 'value' column for the sort to target");
         tableView->sortByColumn(valueCol, Qt::DescendingOrder);
         QCoreApplication::processEvents();
 
-        // Park scrolled away from the (Bottom) tail and seed a
-        // pending tally via a second batch. The new rows arrive
-        // somewhere in the source order; under the descending sort
-        // they slot in *above* most existing rows, but the pill's
-        // count tracks "rows since I scrolled away" without caring
-        // where they ended up visually.
+        // Park scrolled away and seed a pending tally via a
+        // second batch. The count tracks "rows since I scrolled
+        // away" regardless of where they land visually.
         QScrollBar *vbar = tableView->verticalScrollBar();
         vbar->setRange(0, 1000);
         vbar->setValue(vbar->maximum());
@@ -3491,10 +3351,9 @@ private slots:
                            .arg(tableView->PendingNewRowsForTest()))
         );
 
-        // Click the pill. The click handler in `MainWindow`
-        // calls `AcknowledgePendingNewRows()` up-front, before
-        // the proxy-aware scroll, so the count is cleared
-        // regardless of where the scroll actually lands.
+        // Click the pill. The host handler calls
+        // `AcknowledgePendingNewRows` up-front, so the count
+        // clears regardless of where the scroll lands.
         pill->click();
         QCoreApplication::processEvents();
 
@@ -3504,23 +3363,11 @@ private slots:
         model->EndStreaming(false);
     }
 
-    // Pill keyboard accessibility: the affordance must be
-    // reachable for keyboard / screen-reader / switch-control
-    // users. `Qt::NoFocus` would have left them with no way to
-    // invoke "jump to newest" through the pill at all
-    // (`Qt::NoFocus` widgets don't accept focus, don't appear in
-    // the tab order, and can't activate via `Space` / `Enter`).
-    // `Qt::TabFocus` is the minimum that makes the click
-    // affordance keyboard-equivalent; pinning the policy here
-    // catches a future regression that loosens / tightens the
-    // policy without considering the AT impact.
-    //
-    // Also pins the live-update accessible name: screen readers
-    // poll `accessibleName`, not the visible button `text`, so
-    // a static "Jump to newest row" name (the pre-fix state)
-    // would silently swallow every count update. Asserting on
-    // the substring keeps the test robust to wording tweaks
-    // while still catching a missing live update.
+    // Accessibility contract: the pill must be keyboard-reachable
+    // (`Qt::TabFocus`) and its `accessibleName` must include the
+    // running count so AT users hear updates (Qt's bridge prefers
+    // `accessibleName` over the visible `text`). Substring match
+    // on the digit keeps the assertion robust to locale wording.
     void TestJumpToTailPillAccessibilityContract()
     {
         auto *tableView = mWindow->findChild<LogTableView *>();
@@ -3571,13 +3418,10 @@ private slots:
         model->EndStreaming(false);
     }
 
-    // Bug #1 corner case + #14 follow-up: when every visible row
-    // is filtered out (proxy rowCount == 0), `JumpToNewestRow`
-    // has nothing to scroll to and used to early-return without
-    // clearing the pill. The acknowledged-on-empty-proxy branch
-    // forwards through `AcknowledgePendingNewRows` so a pending
-    // tally accumulated before the filter was tightened doesn't
-    // linger across the swallow.
+    // When every row is filtered out, `JumpToNewestRow` has
+    // nothing to scroll to and used to leave the pill stranded.
+    // The empty-proxy branch now acknowledges so a pending tally
+    // doesn't linger across the swallow.
     void TestJumpToNewestRowAcknowledgesWhenProxyEmpty()
     {
         auto *tableView = mWindow->findChild<LogTableView *>();
@@ -3610,9 +3454,8 @@ private slots:
         QCoreApplication::processEvents();
         QCOMPARE(pill->Count(), 4);
 
-        // Tighten the filter to swallow every row -- proxy is
-        // now empty. The pre-fix `JumpToNewestRow` would early-
-        // return without clearing the pill in this branch.
+        // Tighten the filter to swallow every row. Pre-fix the
+        // empty-proxy branch left the pill alone.
         const int valueCol = ColumnByHeader(*model, QStringLiteral("value"));
         QVERIFY2(valueCol >= 0, "MakeSyntheticBatch must produce a 'value' column");
         {

--- a/test/app/src/main_window_test.cpp
+++ b/test/app/src/main_window_test.cpp
@@ -3248,9 +3248,7 @@ private slots:
         // listener (covers the rare "rows removed past value"
         // branch of `OnVerticalScrollRangeChanged`).
         vbar->setRange(0, 0);
-        QVERIFY2(
-            tableView->AtTailEdgeForTest(), "rangeChanged shrinking max back below value must restore at-tail"
-        );
+        QVERIFY2(tableView->AtTailEdgeForTest(), "rangeChanged shrinking max back below value must restore at-tail");
 
         // Neither transition is a user scroll -- the Follow-newest
         // wiring would auto-disengage / re-engage on a stray
@@ -3328,9 +3326,7 @@ private slots:
 
         QCOMPARE(tableView->PendingNewRowsForTest(), 0);
         QCOMPARE(pill->Count(), 0);
-        QVERIFY2(
-            pill->isHidden(), "pill must stay hidden across a batch in the live-tail Follow-newest steady state"
-        );
+        QVERIFY2(pill->isHidden(), "pill must stay hidden across a batch in the live-tail Follow-newest steady state");
 
         // A second batch must also stay silent -- the
         // suppression flag is sticky, not one-shot.

--- a/test/app/src/main_window_test.cpp
+++ b/test/app/src/main_window_test.cpp
@@ -7,6 +7,7 @@
 #include "filter_editor.hpp"
 #include "find_dock.hpp"
 #include "find_record_widget.hpp"
+#include "jump_to_tail_pill.hpp"
 #include "level_cell_delegate.hpp"
 #include "log_filter_model.hpp"
 #include "log_model.hpp"
@@ -2711,6 +2712,288 @@ private slots:
         );
 
         model->EndStreaming(false);
+    }
+
+    // The floating "jump to newest" pill is hidden by default on a
+    // fresh idle window: no rows have arrived, the user isn't
+    // scrolled away from anything, and the call-to-action would
+    // distract from the empty-state placeholder. Pins the resting
+    // state so a future change to the pill's construction order
+    // (e.g. visible-then-fade vs hidden-then-show) is caught here.
+    void TestJumpToTailPillHiddenOnIdle()
+    {
+        const auto *tableView = mWindow->findChild<LogTableView *>();
+        QVERIFY(tableView != nullptr);
+        const JumpToTailPill *pill = tableView->TailPillForTest();
+        QVERIFY2(pill != nullptr, "log table view must construct the jump-to-tail pill");
+        // `isHidden()` rather than `!isVisible()`: under the
+        // offscreen QPA the test window is never mapped, so
+        // `isVisible()` is always false regardless of state.
+        // `isHidden()` reflects the explicit `setVisible(false)`
+        // the pill ctor issues -- the production "would show if
+        // my parent were mapped" property we actually care
+        // about. Same idiom in the rest of this group.
+        QVERIFY2(pill->isHidden(), "pill must be hidden on a fresh idle window");
+        QCOMPARE(pill->Count(), 0);
+        QCOMPARE(tableView->PendingNewRowsForTest(), 0);
+    }
+
+    // While the user is at the tail edge, inserted rows do not
+    // raise the pill: the user is (or, in live-tail with Follow,
+    // is being auto-scrolled to) the newest row already, so a
+    // "catch me up" affordance would be misleading. Drives a
+    // synthetic batch against an at-tail viewport and verifies
+    // the pill stays at zero / hidden.
+    void TestJumpToTailPillStaysHiddenAtTail()
+    {
+        auto *tableView = mWindow->findChild<LogTableView *>();
+        auto *model = mWindow->findChild<LogModel *>();
+        QVERIFY(tableView != nullptr);
+        QVERIFY(model != nullptr);
+        JumpToTailPill *pill = tableView->TailPillForTest();
+        QVERIFY(pill != nullptr);
+
+        loglib::StreamLineSource &streamSource = BeginSyntheticStreamSession(*model);
+        QtStreamingLogSink *sink = model->Sink();
+        QVERIFY(sink != nullptr);
+        loglib::KeyIndex &keys = sink->Keys();
+        const loglib::KeyId valueKey = keys.GetOrInsert(std::string("value"));
+
+        // Verify we start at the tail edge. The default
+        // `TailEdge::Bottom` + empty scrollbar trivially satisfies
+        // `ComputeAtTailEdge`.
+        QVERIFY(tableView->verticalScrollBar()->value() >= tableView->verticalScrollBar()->maximum());
+
+        sink->OnBatch(MakeSyntheticBatch(streamSource, keys, valueKey, 1, 10, /*declareNewKey=*/true));
+        QCoreApplication::processEvents();
+        QCOMPARE(model->rowCount(), 10);
+
+        QCOMPARE(tableView->PendingNewRowsForTest(), 0);
+        QCOMPARE(pill->Count(), 0);
+        QVERIFY2(pill->isHidden(), "pill must stay hidden while the user sits at the tail edge");
+
+        model->EndStreaming(false);
+    }
+
+    // After a real user scroll-away from the tail, the next batch
+    // raises the pill and the count reflects the batch size. Uses
+    // the same `triggerAction(SliderToMinimum)` user-scroll
+    // simulation as `TestFollowNewestDisengagesOnScrollbarAction`
+    // so the scroll-edge state machine sees a user-flagged value
+    // change (programmatic `setValue` would be filtered out and
+    // never disengage the at-tail flag).
+    void TestJumpToTailPillSurfacesAfterScrollAway()
+    {
+        auto *tableView = mWindow->findChild<LogTableView *>();
+        auto *model = mWindow->findChild<LogModel *>();
+        QVERIFY(tableView != nullptr);
+        QVERIFY(model != nullptr);
+        JumpToTailPill *pill = tableView->TailPillForTest();
+        QVERIFY(pill != nullptr);
+
+        loglib::StreamLineSource &streamSource = BeginSyntheticStreamSession(*model);
+        QtStreamingLogSink *sink = model->Sink();
+        QVERIFY(sink != nullptr);
+        loglib::KeyIndex &keys = sink->Keys();
+        const loglib::KeyId valueKey = keys.GetOrInsert(std::string("value"));
+
+        // Seed with a scrollable amount of rows, then simulate a
+        // user Home press to scroll away from the bottom tail.
+        sink->OnBatch(MakeSyntheticBatch(streamSource, keys, valueKey, 1, 30, /*declareNewKey=*/true));
+        QCoreApplication::processEvents();
+
+        QScrollBar *vbar = tableView->verticalScrollBar();
+        vbar->setRange(0, 1000);
+        vbar->setValue(vbar->maximum());
+        // Re-seed the at-tail flag in the view (the previous
+        // programmatic setValue may have transitioned the flag
+        // silently); production code reaches the same state via
+        // `SetTailEdge` after `ApplyDisplayOrder`.
+        tableView->SetTailEdge(LogTableView::TailEdge::Bottom);
+        vbar->triggerAction(QAbstractSlider::SliderToMinimum);
+        QCoreApplication::processEvents();
+
+        // Next batch must surface in the pill.
+        sink->OnBatch(MakeSyntheticBatch(streamSource, keys, valueKey, 31, 7, /*declareNewKey=*/false));
+        QCoreApplication::processEvents();
+
+        QCOMPARE(tableView->PendingNewRowsForTest(), 7);
+        QCOMPARE(pill->Count(), 7);
+        // `!isHidden()` rather than `isVisible()`: under the
+        // offscreen QPA the test window is never mapped, so
+        // `isVisible()` returns false even for a pill that has
+        // been explicitly `show()`-n. `isHidden() == false` is
+        // the closest production-equivalent check ("would show
+        // if my parent were mapped"). Same idiom is used by the
+        // earlier `TestJumpToTailPillHiddenOnIdle`'s inverse
+        // (where the ctor explicitly calls `setVisible(false)`,
+        // so `isHidden()` would be true).
+        QVERIFY2(!pill->isHidden(), "pill must be un-hidden after a scroll-away + batch");
+
+        model->EndStreaming(false);
+    }
+
+    // Two consecutive batches accumulate into the running tally
+    // -- the count is "rows since the user scrolled away", not
+    // "rows in the last batch". Pins the additive contract.
+    void TestJumpToTailPillAccumulatesAcrossBatches()
+    {
+        auto *tableView = mWindow->findChild<LogTableView *>();
+        auto *model = mWindow->findChild<LogModel *>();
+        QVERIFY(tableView != nullptr);
+        QVERIFY(model != nullptr);
+        JumpToTailPill *pill = tableView->TailPillForTest();
+        QVERIFY(pill != nullptr);
+
+        loglib::StreamLineSource &streamSource = BeginSyntheticStreamSession(*model);
+        QtStreamingLogSink *sink = model->Sink();
+        QVERIFY(sink != nullptr);
+        loglib::KeyIndex &keys = sink->Keys();
+        const loglib::KeyId valueKey = keys.GetOrInsert(std::string("value"));
+
+        sink->OnBatch(MakeSyntheticBatch(streamSource, keys, valueKey, 1, 20, /*declareNewKey=*/true));
+        QCoreApplication::processEvents();
+
+        QScrollBar *vbar = tableView->verticalScrollBar();
+        vbar->setRange(0, 1000);
+        vbar->setValue(vbar->maximum());
+        tableView->SetTailEdge(LogTableView::TailEdge::Bottom);
+        vbar->triggerAction(QAbstractSlider::SliderToMinimum);
+        QCoreApplication::processEvents();
+
+        sink->OnBatch(MakeSyntheticBatch(streamSource, keys, valueKey, 21, 3, /*declareNewKey=*/false));
+        QCoreApplication::processEvents();
+        QCOMPARE(tableView->PendingNewRowsForTest(), 3);
+        QCOMPARE(pill->Count(), 3);
+
+        sink->OnBatch(MakeSyntheticBatch(streamSource, keys, valueKey, 24, 5, /*declareNewKey=*/false));
+        QCoreApplication::processEvents();
+        QCOMPARE(tableView->PendingNewRowsForTest(), 8);
+        QCOMPARE(pill->Count(), 8);
+
+        model->EndStreaming(false);
+    }
+
+    // Returning to the tail edge zeroes the counter and the pill
+    // hides. Both the user-edge transition (`SliderToMaximum`
+    // here) and the at-tail flag flip route through
+    // `ResetPendingNewRows`, so a single user scroll back catches
+    // the user up and the pill disappears.
+    void TestJumpToTailPillResetsOnTailReturn()
+    {
+        auto *tableView = mWindow->findChild<LogTableView *>();
+        auto *model = mWindow->findChild<LogModel *>();
+        QVERIFY(tableView != nullptr);
+        QVERIFY(model != nullptr);
+        JumpToTailPill *pill = tableView->TailPillForTest();
+        QVERIFY(pill != nullptr);
+
+        loglib::StreamLineSource &streamSource = BeginSyntheticStreamSession(*model);
+        QtStreamingLogSink *sink = model->Sink();
+        QVERIFY(sink != nullptr);
+        loglib::KeyIndex &keys = sink->Keys();
+        const loglib::KeyId valueKey = keys.GetOrInsert(std::string("value"));
+
+        sink->OnBatch(MakeSyntheticBatch(streamSource, keys, valueKey, 1, 25, /*declareNewKey=*/true));
+        QCoreApplication::processEvents();
+
+        QScrollBar *vbar = tableView->verticalScrollBar();
+        vbar->setRange(0, 1000);
+        vbar->setValue(vbar->maximum());
+        tableView->SetTailEdge(LogTableView::TailEdge::Bottom);
+        vbar->triggerAction(QAbstractSlider::SliderToMinimum);
+        QCoreApplication::processEvents();
+
+        sink->OnBatch(MakeSyntheticBatch(streamSource, keys, valueKey, 26, 4, /*declareNewKey=*/false));
+        QCoreApplication::processEvents();
+        QCOMPARE(pill->Count(), 4);
+
+        // User returns to the tail edge -- `triggerAction` flags
+        // the change as user-initiated, so `OnVerticalScrollValueChanged`
+        // emits `userScrolledToTail` AND drops the pending count.
+        vbar->triggerAction(QAbstractSlider::SliderToMaximum);
+        QCoreApplication::processEvents();
+
+        QCOMPARE(tableView->PendingNewRowsForTest(), 0);
+        QCOMPARE(pill->Count(), 0);
+
+        model->EndStreaming(false);
+    }
+
+    // Clicking the pill emits `jumpToTailRequested` and the
+    // host-side wiring (`MainWindow` -> `JumpToNewestRow`) scrolls
+    // back to tail, which zeroes the counter via the same edge
+    // transition path. Verifies both the signal emission and the
+    // round-trip reset.
+    void TestJumpToTailPillClickJumpsAndResets()
+    {
+        auto *tableView = mWindow->findChild<LogTableView *>();
+        auto *model = mWindow->findChild<LogModel *>();
+        QVERIFY(tableView != nullptr);
+        QVERIFY(model != nullptr);
+        JumpToTailPill *pill = tableView->TailPillForTest();
+        QVERIFY(pill != nullptr);
+
+        loglib::StreamLineSource &streamSource = BeginSyntheticStreamSession(*model);
+        QtStreamingLogSink *sink = model->Sink();
+        QVERIFY(sink != nullptr);
+        loglib::KeyIndex &keys = sink->Keys();
+        const loglib::KeyId valueKey = keys.GetOrInsert(std::string("value"));
+
+        sink->OnBatch(MakeSyntheticBatch(streamSource, keys, valueKey, 1, 40, /*declareNewKey=*/true));
+        QCoreApplication::processEvents();
+
+        QScrollBar *vbar = tableView->verticalScrollBar();
+        vbar->setRange(0, 1000);
+        vbar->setValue(vbar->maximum());
+        tableView->SetTailEdge(LogTableView::TailEdge::Bottom);
+        vbar->triggerAction(QAbstractSlider::SliderToMinimum);
+        QCoreApplication::processEvents();
+
+        sink->OnBatch(MakeSyntheticBatch(streamSource, keys, valueKey, 41, 6, /*declareNewKey=*/false));
+        QCoreApplication::processEvents();
+        QCOMPARE(pill->Count(), 6);
+
+        // Subscribe before triggering so the spy can see the emit.
+        QSignalSpy jumpSpy(tableView, &LogTableView::jumpToTailRequested);
+        QVERIFY(jumpSpy.isValid());
+
+        // `QToolButton::click` triggers the same `clicked` signal a
+        // real mouse-up press would; the pill's lambda re-emits as
+        // `jumpToTailRequested` on the host view.
+        pill->click();
+        QCoreApplication::processEvents();
+
+        QCOMPARE(jumpSpy.count(), 1);
+        // The host slot called `JumpToNewestRow` which issues a
+        // programmatic `scrollTo` back to the bottom -- that
+        // transitions the at-tail flag and invokes
+        // `ResetPendingNewRows`, so the counter is zero again.
+        QCOMPARE(tableView->PendingNewRowsForTest(), 0);
+        QCOMPARE(pill->Count(), 0);
+
+        model->EndStreaming(false);
+    }
+
+    // `SetTailEdge(Top)` must propagate to the pill's arrow
+    // direction so the glyph reads correctly in newest-first
+    // mode. Default (Bottom) shows a down-arrow; flipping to Top
+    // must switch the rendered direction to Up.
+    void TestJumpToTailPillArrowFollowsTailEdge()
+    {
+        auto *tableView = mWindow->findChild<LogTableView *>();
+        QVERIFY(tableView != nullptr);
+        JumpToTailPill *pill = tableView->TailPillForTest();
+        QVERIFY(pill != nullptr);
+
+        QCOMPARE(tableView->GetTailEdge(), LogTableView::TailEdge::Bottom);
+        QCOMPARE(pill->Direction(), JumpToTailPill::ArrowDirection::Down);
+
+        tableView->SetTailEdge(LogTableView::TailEdge::Top);
+        QCOMPARE(pill->Direction(), JumpToTailPill::ArrowDirection::Up);
+
+        tableView->SetTailEdge(LogTableView::TailEdge::Bottom);
+        QCOMPARE(pill->Direction(), JumpToTailPill::ArrowDirection::Down);
     }
 
     // Alternating row colours stay off on the log table regardless

--- a/test/common/src/log_generator.cpp
+++ b/test/common/src/log_generator.cpp
@@ -38,12 +38,8 @@ std::uint32_t MakeRandomSeed()
 
 JsonLogLine GenerateRandomJsonLogLine(std::mt19937 &rng, std::size_t lineIndex)
 {
-    // Distribution ranges intentionally match the previous in-file
-    // `GenerateRandomJsonLogs` helper (level 0-3, component 0-4) so the
-    // `[large]` / `[wide]` benchmark fixture characteristics don't drift
-    // across this refactor.
-    std::uniform_int_distribution<int> levelDist(0, 3);
-    std::uniform_int_distribution<int> componentDist(0, 4);
+    std::uniform_int_distribution<int> levelDist(0, static_cast<int>(LEVELS.size()) - 1);
+    std::uniform_int_distribution<int> componentDist(0, static_cast<int>(COMPONENTS.size()) - 1);
     std::uniform_int_distribution<int> wordDist(0, static_cast<int>(WORDS.size()) - 1);
     std::uniform_int_distribution<int> wordsCountDist(5, 20);
 

--- a/test/lib/src/benchmark_json.cpp
+++ b/test/lib/src/benchmark_json.cpp
@@ -730,8 +730,8 @@ TEST_CASE("Allocation footprint and string_view fast-path fraction", "[.][benchm
     REQUIRE(mmapSliceValues > 0);
 }
 
-// Enum auto-detection benchmark: 4 distinct `level` values across many
-// rows. Reports DictRef fraction and dictionary heap bytes.
+// Enum auto-detection benchmark: a handful of distinct `level` values
+// across many rows. Reports DictRef fraction and dictionary heap bytes.
 TEST_CASE("Stream JSON log to LogTable (enum auto-detection)", "[.][benchmark][json_parser][enum]")
 {
     BENCHMARK_REQUIRES_RELEASE_BUILD();


### PR DESCRIPTION
A floating "↓ N new lines" pill (`JumpToTailPill`) overlays the log table viewport so the existing reading-position preservation in `LogTableView` finally has a discoverable affordance. When the user is scrolled away from the configured tail edge and a new batch lands, the pill fades in with the running count of *visible* new rows; clicking it emits `LogTableView::jumpToTailRequested`, which `MainWindow` turns into a proxy-aware scroll to the newest row and (in live tail) re-engages `actionFollowTail`. Matches the Slack / YouTube / Sentry pattern -- the user finds out new content arrived without losing their reading place.

## Why

`LogTableView::SaveAnchorIfShouldPreserve` / `RestoreAnchorIfSaved` already prevent a live-tail batch from yanking the user's reading position around in newest-first mode, but the success of that preservation was *invisible*: the user scrolled away to read a row, more rows arrived at the tail, and there was no signal that the table had grown -- the only way to find out was to flip Follow newest back on and watch the viewport jump. Every comparable tool (Slack's "N new messages" banner, YouTube's "↓ new comments" pill, Sentry's "N new events" toast) ships exactly this affordance: a non-modal counter that says "there's N new things since you last looked" plus a one-click "catch me up" button.

A floating pill over the viewport (vs. a strip in the status bar or above the table) is the right shape because it stays close to where the new rows are actually accumulating: the pill points *down* toward the bottom tail in default mode, and *up* toward the top tail when newest-first is on. The user's eye is already on the table; the pill surfaces in their existing field of view rather than asking them to track a counter on a remote chrome strip.

Suppression-under-Follow-newest is the other half of the conversation: in the most common live-tail steady state the user *is* at the tail with Follow engaged, and Qt's signal ordering during a row insert can briefly drop `mAtTailEdge` between the geometry pass and the follow-up scroll-back. Without `SetPendingNewRowsSuppressed` the pill flickers once per batch in the very state where it should stay silent. Mirroring `actionFollowTail` into the view's suppression flag keeps the pill quiet in that steady state and lets it do its job the moment the user manually scrolls away.

The pill click-to-acknowledge contract (`AcknowledgePendingNewRows` called up-front, *before* the scroll) is the third subtle piece: a custom column sort can place the source-newest row anywhere in the proxy, and a tail-side filter can swallow it entirely. In either case the resulting `scrollTo(PositionAtBottom)` doesn't necessarily cross `maximum`, so the at-tail edge transition that would normally fire `ResetPendingNewRows` never lands. Acknowledging up front means the announcement clears on click regardless of where the scroll ends up -- the click itself is the user's acknowledgement of the announcement.

## What changed

**`JumpToTailPill` widget (`app/include/jump_to_tail_pill.hpp` + `app/src/jump_to_tail_pill.cpp`).** A `QToolButton` subclass styled as a rounded-rect pill via QSS resolved against `QPalette::Highlight` / `HighlightedText` so the call-to-action stays legible under every shipped theme without per-theme assets. Public surface is intentionally tiny: `SetCount(int)` drives both the displayed text and the fade animation, `SetArrowDirection(Up|Down)` re-tints + rotates the arrow to track `LogTableView::TailEdge`, and `contentSizeChanged()` lets the host re-anchor when the text width shifts.

Implementation details:

- `QGraphicsOpacityEffect` + `QPropertyAnimation` drive a 150 ms `OutQuad` fade. `SetCount(0)` fades out *and* hides the widget at the end of the animation (via `QPropertyAnimation::finished`) so the hidden pill leaves the input + accessibility trees. `FadeTo` retargets any in-flight animation so a fade-in interrupted by a fade-out (or vice versa) stays smooth instead of snapping to the previous endpoint.
- `SetCount(0)` calls `setVisible(true)` *before* fading in: a hidden widget does not paint its graphics effect, so animating opacity is a no-op visually.
- Arrow icon is the existing `:/icons/arrow-down-to-line.svg` (reused from the Follow-tail toolbar action), rendered through `icon_loader::MakeThemedPixmap` so the tint tracks `HighlightedText` across theme flips. The Up variant is the same pixmap rotated 180° via `QTransform`, so no new SVG asset is needed.
- QSS hover / pressed states branch on perceived lightness of the highlight colour (`LIGHTNESS_DARK_THEME_THRESHOLD = 0.5`). `QColor::darker` on a dark-theme highlight would pull the hover *into* the surrounding black and hide the pill; lighten on dark themes, darken on light ones, so the adjustment always *increases* contrast.
- `mApplyingPalette` re-entrancy guard breaks the implicit recursion that Qt 6 introduces by synchronously emitting `PaletteChange` / `StyleChange` from inside `setStyleSheet`. The guard is released through `qScopeGuard` and asserted at the top of `ApplyStyleSheet` (debug build) so a future caller that forgets the gate trips immediately rather than silently stack-overflowing during construction. The no-op `setStyleSheet` short-circuit avoids the bounce-through entirely when the resolved sheet hasn't actually changed.
- `changeEvent` re-runs `ApplyStyleSheet` + `RefreshIcon` on `PaletteChange` / `ApplicationPaletteChange` so theme switches refresh without restart.
- Accessibility: `setFocusPolicy(Qt::TabFocus)` keeps the pill reachable for keyboard / screen-reader / switch-control users (`Space` / `Enter` activate it via `QAbstractButton`). `accessibleDescription` carries the action and `accessibleName` carries the running count -- Qt's AT bridge prefers `accessibleName` over the visible `text`, so `RebuildText` refreshes it on every count change so screen readers actually hear the number. The arrow glyph also leads the visible text (a Unicode `↓` / `↑`) so a screen reader announcing the visible text still conveys direction.
- Translation: counts below `DISPLAYED_COUNT_CAP` (999) use `%n new lines` for plural-aware translation; past the cap the count is bounded and a plural-agnostic `%1+` is clearer for translators. English "new lines" also covers `count == 1` to avoid a 150 ms fade flicker between "1 new line" and "2 new lines"; locales with strict plural rules can still override in the catalog.

**`LogHeaderView` -- unrelated helper hoisted out of `log_table.cpp`** (`app/include/log_table_view.hpp` + `app/src/log_table_view.cpp`). The icon-only-section centring helper was already in `log_table_view.cpp` for the level icon work in #59 but lacked a class to live on. Hoisting it into a tiny `QHeaderView` subclass attaches the rule generically and keeps the diff for this branch self-contained. No behavioural change to existing call sites -- exactly the same `Qt::AlignCenter` flip happens on the same condition (icon set, text empty).

**`LogTableView` host wiring (`app/include/log_table_view.hpp` + `app/src/log_table_view.cpp`).** The view owns the pill and the pending-new-rows state machine; `MainWindow` owns the policy on top:

- Pill construction in the ctor parents `mTailPill` to `viewport()` so it overlays rows without being clipped by the grid. `QPointer` so a viewport teardown zeroes the pointer before the destructor runs. The pill's click signal forwards to a new `LogTableView::jumpToTailRequested` signal -- the view stays ignorant of proxies and `actionFollowTail`.
- `PositionTailPill` re-anchors the pill against the tail-side viewport edge (bottom for `TailEdge::Bottom`, top for `Top`), centred horizontally and clamped so a viewport narrower than the pill keeps the click target fully visible. Fired from the viewport-resize event filter (`eventFilter` watches `viewport()` for `QEvent::Resize`), from `SetTailEdge`, from `OnRowsInserted` after a count-bump, and from `JumpToTailPill::contentSizeChanged` (covers shrinking counts and the "999+" cap crossing that `OnRowsInserted` misses).
- `mPendingNewRows` accumulates *visible* (post-filter) row inserts in `OnRowsInserted` when `!mAtTailEdge && !mPendingNewRowsSuppressed`. The slot is wired to the outermost proxy, so `batch` already excludes filtered rows -- matching the user's mental model of "rows you missed since you scrolled away".
- `OnVerticalScrollValueChanged` now drops the pending tally on *any* tail-edge landing (user or programmatic), not just the user-edge transitions. Without this, a programmatic scroll-back from the pill click would land the user at the tail but leave the counter stranded until the next batch arrived.
- `OnVerticalScrollRangeChanged` is a new connection on the scrollbar's `rangeChanged`. Row inserts that grow `maximum` without moving `value` don't fire `valueChanged`, so a user sitting at the previous tail would silently drift below it and the pill counter would never arm. The handler refreshes `mAtTailEdge` against the current value but stays silent on the user-scroll signals (a range change is not a user scroll).
- `setModel` resets the pending tally before the new model attaches so it can't briefly flash with a stale count. The new `modelReset` connection covers the same path for in-place resets -- in particular `clearAllFilters` -> proxy reset which never emits `rowsRemoved`.
- `SetTailEdge` re-evaluates `mAtTailEdge` *every* call (even when `edge == mTailEdge`), updates the pill's arrow direction + re-positions, and drops the pending tally when either the orientation flipped (the count belongs to the old direction) or the re-seed lands at the new tail. Gating on `mAtTailEdge` alone would strand a mid-scroll flip with a stale count under the new arrow.
- `SetPendingNewRowsSuppressed(bool)` is mirrored from `actionFollowTail` by the host. Engaging suppression also drops the pending tally: toggling Follow back on counts as an acknowledgement of whatever announcement was showing.
- `AcknowledgePendingNewRows()` is the public clear-now hook the host uses up-front during the pill-click handler.
- `ResetPendingNewRows()` gates on `isHidden()` rather than `!isVisible()` because under the offscreen QPA used in CI tests `isVisible()` is always false even for a logically-shown widget, so it would mask the redundant-work guard. `SetCount(0)` is idempotent regardless.

**`MainWindow` policy (`app/include/main_window.hpp` + `app/src/main_window.cpp`).** Three additions, all in the constructor body so the wiring lives alongside the existing toolbar / dock construction:

- `actionFollowTail::toggled` mirrored into `mTableView->SetPendingNewRowsSuppressed`. `toggled` (not `triggered`) so a programmatic `setChecked` from the pill-click handler below takes the same path as a user toolbar click. Seeded once at the end of the ctor from the action's initial state -- the `.ui` declares Follow on by default but `toggled` only fires on changes, so without the one-shot seed the view would start un-suppressed.
- `mTableView->jumpToTailRequested` handler: `AcknowledgePendingNewRows()` *first* (clears the count even when the scroll lands short of the visual tail), then `JumpToNewestRow()`, then a re-engage of `actionFollowTail` in live-tail sessions. Keeping the policy on the host means the view stays ignorant of `IsLiveTailSession()` and the Follow action.
- `JumpToNewestRow()` is factored out of `ScrollToNewestRowIfFollowing` (which now just gates on `actionFollowTail->isChecked() && IsLiveTailSession()` and forwards). The pill click needs the proxy-aware scroll without the streaming-policy gate, so the helper covers both callers. Three-stage target resolution:
  1. Map the source-newest row through both proxy layers. Lands on the absolute newest line under sort + filter when it survives the filter.
  2. **Bounded-walk fallback.** Source-newest is filtered out (common under live tail with a level/error filter). Walk backwards from newest and take the first source row that survives the proxy. Bounded at `JUMP_FALLBACK_WALK_LIMIT = 256` so a filter excluding the entire tail can't turn an O(1) jump into an O(N) GUI-thread scan.
  3. **Visual-tail snap.** Nothing survived the walk -- snap to the proxy's visual tail (row `0` for `TailEdge::Top`, `rowCount-1` for `Bottom`) so the click always moves the viewport instead of silently doing nothing.
  When the proxy is genuinely empty (e.g. every row filtered out, no visible tail at all), call `AcknowledgePendingNewRows()` so a pending tally doesn't linger across the swallow.

  Tail direction is sourced from `mTableView->GetTailEdge()` rather than `RowOrderProxyModel::IsReversed()` -- they're kept in lockstep, but the view is what the user actually sees and the test fixtures pin the same source of truth.

**Public test seam (`MainWindow::JumpToNewestRowForTest`).** A `LOGAPP_BUILD_TESTING` wrapper around the private `JumpToNewestRow` so the filtered-newest-row fallback (stage 2) and the empty-proxy acknowledgement (stage 3) are exercisable without synthesising a real pill click + scroll round trip.

**Two `NOLINTNEXTLINE(bugprone-exception-escape)` markers on `AppendSortByEntries` (`app/src/main_window.cpp`).** clang-tidy started flagging the two `QAction::triggered` lambdas this branch wraps when the existing `vector<string>` captures became more prominent after the new pill plumbing landed; the capture copy can technically throw `bad_alloc` but the lambda body cannot recover from it inside a Qt signal handler. Adding the suppression matches the surrounding files' approach to the same diagnostic.

**`test/common/src/log_generator.cpp` -- broaden the synthetic level distribution.** `levelDist` and `componentDist` previously hard-coded the old `(0, 3)` and `(0, 4)` ranges with a comment about preserving benchmark characteristics. The pill tests want all six canonical levels (`trace` through `fatal`) to appear in the synthetic fixtures so the filter-out-the-tail path (stage 2 fallback) actually exercises the level-filter case the production caller cares about. Widened to `(0, size-1)` for both arrays; benchmark fixtures still have the same shape and distribution character (uniform over the level / component sets), just over the full canonical set rather than a partial slice. The matching docstring update in `test/lib/src/benchmark_json.cpp` swaps "4 distinct level values" for "a handful of" so a reader doesn't get confused by the now-six-values reality.

**Tests (`test/app/src/main_window_test.cpp`, +768 lines, 15 new cases).** Full lifecycle coverage:

- `TestJumpToTailPillHiddenOnIdle` -- resting state: no rows, no scroll-away, pill hidden, counter zero. Pins the construction order so a future change is caught.
- `TestJumpToTailPillStaysHiddenAtTail` -- the at-tail-with-Follow steady state: inserted rows do not raise the pill. The pre-suppression baseline this branch fixes.
- `TestJumpToTailPillSurfacesAfterScrollAway` -- after a user `SliderToMinimum` (the user-flagged path that survives the programmatic-scroll filter), the next batch raises the pill with the matching count.
- `TestJumpToTailPillAccumulatesAcrossBatches` -- count accumulates across batches ("rows since you scrolled away", not "rows in last batch").
- `TestJumpToTailPillResetsOnTailReturn` -- user `SliderToMaximum` clears the counter and hides the pill in one round trip.
- `TestJumpToTailPillClickJumpsAndResets` -- pill click fires `jumpToTailRequested` (signal-spy pin), the host's handler scrolls back to the tail, and the at-tail transition zeroes the counter.
- `TestJumpToTailPillArrowFollowsTailEdge` -- `SetTailEdge(Bottom)` / `Top` round-trips the arrow direction.
- `TestJumpToTailPillResetsOnEdgeFlipMidScroll` -- a mid-scroll orientation flip (counter currently 5) drops the pending tally so the new arrow doesn't carry a stale count from the previous direction.
- `TestJumpToNewestRowFallbackToVisualTailWhenFiltered` -- pin the stage-2 / stage-3 fallback: with a filter excluding the source-newest row, `JumpToNewestRowForTest` still advances the scrollbar to a visible row rather than bailing.
- `TestRangeChangeFreshensAtTailFlag` -- a row insert that grows `maximum` past `value` updates `mAtTailEdge` via the new `rangeChanged` hook (rather than waiting for a `valueChanged` that never fires).
- `TestJumpToTailPillStaysZeroUnderFollowNewest` -- with Follow newest engaged, an off-tail row insert never raises the pill (`mPendingNewRowsSuppressed` mirrors the action).
- `TestFollowNewestEngagingClearsPendingTally` -- engaging Follow with a non-zero pending tally drops the tally immediately (toggling Follow back on counts as an acknowledgement).
- `TestJumpToTailPillClickAcknowledgesUnderCustomSort` -- under a custom column sort placing source-newest in the middle of the proxy, the pill-click `AcknowledgePendingNewRows`-first contract clears the count even when the resulting scroll doesn't cross `maximum`.
- `TestJumpToTailPillAccessibilityContract` -- `focusPolicy == Qt::TabFocus`; `accessibleName` references the action at zero and includes the running count once non-zero (substring match on the digit so the assertion stays robust to locale rewording).
- `TestJumpToNewestRowAcknowledgesWhenProxyEmpty` -- the all-rows-filtered branch: `JumpToNewestRow` cannot scroll to any row, so it acknowledges instead of leaving the pill stranded with a stale count.

**Code review fixups -- five trailing commits.** A `feature/jump-to-tail-pill` review loop landed in this order:

- `9cc2bd7` -- ctor recursion fix (the QSS / `PaletteChange` bounce surfaced as a stack overflow on the very first construction) + the matching `mApplyingPalette` guard + assert.
- `e8df11d` -- range-aware `mAtTailEdge` + filtered-newest stage-2 fallback.
- `ee666c7` (`ee962dc7`?) -- edge-flip pending-tally reset + bounded fallback walk + i18n + asserts.
- `3b91d2a` -- acknowledge-on-click (stage 3 unification), Follow-engaged suppression (mirror from `actionFollowTail`), a11y contract (focus policy, accessible name with count, tab-reachable).
- `91922e9` -- broaden the synthetic level distribution in `test/common/src/log_generator.cpp` so the filter-out-the-tail tests actually exercise all six canonical levels.
- `f61748d` + `943ace1` + `2e39d53` -- `pre-commit` + `run-clang-tidy` sweeps over the new / heavily-modified TUs and the matching docstring tightening to match the surrounding codebase style.

## Test plan

- [x] `ctest -LE benchmark` green locally on Windows + MSVC + Release + IPO (offscreen), including the 15 new `TestJumpToTailPill*` / `TestJumpToNewestRow*` / `TestRangeChangeFreshensAtTailFlag` / `TestFollowNewestEngagingClearsPendingTally` cases.
- [x] `run-clang-tidy` over `jump_to_tail_pill.{hpp,cpp}`, `log_table_view.{hpp,cpp}`, `main_window.{hpp,cpp}`, and `main_window_test.cpp` reports zero warnings on the new code.
- [x] Manual smoke: open a JSON Lines log, scroll away from the bottom -- start a live tail (`Stream -> Open log stream`) and let new rows accumulate -- the pill fades in with `↓ N new lines` over the bottom-right of the viewport. Click the pill -- the viewport scrolls back to the newest row, the pill fades out, and Follow newest re-engages (toolbar button checked).
- [x] Manual smoke: flip *View -> Show newest lines first* -- the pill arrow flips to `↑` and re-anchors at the top edge; new rows arriving while scrolled away bump the count under the new arrow.
- [x] Manual smoke: with Follow newest engaged + sitting at the tail, watch a hot stream -- the pill never flashes during the steady state.
- [x] Manual smoke: with a level filter swallowing every row, click the pill -- nothing visible to scroll to, but the count clears immediately (no stranded "↓ 47 new lines" announcement).
- [x] Manual smoke: under a custom column sort placing newest in the middle of the proxy, click the pill -- the count clears even though the scroll lands mid-table (the explicit acknowledgement covers the case `scrollTo` doesn't cross `maximum`).
- [x] Manual smoke: tab-cycle into the pill -- it receives focus with a visible focus ring; `Space` / `Enter` activates it.
- [x] Manual smoke: switch themes via Preferences (Light <-> Dark) and via the OS theme switcher -- the pill background re-tints to the new `Highlight` colour without restart; hover stays legible (contrast adjustment branches on perceived lightness).
- [x] CI: `build-linux`, `build-macos`, `build-windows`, `clang-ci (asan-ubsan / tsan / coverage)`, `pre-commit`, CodeQL all green on this PR.
