### PR TITLE
Release v0.13.0

### DIFF
--- a/test/lib/src/common.cpp
+++ b/test/lib/src/common.cpp
@@ -10,6 +10,7 @@
 #include <date/tz.h>
 
 #include <cassert>
+#include <cstdint>
 #include <filesystem>
 #include <fstream>
 #include <random>
@@ -22,6 +23,42 @@ using namespace loglib;
 
 namespace
 {
+
+// Per-process scratch directory under `std::filesystem::temp_directory_path()`.
+// Bare relative fixture names (e.g. `"test_file.json"`,
+// `"regex_templates_<template>.log"`) resolve inside this directory so ad-hoc
+// runs of a test binary from the workspace root can't leak stray files into
+// the source tree. The random suffix keeps parallel `ctest -j` runs (and
+// concurrent test binaries) from colliding on a fixed path; the directory
+// itself is not removed at process exit because individual fixtures already
+// remove their own files in their dtors and the OS reclaims the empty dir
+// on its usual temp-cleanup cadence.
+const std::filesystem::path &ScratchDir()
+{
+    static const std::filesystem::path SCRATCH_DIR = [] {
+        std::random_device rd;
+        std::mt19937_64 gen(rd());
+        const std::uint64_t suffix = gen();
+        auto path = std::filesystem::temp_directory_path() / ("loglib_tests_" + std::to_string(suffix));
+        std::error_code ec;
+        std::filesystem::create_directories(path, ec);
+        return path;
+    }();
+    return SCRATCH_DIR;
+}
+
+// Resolve a caller-supplied path to a concrete on-disk location. Absolute
+// paths pass through unchanged (a small number of tests deliberately point
+// at fixed OS-temp locations); everything else lands inside `ScratchDir()`.
+std::string ResolveScratchPath(std::string filePath)
+{
+    std::filesystem::path fsPath(filePath);
+    if (fsPath.is_absolute())
+    {
+        return filePath;
+    }
+    return (ScratchDir() / fsPath).string();
+}
 
 // Open @p fsPath for binary writing (no '\n' translation, so offsets match
 // `LogFile`), emit the format header if non-empty, and return the stream.
@@ -41,15 +78,16 @@ std::ofstream OpenStructuredFile(
 
 // Resolve the on-disk fixture name: explicit `filePath` wins, otherwise
 // `test<format-extension>` (so different-format fixtures don't collide).
+// Both branches then land inside `ScratchDir()` via `ResolveScratchPath`.
 std::string ResolveStructuredFilePath(std::string filePath, const test_common::LogFormat &format)
 {
     if (!filePath.empty())
     {
-        return filePath;
+        return ResolveScratchPath(std::move(filePath));
     }
     std::string derived = "test";
     derived.append(format.suggestedExtension);
-    return derived;
+    return ResolveScratchPath(std::move(derived));
 }
 
 } // namespace
@@ -133,7 +171,7 @@ const std::vector<test_common::LogRecord> &TestStructuredLogFile::Records() cons
 }
 
 TestLogConfiguration::TestLogConfiguration(std::string filePath)
-    : mFilePath(std::move(filePath)), mFsPath(mFilePath)
+    : mFilePath(ResolveScratchPath(std::move(filePath))), mFsPath(mFilePath)
 {
     const std::ofstream file(mFsPath);
     REQUIRE(file.is_open());
@@ -169,7 +207,7 @@ const std::string &TestLogFile::GetFilePath() const
 }
 
 TestLogFile::TestLogFile(std::string filePath)
-    : mFilePath(std::move(filePath)), mFsPath(mFilePath)
+    : mFilePath(ResolveScratchPath(std::move(filePath))), mFsPath(mFilePath)
 {
     const std::ofstream file(mFsPath, std::ios::binary);
     REQUIRE(file.is_open());

--- a/test/lib/src/common.cpp
+++ b/test/lib/src/common.cpp
@@ -52,7 +52,7 @@ const std::filesystem::path &ScratchDir()
 // at fixed OS-temp locations); everything else lands inside `ScratchDir()`.
 std::string ResolveScratchPath(std::string filePath)
 {
-    std::filesystem::path fsPath(filePath);
+    const std::filesystem::path fsPath(filePath);
     if (fsPath.is_absolute())
     {
         return filePath;

--- a/test/lib/src/test_log_line.cpp
+++ b/test/lib/src/test_log_line.cpp
@@ -36,7 +36,10 @@ TEST_CASE("Construct LogLine with valid values and file reference", "[log_line]"
     CHECK(std::holds_alternative<std::monostate>(line.GetValue("key6")));
 
     REQUIRE(line.Source() != nullptr);
-    CHECK(line.Source()->Path() == "test_file.json");
+    // `TestLogFile` resolves the fixture under a per-process scratch dir, so
+    // compare against the fixture's own resolved path rather than the bare
+    // filename literal.
+    CHECK(line.Source()->Path() == testLogFile.GetFilePath());
     CHECK(line.LineId() == 1);
     CHECK(line.Source()->RawLine(line.LineId()) == "efgh");
 


### PR DESCRIPTION
## Summary

Cut **v0.13.0** to cover the regex-template log format shipped since v0.12.0: `RegexParser` as the fourth first-class peer of `JsonParser` / `LogfmtParser` / `CsvParser`, the 27-entry built-in catalog under `library/data/regex_templates/*.json`, the `Settings → Regex templates...` editor, and the `Regex template` + `Custom...` picker in the Network Stream dialog (#68).

The `CMakeLists.txt` version bump (`0.12.0 → 0.13.0`) and the matching `README.md` / `doc/README.md` / `CONTRIBUTING.md` / `ROADMAP.md` refresh already landed on `main` as part of #68, so this branch ships **no** version or doc churn on top of `main`.

## Test-side polish

Route the three shared file fixtures (`TestLogFile` / `TestStructuredLogFile` / `TestLogConfiguration`) through a per-process `ScratchDir()` under `std::filesystem::temp_directory_path()`. Without it, invoking a test binary directly from the workspace root (rather than through `ctest`'s pinned `WORKING_DIRECTORY`) leaks `test_file.json`, `test.jsonl`, and up to 27 `regex_templates_<name>.log` files (one per built-in template) into the source tree. Mirrors the existing `TempDir` idiom in `test_tailing_bytes_producer.cpp` / `benchmark_stream.cpp` / `test_tcp_server_producer_tls.cpp`. `GetFilePath()` returns the resolved path so `ParseFile` / `LogFile` consumers work unchanged; the one stale assertion in `test_log_line.cpp` that hard-coded `"test_file.json"` was updated to compare against the fixture's resolved path.

## Test plan

- [x] `ctest --preset debug` green locally on Windows + MSVC + Debug + offscreen Qt after the scratch-dir refactor.
- [x] `pre-commit run --files test/lib/src/common.cpp test/lib/src/test_log_line.cpp` clean locally.
- [x] Manual smoke: `.\tests.exe "[regex_templates]"` from the workspace root -- fixtures land in `%TEMP%/loglib_tests_<random>/` and `git status` stays clean.
- [x] CI: `build-linux`, `build-macos`, `build-windows`, `clang-ci (asan-ubsan / tsan / coverage)`, `pre-commit`, CodeQL all green on this PR.
- [x] After merge, tag `v0.13.0` on the merge commit and push -- the `Build` workflow attaches AppImage / ZIP / DMG (with `.sha256` sidecars + `.zsync` for the AppImage) to a fresh `v0.13.0` GitHub Release.
