### PR TITLE
Release v0.11.0

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.28)
 
-project(structured_log_viewer VERSION 0.10.0 LANGUAGES CXX)
+project(structured_log_viewer VERSION 0.11.0 LANGUAGES CXX)
 
 # IPO/LTO on for Release / RelWithDebInfo, off for Debug. `NOT DEFINED` gates
 # let sanitizer presets override via the cache; a plain `set(... ON)` would

--- a/README.md
+++ b/README.md
@@ -19,9 +19,9 @@ Three ingestion modes are available:
 
 - **Static mode** (`File → Open…`, drag & drop) opens one or more finished log files and parses them in parallel with the TBB pipeline. Use this for post-mortem analysis of complete logs.
 - **Stream Mode** (`File → Open Log Stream…`) tails a single file that is still being written, pre-fills the last *N* complete lines, then appends every new line as it arrives. It survives `logrotate` rotations, supports Pause / Follow newest / Stop, and bounds memory via a configurable retention cap. Use this when watching a live service.
-- **Network Stream Mode** (`File → Open Network Stream…`, `Ctrl+Shift+L`) listens on a TCP or UDP port and ingests JSON Lines pushed by your application. TCP supports many concurrent clients with line-granular interleaving and (when the binary is built with `LOGLIB_NETWORK_TLS=ON`) optional TLS via `asio::ssl`; UDP is one record per datagram and plaintext-only. Use this for distributed systems where redirecting stdout/stderr to a log file is not practical, or when you want a quick local-loopback firehose during development.
+- **Network Stream Mode** (`File → Open Network Stream…`, `Ctrl+Shift+L`) listens on a TCP or UDP port and ingests structured logs pushed by your application. TCP supports many concurrent clients with line-granular interleaving and (when the binary is built with `LOGLIB_NETWORK_TLS=ON`) optional TLS via `asio::ssl`; UDP is one record per datagram and plaintext-only. Use this for distributed systems where redirecting stdout/stderr to a log file is not practical, or when you want a quick local-loopback firehose during development.
 
-Currently, only JSON Lines (one JSON object per line) logs are supported in all three modes.
+Two structured-log formats ship out of the box: **JSON Lines / NDJSON** (one JSON object per line) and **logfmt** (the Heroku / `kr/logfmt` flavour: whitespace-separated `key=value` pairs, optionally double-quoted values). The format is auto-detected per file on `File → Open…` and per session for live tail; the Network Stream dialog has an explicit Format picker (no on-disk content to sniff).
 
 ## Application
 


### PR DESCRIPTION
## Summary

- Bump `project(... VERSION ...)` in `CMakeLists.txt` from **0.10.0** to **0.11.0** to cover the logfmt support shipped since v0.10.0: `LogfmtParser` as a first-class peer of `JsonParser` (#63) and the multi-format `log_generator` + cross-format benchmark harness (#64).
- Refresh the root `README.md` so it stops describing the viewer as JSON-only — `doc/README.md` and `CONTRIBUTING.md` were already updated as part of #63 and #64.

## Doc changes

- `README.md` (root):
  - **Network Stream Mode** bullet: replace "ingests JSON Lines pushed by your application" with "ingests structured logs pushed by your application"; the per-mode behaviour (TCP many-clients + optional TLS, UDP one-record-per-datagram + plaintext-only, retention cap, etc.) is unchanged.
  - Replace the "Currently, only JSON Lines (one JSON object per line) logs are supported in all three modes" line with a short paragraph naming both shipped formats — JSON Lines / NDJSON and logfmt (Heroku / `kr/logfmt` flavour, whitespace-separated `key=value` pairs, optional double-quoted values) — and noting how the format is selected (auto-detected per file on `File → Open…` and per session for live tail; explicit Format picker in the Network Stream dialog because there is no on-disk content to sniff).
- No `doc/README.md` or `CONTRIBUTING.md` changes in this PR — those are already up to date:
  - **Format coverage** in `doc/README.md` (Supported Input Formats, Static Mode picker, Network Stream Format combobox, Troubleshooting "Failed to parse / No valid log data found") and in the `CONTRIBUTING.md` library overview already document logfmt as a first-class peer of JSON Lines (#63).
  - **`Adding a New Structured Log Format`** in `CONTRIBUTING.md` already covers the new `LogParserFactory` thunk on `LogModel::BeginStreaming`, per-file format sniffing in `MainWindow::DetectFormatForPath`, and the `Source::Format` round-trip on saved sessions; the **Generator + fixtures** sub-bullet already lists the `test_common::LogFormat` serializer factory + the three things that fall out for free (`TestStructuredLogFile`, `log_generator --format <fmt>`, a `benchmark_<fmt>.cpp` mirroring `benchmark_logfmt.cpp`) (#64).
  - **Fixture inventory** in `CONTRIBUTING.md` is already the 14-row table that pairs `[json_parser][large]` ↔ `[logfmt_parser][large]` and `[json_parser][wide]` ↔ `[logfmt_parser][wide]` with their pinned-seed annotations (`LARGE_FIXTURE_SEED` / `WIDE_FIXTURE_SEED` + `DeterministicBenchmarkTimestamps()`) so cross-format `lines/s` is directly comparable (#64).

## Test plan

- [x] CI green on this branch (build + tests + packaging on Linux / Windows / macOS — the workflow triggers on `release/**` per `.github/workflows/build.yml`).
- [x] `pre-commit run --files CMakeLists.txt README.md` clean locally.
- [x] After merge, tag `v0.11.0` on the merge commit and push — the `Build` workflow runs on the tag and attaches AppImage / ZIP / DMG artifacts to a fresh GitHub Release.
