### PR TITLE
Add match overview rail / minimap

### DIFF
--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -152,14 +152,14 @@
         },
         {
             "name": "clang-tsan",
-            "displayName": "TSan tests (excludes benchmarks and apptest)",
-            "description": "Runs the loglib unit tests + apptest_queue under ThreadSanitizer. Excludes apptest by name regex because Qt's internal mutexes generate false positives that drown the signal; the threading code worth testing (TBB pipeline, StreamLineSource, TailingBytesProducer, LogModel::Reset teardown, BoundedBatchQueue) lives in the tests that still run.",
+            "displayName": "TSan tests (excludes benchmarks, apptest and apptest_overview_rail)",
+            "description": "Runs the loglib unit tests + apptest_queue under ThreadSanitizer. Excludes the Qt-coupled apptest and apptest_overview_rail suites by name regex because Qt's raster thread pool and private mutexes generate false positives that drown the signal (e.g. concurrent QArrayData allocations on the pooled paint workers spawned by QWidget::show()). The threading code worth testing (TBB pipeline, StreamLineSource, TailingBytesProducer, LogModel::Reset teardown, BoundedBatchQueue) lives in the tests that still run.",
             "configurePreset": "clang-tsan",
             "inherits": "_test_base",
             "filter": {
                 "exclude": {
                     "label": "benchmark",
-                    "name": "^apptest$"
+                    "name": "^apptest(_overview_rail)?$"
                 }
             },
             "environment": {

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -254,9 +254,9 @@ When the user opens `app.log`, also surface `app.log.1`, `app.log.2`, `app.log.1
 
 Sessions already persist a single filter set. Real triage needs a small library of named presets: `@errors`, `@my-service`, `@slow-requests`, swappable from a dropdown next to the filter bar. The chosen "view" applies its filters + sort + visible-column set in one click. Views live in a new section of the user configuration; the global library lives under `<AppDataLocation>/views/*.json` with the same shadowing rules as themes and regex templates.
 
-### 13. Match overview rail / minimap
+### 13. ~~Match overview rail / minimap~~
 
-A vertical colour strip to the right of the scrollbar showing where in the source the matches, anchors, errors, and high-severity rows are. Klogg's overview rail and Logan's minimap are the references. Cheap to render once the level / match indices exist; reuses the histogram's bucket data structure ([item 2](#2-histogram--activity-rate-strip)) tilted 90°.
+> **Shipped.** `OverviewRailWidget` renders a thin vertical strip to the right of the table's viewport (Qt Creator gutter model, reserved via `QAbstractScrollArea::setViewportMargins`), showing where in the proxy stream matches, anchors, and level-coloured bands sit. Width tracks `QStyle::PM_ScrollBarExtent` so it scales cleanly across DPI / style changes; the viewport indicator mirrors the visible slice and supports click / drag / wheel to jump the table (coalesced through `MainWindow::ScrollToProxyRow`). On by default; toggle from **View → Overview Rail** or `Ctrl+Shift+O`; state persists in `QSettings`. Backing bits: `OverviewRailModel` (bucketed index over proxy rows, reuses `loglib::LevelBucket` for level counts, subscribes to `rowsInserted` / `rowsRemoved` / `modelReset` / `layoutChanged` / `AnchorManager` signals with a 50 ms coalesce timer), `LogTableView::AttachOverviewRail` (viewport-margin hook with `sizeHint` → `minimumSizeHint` → `width` fallback for width resolution), and `MainWindow` wiring that pushes `mFindMatchCache` results into the model on every rebuild / invalidation / FindDock open-close. See [`doc/README.md § Match overview rail`](doc/README.md#match-overview-rail) for the user-facing surface.
 
 ### 14. Per-cell quick filter
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -256,7 +256,7 @@ Sessions already persist a single filter set. Real triage needs a small library 
 
 ### 13. ~~Match overview rail / minimap~~
 
-> **Shipped.** `OverviewRailWidget` renders a thin vertical strip to the right of the table's viewport (Qt Creator gutter model, reserved via `QAbstractScrollArea::setViewportMargins`), showing where in the proxy stream matches, anchors, and level-coloured bands sit. Width tracks `QStyle::PM_ScrollBarExtent` so it scales cleanly across DPI / style changes; the viewport indicator mirrors the visible slice and supports click / drag / wheel to jump the table (coalesced through `MainWindow::ScrollToProxyRow`). On by default; toggle from **View → Overview Rail** or `Ctrl+Shift+O`; state persists in `QSettings`. Backing bits: `OverviewRailModel` (bucketed index over proxy rows, reuses `loglib::LevelBucket` for level counts, subscribes to `rowsInserted` / `rowsRemoved` / `modelReset` / `layoutChanged` / `AnchorManager` signals with a 50 ms coalesce timer), `LogTableView::AttachOverviewRail` (viewport-margin hook with `sizeHint` → `minimumSizeHint` → `width` fallback for width resolution), and `MainWindow` wiring that pushes `mFindMatchCache` results into the model on every rebuild / invalidation / FindDock open-close. See [`doc/README.md § Match overview rail`](doc/README.md#match-overview-rail) for the user-facing surface.
+> **Shipped.** Vertical strip to the right of the table showing matches, anchors, and level-coloured bands over the whole proxy stream, with a click / drag / wheel viewport indicator. On by default; toggle from **View → Overview Rail** (`Ctrl+Shift+O`). See [`doc/README.md § Match overview rail`](doc/README.md#match-overview-rail).
 
 ### 14. Per-cell quick filter
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -256,7 +256,7 @@ Sessions already persist a single filter set. Real triage needs a small library 
 
 ### 13. ~~Match overview rail / minimap~~
 
-> **Shipped.** Vertical strip to the right of the table showing matches, anchors, and level-coloured bands over the whole proxy stream, with a click / drag / wheel viewport indicator. On by default; toggle from **View → Overview Rail** (`Ctrl+Shift+O`). See [`doc/README.md § Match overview rail`](doc/README.md#match-overview-rail).
+> **Shipped.** Vertical strip to the right of the table showing matches, anchors, and level-coloured bands over the whole proxy stream, with a click / drag / wheel viewport indicator. On by default; toggle from **View → Overview Rail** (`Ctrl+Shift+R`). See [`doc/README.md § Match overview rail`](doc/README.md#match-overview-rail).
 
 ### 14. Per-cell quick filter
 

--- a/app/CMakeLists.txt
+++ b/app/CMakeLists.txt
@@ -34,6 +34,10 @@ set(PROJECT_SOURCES
     include/histogram_model.hpp
     src/histogram_widget.cpp
     include/histogram_widget.hpp
+    src/overview_rail_model.cpp
+    include/overview_rail_model.hpp
+    src/overview_rail_widget.cpp
+    include/overview_rail_widget.hpp
     src/icon_loader.cpp
     include/icon_loader.hpp
     src/jump_to_tail_pill.cpp

--- a/app/include/find_record_widget.hpp
+++ b/app/include/find_record_widget.hpp
@@ -43,13 +43,10 @@ public slots:
     ///   buttons don't jitter).
     /// - `current <= 0`: shows "*N* matches".
     /// - `current > 0`: shows "*i* of *N*".
-    /// - `overflowed`: appends "+" to `total` so the user sees the
-    ///   count as a lower bound (scan may have early-exited once
-    ///   every rail bucket had a hit and the cursor-position cache
-    ///   was full), and installs a tooltip explaining both effects
-    ///   — visible text alone used to be ambiguous between "*at
-    ///   least* N matches" and "*exactly* N matches but position
-    ///   lookup is degraded".
+    /// - `overflowed`: appends "+" to `total` (count is a lower
+    ///   bound) and installs a tooltip explaining that the
+    ///   current-match index may read as 0 once the scan
+    ///   early-exits past the cursor-position cache.
     void SetMatchInfo(int current, int total, bool overflowed = false);
 
     /// Close the host `QDockWidget`. Wired to Escape; no-op when not
@@ -70,9 +67,9 @@ signals:
 
 public:
     /// Catches Return / Shift+Return on `mEdit` before `QLineEdit`
-    /// handles them. Plain Return must be consumed here: `QLineEdit`
-    /// ignores the key after `returnPressed`, so a parent
-    /// `keyPressEvent` would otherwise fire FindNext a second time.
+    /// handles them. `QLineEdit` emits `returnPressed` but then
+    /// ignores the key, so without this filter the parent
+    /// `keyPressEvent` would fire FindNext a second time.
     /// Public to match `QObject::eventFilter`'s visibility.
     bool eventFilter(QObject *watched, QEvent *event) override;
 

--- a/app/include/find_record_widget.hpp
+++ b/app/include/find_record_widget.hpp
@@ -69,9 +69,10 @@ signals:
     void MatchCountRequested(const QString &text, bool wildcards, bool regularExpressions);
 
 public:
-    /// Catches `Shift+Return` on `mEdit` before `QLineEdit` swallows
-    /// it; `returnPressed` is modifier-agnostic and `keyPressEvent`
-    /// doesn't bubble, so the filter is the only way to wire find-prev.
+    /// Catches Return / Shift+Return on `mEdit` before `QLineEdit`
+    /// handles them. Plain Return must be consumed here: `QLineEdit`
+    /// ignores the key after `returnPressed`, so a parent
+    /// `keyPressEvent` would otherwise fire FindNext a second time.
     /// Public to match `QObject::eventFilter`'s visibility.
     bool eventFilter(QObject *watched, QEvent *event) override;
 

--- a/app/include/find_record_widget.hpp
+++ b/app/include/find_record_widget.hpp
@@ -43,8 +43,13 @@ public slots:
     ///   buttons don't jitter).
     /// - `current <= 0`: shows "*N* matches".
     /// - `current > 0`: shows "*i* of *N*".
-    /// - `overflowed`: appends "+" so the user can tell the count was
-    ///   capped rather than landing exactly at the cap.
+    /// - `overflowed`: appends "+" to `total` so the user sees the
+    ///   count as a lower bound (scan may have early-exited once
+    ///   every rail bucket had a hit and the cursor-position cache
+    ///   was full), and installs a tooltip explaining both effects
+    ///   — visible text alone used to be ambiguous between "*at
+    ///   least* N matches" and "*exactly* N matches but position
+    ///   lookup is degraded".
     void SetMatchInfo(int current, int total, bool overflowed = false);
 
     /// Close the host `QDockWidget`. Wired to Escape; no-op when not

--- a/app/include/log_filter_model.hpp
+++ b/app/include/log_filter_model.hpp
@@ -14,6 +14,7 @@
 #include <QVariant>
 
 #include <cstddef>
+#include <functional>
 #include <unordered_map>
 #include <vector>
 
@@ -60,7 +61,14 @@ public:
     [[nodiscard]] static Qt::MatchFlags ComposeFindFlags(bool wildcards, bool regularExpressions);
 
     /// Find proxy-coord rows whose cell matches @p value under @p role.
-    /// Returns up to @p hits matches (all when `UNLIMITED_HITS`).
+    /// Returns up to @p hits matches. `hits` must be either
+    /// `UNLIMITED_HITS` (return every match) or `>= 1`; `0` is
+    /// rejected via `Q_ASSERT` (asking for zero results is a
+    /// programming error, and the wrapper's stop-condition
+    /// `size < hits` would otherwise stop after the first match
+    /// under `hits == 0`, which is a silent behaviour change
+    /// from the previous "0 == all" alias — force callers to
+    /// pick a real value instead).
     QList<QModelIndex> MatchRow(
         const QModelIndex &start,
         int role,
@@ -69,6 +77,30 @@ public:
         Qt::MatchFlags flags = Qt::MatchStartsWith | Qt::MatchWrap,
         bool forward = true,
         int skipFirstN = 0
+    ) const;
+
+    /// Callback invoked once per matching proxy-coord row in
+    /// `ForEachMatchingRow`. Returning `true` continues the walk;
+    /// returning `false` stops it. Only one cell per row is
+    /// reported (the first matching column in scan order), mirroring
+    /// `MatchRow`.
+    using MatchRowCallback = std::function<bool(const QModelIndex &proxyIndex)>;
+
+    /// Iterate matching proxy-coord rows via a callback rather than
+    /// materialising them into a `QList<QModelIndex>`. Same probe
+    /// semantics as `MatchRow` (hidden columns skipped, `MatchWrap`
+    /// honoured, `DisplayRole` fast path through `LogTable`), but
+    /// avoids the O(matches) list allocation when the caller only
+    /// needs to accumulate aggregates (per-bucket counters, total
+    /// count). `MatchRow` is now a thin wrapper on top of this.
+    void ForEachMatchingRow(
+        const QModelIndex &start,
+        int role,
+        const QVariant &value,
+        Qt::MatchFlags flags,
+        bool forward,
+        int skipFirstN,
+        const MatchRowCallback &onMatch
     ) const;
 
     /// Replace the active predicate list and rebuild the row map.

--- a/app/include/log_filter_model.hpp
+++ b/app/include/log_filter_model.hpp
@@ -62,13 +62,9 @@ public:
 
     /// Find proxy-coord rows whose cell matches @p value under @p role.
     /// Returns up to @p hits matches. `hits` must be either
-    /// `UNLIMITED_HITS` (return every match) or `>= 1`; `0` is
-    /// rejected via `Q_ASSERT` (asking for zero results is a
-    /// programming error, and the wrapper's stop-condition
-    /// `size < hits` would otherwise stop after the first match
-    /// under `hits == 0`, which is a silent behaviour change
-    /// from the previous "0 == all" alias — force callers to
-    /// pick a real value instead).
+    /// `UNLIMITED_HITS` (all) or `>= 1`; `0` is rejected via
+    /// `Q_ASSERT` because the stop-condition `size < hits` would
+    /// otherwise silently stop after the first match.
     QList<QModelIndex> MatchRow(
         const QModelIndex &start,
         int role,
@@ -79,20 +75,17 @@ public:
         int skipFirstN = 0
     ) const;
 
-    /// Callback invoked once per matching proxy-coord row in
-    /// `ForEachMatchingRow`. Returning `true` continues the walk;
-    /// returning `false` stops it. Only one cell per row is
-    /// reported (the first matching column in scan order), mirroring
+    /// Callback for `ForEachMatchingRow`, invoked once per matching
+    /// proxy-coord row. Return `true` to continue, `false` to stop.
+    /// Only the first matching column per row is reported, matching
     /// `MatchRow`.
     using MatchRowCallback = std::function<bool(const QModelIndex &proxyIndex)>;
 
-    /// Iterate matching proxy-coord rows via a callback rather than
-    /// materialising them into a `QList<QModelIndex>`. Same probe
-    /// semantics as `MatchRow` (hidden columns skipped, `MatchWrap`
-    /// honoured, `DisplayRole` fast path through `LogTable`), but
-    /// avoids the O(matches) list allocation when the caller only
-    /// needs to accumulate aggregates (per-bucket counters, total
-    /// count). `MatchRow` is now a thin wrapper on top of this.
+    /// Iterate matching proxy-coord rows via a callback instead of
+    /// building a `QList<QModelIndex>`. Same probe semantics as
+    /// `MatchRow`, but avoids the O(matches) list allocation when
+    /// the caller only accumulates aggregates. `MatchRow` is a thin
+    /// wrapper on top of this.
     void ForEachMatchingRow(
         const QModelIndex &start,
         int role,

--- a/app/include/log_table_view.hpp
+++ b/app/include/log_table_view.hpp
@@ -12,7 +12,6 @@
 #include <QStyleOptionHeader>
 #include <QTableView>
 
-#include <cstdint>
 #include <vector>
 
 /// Horizontal header that centres the icon in icon-only sections
@@ -91,6 +90,30 @@ public:
     /// crossing `maximum`).
     void AcknowledgePendingNewRows();
 
+    /// Reserve the right viewport margin for an overview rail
+    /// widget. Passing nullptr detaches the current rail and
+    /// reclaims the strip. When @p rail is non-null it is
+    /// reparented to `this`, positioned inside the reserved
+    /// margin, and its geometry is tracked via `resizeEvent` /
+    /// `changeEvent(StyleChange, ScreenChangeInternal)`. The
+    /// previously-attached rail (if any) is hidden and detached
+    /// but not deleted — ownership is the caller's.
+    void AttachOverviewRail(QWidget *rail);
+
+    /// Currently-attached overview rail (nullptr when detached).
+    /// Non-owning.
+    [[nodiscard]] QWidget *OverviewRail() const noexcept
+    {
+        return mOverviewRail.data();
+    }
+
+    /// Current reserved right-margin width in device-independent
+    /// px (0 when no rail is attached). Exposed for tests.
+    [[nodiscard]] int ReservedRightMargin() const noexcept
+    {
+        return mReservedRightMargin;
+    }
+
 public slots:
     void CopySelectedRowsToClipboard();
 
@@ -140,12 +163,25 @@ protected:
     /// Mark the next `valueChanged` as user-initiated.
     void wheelEvent(QWheelEvent *event) override;
 
+    /// Repositions the overview rail (if attached) and forwards
+    /// to the base class for the standard scroll-area layout.
+    void resizeEvent(QResizeEvent *event) override;
+
+    /// Refreshes the reserved right margin on style / screen /
+    /// font changes so a DPI-fluent rail resizes with the
+    /// platform's scrollbar extent.
+    void changeEvent(QEvent *event) override;
+
     /// Watches the viewport for resize events so the floating pill
     /// stays glued to the tail-side edge without subclassing the
     /// viewport.
     bool eventFilter(QObject *watched, QEvent *event) override;
 
 private:
+    /// Refresh the reserved right margin from the currently
+    /// attached rail's `sizeHint().width()` and reposition it to
+    /// span the viewport height. No-op when no rail is attached.
+    void UpdateOverviewRailGeometry();
     void OnVerticalScrollValueChanged(int value);
 
     /// Refresh `mAtTailEdge` when the scrollbar range changes
@@ -230,6 +266,16 @@ private:
     /// scroll-back. Kept separate from `mAtTailEdge` because that
     /// flag also feeds the anchor / signal state machines.
     bool mPendingNewRowsSuppressed = false;
+
+    /// Non-owning. `QPointer` so a rail widget destroyed by its
+    /// original owner zeroes here before our next geometry pass.
+    QPointer<QWidget> mOverviewRail;
+
+    /// Current reserved right-margin width in device-independent
+    /// px. Zero when no rail is attached. Cached so
+    /// `resizeEvent` can reuse the last known width without
+    /// re-querying the rail's `sizeHint`.
+    int mReservedRightMargin = 0;
 
 #ifdef LOGAPP_BUILD_TESTING
 public:

--- a/app/include/log_table_view.hpp
+++ b/app/include/log_table_view.hpp
@@ -182,6 +182,12 @@ private:
     /// attached rail's `sizeHint().width()` and reposition it to
     /// span the viewport height. No-op when no rail is attached.
     void UpdateOverviewRailGeometry();
+
+    /// Resolve the rail's effective width for margin reservation,
+    /// preferring `sizeHint` and falling back to `minimumSizeHint`
+    /// / `width` so callers that ship a fixed-width rail (via
+    /// `setFixedWidth`) still get a positive reservation.
+    [[nodiscard]] static int ResolvedRailWidth(const QWidget *rail);
     void OnVerticalScrollValueChanged(int value);
 
     /// Refresh `mAtTailEdge` when the scrollbar range changes

--- a/app/include/log_table_view.hpp
+++ b/app/include/log_table_view.hpp
@@ -6,6 +6,7 @@
 #include <QHeaderView>
 #include <QItemSelectionModel>
 #include <QList>
+#include <QMargins>
 #include <QMetaObject>
 #include <QPersistentModelIndex>
 #include <QPointer>
@@ -98,6 +99,15 @@ public:
     /// `changeEvent(StyleChange, ScreenChangeInternal)`. The
     /// previously-attached rail (if any) is hidden and detached
     /// but not deleted — ownership is the caller's.
+    ///
+    /// Implementation note: `QTableView::updateGeometries()` calls
+    /// `setViewportMargins(vHeaderWidth, hHeaderHeight, 0, 0)`
+    /// every time it runs (see qtableview.cpp), which would wipe
+    /// any right margin we set here. `LogTableView` overrides
+    /// `updateGeometries()` to re-apply `mReservedRightMargin`
+    /// after the base call, so the rail's slot stays reserved
+    /// across every implicit re-layout (row insert, column
+    /// change, header resize, viewport show).
     void AttachOverviewRail(QWidget *rail);
 
     /// Currently-attached overview rail (nullptr when detached).
@@ -172,6 +182,23 @@ protected:
     /// platform's scrollbar extent.
     void changeEvent(QEvent *event) override;
 
+    /// Re-applies our reserved right margin after the base's
+    /// `updateGeometries()` resets it. `QTableView::updateGeometries`
+    /// unconditionally calls `setViewportMargins(vHeaderW,
+    /// hHeaderH, 0, 0)` on every geometry pass (line 2330 in
+    /// qtableview.cpp), which would wipe the rail's slot on every
+    /// row insert or column change. Overriding here lets us
+    /// re-set the right margin *after* the base runs, so the
+    /// viewport keeps a stable width even during heavy streaming.
+    void updateGeometries() override;
+
+    /// Suppresses the viewport `Resize` event that our own
+    /// `setViewportMargins()` call triggers during rail margin
+    /// re-application, breaking the recursive
+    /// `updateGeometries` cascade that would otherwise wipe the
+    /// margin back to zero.
+    bool viewportEvent(QEvent *event) override;
+
     /// Watches the viewport for resize events so the floating pill
     /// stays glued to the tail-side edge without subclassing the
     /// viewport.
@@ -188,6 +215,7 @@ private:
     /// / `width` so callers that ship a fixed-width rail (via
     /// `setFixedWidth`) still get a positive reservation.
     [[nodiscard]] static int ResolvedRailWidth(const QWidget *rail);
+
     void OnVerticalScrollValueChanged(int value);
 
     /// Refresh `mAtTailEdge` when the scrollbar range changes
@@ -278,10 +306,28 @@ private:
     QPointer<QWidget> mOverviewRail;
 
     /// Current reserved right-margin width in device-independent
-    /// px. Zero when no rail is attached. Cached so
-    /// `resizeEvent` can reuse the last known width without
-    /// re-querying the rail's `sizeHint`.
+    /// px, equal to the rail's `sizeHint().width()`. Zero when no
+    /// rail is attached. Cached so every `updateGeometries` pass
+    /// (which runs on every model / column / header change) can
+    /// re-apply the same margin without re-querying the rail's
+    /// `sizeHint`.
+    ///
+    /// `QAbstractScrollArea::layoutChildren_helper` reserves
+    /// `PM_ScrollBarExtent` on the right for the vertical
+    /// scrollbar *independently* of viewport margins, so the
+    /// margin here is JUST the rail width -- the scrollbar sits
+    /// past the rail with no additional bookkeeping. See the
+    /// docstring on `AttachOverviewRail` for the interaction with
+    /// `QTableView::updateGeometries`.
     int mReservedRightMargin = 0;
+
+    /// True while our `updateGeometries()` override is inside the
+    /// rail-margin `setViewportMargins()` call. Read by
+    /// `viewportEvent()` to swallow the viewport `Resize` event
+    /// that would otherwise cascade back into `updateGeometries`
+    /// (via `QAbstractItemView::resizeEvent`) and wipe the margin
+    /// we just applied.
+    bool mApplyingRailMargin = false;
 
 #ifdef LOGAPP_BUILD_TESTING
 public:
@@ -304,6 +350,20 @@ public:
     [[nodiscard]] bool AtTailEdgeForTest() const noexcept
     {
         return mAtTailEdge;
+    }
+    /// Test seam over the protected `updateGeometries` slot so
+    /// the rail-margin regression can force a base-class layout
+    /// pass without waiting for a resize or model-reset trigger.
+    void UpdateGeometriesForTest()
+    {
+        updateGeometries();
+    }
+    /// Test seam over the protected `viewportMargins()` accessor.
+    /// Lets the same regression read the *live* margin the base
+    /// left behind so it can pin our override's re-application.
+    [[nodiscard]] QMargins ViewportMarginsForTest() const
+    {
+        return viewportMargins();
     }
 #endif
 };

--- a/app/include/log_table_view.hpp
+++ b/app/include/log_table_view.hpp
@@ -124,6 +124,26 @@ public:
         return mReservedRightMargin;
     }
 
+    /// Mark the next vertical-scrollbar `valueChanged` as
+    /// user-initiated so `userScrolledAwayFromTail` /
+    /// `userScrolledToTail` can fire. Used by
+    /// `OverviewRailWidget::wheelEvent`, which forwards the
+    /// wheel directly to the scrollbar and therefore bypasses
+    /// `LogTableView::wheelEvent` (the usual attribution path).
+    /// Consumed by `OnVerticalScrollValueChanged` on the next
+    /// value change (or cleared without emitting if the value
+    /// does not move).
+    void AttributeNextScrollToUser() noexcept
+    {
+        mNextValueChangeIsUser = true;
+    }
+
+    /// Re-read the attached rail's `sizeHint().width()` into
+    /// `mReservedRightMargin` and re-run geometry. Call after
+    /// `OverviewRailWidget::SetWidthMode` so the viewport margin
+    /// tracks the new preset. No-op when no rail is attached.
+    void RefreshOverviewRailMargin();
+
 public slots:
     void CopySelectedRowsToClipboard();
 

--- a/app/include/log_table_view.hpp
+++ b/app/include/log_table_view.hpp
@@ -138,6 +138,21 @@ public:
         mNextValueChangeIsUser = true;
     }
 
+    /// Clear a previously-set user-attribution flag when the
+    /// caller can confirm the wheel / scroll did not move the
+    /// value (e.g. the scrollbar was pinned at `minimum()` /
+    /// `maximum()` in the direction of the delta). Without
+    /// this, the flag survives until the next value change —
+    /// which could be programmatic — and misattributes that
+    /// change as user input, spuriously firing
+    /// `userScrolled{To,AwayFrom}Tail` and disengaging Follow
+    /// newest. Paired with `AttributeNextScrollToUser` in
+    /// `OverviewRailWidget::wheelEvent`.
+    void ClearNextScrollUserAttribution() noexcept
+    {
+        mNextValueChangeIsUser = false;
+    }
+
     /// Re-read the attached rail's `sizeHint().width()` into
     /// `mReservedRightMargin` and re-run geometry. Call after
     /// `OverviewRailWidget::SetWidthMode` so the viewport margin

--- a/app/include/log_table_view.hpp
+++ b/app/include/log_table_view.hpp
@@ -94,20 +94,15 @@ public:
     /// Reserve the right viewport margin for an overview rail
     /// widget. Passing nullptr detaches the current rail and
     /// reclaims the strip. When @p rail is non-null it is
-    /// reparented to `this`, positioned inside the reserved
-    /// margin, and its geometry is tracked via `resizeEvent` /
-    /// `changeEvent(StyleChange, ScreenChangeInternal)`. The
-    /// previously-attached rail (if any) is hidden and detached
-    /// but not deleted — ownership is the caller's.
+    /// reparented to `this` and positioned in the reserved margin;
+    /// ownership stays with the caller (detached rails are hidden,
+    /// not deleted).
     ///
-    /// Implementation note: `QTableView::updateGeometries()` calls
-    /// `setViewportMargins(vHeaderWidth, hHeaderHeight, 0, 0)`
-    /// every time it runs (see qtableview.cpp), which would wipe
-    /// any right margin we set here. `LogTableView` overrides
-    /// `updateGeometries()` to re-apply `mReservedRightMargin`
-    /// after the base call, so the rail's slot stays reserved
-    /// across every implicit re-layout (row insert, column
-    /// change, header resize, viewport show).
+    /// `QTableView::updateGeometries()` unconditionally resets the
+    /// right margin to zero on every layout pass. `updateGeometries`
+    /// is overridden here to re-apply `mReservedRightMargin` after
+    /// the base call, so the rail's slot survives every implicit
+    /// re-layout (row insert, column change, viewport show).
     void AttachOverviewRail(QWidget *rail);
 
     /// Currently-attached overview rail (nullptr when detached).
@@ -124,30 +119,21 @@ public:
         return mReservedRightMargin;
     }
 
-    /// Mark the next vertical-scrollbar `valueChanged` as
-    /// user-initiated so `userScrolledAwayFromTail` /
-    /// `userScrolledToTail` can fire. Used by
-    /// `OverviewRailWidget::wheelEvent`, which forwards the
-    /// wheel directly to the scrollbar and therefore bypasses
-    /// `LogTableView::wheelEvent` (the usual attribution path).
-    /// Consumed by `OnVerticalScrollValueChanged` on the next
-    /// value change (or cleared without emitting if the value
-    /// does not move).
+    /// Mark the next scrollbar `valueChanged` as user-initiated so
+    /// `userScrolled{To,AwayFrom}Tail` can fire. Used by
+    /// `OverviewRailWidget::wheelEvent`, which forwards the wheel
+    /// directly to the scrollbar and bypasses the usual
+    /// `LogTableView::wheelEvent` attribution path.
     void AttributeNextScrollToUser() noexcept
     {
         mNextValueChangeIsUser = true;
     }
 
-    /// Clear a previously-set user-attribution flag when the
-    /// caller can confirm the wheel / scroll did not move the
-    /// value (e.g. the scrollbar was pinned at `minimum()` /
-    /// `maximum()` in the direction of the delta). Without
-    /// this, the flag survives until the next value change —
-    /// which could be programmatic — and misattributes that
-    /// change as user input, spuriously firing
-    /// `userScrolled{To,AwayFrom}Tail` and disengaging Follow
-    /// newest. Paired with `AttributeNextScrollToUser` in
-    /// `OverviewRailWidget::wheelEvent`.
+    /// Clear the user-attribution flag when the caller can confirm
+    /// no `valueChanged` will follow (e.g. scrollbar pinned at the
+    /// edge). Without this, the flag would linger and misattribute
+    /// the next — possibly programmatic — value change, spuriously
+    /// disengaging Follow newest.
     void ClearNextScrollUserAttribution() noexcept
     {
         mNextValueChangeIsUser = false;
@@ -218,20 +204,15 @@ protected:
     void changeEvent(QEvent *event) override;
 
     /// Re-applies our reserved right margin after the base's
-    /// `updateGeometries()` resets it. `QTableView::updateGeometries`
-    /// unconditionally calls `setViewportMargins(vHeaderW,
-    /// hHeaderH, 0, 0)` on every geometry pass (line 2330 in
-    /// qtableview.cpp), which would wipe the rail's slot on every
-    /// row insert or column change. Overriding here lets us
-    /// re-set the right margin *after* the base runs, so the
-    /// viewport keeps a stable width even during heavy streaming.
+    /// `updateGeometries()` resets it to zero. Without this the
+    /// rail's slot would be wiped on every row insert or column
+    /// change.
     void updateGeometries() override;
 
-    /// Suppresses the viewport `Resize` event that our own
-    /// `setViewportMargins()` call triggers during rail margin
-    /// re-application, breaking the recursive
-    /// `updateGeometries` cascade that would otherwise wipe the
-    /// margin back to zero.
+    /// Suppresses the viewport `Resize` event our own
+    /// `setViewportMargins()` call triggers during rail-margin
+    /// re-application. Breaks the recursion that would otherwise
+    /// wipe the margin back to zero.
     bool viewportEvent(QEvent *event) override;
 
     /// Watches the viewport for resize events so the floating pill
@@ -340,28 +321,21 @@ private:
     /// original owner zeroes here before our next geometry pass.
     QPointer<QWidget> mOverviewRail;
 
-    /// Current reserved right-margin width in device-independent
-    /// px, equal to the rail's `sizeHint().width()`. Zero when no
-    /// rail is attached. Cached so every `updateGeometries` pass
-    /// (which runs on every model / column / header change) can
-    /// re-apply the same margin without re-querying the rail's
-    /// `sizeHint`.
+    /// Reserved right-margin width in device-independent px (the
+    /// rail's `sizeHint().width()`; zero when no rail is attached).
+    /// Cached so `updateGeometries` doesn't re-query `sizeHint` on
+    /// every model / column / header change.
     ///
-    /// `QAbstractScrollArea::layoutChildren_helper` reserves
-    /// `PM_ScrollBarExtent` on the right for the vertical
-    /// scrollbar *independently* of viewport margins, so the
-    /// margin here is JUST the rail width -- the scrollbar sits
-    /// past the rail with no additional bookkeeping. See the
-    /// docstring on `AttachOverviewRail` for the interaction with
-    /// `QTableView::updateGeometries`.
+    /// `QAbstractScrollArea` reserves `PM_ScrollBarExtent` for the
+    /// vertical scrollbar independently of viewport margins, so
+    /// this margin is *just* the rail width — the scrollbar sits
+    /// past the rail.
     int mReservedRightMargin = 0;
 
-    /// True while our `updateGeometries()` override is inside the
-    /// rail-margin `setViewportMargins()` call. Read by
-    /// `viewportEvent()` to swallow the viewport `Resize` event
-    /// that would otherwise cascade back into `updateGeometries`
-    /// (via `QAbstractItemView::resizeEvent`) and wipe the margin
-    /// we just applied.
+    /// True while `updateGeometries()` is inside the rail-margin
+    /// `setViewportMargins()` call. `viewportEvent()` reads this to
+    /// swallow the viewport `Resize` event that would otherwise
+    /// re-enter `updateGeometries` and wipe the margin.
     bool mApplyingRailMargin = false;
 
 #ifdef LOGAPP_BUILD_TESTING
@@ -387,15 +361,13 @@ public:
         return mAtTailEdge;
     }
     /// Test seam over the protected `updateGeometries` slot so
-    /// the rail-margin regression can force a base-class layout
-    /// pass without waiting for a resize or model-reset trigger.
+    /// tests can force a layout pass without waiting for a
+    /// resize / model-reset trigger.
     void UpdateGeometriesForTest()
     {
         updateGeometries();
     }
     /// Test seam over the protected `viewportMargins()` accessor.
-    /// Lets the same regression read the *live* margin the base
-    /// left behind so it can pin our override's re-application.
     [[nodiscard]] QMargins ViewportMarginsForTest() const
     {
         return viewportMargins();

--- a/app/include/main_window.hpp
+++ b/app/include/main_window.hpp
@@ -47,6 +47,7 @@
 
 #include <array>
 #include <chrono>
+#include <cstdint>
 #include <functional>
 #include <memory>
 #include <optional>
@@ -570,6 +571,14 @@ private slots:
     /// Drop the cached match-row list. Wired to model resets and
     /// proxy layout changes so a stale cache cannot survive.
     void InvalidateFindMatchCache();
+
+    /// Push the current `mFindMatchCache` match state into the
+    /// overview rail. Prefers cached per-bucket counts (unbiased
+    /// even when `sortedRows` is capped); when those are missing
+    /// or size-mismatched against the live rail (scan ran while
+    /// the rail was hidden, or H changed), forces a full recount
+    /// so the rail never paints a top-biased tick strip.
+    void PushFindMatchesToOverviewRail();
 
     /// Centralised invalidate + debounced re-request. Wired to every
     /// model / proxy signal that can change the match set; a sync
@@ -1225,24 +1234,36 @@ private:
     /// has entries; clicking it opens the dock.
     QPushButton *mParseErrorsStatusButton = nullptr;
 
-    /// Soft cap used only for shaping the initial `MatchRow`
-    /// reserve and for legacy `overflowed`-flag preservation.
-    /// The find-match scan itself is uncapped now (bounded by
-    /// the proxy's row count) so both the "*i* of *N*"
-    /// indicator and the overview rail always see every match
-    /// -- capping the scan biased the row list to the top of
-    /// the log and caused the rail's search highlights to
-    /// "stop working" whenever a common needle produced more
-    /// than N hits.
+    /// Hard cap on `sortedRows`, the vector used for the
+    /// "*i* of *N*" binary search. Past this many hits the scan
+    /// may early-exit (see `UpdateFindMatchCount`) once the
+    /// overview rail's presence fold is settled, so a common
+    /// needle on a million-row proxy cannot freeze the GUI for
+    /// a full-table walk. `sortedRows` itself never grows past
+    /// this size. When `overflowed` is set, `totalMatches` is a
+    /// lower bound and the per-hit cursor-position lookup
+    /// degrades for match `#10 001` or later.
     static constexpr int MAX_FIND_MATCH_COUNT = 10000;
 
-    /// Cached match-row list for the "*i* of *N*" indicator. Keyed by
+    /// Cached match state for the "*i* of *N*" indicator. Keyed by
     /// `(needle, wildcards, regex)` so a Next / Previous click can
     /// resolve the new `i` via binary search instead of re-scanning.
-    /// Row-deduplicated so the indicator agrees with how `FindRecords`
-    /// walks the table. `overflowed` is retained for struct
-    /// backward-compat but is always `false` under the uncapped
-    /// scan (the count in `sortedRows.size()` is exact).
+    /// `sortedRows` is deduplicated and capped at
+    /// `MAX_FIND_MATCH_COUNT`; `totalMatches` is exact when
+    /// `!overflowed`, otherwise a lower bound from an early-exit
+    /// or capped navigator list. `overflowed` is `true` when the
+    /// scan stopped short of exhausting the proxy (or the
+    /// navigator list hit the cap after a full walk) — a
+    /// "current" cursor at match `#10 001` or later will resolve
+    /// to `0` (no position highlight) in that case.
+    /// `bucketCounts` mirrors the per-bucket totals pushed to the
+    /// overview rail (empty when the rail was hidden / had zero
+    /// buckets during the scan); find-dock reveal restores from
+    /// this so a cache-hit recount cannot leave the rail stuck on
+    /// the capped `sortedRows` strip. Counts may be density-
+    /// incomplete after an early-exit, but every bucket that has
+    /// a match still carries `matchCount > 0` (paint is presence-
+    /// only).
     struct FindMatchCache
     {
         QString needle;
@@ -1250,6 +1271,8 @@ private:
         bool regularExpressions = false;
         bool overflowed = false;
         std::vector<int> sortedRows;
+        uint32_t totalMatches = 0;
+        std::vector<uint32_t> bucketCounts;
     };
     std::optional<FindMatchCache> mFindMatchCache;
     PreferencesEditor *mPreferencesEditor;

--- a/app/include/main_window.hpp
+++ b/app/include/main_window.hpp
@@ -350,27 +350,24 @@ public:
     void JumpToFirstRowInBucket(std::size_t bucketIndex);
 
     /// Scroll the table so proxy row @p proxyRow is centred.
-    /// Wired to `OverviewRailWidget::proxyRowClicked`; no-op
-    /// when the row is out of range (rail geometry can briefly
-    /// out-race a `modelReset`).
+    /// Wired to `OverviewRailWidget::proxyRowClicked`; no-op when
+    /// the row is out of range.
     ///
-    /// @p replaceSelection is `true` on a fresh rail click
-    /// (destructive: clears the existing selection and selects
-    /// just @p proxyRow, matching `SelectSourceRow`); `false`
-    /// during a drag scrub (the scroll happens but selection is
-    /// left alone, so a carefully-built multi-row selection
-    /// survives a scroll-by-rail).
+    /// @p replaceSelection: `true` on a fresh rail click (clears
+    /// the existing selection and selects just @p proxyRow);
+    /// `false` during a drag scrub (leaves selection alone so a
+    /// multi-row selection survives a rail scroll).
     ///
     /// Always disengages Follow newest: rail navigation is
-    /// intentional browsing, and a programmatic `scrollTo` would
-    /// not otherwise fire `userScrolledAwayFromTail`.
+    /// intentional browsing, and `scrollTo` alone wouldn't fire
+    /// `userScrolledAwayFromTail`.
     void ScrollToProxyRow(int proxyRow, bool replaceSelection = true);
 
-    /// Attach or detach `mOverviewRailWidget` on the table view,
-    /// persist the visibility to `QSettings("ui/showOverviewRail")`,
-    /// and mirror the state onto `mActionToggleOverviewRail`. The
-    /// slot is idempotent so the load-time seed / user toggle
-    /// share one code path.
+    /// Attach / detach `mOverviewRailWidget` on the table view,
+    /// persist visibility to `QSettings("ui/showOverviewRail")`,
+    /// and mirror the state onto `mActionToggleOverviewRail`.
+    /// Idempotent so the load-time seed and the user toggle share
+    /// one code path.
     void SetOverviewRailVisible(bool visible);
 
     /// Install a `Type::Time` filter on
@@ -578,13 +575,12 @@ private slots:
 
     /// Push the current `mFindMatchCache` match state into the
     /// overview rail. No-op when the find bar is not visible —
-    /// match ticks mirror the find indicator and must not
-    /// reappear from a surviving cache after find was closed.
-    /// Prefers cached per-bucket counts (unbiased even when
-    /// `sortedRows` is capped); when those are missing or
-    /// size-mismatched against the live rail (scan ran while the
-    /// rail was hidden, or H changed), forces a full recount so
-    /// the rail never paints a top-biased tick strip.
+    /// ticks mirror the find indicator, they must not reappear
+    /// from a stale cache after find was closed. Prefers cached
+    /// per-bucket counts (unbiased even when `sortedRows` is
+    /// capped); forces a full recount when they're missing or
+    /// size-mismatched so the rail never paints a top-biased
+    /// strip.
     void PushFindMatchesToOverviewRail();
 
     /// Centralised invalidate + debounced re-request. Wired to every
@@ -1241,36 +1237,27 @@ private:
     /// has entries; clicking it opens the dock.
     QPushButton *mParseErrorsStatusButton = nullptr;
 
-    /// Hard cap on `sortedRows`, the vector used for the
-    /// "*i* of *N*" binary search. Past this many hits the scan
-    /// may early-exit (see `UpdateFindMatchCount`) once the
-    /// overview rail's presence fold is settled, so a common
-    /// needle on a million-row proxy cannot freeze the GUI for
-    /// a full-table walk. `sortedRows` itself never grows past
-    /// this size. When `overflowed` is set, `totalMatches` is a
-    /// lower bound and the per-hit cursor-position lookup
-    /// degrades for match `#10 001` or later.
+    /// Cap on `sortedRows` (the vector powering the "*i* of *N*"
+    /// binary search). Past this many hits the scan may early-exit
+    /// once the rail's presence fold is settled, keeping the GUI
+    /// bounded on huge tables with a common needle. When
+    /// `overflowed` is set, `totalMatches` is a lower bound and
+    /// the position lookup degrades for match `#10 001` or later.
     static constexpr int MAX_FIND_MATCH_COUNT = 10000;
 
     /// Cached match state for the "*i* of *N*" indicator. Keyed by
-    /// `(needle, wildcards, regex)` so a Next / Previous click can
-    /// resolve the new `i` via binary search instead of re-scanning.
-    /// `sortedRows` is deduplicated and capped at
-    /// `MAX_FIND_MATCH_COUNT`; `totalMatches` is exact when
-    /// `!overflowed`, otherwise a lower bound from an early-exit
-    /// or capped navigator list. `overflowed` is `true` when the
-    /// scan stopped short of exhausting the proxy (or the
-    /// navigator list hit the cap after a full walk) — a
-    /// "current" cursor at match `#10 001` or later will resolve
-    /// to `0` (no position highlight) in that case.
-    /// `bucketCounts` mirrors the per-bucket totals pushed to the
-    /// overview rail (empty when the rail was hidden / had zero
-    /// buckets during the scan); find-dock reveal restores from
-    /// this so a cache-hit recount cannot leave the rail stuck on
-    /// the capped `sortedRows` strip. Counts may be density-
-    /// incomplete after an early-exit, but every bucket that has
-    /// a match still carries `matchCount > 0` (paint is presence-
-    /// only).
+    /// `(needle, wildcards, regex)` so Next / Previous can resolve
+    /// the new `i` via binary search instead of re-scanning.
+    ///
+    /// - `sortedRows`: deduplicated, capped at `MAX_FIND_MATCH_COUNT`.
+    /// - `totalMatches`: exact when `!overflowed`, otherwise a
+    ///   lower bound. A cursor at match `#10 001` or later resolves
+    ///   to `0` (no position highlight) under overflow.
+    /// - `bucketCounts`: per-bucket totals mirrored to the rail
+    ///   (empty when the rail had zero buckets during the scan).
+    ///   Restored on find-dock reveal so a cache-hit recount can't
+    ///   leave the rail on a top-biased strip. Presence-only —
+    ///   density may be incomplete after an early-exit.
     struct FindMatchCache
     {
         QString needle;
@@ -1315,21 +1302,19 @@ private:
     /// `RebuildViewMenu`. Programmatic because the .ui has no entry.
     QAction *mActionToggleHistogram = nullptr;
 
-    /// Owned QObject. Bucketed index of the outermost proxy row
-    /// space that feeds `mOverviewRailWidget`. Lives even when
-    /// the rail is hidden — cheap to keep in sync so the toggle
-    /// is instant.
+    /// Bucketed index of the outermost proxy row space that feeds
+    /// `mOverviewRailWidget`. Kept alive even when the rail is
+    /// hidden so the toggle is instant.
     OverviewRailModel *mOverviewRailModel = nullptr;
 
-    /// Owned by `mTableView` (via `LogTableView::AttachOverviewRail`
-    /// while visible; via `this` while detached). `QPointer` so a
-    /// teardown-time delete zeroes here before the attach helper
-    /// runs.
+    /// Parented on `mTableView` while visible (via
+    /// `LogTableView::AttachOverviewRail`), on `this` while detached.
+    /// `QPointer` so a teardown-time delete zeroes the slot.
     QPointer<OverviewRailWidget> mOverviewRailWidget;
 
-    /// Toggle action for the overview rail. Checkable, mirrored
-    /// onto the primary toolbar and View menu; persists through
-    /// `ui/showOverviewRail` in `QSettings`.
+    /// Checkable toggle for the overview rail, mirrored onto the
+    /// primary toolbar and the View menu. Persisted through
+    /// `ui/showOverviewRail`.
     QAction *mActionToggleOverviewRail = nullptr;
 
     /// Anchor hotkey actions: index N maps to `Ctrl+(N+1)`.

--- a/app/include/main_window.hpp
+++ b/app/include/main_window.hpp
@@ -1225,17 +1225,24 @@ private:
     /// has entries; clicking it opens the dock.
     QPushButton *mParseErrorsStatusButton = nullptr;
 
-    /// Hard cap on the "*i* of *N*" scan. The scan runs synchronously
-    /// on the GUI thread; an unbounded walk over a million-row proxy
-    /// with a frequent needle would freeze the UI per recount. Past
-    /// the cap the indicator shows "*N*+"; Next / Previous still work.
+    /// Soft cap used only for shaping the initial `MatchRow`
+    /// reserve and for legacy `overflowed`-flag preservation.
+    /// The find-match scan itself is uncapped now (bounded by
+    /// the proxy's row count) so both the "*i* of *N*"
+    /// indicator and the overview rail always see every match
+    /// -- capping the scan biased the row list to the top of
+    /// the log and caused the rail's search highlights to
+    /// "stop working" whenever a common needle produced more
+    /// than N hits.
     static constexpr int MAX_FIND_MATCH_COUNT = 10000;
 
     /// Cached match-row list for the "*i* of *N*" indicator. Keyed by
     /// `(needle, wildcards, regex)` so a Next / Previous click can
     /// resolve the new `i` via binary search instead of re-scanning.
     /// Row-deduplicated so the indicator agrees with how `FindRecords`
-    /// walks the table. `overflowed` is set when the scan hit the cap.
+    /// walks the table. `overflowed` is retained for struct
+    /// backward-compat but is always `false` under the uncapped
+    /// scan (the count in `sortedRows.size()` is exact).
     struct FindMatchCache
     {
         QString needle;

--- a/app/include/main_window.hpp
+++ b/app/include/main_window.hpp
@@ -348,11 +348,18 @@ public:
     /// @p bucketIndex. Wired to `HistogramDock::bucketClicked`.
     void JumpToFirstRowInBucket(std::size_t bucketIndex);
 
-    /// Scroll the table so proxy row @p proxyRow is centred, and
-    /// select it. Wired to `OverviewRailWidget::proxyRowClicked`;
-    /// no-op when the row is out of range (rail geometry can
-    /// briefly out-race a `modelReset`).
-    void ScrollToProxyRow(int proxyRow);
+    /// Scroll the table so proxy row @p proxyRow is centred.
+    /// Wired to `OverviewRailWidget::proxyRowClicked`; no-op
+    /// when the row is out of range (rail geometry can briefly
+    /// out-race a `modelReset`).
+    ///
+    /// @p replaceSelection is `true` on a fresh rail click
+    /// (destructive: clears the existing selection and selects
+    /// just @p proxyRow, matching `SelectSourceRow`); `false`
+    /// during a drag scrub (the scroll happens but selection is
+    /// left alone, so a carefully-built multi-row selection
+    /// survives a scroll-by-rail).
+    void ScrollToProxyRow(int proxyRow, bool replaceSelection = true);
 
     /// Attach or detach `mOverviewRailWidget` on the table view,
     /// persist the visibility to `QSettings("ui/showOverviewRail")`,

--- a/app/include/main_window.hpp
+++ b/app/include/main_window.hpp
@@ -360,6 +360,10 @@ public:
     /// during a drag scrub (the scroll happens but selection is
     /// left alone, so a carefully-built multi-row selection
     /// survives a scroll-by-rail).
+    ///
+    /// Always disengages Follow newest: rail navigation is
+    /// intentional browsing, and a programmatic `scrollTo` would
+    /// not otherwise fire `userScrolledAwayFromTail`.
     void ScrollToProxyRow(int proxyRow, bool replaceSelection = true);
 
     /// Attach or detach `mOverviewRailWidget` on the table view,
@@ -573,11 +577,14 @@ private slots:
     void InvalidateFindMatchCache();
 
     /// Push the current `mFindMatchCache` match state into the
-    /// overview rail. Prefers cached per-bucket counts (unbiased
-    /// even when `sortedRows` is capped); when those are missing
-    /// or size-mismatched against the live rail (scan ran while
-    /// the rail was hidden, or H changed), forces a full recount
-    /// so the rail never paints a top-biased tick strip.
+    /// overview rail. No-op when the find bar is not visible —
+    /// match ticks mirror the find indicator and must not
+    /// reappear from a surviving cache after find was closed.
+    /// Prefers cached per-bucket counts (unbiased even when
+    /// `sortedRows` is capped); when those are missing or
+    /// size-mismatched against the live rail (scan ran while the
+    /// rail was hidden, or H changed), forces a full recount so
+    /// the rail never paints a top-biased tick strip.
     void PushFindMatchesToOverviewRail();
 
     /// Centralised invalidate + debounced re-request. Wired to every

--- a/app/include/main_window.hpp
+++ b/app/include/main_window.hpp
@@ -8,6 +8,8 @@
 #include "log_filter_model.hpp"
 #include "log_model.hpp"
 #include "log_table_view.hpp"
+#include "overview_rail_model.hpp"
+#include "overview_rail_widget.hpp"
 #include "parse_errors_dock.hpp"
 #include "preferences_editor.hpp"
 #include "record_detail_dock.hpp"
@@ -345,6 +347,19 @@ public:
     /// Jump the table to the first row in histogram bucket
     /// @p bucketIndex. Wired to `HistogramDock::bucketClicked`.
     void JumpToFirstRowInBucket(std::size_t bucketIndex);
+
+    /// Scroll the table so proxy row @p proxyRow is centred, and
+    /// select it. Wired to `OverviewRailWidget::proxyRowClicked`;
+    /// no-op when the row is out of range (rail geometry can
+    /// briefly out-race a `modelReset`).
+    void ScrollToProxyRow(int proxyRow);
+
+    /// Attach or detach `mOverviewRailWidget` on the table view,
+    /// persist the visibility to `QSettings("ui/showOverviewRail")`,
+    /// and mirror the state onto `mActionToggleOverviewRail`. The
+    /// slot is idempotent so the load-time seed / user toggle
+    /// share one code path.
+    void SetOverviewRailVisible(bool visible);
 
     /// Install a `Type::Time` filter on
     /// `[fromEpochMicros, toEpochMicros]` for the histogram's time
@@ -1255,6 +1270,23 @@ private:
     /// Toggle action for the Histogram dock; re-added on every
     /// `RebuildViewMenu`. Programmatic because the .ui has no entry.
     QAction *mActionToggleHistogram = nullptr;
+
+    /// Owned QObject. Bucketed index of the outermost proxy row
+    /// space that feeds `mOverviewRailWidget`. Lives even when
+    /// the rail is hidden — cheap to keep in sync so the toggle
+    /// is instant.
+    OverviewRailModel *mOverviewRailModel = nullptr;
+
+    /// Owned by `mTableView` (via `LogTableView::AttachOverviewRail`
+    /// while visible; via `this` while detached). `QPointer` so a
+    /// teardown-time delete zeroes here before the attach helper
+    /// runs.
+    QPointer<OverviewRailWidget> mOverviewRailWidget;
+
+    /// Toggle action for the overview rail. Checkable, mirrored
+    /// onto the primary toolbar and View menu; persists through
+    /// `ui/showOverviewRail` in `QSettings`.
+    QAction *mActionToggleOverviewRail = nullptr;
 
     /// Anchor hotkey actions: index N maps to `Ctrl+(N+1)`.
     /// `mActionClearRowAnchor` is `Ctrl+0`; jumps are `F2` /

--- a/app/include/overview_rail_model.hpp
+++ b/app/include/overview_rail_model.hpp
@@ -39,13 +39,12 @@ class OverviewRailModel : public QObject
     Q_OBJECT
 
 public:
-    /// One entry per rail pixel row. Aggregate on purpose:
-    /// `OverviewRailWidget` reads the counts, tick flags, and
-    /// anchor slots directly on the paint path. Reuses
-    /// `loglib::LevelBucket` (same struct the histogram
-    /// consumes) so the two features share their per-level
-    /// counts layout — ROADMAP item 13 explicitly calls this
-    /// "the histogram's bucket data structure tilted 90°".
+    /// One entry per rail pixel row. Aggregate on purpose: the
+    /// widget reads counts / tick flags / anchor slots directly on
+    /// the paint path. Reuses `loglib::LevelBucket` so the rail and
+    /// the histogram share the per-level counts layout — ROADMAP
+    /// item 13 calls this "the histogram's bucket data structure
+    /// tilted 90°".
     struct Bucket
     {
         // NOLINTBEGIN(misc-non-private-member-variables-in-classes)
@@ -72,72 +71,47 @@ public:
     );
 
     /// Set the number of rail pixel rows. Triggers a synchronous
-    /// rebuild when the bucket count changes so the caller sees
-    /// fresh data on return. The widget calls this from
-    /// `showEvent` (immediate) and from a debounced
-    /// `resizeEvent` path (`BUCKET_SYNC_DEBOUNCE_MS`) so interactive
-    /// window-drag storms collapse to one rebuild + one find
-    /// rescan. Zero is legal (widget hidden / zero-height) and
-    /// produces an empty bucket vector; `RebuildInternal`
-    /// short-circuits on that branch, which is the mechanism that
-    /// lets `MainWindow::SetOverviewRailVisible(false)` stop
-    /// paying rebuild cost while the rail is hidden.
+    /// rebuild on a size change so the caller sees fresh data on
+    /// return. Zero is legal (widget hidden) and produces an empty
+    /// bucket vector; incoming proxy signals then short-circuit
+    /// inside `RebuildInternal`, which is what lets
+    /// `MainWindow::SetOverviewRailVisible(false)` skip rebuild
+    /// cost while hidden.
     void SetBucketCount(std::size_t nBuckets);
 
     /// Push the current find-match proxy rows. Only touches
-    /// `matchCount`, not the level counts or anchor bits — a
-    /// bucket rebuild is unnecessary for a match-set change. Rows
-    /// outside the current proxy range are silently dropped, and
-    /// the incoming list is de-duplicated internally (a duplicate
-    /// row would otherwise be double-counted into its bucket).
-    /// Emits `matchesChanged` immediately so the widget repaints
-    /// on the next event-loop pass; find updates are already
-    /// debounced upstream.
+    /// `matchCount`; the level counts and anchor bits are left
+    /// alone. Out-of-range rows are dropped and the list is
+    /// de-duplicated internally. Emits `matchesChanged` immediately
+    /// — find updates are already debounced upstream.
     ///
     /// Refreshes the cached proxy row count from the live proxy
-    /// before folding so a caller that scanned against a newer
-    /// row count than the last coalesced rebuild doesn't drop
-    /// tail-row hits (row indices past the stale cache) or land
-    /// them in the last bucket via a divide-by-smaller-M.
+    /// before folding so tail-row hits scanned against a newer
+    /// row count than the last coalesced rebuild are attributed to
+    /// the right bucket.
     void SetMatchProxyRows(std::vector<int> proxyRows);
 
-    /// Push per-bucket match counts directly, bypassing the
-    /// `mMatchProxyRows` vector. Preferred over `SetMatchProxyRows`
-    /// when the caller already knows the totals per bucket and
-    /// wants to skip materializing every matching row — the whole
-    /// point is to avoid an O(matches) vector allocation for
-    /// broad needles that hit most rows.
+    /// Push per-bucket match counts directly, skipping the row-list
+    /// path. Preferred when the caller already has per-bucket totals
+    /// — avoids the O(matches) allocation for broad needles.
     ///
-    /// @p perBucketCounts must have `BucketCount()` entries. When
-    /// the size mismatches (mid-resize race, or the caller has
-    /// stale bucket-count info), the update is dropped silently
-    /// and the previous match ticks stay put — a subsequent call
-    /// after the resize settles will fix it. @p totalMatches is
-    /// the exact pre-cap match total (used for `HasMatchTicks`
-    /// and as a fast source of truth for the sum, so the model
-    /// doesn't have to re-add the counters).
+    /// @p perBucketCounts must have `BucketCount()` entries; a
+    /// size mismatch (resize race) drops the update silently.
+    /// @p totalMatches is the exact pre-cap total.
     ///
-    /// Clears `mMatchProxyRows` so the next coalesced rebuild
-    /// does not double-count a stale row-list fold on top of the
-    /// pre-bucketed values, and retains `@p perBucketCounts` as
-    /// durable state so `RebuildInternal` (anchor edits, resize
-    /// with the same H, hide→show) can re-apply the ticks without
-    /// the caller re-pushing. Emits `matchesChanged` only (level
-    /// counts / anchor bits are untouched, same as
-    /// `SetMatchProxyRows`).
+    /// Clears `mMatchProxyRows` and stores the counts as durable
+    /// state so `RebuildInternal` (anchor edits, same-H resize,
+    /// hide→show) can re-apply the ticks without the caller
+    /// re-pushing. Emits `matchesChanged` only.
     void SetMatchBucketCounts(std::vector<uint32_t> perBucketCounts, uint32_t totalMatches);
 
-    /// Request a full bucket rebuild. Coalesced through the 50 ms
-    /// emit timer so a burst of proxy signals (per-row inserts
-    /// under an active sort, anchor bulk edits, ...) collapses to
-    /// a single O(rowCount) walk + one repaint per quiet window.
-    /// Prefer this over `RebuildInternal` on every signal path.
+    /// Request a coalesced rebuild (~50 ms). A burst of proxy
+    /// signals collapses to a single O(rowCount) walk + one
+    /// repaint per quiet window.
     void Rebuild();
 
-    /// Rebuild synchronously without waiting for the coalesce
-    /// timer. Only used by call sites that need the fresh bucket
-    /// vector on return (widget resize, initial attach). Tests
-    /// exercise the coalescing behaviour via `Rebuild()`.
+    /// Rebuild synchronously. Used by callers that need fresh
+    /// buckets on return (widget resize, initial attach).
     void RebuildNow();
 
     [[nodiscard]] std::span<const Bucket> Buckets() const noexcept
@@ -158,15 +132,11 @@ public:
     }
 
     /// Majority-count `LogLevel` in @p bucket, tie-broken by
-    /// severity (Fatal > Error > Warn > Info > Debug > Trace >
-    /// Unknown), or `Unknown` when the bucket is empty or out
-    /// of range. The rail widget itself no longer picks a single
-    /// bucket colour via this method -- it iterates the per-level
-    /// counts (`Buckets()[i].levels.counts`) and paints stacked
-    /// severity segments so both density and rare high-severity
-    /// anomalies are visible at once. Retained on the model for
-    /// callers that want a single representative colour (anchor
-    /// tick legend, tests, future summary widgets).
+    /// severity (Fatal > Error > … > Unknown). Returns `Unknown`
+    /// for an empty / out-of-range bucket. The rail widget paints
+    /// stacked severity segments instead of a single colour;
+    /// retained for callers that want one representative colour
+    /// (anchor tick legend, tests).
     [[nodiscard]] loglib::LogLevel DominantLevel(std::size_t bucket) const noexcept;
 
     /// Cached first-`Type::Level` column index, `-1` when none.
@@ -184,46 +154,41 @@ public:
     }
 
     /// True iff any bucket carries at least one match tick.
-    /// Widget uses this to skip the tick pass entirely. Tracks
-    /// the *bucketed* total (not `mMatchProxyRows.size()`) so a
-    /// stale match list that only contains rows outside the
-    /// current proxy range correctly reports "no ticks".
+    /// Tracks the *bucketed* total (not the raw row-list size) so
+    /// a stale match list whose rows all fall outside the current
+    /// proxy range correctly reports "no ticks".
     [[nodiscard]] bool HasMatchTicks() const noexcept
     {
         return mBucketedMatchCount > 0;
     }
 
-    /// First proxy row whose bucket falls in @p bucket, or `-1`
-    /// when the bucket is empty or out of range. Backed by the
-    /// linear mapping (proxy row -> bucket = row * N / M) so it's
-    /// O(1) once the row count is known.
+    /// First proxy row in @p bucket, or `-1` for empty / out of
+    /// range. O(1) via `row = ceil(bucket * M / N)`.
     [[nodiscard]] int FirstProxyRowInBucket(std::size_t bucket) const noexcept;
 
-    /// Rail pixel Y (top-anchored, 0..railHeight-1) → proxy row.
+    /// Rail pixel Y (top-anchored, `0..railHeight-1`) → proxy row.
     /// Clamped into `[0, proxyRowCount)`; returns `-1` when the
-    /// proxy is empty. Rail widget uses this on click / drag.
+    /// proxy is empty.
     [[nodiscard]] int ProxyRowForYPixel(int y, int railHeight) const noexcept;
 
 signals:
-    /// Buckets have repaint-worthy new content. Typically
-    /// coalesced (~50 ms) via the rebuild timer, but forced
-    /// paths (`SetBucketCount`, `RebuildNow`) emit synchronously
-    /// so callers that need fresh buckets on return get them.
+    /// Buckets have repaint-worthy new content. Coalesced via the
+    /// ~50 ms rebuild timer; forced paths (`SetBucketCount`,
+    /// `RebuildNow`) emit synchronously.
     void bucketsChanged();
 
-    /// Match rows changed. Not coalesced — user typing in the
-    /// find bar is already debounced upstream, and one paint per
-    /// find recompute is desirable.
+    /// Match rows changed. Not coalesced — find updates are
+    /// already debounced upstream.
     void matchesChanged();
 
     /// Anchor mask on at least one bucket changed. Not coalesced;
-    /// anchor edits are user-driven and low-frequency.
+    /// anchor edits are user-driven and rare.
     void anchorBucketsChanged();
 
 private:
     // Signal handlers. All hand off to `Rebuild()` today; kept
-    // as separate slots so we can inline incremental append later
-    // without disturbing the wiring surface.
+    // as separate slots so a future incremental-append can be
+    // inlined without changing the wiring.
     void OnRowsInserted(const QModelIndex &parent, int first, int last);
     void OnRowsRemoved(const QModelIndex &parent, int first, int last);
     void OnModelReset();
@@ -233,66 +198,46 @@ private:
     void OnAnchorChanged(const AnchorManager::Key &key);
     void OnAnchorsReset();
 
-    /// Full rebuild body — walks the proxy row set, refreshes
-    /// level counts + anchor bits, then re-folds the current
-    /// match rows in. Factored so `SetBucketCount` can trigger
-    /// it synchronously without re-entering the coalesce timer.
+    /// Full rebuild — walks the proxy, refreshes level counts +
+    /// anchor bits, then re-folds the current match rows. Factored
+    /// so `SetBucketCount` can run it synchronously.
     void RebuildInternal();
 
     /// Zero + refill `matchCount` on every bucket from
-    /// `mMatchProxyRows`. Leaves level counts and anchor bits
-    /// alone — cheap enough (`O(nBuckets + nMatchRows)`) to run
-    /// on every find-bar keystroke without coalescing. Keeps
-    /// `mBucketedMatchCount` in sync so `HasMatchTicks` stays
-    /// truthful.
+    /// `mMatchProxyRows`. `O(nBuckets + nMatchRows)`, cheap enough
+    /// to run on every find keystroke without coalescing.
     void RefreshMatchTicks();
 
-    /// Shared inner loop: fold `mMatchProxyRows` into the
-    /// buckets' `matchCount` fields. Bucket zeroing is the
-    /// caller's job (`RebuildInternal` folds after a full clear,
-    /// `RefreshMatchTicks` zeroes only the tick counters).
-    /// Updates `mBucketedMatchCount` in lockstep so the fast
-    /// `HasMatchTicks` check stays accurate.
+    /// Fold `mMatchProxyRows` into `matchCount`. Caller zeroes the
+    /// counters first. Keeps `mBucketedMatchCount` in lockstep.
     void FoldMatchTicksIntoBuckets();
 
-    /// Re-apply `mMatchBucketCounts` into the live bucket vector
-    /// when the sizes still agree (same H since the last
-    /// `SetMatchBucketCounts`). No-op when the durable vector is
-    /// empty or size-mismatched (caller must rescan). Used by
-    /// `RebuildInternal` after the raw-rows fold so the
-    /// bucket-counts path survives coalesced rebuilds the same
-    /// way `mMatchProxyRows` already does.
+    /// Re-apply `mMatchBucketCounts` when sizes still agree (same
+    /// H since the last `SetMatchBucketCounts`). No-op otherwise;
+    /// caller must rescan. Lets the bucket-counts path survive
+    /// coalesced rebuilds.
     void ApplyStoredMatchBucketCounts();
 
-    /// (Re)start the coalesce timer. On timeout the timer body
-    /// runs a full `RebuildInternal` and emits `bucketsChanged`
-    /// as one operation, so a burst of signals collapses to one
-    /// walk + one repaint.
+    /// (Re)start the coalesce timer. Timeout runs `RebuildInternal`
+    /// and emits `bucketsChanged`.
     void ScheduleRebuild();
 
-    /// Timer slot: drain the pending-rebuild flag, run
-    /// `RebuildInternal`, and emit `bucketsChanged`. Hoisted so
-    /// `SetBucketCount` (which needs a sync rebuild) can share
-    /// the emit path.
+    /// Timer slot: run `RebuildInternal` and emit `bucketsChanged`.
     void OnRebuildTimeout();
 
-    /// Bucket index for proxy row @p proxyRow, or -1 when out of
-    /// range or when the bucket vector is empty. Public math but
-    /// kept private so callers go through `FirstProxyRowInBucket`
-    /// / `ProxyRowForYPixel` for the direction they need.
+    /// Bucket index for proxy row @p proxyRow, or `-1` for out of
+    /// range / empty bucket vector.
     [[nodiscard]] int BucketForProxyRow(int proxyRow) const noexcept;
 
     /// Walk the proxy chain down to a source `LogModel` row.
-    /// Returns -1 when the chain doesn't terminate at `mSourceModel`
-    /// or when any proxy hides the row. Uses the cached
-    /// `mProxyChain` populated by `RebuildProxyChainCache` so the
-    /// hot path avoids a `qobject_cast` per row.
+    /// Returns `-1` when the chain doesn't terminate at
+    /// `mSourceModel`. Uses the cached `mProxyChain` so the hot
+    /// path skips a `qobject_cast` per row.
     [[nodiscard]] int ProxyToSourceRow(int proxyRow) const noexcept;
 
-    /// (Re)populate `mProxyChain` / `mProxyChainTerminatesAtSource`
-    /// by walking `mProxyModel` down until the terminal source
-    /// model. Called from the constructor and on `modelReset` so
-    /// the rebuild hot path can skip repeated `qobject_cast`s.
+    /// (Re)populate `mProxyChain` / `mProxyChainTerminatesAtSource`.
+    /// Called from the constructor and on `modelReset` so the
+    /// rebuild hot path can skip repeated `qobject_cast`s.
     void RebuildProxyChainCache();
 
     /// Level lookup for source row @p sourceRow. Returns
@@ -312,36 +257,21 @@ private:
     QPointer<LogModel> mSourceModel;
     QPointer<AnchorManager> mAnchors;
 
-    /// Cached proxy layers between `mProxyModel` and `mSourceModel`.
-    /// Populated once from `RebuildProxyChainCache` so the per-row
-    /// `qobject_cast` inside `ProxyToSourceRow` disappears from the
-    /// rebuild hot path. Rebuilt on `modelReset`; empty when the
-    /// outermost proxy is the source model itself (no proxies) or
-    /// when there is no proxy at all.
-    ///
-    /// Held as `QPointer` so an inner proxy destroyed under us —
-    /// without a `modelReset` on the outermost proxy — zeroes the
-    /// slot before the next `ProxyToSourceRow` walk dereferences
-    /// it. `ProxyToSourceRow` short-circuits to `-1` on a null
-    /// entry rather than crashing.
+    /// Cached proxy layers between `mProxyModel` and `mSourceModel`,
+    /// populated once from `RebuildProxyChainCache`. Empty when the
+    /// outermost proxy IS the source model. `QPointer` so an inner
+    /// proxy destroyed without a `modelReset` zeroes the slot;
+    /// `ProxyToSourceRow` short-circuits to `-1` rather than crash.
     std::vector<QPointer<QAbstractProxyModel>> mProxyChain;
 
-    /// True iff the last-cached `mProxyChain` terminates at
-    /// `mSourceModel`. `ProxyToSourceRow` short-circuits to `-1`
-    /// when this is false so a mismatched attach can't miscount
-    /// rows.
+    /// True iff `mProxyChain` terminates at `mSourceModel`.
+    /// `ProxyToSourceRow` short-circuits to `-1` when false.
     bool mProxyChainTerminatesAtSource = false;
 
-    /// One-shot flag: set the first time `ProxyToSourceRow`
-    /// detects the walked chain no longer terminates at
-    /// `mSourceModel`. Prevents the `qWarning` breadcrumb from
-    /// spamming the log at scan cadence (~1 M rows). Reset on
-    /// every `RebuildProxyChainCache` so a subsequent drift after
-    /// a fresh cache still surfaces once.
-    ///
-    /// `mutable` because the flag is set from the `const`
-    /// `ProxyToSourceRow` observer — it's a diagnostic side-effect,
-    /// not part of the model's logical state.
+    /// One-shot flag preventing per-row `qWarning` spam when the
+    /// chain drifts off the cached source model. Reset on every
+    /// `RebuildProxyChainCache`. `mutable` because
+    /// `ProxyToSourceRow` is `const`.
     mutable bool mProxyChainDriftWarned = false;
 
     std::vector<Bucket> mBuckets;
@@ -349,23 +279,20 @@ private:
 
     /// Durable per-bucket match totals from the last successful
     /// `SetMatchBucketCounts`. Mutually exclusive with a non-empty
-    /// `mMatchProxyRows`: the bucketed API clears the row list
-    /// (and vice versa) so a rebuild never double-folds. Empty
-    /// when the row-list path is active or matches were cleared.
+    /// `mMatchProxyRows`: whichever API is active clears the other
+    /// so a rebuild never double-folds.
     std::vector<uint32_t> mMatchBucketCounts;
 
-    /// Exact match total paired with `mMatchBucketCounts` (may
-    /// exceed the sum of a capped scan's row list upstream).
+    /// Exact total paired with `mMatchBucketCounts` (may exceed
+    /// the sum of a capped scan's row list upstream).
     uint32_t mMatchBucketTotal = 0;
 
     /// Cached row count from the last rebuild. Used by
-    /// `ProxyRowForYPixel` so the widget doesn't have to
-    /// re-query the proxy after every scroll.
+    /// `ProxyRowForYPixel` so scroll paths skip a proxy query.
     int mProxyRowCount = 0;
 
-    /// Cached first-`Type::Level` column index in source-model
-    /// coords, `-1` when none. Refreshed on model reset and
-    /// column-shape signals.
+    /// Cached first `Type::Level` column index in source-model
+    /// coords, `-1` when none.
     int mLevelColumnIndex = -1;
 
     /// Running popcount of `mBuckets[*].anchorSlots` so
@@ -373,13 +300,10 @@ private:
     std::size_t mAnchorBucketBitsSet = 0;
 
     /// Running sum of `mBuckets[*].matchCount` — the source of
-    /// truth for `HasMatchTicks`. Refreshed by
-    /// `RefreshMatchTicks` and `RebuildInternal`.
+    /// truth for `HasMatchTicks`.
     uint32_t mBucketedMatchCount = 0;
 
-    /// Coalesce timer for `Rebuild()`. When active, one or more
-    /// callers have requested a rebuild; the timer's `timeout`
-    /// runs `OnRebuildTimeout` which does the walk once and
-    /// emits `bucketsChanged`.
+    /// Coalesce timer for `Rebuild()`. Timeout runs
+    /// `OnRebuildTimeout` once and emits `bucketsChanged`.
     QTimer *mRebuildTimer = nullptr;
 };

--- a/app/include/overview_rail_model.hpp
+++ b/app/include/overview_rail_model.hpp
@@ -318,13 +318,31 @@ private:
     /// rebuild hot path. Rebuilt on `modelReset`; empty when the
     /// outermost proxy is the source model itself (no proxies) or
     /// when there is no proxy at all.
-    std::vector<QAbstractProxyModel *> mProxyChain;
+    ///
+    /// Held as `QPointer` so an inner proxy destroyed under us —
+    /// without a `modelReset` on the outermost proxy — zeroes the
+    /// slot before the next `ProxyToSourceRow` walk dereferences
+    /// it. `ProxyToSourceRow` short-circuits to `-1` on a null
+    /// entry rather than crashing.
+    std::vector<QPointer<QAbstractProxyModel>> mProxyChain;
 
     /// True iff the last-cached `mProxyChain` terminates at
     /// `mSourceModel`. `ProxyToSourceRow` short-circuits to `-1`
     /// when this is false so a mismatched attach can't miscount
     /// rows.
     bool mProxyChainTerminatesAtSource = false;
+
+    /// One-shot flag: set the first time `ProxyToSourceRow`
+    /// detects the walked chain no longer terminates at
+    /// `mSourceModel`. Prevents the `qWarning` breadcrumb from
+    /// spamming the log at scan cadence (~1 M rows). Reset on
+    /// every `RebuildProxyChainCache` so a subsequent drift after
+    /// a fresh cache still surfaces once.
+    ///
+    /// `mutable` because the flag is set from the `const`
+    /// `ProxyToSourceRow` observer — it's a diagnostic side-effect,
+    /// not part of the model's logical state.
+    mutable bool mProxyChainDriftWarned = false;
 
     std::vector<Bucket> mBuckets;
     std::vector<int> mMatchProxyRows;

--- a/app/include/overview_rail_model.hpp
+++ b/app/include/overview_rail_model.hpp
@@ -18,6 +18,7 @@
 
 class LogModel;
 class QAbstractItemModel;
+class QAbstractProxyModel;
 class QTimer;
 
 /// Data source for the overview rail. Owns a densely-bucketed
@@ -84,7 +85,9 @@ public:
     /// Push the current find-match proxy rows. Only touches
     /// `matchCount`, not the level counts or anchor bits — a
     /// bucket rebuild is unnecessary for a match-set change. Rows
-    /// outside the current proxy range are silently dropped.
+    /// outside the current proxy range are silently dropped, and
+    /// the incoming list is de-duplicated internally (a duplicate
+    /// row would otherwise be double-counted into its bucket).
     /// Emits `matchesChanged` and `bucketsChanged` immediately so
     /// the widget repaints on the next event-loop pass; find
     /// updates are already debounced upstream.
@@ -232,8 +235,16 @@ private:
 
     /// Walk the proxy chain down to a source `LogModel` row.
     /// Returns -1 when the chain doesn't terminate at `mSourceModel`
-    /// or when any proxy hides the row.
+    /// or when any proxy hides the row. Uses the cached
+    /// `mProxyChain` populated by `RebuildProxyChainCache` so the
+    /// hot path avoids a `qobject_cast` per row.
     [[nodiscard]] int ProxyToSourceRow(int proxyRow) const noexcept;
+
+    /// (Re)populate `mProxyChain` / `mProxyChainTerminatesAtSource`
+    /// by walking `mProxyModel` down until the terminal source
+    /// model. Called from the constructor and on `modelReset` so
+    /// the rebuild hot path can skip repeated `qobject_cast`s.
+    void RebuildProxyChainCache();
 
     /// Level lookup for source row @p sourceRow. Returns
     /// `LogLevel::Unknown` when no level column is configured
@@ -251,6 +262,20 @@ private:
     QPointer<QAbstractItemModel> mProxyModel;
     QPointer<LogModel> mSourceModel;
     QPointer<AnchorManager> mAnchors;
+
+    /// Cached proxy layers between `mProxyModel` and `mSourceModel`.
+    /// Populated once from `RebuildProxyChainCache` so the per-row
+    /// `qobject_cast` inside `ProxyToSourceRow` disappears from the
+    /// rebuild hot path. Rebuilt on `modelReset`; empty when the
+    /// outermost proxy is the source model itself (no proxies) or
+    /// when there is no proxy at all.
+    std::vector<QAbstractProxyModel *> mProxyChain;
+
+    /// True iff the last-cached `mProxyChain` terminates at
+    /// `mSourceModel`. `ProxyToSourceRow` short-circuits to `-1`
+    /// when this is false so a mismatched attach can't miscount
+    /// rows.
+    bool mProxyChainTerminatesAtSource = false;
 
     std::vector<Bucket> mBuckets;
     std::vector<int> mMatchProxyRows;

--- a/app/include/overview_rail_model.hpp
+++ b/app/include/overview_rail_model.hpp
@@ -70,20 +70,38 @@ public:
         QAbstractItemModel *proxyModel, LogModel *sourceModel, AnchorManager *anchors, QObject *parent = nullptr
     );
 
-    /// Set the number of rail pixel rows. Triggers a rebuild when
-    /// the bucket count changes. Zero is legal (widget hidden /
-    /// zero-height) and produces an empty bucket vector.
+    /// Set the number of rail pixel rows. Triggers a synchronous
+    /// rebuild when the bucket count changes so the widget's next
+    /// paint sees fresh data (called from the widget's own
+    /// `resizeEvent`, where a coalesced rebuild would race the
+    /// paint). Zero is legal (widget hidden / zero-height) and
+    /// produces an empty bucket vector; `RebuildInternal`
+    /// short-circuits on that branch, which is the mechanism that
+    /// lets `MainWindow::SetOverviewRailVisible(false)` stop
+    /// paying rebuild cost while the rail is hidden.
     void SetBucketCount(std::size_t nBuckets);
 
-    /// Push the current find-match proxy rows. Coalesced with
-    /// bucket rebuilds through the same 50 ms timer. Rows outside
-    /// the current proxy range are silently dropped.
+    /// Push the current find-match proxy rows. Only touches
+    /// `matchCount`, not the level counts or anchor bits — a
+    /// bucket rebuild is unnecessary for a match-set change. Rows
+    /// outside the current proxy range are silently dropped.
+    /// Emits `matchesChanged` and `bucketsChanged` immediately so
+    /// the widget repaints on the next event-loop pass; find
+    /// updates are already debounced upstream.
     void SetMatchProxyRows(std::vector<int> proxyRows);
 
-    /// Rebuild every bucket from scratch. Called from every
-    /// signal that shifts the proxy row set. O(rowCount +
-    /// matchCount + anchorCount).
+    /// Request a full bucket rebuild. Coalesced through the 50 ms
+    /// emit timer so a burst of proxy signals (per-row inserts
+    /// under an active sort, anchor bulk edits, ...) collapses to
+    /// a single O(rowCount) walk + one repaint per quiet window.
+    /// Prefer this over `RebuildInternal` on every signal path.
     void Rebuild();
+
+    /// Rebuild synchronously without waiting for the coalesce
+    /// timer. Only used by call sites that need the fresh bucket
+    /// vector on return (widget resize, initial attach). Tests
+    /// exercise the coalescing behaviour via `Rebuild()`.
+    void RebuildNow();
 
     [[nodiscard]] std::span<const Bucket> Buckets() const noexcept
     {
@@ -123,10 +141,13 @@ public:
     }
 
     /// True iff any bucket carries at least one match tick.
-    /// Widget uses this to skip the tick pass entirely.
+    /// Widget uses this to skip the tick pass entirely. Tracks
+    /// the *bucketed* total (not `mMatchProxyRows.size()`) so a
+    /// stale match list that only contains rows outside the
+    /// current proxy range correctly reports "no ticks".
     [[nodiscard]] bool HasMatchTicks() const noexcept
     {
-        return !mMatchProxyRows.empty();
+        return mBucketedMatchCount > 0;
     }
 
     /// First proxy row whose bucket falls in @p bucket, or `-1`
@@ -166,14 +187,39 @@ private:
     void OnAnchorChanged(const AnchorManager::Key &key);
     void OnAnchorsReset();
 
-    /// Full rebuild body — factored so `SetBucketCount` and
-    /// `SetMatchProxyRows` can trigger it inline without
-    /// re-entering the coalesce timer.
+    /// Full rebuild body — walks the proxy row set, refreshes
+    /// level counts + anchor bits, then re-folds the current
+    /// match rows in. Factored so `SetBucketCount` can trigger
+    /// it synchronously without re-entering the coalesce timer.
     void RebuildInternal();
 
-    /// (Re)start the coalesce timer. Fires `bucketsChanged`
-    /// after one quiet window.
-    void ScheduleEmit();
+    /// Zero + refill `matchCount` on every bucket from
+    /// `mMatchProxyRows`. Leaves level counts and anchor bits
+    /// alone — cheap enough (`O(nBuckets + nMatchRows)`) to run
+    /// on every find-bar keystroke without coalescing. Keeps
+    /// `mBucketedMatchCount` in sync so `HasMatchTicks` stays
+    /// truthful.
+    void RefreshMatchTicks();
+
+    /// Shared inner loop: fold `mMatchProxyRows` into the
+    /// buckets' `matchCount` fields. Bucket zeroing is the
+    /// caller's job (`RebuildInternal` folds after a full clear,
+    /// `RefreshMatchTicks` zeroes only the tick counters).
+    /// Updates `mBucketedMatchCount` in lockstep so the fast
+    /// `HasMatchTicks` check stays accurate.
+    void FoldMatchTicksIntoBuckets();
+
+    /// (Re)start the coalesce timer. On timeout the timer body
+    /// runs a full `RebuildInternal` and emits `bucketsChanged`
+    /// as one operation, so a burst of signals collapses to one
+    /// walk + one repaint.
+    void ScheduleRebuild();
+
+    /// Timer slot: drain the pending-rebuild flag, run
+    /// `RebuildInternal`, and emit `bucketsChanged`. Hoisted so
+    /// `SetBucketCount` (which needs a sync rebuild) can share
+    /// the emit path.
+    void OnRebuildTimeout();
 
     /// Bucket index for proxy row @p proxyRow, or -1 when out of
     /// range or when the bucket vector is empty. Public math but
@@ -220,5 +266,14 @@ private:
     /// `HasAnchorTicks` stays O(1).
     std::size_t mAnchorBucketBitsSet = 0;
 
-    QTimer *mEmitTimer = nullptr;
+    /// Running sum of `mBuckets[*].matchCount` — the source of
+    /// truth for `HasMatchTicks`. Refreshed by
+    /// `RefreshMatchTicks` and `RebuildInternal`.
+    uint32_t mBucketedMatchCount = 0;
+
+    /// Coalesce timer for `Rebuild()`. When active, one or more
+    /// callers have requested a rebuild; the timer's `timeout`
+    /// runs `OnRebuildTimeout` which does the walk once and
+    /// emits `bucketsChanged`.
+    QTimer *mRebuildTimer = nullptr;
 };

--- a/app/include/overview_rail_model.hpp
+++ b/app/include/overview_rail_model.hpp
@@ -162,7 +162,10 @@ public:
     [[nodiscard]] int ProxyRowForYPixel(int y, int railHeight) const noexcept;
 
 signals:
-    /// Buckets have repaint-worthy new content. Coalesced (~50 ms).
+    /// Buckets have repaint-worthy new content. Typically
+    /// coalesced (~50 ms) via the rebuild timer, but forced
+    /// paths (`SetBucketCount`, `RebuildNow`) emit synchronously
+    /// so callers that need fresh buckets on return get them.
     void bucketsChanged();
 
     /// Match rows changed. Not coalesced — user typing in the

--- a/app/include/overview_rail_model.hpp
+++ b/app/include/overview_rail_model.hpp
@@ -88,10 +88,42 @@ public:
     /// outside the current proxy range are silently dropped, and
     /// the incoming list is de-duplicated internally (a duplicate
     /// row would otherwise be double-counted into its bucket).
-    /// Emits `matchesChanged` and `bucketsChanged` immediately so
-    /// the widget repaints on the next event-loop pass; find
-    /// updates are already debounced upstream.
+    /// Emits `matchesChanged` immediately so the widget repaints
+    /// on the next event-loop pass; find updates are already
+    /// debounced upstream.
+    ///
+    /// Refreshes the cached proxy row count from the live proxy
+    /// before folding so a caller that scanned against a newer
+    /// row count than the last coalesced rebuild doesn't drop
+    /// tail-row hits (row indices past the stale cache) or land
+    /// them in the last bucket via a divide-by-smaller-M.
     void SetMatchProxyRows(std::vector<int> proxyRows);
+
+    /// Push per-bucket match counts directly, bypassing the
+    /// `mMatchProxyRows` vector. Preferred over `SetMatchProxyRows`
+    /// when the caller already knows the totals per bucket and
+    /// wants to skip materializing every matching row — the whole
+    /// point is to avoid an O(matches) vector allocation for
+    /// broad needles that hit most rows.
+    ///
+    /// @p perBucketCounts must have `BucketCount()` entries. When
+    /// the size mismatches (mid-resize race, or the caller has
+    /// stale bucket-count info), the update is dropped silently
+    /// and the previous match ticks stay put — a subsequent call
+    /// after the resize settles will fix it. @p totalMatches is
+    /// the exact pre-cap match total (used for `HasMatchTicks`
+    /// and as a fast source of truth for the sum, so the model
+    /// doesn't have to re-add the counters).
+    ///
+    /// Clears `mMatchProxyRows` so the next coalesced rebuild
+    /// does not double-count a stale row-list fold on top of the
+    /// pre-bucketed values, and retains `@p perBucketCounts` as
+    /// durable state so `RebuildInternal` (anchor edits, resize
+    /// with the same H, hide→show) can re-apply the ticks without
+    /// the caller re-pushing. Emits `matchesChanged` only (level
+    /// counts / anchor bits are untouched, same as
+    /// `SetMatchProxyRows`).
+    void SetMatchBucketCounts(std::vector<uint32_t> perBucketCounts, uint32_t totalMatches);
 
     /// Request a full bucket rebuild. Coalesced through the 50 ms
     /// emit timer so a burst of proxy signals (per-row inserts
@@ -221,6 +253,15 @@ private:
     /// `HasMatchTicks` check stays accurate.
     void FoldMatchTicksIntoBuckets();
 
+    /// Re-apply `mMatchBucketCounts` into the live bucket vector
+    /// when the sizes still agree (same H since the last
+    /// `SetMatchBucketCounts`). No-op when the durable vector is
+    /// empty or size-mismatched (caller must rescan). Used by
+    /// `RebuildInternal` after the raw-rows fold so the
+    /// bucket-counts path survives coalesced rebuilds the same
+    /// way `mMatchProxyRows` already does.
+    void ApplyStoredMatchBucketCounts();
+
     /// (Re)start the coalesce timer. On timeout the timer body
     /// runs a full `RebuildInternal` and emits `bucketsChanged`
     /// as one operation, so a burst of signals collapses to one
@@ -285,6 +326,17 @@ private:
 
     std::vector<Bucket> mBuckets;
     std::vector<int> mMatchProxyRows;
+
+    /// Durable per-bucket match totals from the last successful
+    /// `SetMatchBucketCounts`. Mutually exclusive with a non-empty
+    /// `mMatchProxyRows`: the bucketed API clears the row list
+    /// (and vice versa) so a rebuild never double-folds. Empty
+    /// when the row-list path is active or matches were cleared.
+    std::vector<uint32_t> mMatchBucketCounts;
+
+    /// Exact match total paired with `mMatchBucketCounts` (may
+    /// exceed the sum of a capped scan's row list upstream).
+    uint32_t mMatchBucketTotal = 0;
 
     /// Cached row count from the last rebuild. Used by
     /// `ProxyRowForYPixel` so the widget doesn't have to

--- a/app/include/overview_rail_model.hpp
+++ b/app/include/overview_rail_model.hpp
@@ -1,0 +1,224 @@
+#pragma once
+
+#include "anchor_manager.hpp"
+
+#include <loglib/histogram_bucket_index.hpp>
+#include <loglib/log_level.hpp>
+#include <loglib/theme.hpp>
+
+#include <QModelIndex>
+#include <QObject>
+#include <QPointer>
+
+#include <bitset>
+#include <cstddef>
+#include <cstdint>
+#include <span>
+#include <vector>
+
+class LogModel;
+class QAbstractItemModel;
+class QTimer;
+
+/// Data source for the overview rail. Owns a densely-bucketed
+/// view of the *proxy* row space so the rail stays 1-to-1 aligned
+/// with the scrollbar's usable Y range (a pixel in the rail maps
+/// to a bucket of adjacent proxy rows).
+///
+/// Not a `QAbstractItemModel`: the rail widget reads `Buckets()`
+/// directly and interprets pixel Y positions through
+/// `ProxyRowForYPixel` / `FirstProxyRowInBucket`.
+///
+/// Keyed on the *outermost* proxy so newest-first orientation
+/// (via `RowOrderProxyModel` in the chain) flips the rail for
+/// free — proxy row 0 is visually the topmost row in the table
+/// under both orientations.
+class OverviewRailModel : public QObject
+{
+    Q_OBJECT
+
+public:
+    /// One entry per rail pixel row. Aggregate on purpose:
+    /// `OverviewRailWidget` reads the counts, tick flags, and
+    /// anchor slots directly on the paint path. Reuses
+    /// `loglib::LevelBucket` (same struct the histogram
+    /// consumes) so the two features share their per-level
+    /// counts layout — ROADMAP item 13 explicitly calls this
+    /// "the histogram's bucket data structure tilted 90°".
+    struct Bucket
+    {
+        // NOLINTBEGIN(misc-non-private-member-variables-in-classes)
+        /// Per-level row counts. Slot 0 is `Unknown`, so
+        /// unresolved-level rows still contribute a colour.
+        loglib::LevelBucket levels{};
+
+        /// Number of find-match rows folded into this bucket.
+        uint32_t matchCount = 0;
+
+        /// Bit `s` set means at least one row in this bucket
+        /// carries an anchor coloured with palette slot `s`.
+        std::bitset<loglib::ANCHOR_PALETTE_SIZE> anchorSlots;
+        // NOLINTEND(misc-non-private-member-variables-in-classes)
+    };
+
+    /// @p proxyModel is the outermost proxy (`LogFilterModel` in
+    /// production); may be null in constructor-time test fixtures.
+    /// @p sourceModel is the underlying `LogModel`; borrowed and
+    /// must outlive this object. @p anchors is optional; pass
+    /// nullptr to disable anchor tick tracking.
+    OverviewRailModel(
+        QAbstractItemModel *proxyModel, LogModel *sourceModel, AnchorManager *anchors, QObject *parent = nullptr
+    );
+
+    /// Set the number of rail pixel rows. Triggers a rebuild when
+    /// the bucket count changes. Zero is legal (widget hidden /
+    /// zero-height) and produces an empty bucket vector.
+    void SetBucketCount(std::size_t nBuckets);
+
+    /// Push the current find-match proxy rows. Coalesced with
+    /// bucket rebuilds through the same 50 ms timer. Rows outside
+    /// the current proxy range are silently dropped.
+    void SetMatchProxyRows(std::vector<int> proxyRows);
+
+    /// Rebuild every bucket from scratch. Called from every
+    /// signal that shifts the proxy row set. O(rowCount +
+    /// matchCount + anchorCount).
+    void Rebuild();
+
+    [[nodiscard]] std::span<const Bucket> Buckets() const noexcept
+    {
+        return {mBuckets.data(), mBuckets.size()};
+    }
+
+    [[nodiscard]] std::size_t BucketCount() const noexcept
+    {
+        return mBuckets.size();
+    }
+
+    /// Number of proxy rows the rail was last built against;
+    /// `0` when the proxy is empty or unbound.
+    [[nodiscard]] int ProxyRowCount() const noexcept
+    {
+        return mProxyRowCount;
+    }
+
+    /// Dominant `LogLevel` in @p bucket, or `Unknown` when the
+    /// bucket is empty or out of range. Ties break in favour of
+    /// higher severity so a bucket with equal error and info rows
+    /// paints red, not blue (triage bias).
+    [[nodiscard]] loglib::LogLevel DominantLevel(std::size_t bucket) const noexcept;
+
+    /// Cached first-`Type::Level` column index, `-1` when none.
+    /// Test-only.
+    [[nodiscard]] int LevelColumnIndexForTest() const noexcept
+    {
+        return mLevelColumnIndex;
+    }
+
+    /// True iff any bucket carries at least one anchor tick.
+    /// Same fast-path idea as `HistogramModel::HasAnchorTicks`.
+    [[nodiscard]] bool HasAnchorTicks() const noexcept
+    {
+        return mAnchorBucketBitsSet > 0;
+    }
+
+    /// True iff any bucket carries at least one match tick.
+    /// Widget uses this to skip the tick pass entirely.
+    [[nodiscard]] bool HasMatchTicks() const noexcept
+    {
+        return !mMatchProxyRows.empty();
+    }
+
+    /// First proxy row whose bucket falls in @p bucket, or `-1`
+    /// when the bucket is empty or out of range. Backed by the
+    /// linear mapping (proxy row -> bucket = row * N / M) so it's
+    /// O(1) once the row count is known.
+    [[nodiscard]] int FirstProxyRowInBucket(std::size_t bucket) const noexcept;
+
+    /// Rail pixel Y (top-anchored, 0..railHeight-1) → proxy row.
+    /// Clamped into `[0, proxyRowCount)`; returns `-1` when the
+    /// proxy is empty. Rail widget uses this on click / drag.
+    [[nodiscard]] int ProxyRowForYPixel(int y, int railHeight) const noexcept;
+
+signals:
+    /// Buckets have repaint-worthy new content. Coalesced (~50 ms).
+    void bucketsChanged();
+
+    /// Match rows changed. Not coalesced — user typing in the
+    /// find bar is already debounced upstream, and one paint per
+    /// find recompute is desirable.
+    void matchesChanged();
+
+    /// Anchor mask on at least one bucket changed. Not coalesced;
+    /// anchor edits are user-driven and low-frequency.
+    void anchorBucketsChanged();
+
+private:
+    // Signal handlers. All hand off to `Rebuild()` today; kept
+    // as separate slots so we can inline incremental append later
+    // without disturbing the wiring surface.
+    void OnRowsInserted(const QModelIndex &parent, int first, int last);
+    void OnRowsRemoved(const QModelIndex &parent, int first, int last);
+    void OnModelReset();
+    void OnLayoutChanged();
+    void OnColumnsChanged();
+    void OnEnumColumnsChanged();
+    void OnAnchorChanged(const AnchorManager::Key &key);
+    void OnAnchorsReset();
+
+    /// Full rebuild body — factored so `SetBucketCount` and
+    /// `SetMatchProxyRows` can trigger it inline without
+    /// re-entering the coalesce timer.
+    void RebuildInternal();
+
+    /// (Re)start the coalesce timer. Fires `bucketsChanged`
+    /// after one quiet window.
+    void ScheduleEmit();
+
+    /// Bucket index for proxy row @p proxyRow, or -1 when out of
+    /// range or when the bucket vector is empty. Public math but
+    /// kept private so callers go through `FirstProxyRowInBucket`
+    /// / `ProxyRowForYPixel` for the direction they need.
+    [[nodiscard]] int BucketForProxyRow(int proxyRow) const noexcept;
+
+    /// Walk the proxy chain down to a source `LogModel` row.
+    /// Returns -1 when the chain doesn't terminate at `mSourceModel`
+    /// or when any proxy hides the row.
+    [[nodiscard]] int ProxyToSourceRow(int proxyRow) const noexcept;
+
+    /// Level lookup for source row @p sourceRow. Returns
+    /// `LogLevel::Unknown` when no level column is configured
+    /// or the slot is unmapped.
+    [[nodiscard]] loglib::LogLevel LevelForSourceRow(int sourceRow) const noexcept;
+
+    /// Linear scan for the first `Type::Level` column in the
+    /// current configuration; `-1` when none.
+    [[nodiscard]] int ComputeLevelColumnIndex() const noexcept;
+
+    /// Emit `anchorBucketsChanged` when the aggregate bit-count
+    /// changed. Called after every full rebuild.
+    void EmitAnchorChangeIfDifferent(std::size_t previousBitsSet);
+
+    QPointer<QAbstractItemModel> mProxyModel;
+    QPointer<LogModel> mSourceModel;
+    QPointer<AnchorManager> mAnchors;
+
+    std::vector<Bucket> mBuckets;
+    std::vector<int> mMatchProxyRows;
+
+    /// Cached row count from the last rebuild. Used by
+    /// `ProxyRowForYPixel` so the widget doesn't have to
+    /// re-query the proxy after every scroll.
+    int mProxyRowCount = 0;
+
+    /// Cached first-`Type::Level` column index in source-model
+    /// coords, `-1` when none. Refreshed on model reset and
+    /// column-shape signals.
+    int mLevelColumnIndex = -1;
+
+    /// Running popcount of `mBuckets[*].anchorSlots` so
+    /// `HasAnchorTicks` stays O(1).
+    std::size_t mAnchorBucketBitsSet = 0;
+
+    QTimer *mEmitTimer = nullptr;
+};

--- a/app/include/overview_rail_model.hpp
+++ b/app/include/overview_rail_model.hpp
@@ -123,10 +123,16 @@ public:
         return mProxyRowCount;
     }
 
-    /// Dominant `LogLevel` in @p bucket, or `Unknown` when the
-    /// bucket is empty or out of range. Ties break in favour of
-    /// higher severity so a bucket with equal error and info rows
-    /// paints red, not blue (triage bias).
+    /// Majority-count `LogLevel` in @p bucket, tie-broken by
+    /// severity (Fatal > Error > Warn > Info > Debug > Trace >
+    /// Unknown), or `Unknown` when the bucket is empty or out
+    /// of range. The rail widget itself no longer picks a single
+    /// bucket colour via this method -- it iterates the per-level
+    /// counts (`Buckets()[i].levels.counts`) and paints stacked
+    /// severity segments so both density and rare high-severity
+    /// anomalies are visible at once. Retained on the model for
+    /// callers that want a single representative colour (anchor
+    /// tick legend, tests, future summary widgets).
     [[nodiscard]] loglib::LogLevel DominantLevel(std::size_t bucket) const noexcept;
 
     /// Cached first-`Type::Level` column index, `-1` when none.

--- a/app/include/overview_rail_model.hpp
+++ b/app/include/overview_rail_model.hpp
@@ -72,10 +72,12 @@ public:
     );
 
     /// Set the number of rail pixel rows. Triggers a synchronous
-    /// rebuild when the bucket count changes so the widget's next
-    /// paint sees fresh data (called from the widget's own
-    /// `resizeEvent`, where a coalesced rebuild would race the
-    /// paint). Zero is legal (widget hidden / zero-height) and
+    /// rebuild when the bucket count changes so the caller sees
+    /// fresh data on return. The widget calls this from
+    /// `showEvent` (immediate) and from a debounced
+    /// `resizeEvent` path (`BUCKET_SYNC_DEBOUNCE_MS`) so interactive
+    /// window-drag storms collapse to one rebuild + one find
+    /// rescan. Zero is legal (widget hidden / zero-height) and
     /// produces an empty bucket vector; `RebuildInternal`
     /// short-circuits on that branch, which is the mechanism that
     /// lets `MainWindow::SetOverviewRailVisible(false)` stop

--- a/app/include/overview_rail_widget.hpp
+++ b/app/include/overview_rail_widget.hpp
@@ -13,6 +13,7 @@ class QAbstractItemView;
 class QMouseEvent;
 class QPaintEvent;
 class QResizeEvent;
+class QShowEvent;
 class QWheelEvent;
 
 /// Klogg / Qt-Creator-inspired match overview rail. A slim
@@ -79,9 +80,12 @@ public:
 signals:
     /// Emitted after the widget resolves a click / drag Y to a
     /// proxy row. `MainWindow` connects this to
-    /// `ScrollToProxyRow` (or a moral equivalent) so the table
-    /// scrolls and the current selection follows.
-    void proxyRowClicked(int proxyRow);
+    /// `ScrollToProxyRow`; @p replaceSelection is `true` on a
+    /// fresh click (the user is committing to that row, so it's
+    /// safe to replace the existing selection) and `false`
+    /// during a drag scrub (the user is exploring, so any
+    /// existing multi-selection is preserved).
+    void proxyRowClicked(int proxyRow, bool replaceSelection);
 
 protected:
     void paintEvent(QPaintEvent *event) override;
@@ -91,6 +95,14 @@ protected:
     void wheelEvent(QWheelEvent *event) override;
     void resizeEvent(QResizeEvent *event) override;
     void changeEvent(QEvent *event) override;
+
+    /// Re-sync the model's bucket count on every show. Needed
+    /// because `MainWindow::SetOverviewRailVisible(false)` drops
+    /// the bucket vector to skip rebuilds while the rail is
+    /// hidden — a subsequent show whose viewport height didn't
+    /// change would not re-fire `resizeEvent`, and the rail
+    /// would paint blank against a zero-bucket model.
+    void showEvent(QShowEvent *event) override;
 
 private:
     /// Rail Y range that maps 1-to-1 to proxy rows. Excludes a
@@ -110,8 +122,10 @@ private:
     /// Resolve mouse Y to a proxy row and emit
     /// `proxyRowClicked`. Filters out consecutive same-row
     /// emissions during a drag so downstream handlers aren't
-    /// spammed with duplicate scrolls.
-    void EmitProxyRowForY(int y);
+    /// spammed with duplicate scrolls. @p replaceSelection is
+    /// forwarded to the signal so the initial click and the
+    /// scrubbing moves can request different selection policies.
+    void EmitProxyRowForY(int y, bool replaceSelection);
 
     QPointer<OverviewRailModel> mModel;
     QPointer<ThemeControl> mTheme;

--- a/app/include/overview_rail_widget.hpp
+++ b/app/include/overview_rail_widget.hpp
@@ -5,6 +5,7 @@
 #include <QSize>
 #include <QWidget>
 
+#include <climits>
 #include <cstddef>
 
 class OverviewRailModel;
@@ -133,7 +134,10 @@ private:
 
     /// Last emitted proxy row during an active drag. Sentinel
     /// `INT_MIN` while idle so the first click still emits.
-    int mLastEmittedRow;
+    /// Default-initialised in-class so a future ctor overload
+    /// that forgets the init list can't leak an indeterminate
+    /// value into the first `EmitProxyRowForY` comparison.
+    int mLastEmittedRow = INT_MIN;
 
     /// True while the user is holding the left button on the
     /// rail. Used to differentiate a wheel-through-rail scroll

--- a/app/include/overview_rail_widget.hpp
+++ b/app/include/overview_rail_widget.hpp
@@ -63,7 +63,8 @@ public:
     /// Retrieve the widget's currently-cached DPI-fluent width.
     /// Kept as a helper (over `sizeHint().width()`) because
     /// `sizeHint()` is const and re-runs the platform-metric
-    /// query on every call. Test-only.
+    /// query on every call. Returns `mCachedRailWidth`, refreshed
+    /// as a side-effect of `sizeHint()`. Test-only.
     [[nodiscard]] int RailWidthForTest() const;
 
     /// Rail rect for the viewport indicator overlay. Empty
@@ -144,4 +145,10 @@ private:
     /// (idle state, forward to scrollbar) from a drag scrub
     /// (active state, do not forward).
     bool mDragging = false;
+
+    /// Last DPI-fluent width computed by `sizeHint()`. Mutable so
+    /// `sizeHint() const` can refresh it as a side-effect, and
+    /// `RailWidthForTest()` can return it without re-running the
+    /// platform-metric query.
+    mutable int mCachedRailWidth = 0;
 };

--- a/app/include/overview_rail_widget.hpp
+++ b/app/include/overview_rail_widget.hpp
@@ -1,0 +1,129 @@
+#pragma once
+
+#include <QPointer>
+#include <QRect>
+#include <QSize>
+#include <QWidget>
+
+#include <cstddef>
+
+class OverviewRailModel;
+class ThemeControl;
+class QAbstractItemView;
+class QMouseEvent;
+class QPaintEvent;
+class QResizeEvent;
+class QWheelEvent;
+
+/// Klogg / Qt-Creator-inspired match overview rail. A slim
+/// vertical strip painted in a reserved right-hand viewport
+/// margin of `LogTableView` (via
+/// `LogTableView::AttachOverviewRail`). Renders:
+///
+/// - A **subtle wash background** (`QPalette::Base` blended
+///   toward `QPalette::Window`) so the rail reads as an
+///   integrated frame element in every theme.
+/// - A **dominant-level colour underlay** per bucket, drawn at
+///   ~50 % alpha over the wash. Severity ties break in favour
+///   of the higher level (Fatal beats Error beats Warn).
+/// - **Find match ticks** for buckets containing at least one
+///   find match, painted in the palette's Highlight accent.
+/// - **Anchor tick bands** per set anchor palette slot,
+///   coloured via `ThemeControl::AnchorBrushFor`.
+/// - A **rounded viewport indicator** showing the currently
+///   visible proxy-row range, tracked from the attached table
+///   view's vertical scrollbar. Anti-aliased translucent fill
+///   with a 2 px cosmetic outline (the "glass thumb" look).
+///
+/// Rail width is DPI-fluent: `sizeHint()` returns
+/// `max(fontMetrics('M'), style()->PM_ScrollBarExtent)` so the
+/// rail scales with the platform's own DPI-aware scrollbar
+/// sizing. Repositioning is owned by `LogTableView`; this
+/// widget just paints and forwards mouse events.
+class OverviewRailWidget : public QWidget
+{
+    Q_OBJECT
+
+public:
+    /// @p model is borrowed and must outlive this widget.
+    /// @p theme is optional; when null, level colours fall back
+    /// to `QPalette::Highlight` and anchor bands to
+    /// `QPalette::Highlight`. @p tableView is used solely to
+    /// resolve viewport-indicator geometry (via its vertical
+    /// scrollbar); the widget does not take ownership.
+    OverviewRailWidget(
+        OverviewRailModel *model, ThemeControl *theme, QAbstractItemView *tableView, QWidget *parent = nullptr
+    );
+
+    [[nodiscard]] QSize sizeHint() const override;
+    [[nodiscard]] QSize minimumSizeHint() const override;
+
+    /// Retrieve the widget's currently-cached DPI-fluent width.
+    /// Kept as a helper (over `sizeHint().width()`) because
+    /// `sizeHint()` is const and re-runs the platform-metric
+    /// query on every call. Test-only.
+    [[nodiscard]] int RailWidthForTest() const;
+
+    /// Rail rect for the viewport indicator overlay. Empty
+    /// when there is no attached table view or the model
+    /// reports zero rows. Test-only.
+    [[nodiscard]] QRect ViewportIndicatorRectForTest() const;
+
+    /// Bucket at pixel Y, or nullopt when the widget is empty
+    /// / height 0. Test-only.
+    [[nodiscard]] int BucketAtYForTest(int y) const;
+
+    /// Y coordinate of the top of bucket @p bucket. Test-only.
+    [[nodiscard]] int YForBucketForTest(std::size_t bucket) const;
+
+signals:
+    /// Emitted after the widget resolves a click / drag Y to a
+    /// proxy row. `MainWindow` connects this to
+    /// `ScrollToProxyRow` (or a moral equivalent) so the table
+    /// scrolls and the current selection follows.
+    void proxyRowClicked(int proxyRow);
+
+protected:
+    void paintEvent(QPaintEvent *event) override;
+    void mousePressEvent(QMouseEvent *event) override;
+    void mouseMoveEvent(QMouseEvent *event) override;
+    void mouseReleaseEvent(QMouseEvent *event) override;
+    void wheelEvent(QWheelEvent *event) override;
+    void resizeEvent(QResizeEvent *event) override;
+    void changeEvent(QEvent *event) override;
+
+private:
+    /// Rail Y range that maps 1-to-1 to proxy rows. Excludes a
+    /// 2 px inset at the top and bottom so tick outlines don't
+    /// clip against the widget edges.
+    [[nodiscard]] QRect InteractiveRailRect() const;
+
+    /// Compute the currently-visible proxy-row Y range on the
+    /// rail, or an empty rect when the row count is 0.
+    [[nodiscard]] QRect ComputeViewportIndicatorRect() const;
+
+    /// Push the current widget height into the model so the
+    /// bucket vector matches the rail's usable pixel count.
+    /// Idempotent when the height matches.
+    void SyncBucketCountToHeight();
+
+    /// Resolve mouse Y to a proxy row and emit
+    /// `proxyRowClicked`. Filters out consecutive same-row
+    /// emissions during a drag so downstream handlers aren't
+    /// spammed with duplicate scrolls.
+    void EmitProxyRowForY(int y);
+
+    QPointer<OverviewRailModel> mModel;
+    QPointer<ThemeControl> mTheme;
+    QPointer<QAbstractItemView> mTableView;
+
+    /// Last emitted proxy row during an active drag. Sentinel
+    /// `INT_MIN` while idle so the first click still emits.
+    int mLastEmittedRow;
+
+    /// True while the user is holding the left button on the
+    /// rail. Used to differentiate a wheel-through-rail scroll
+    /// (idle state, forward to scrollbar) from a drag scrub
+    /// (active state, do not forward).
+    bool mDragging = false;
+};

--- a/app/include/overview_rail_widget.hpp
+++ b/app/include/overview_rail_widget.hpp
@@ -1,8 +1,10 @@
 #pragma once
 
+#include <QMetaType>
 #include <QPointer>
 #include <QRect>
 #include <QSize>
+#include <QString>
 #include <QWidget>
 
 #include <climits>
@@ -14,9 +16,32 @@ class ThemeControl;
 class QAbstractItemView;
 class QMouseEvent;
 class QPaintEvent;
+class QHideEvent;
 class QResizeEvent;
 class QShowEvent;
+class QTimer;
 class QWheelEvent;
+
+/// User-selectable overview-rail width preset. All three modes
+/// share the same DPI-fluent base formula (`2 × scrollbar
+/// extent`, etc.); the mode only scales that base.
+/// Persisted as `ui/overviewRailWidth` (`"narrow"` / `"medium"`
+/// / `"wide"`). Default is `Medium`.
+enum class OverviewRailWidthMode
+{
+    Narrow,
+    Medium,
+    Wide,
+};
+
+/// Parse a `QSettings` string into a width mode. Unknown /
+/// empty values map to `Medium` (the shipped default).
+[[nodiscard]] OverviewRailWidthMode ParseOverviewRailWidthMode(const QString &value);
+
+/// Serialise a width mode for `QSettings`.
+[[nodiscard]] QString OverviewRailWidthModeToSettingsString(OverviewRailWidthMode mode);
+
+Q_DECLARE_METATYPE(OverviewRailWidthMode)
 
 /// Klogg / Qt-Creator-inspired match overview rail. A slim
 /// vertical strip painted in a reserved right-hand viewport
@@ -57,10 +82,10 @@ class QWheelEvent;
 ///   view's vertical scrollbar. Anti-aliased translucent fill
 ///   with a 2 px cosmetic outline (the "glass thumb" look).
 ///
-/// Rail width is DPI-fluent: `sizeHint()` returns
-/// `max(fontMetrics('M'), style()->PM_ScrollBarExtent)` so the
-/// rail scales with the platform's own DPI-aware scrollbar
-/// sizing. Repositioning is owned by `LogTableView`; this
+/// Rail width is DPI-fluent: `sizeHint()` builds a base from
+/// `2 × max(PM_ScrollBarExtent, font 'M')` then multiplies by
+/// the active `OverviewRailWidthMode` (Narrow 1.0 / Medium 1.5 /
+/// Wide 2.0). Repositioning is owned by `LogTableView`; this
 /// widget just paints and forwards mouse events.
 class OverviewRailWidget : public QWidget
 {
@@ -79,6 +104,16 @@ public:
 
     [[nodiscard]] QSize sizeHint() const override;
     [[nodiscard]] QSize minimumSizeHint() const override;
+
+    /// Select the DPI-fluent width preset. No-op when unchanged.
+    /// Calls `updateGeometry()` so `LogTableView` can re-reserve
+    /// the right viewport margin.
+    void SetWidthMode(OverviewRailWidthMode mode);
+
+    [[nodiscard]] OverviewRailWidthMode WidthMode() const noexcept
+    {
+        return mWidthMode;
+    }
 
     /// Retrieve the widget's currently-cached DPI-fluent width.
     /// Kept as a helper (over `sizeHint().width()`) because
@@ -141,7 +176,33 @@ protected:
     /// hidden — a subsequent show whose viewport height didn't
     /// change would not re-fire `resizeEvent`, and the rail
     /// would paint blank against a zero-bucket model.
+    ///
+    /// Runs synchronously (bypasses `mBucketSyncTimer`) so the
+    /// first paint after a show already has correct bucket
+    /// geometry. The debounce is only there to coalesce interactive
+    /// window-resize storms; a show event is a discrete user action
+    /// and should feel instant.
     void showEvent(QShowEvent *event) override;
+
+    /// Cancel any pending debounced bucket-sync when the widget
+    /// hides. `MainWindow::SetOverviewRailVisible(false)` also
+    /// drops the model's bucket vector to skip rebuild cost while
+    /// hidden; without cancelling the timer, a queued
+    /// `SyncBucketCountToHeight()` firing right after the hide
+    /// would immediately re-populate the buckets against the
+    /// widget's persisted height, undoing the visibility-toggle
+    /// optimisation.
+    void hideEvent(QHideEvent *event) override;
+
+#ifdef LOGAPP_BUILD_TESTING
+public:
+    /// Flush any pending debounced `SyncBucketCountToHeight()`
+    /// call now. Tests that resize the widget after `show()` and
+    /// expect the bucket vector to update before the next paint
+    /// call this to skip the debounce wait. No-op when no sync is
+    /// pending.
+    void FlushPendingBucketSyncForTest();
+#endif
 
 private:
     /// Rail Y range that maps 1-to-1 to proxy rows. Excludes a
@@ -155,7 +216,11 @@ private:
 
     /// Push the current widget height into the model so the
     /// bucket vector matches the rail's usable pixel count.
-    /// Idempotent when the height matches.
+    /// Idempotent when the height matches. Called synchronously
+    /// from `showEvent` and via `mBucketSyncTimer` from
+    /// `resizeEvent` so a drag-resize storm coalesces to a
+    /// single `SetBucketCount(H)` call (see
+    /// `BUCKET_SYNC_DEBOUNCE_MS` in the .cpp for the rationale).
     void SyncBucketCountToHeight();
 
     /// Resolve mouse Y to a proxy row and emit
@@ -183,6 +248,11 @@ private:
     /// (active state, do not forward).
     bool mDragging = false;
 
+    /// Active width preset. Default Medium matches the
+    /// Preferences / `QSettings` default so a brand-new widget
+    /// agrees with a first-launch MainWindow before settings load.
+    OverviewRailWidthMode mWidthMode = OverviewRailWidthMode::Medium;
+
     /// Last DPI-fluent width computed by `sizeHint()`. Mutable so
     /// `sizeHint() const` can refresh it as a side-effect, and
     /// `RailWidthForTest()` can return it without re-running the
@@ -200,4 +270,15 @@ private:
     std::size_t mCachedYEdgesBuckets = 0;
     int mCachedYEdgesRailTop = INT_MIN;
     int mCachedYEdgesRailHeight = INT_MIN;
+
+    /// Debounce timer for `SyncBucketCountToHeight()` on
+    /// `resizeEvent`. Interactive window-drag resizes fire a
+    /// resize event per changed pixel, and each `SetBucketCount(H)`
+    /// call reallocates buckets, drops the durable find-match
+    /// counts (sizes disagree), and forces a synchronous
+    /// full-table rescan through the `MainWindow`
+    /// `bucketsChanged` -> `PushFindMatchesToOverviewRail`
+    /// lambda. Coalescing collapses a drag burst into one
+    /// bucket-count update + one rescan.
+    QTimer *mBucketSyncTimer = nullptr;
 };

--- a/app/include/overview_rail_widget.hpp
+++ b/app/include/overview_rail_widget.hpp
@@ -7,6 +7,7 @@
 
 #include <climits>
 #include <cstddef>
+#include <cstdint>
 
 class OverviewRailModel;
 class ThemeControl;
@@ -20,18 +21,37 @@ class QWheelEvent;
 /// Klogg / Qt-Creator-inspired match overview rail. A slim
 /// vertical strip painted in a reserved right-hand viewport
 /// margin of `LogTableView` (via
-/// `LogTableView::AttachOverviewRail`). Renders:
+/// `LogTableView::AttachOverviewRail`). Renders one full-width
+/// content section with three stacked layers:
 ///
-/// - A **subtle wash background** (`QPalette::Base` blended
-///   toward `QPalette::Window`) so the rail reads as an
-///   integrated frame element in every theme.
-/// - A **dominant-level colour underlay** per bucket, drawn at
-///   ~50 % alpha over the wash. Severity ties break in favour
-///   of the higher level (Fatal beats Error beats Warn).
-/// - **Find match ticks** for buckets containing at least one
-///   find match, painted in the palette's Highlight accent.
-/// - **Anchor tick bands** per set anchor palette slot,
-///   coloured via `ThemeControl::AnchorBrushFor`.
+/// - A **base wash** in `QPalette::Base` so the rail reads as an
+///   integrated extension of the table's data area in every
+///   theme.
+/// - A **stacked-severity bin bar** per non-empty bucket. Bar
+///   width encodes total row density (log-scaled); the bar is
+///   split into per-level segments in severity-descending order
+///   (Fatal / Error / Warn / Info / Debug / Trace / Unknown),
+///   each sized by that level's `log2(count + 1)`-weighted
+///   share of the bucket with a 1 px floor so rare severities
+///   never round away. The log-weighted split compresses the
+///   dynamic range: a 500 Trace + 1 Fatal bucket paints a
+///   noticeable Fatal band instead of a single-pixel needle,
+///   while still keeping the majority level clearly dominant.
+///   Segment colours come from the active theme's row
+///   *background* (via `ThemeControl::BackgroundFor`) so the
+///   rail reads as a mini-map of the row-tinted table rather
+///   than a bright pastel band. `BackgroundFor` respects
+///   `mHighContrast`, so the "high contrast levels" preference
+///   automatically recolours the rail with the loud
+///   `levelsHighContrast` variants. Theme-unstyled levels fall
+///   back to `QPalette::PlaceholderText` painted at reduced
+///   alpha (`LEVEL_FALLBACK_ALPHA`).
+/// - **Match / anchor overlays** repaint the whole content
+///   width for buckets that carry a search hit or an anchor.
+///   Anchors are drawn on top of matches so a user-set marker
+///   always wins over live search state; both use only theme
+///   palette colours (`QPalette::Highlight` for matches,
+///   `ThemeControl::AnchorBrushFor` for anchors).
 /// - A **rounded viewport indicator** showing the currently
 ///   visible proxy-row range, tracked from the attached table
 ///   view's vertical scrollbar. Anti-aliased translucent fill
@@ -78,6 +98,23 @@ public:
 
     /// Y coordinate of the top of bucket @p bucket. Test-only.
     [[nodiscard]] int YForBucketForTest(std::size_t bucket) const;
+
+    /// Bar width (in device-independent px) the level pass would
+    /// paint for a bucket with @p count rows against a rail-wide
+    /// @p maxCount, laid out in a level column of @p columnWidth
+    /// pixels. Exposes the log-scale + `MIN_BAR_WIDTH_PX` clamp
+    /// so the paint math can be verified without pixel-scraping
+    /// the widget. Test-only.
+    [[nodiscard]] static int WidthForCountForTest(std::uint32_t count, std::uint32_t maxCount, int columnWidth);
+
+    /// Single content rect inside the usable underlay. Returned
+    /// with `.left / .width` populated and `.top / .height` zero
+    /// because each bucket's paint pass fills its own Y slice
+    /// on top of this. The bin bar, match overlay, and anchor
+    /// overlay all share this same horizontal slot -- the old
+    /// three-column layout collapsed into a single slot with
+    /// paint order handling overlap. Test-only.
+    [[nodiscard]] static QRect ContentRectForTest(int underlayLeft, int underlayWidth);
 
 signals:
     /// Emitted after the widget resolves a click / drag Y to a

--- a/app/include/overview_rail_widget.hpp
+++ b/app/include/overview_rail_widget.hpp
@@ -22,11 +22,9 @@ class QShowEvent;
 class QTimer;
 class QWheelEvent;
 
-/// User-selectable overview-rail width preset. All three modes
-/// share the same DPI-fluent base formula (`2 × scrollbar
-/// extent`, etc.); the mode only scales that base.
-/// Persisted as `ui/overviewRailWidth` (`"narrow"` / `"medium"`
-/// / `"wide"`). Default is `Medium`.
+/// Width preset for the overview rail. Scales the shared
+/// DPI-fluent base formula. Persisted as `ui/overviewRailWidth`
+/// (`"narrow"` / `"medium"` / `"wide"`); default `Medium`.
 enum class OverviewRailWidthMode
 {
     Narrow,
@@ -43,50 +41,34 @@ enum class OverviewRailWidthMode
 
 Q_DECLARE_METATYPE(OverviewRailWidthMode)
 
-/// Klogg / Qt-Creator-inspired match overview rail. A slim
-/// vertical strip painted in a reserved right-hand viewport
-/// margin of `LogTableView` (via
-/// `LogTableView::AttachOverviewRail`). Renders one full-width
-/// content section with three stacked layers:
+/// Klogg / Qt-Creator-inspired match overview rail. A vertical
+/// strip painted in a reserved right-hand viewport margin of
+/// `LogTableView` (via `LogTableView::AttachOverviewRail`).
 ///
-/// - A **base wash** in `QPalette::Base` so the rail reads as an
-///   integrated extension of the table's data area in every
-///   theme.
-/// - A **stacked-severity bin bar** per non-empty bucket. Bar
-///   width encodes total row density (log-scaled); the bar is
-///   split into per-level segments in severity-descending order
-///   (Fatal / Error / Warn / Info / Debug / Trace / Unknown),
-///   each sized by that level's `log2(count + 1)`-weighted
-///   share of the bucket with a 1 px floor so rare severities
-///   never round away. The log-weighted split compresses the
-///   dynamic range: a 500 Trace + 1 Fatal bucket paints a
-///   noticeable Fatal band instead of a single-pixel needle,
-///   while still keeping the majority level clearly dominant.
-///   Segment colours come from the active theme's row
-///   *background* (via `ThemeControl::BackgroundFor`) so the
-///   rail reads as a mini-map of the row-tinted table rather
-///   than a bright pastel band. `BackgroundFor` respects
-///   `mHighContrast`, so the "high contrast levels" preference
-///   automatically recolours the rail with the loud
-///   `levelsHighContrast` variants. Theme-unstyled levels fall
-///   back to `QPalette::PlaceholderText` painted at reduced
-///   alpha (`LEVEL_FALLBACK_ALPHA`).
-/// - **Match / anchor overlays** repaint the whole content
-///   width for buckets that carry a search hit or an anchor.
-///   Anchors are drawn on top of matches so a user-set marker
-///   always wins over live search state; both use only theme
-///   palette colours (`QPalette::Highlight` for matches,
-///   `ThemeControl::AnchorBrushFor` for anchors).
-/// - A **rounded viewport indicator** showing the currently
-///   visible proxy-row range, tracked from the attached table
-///   view's vertical scrollbar. Anti-aliased translucent fill
-///   with a 2 px cosmetic outline (the "glass thumb" look).
+/// Paint layers, bottom-up:
 ///
-/// Rail width is DPI-fluent: `sizeHint()` builds a base from
-/// `2 × max(PM_ScrollBarExtent, font 'M')` then multiplies by
-/// the active `OverviewRailWidthMode` (Narrow 1.0 / Medium 1.5 /
-/// Wide 2.0). Repositioning is owned by `LogTableView`; this
-/// widget just paints and forwards mouse events.
+/// - **Base wash** in `QPalette::Base` so the rail reads as an
+///   extension of the table's data area.
+/// - **Stacked-severity bin bar** per non-empty bucket. Bar width
+///   encodes total density (log-scaled); the bar splits into
+///   per-level segments in severity-descending order, each sized
+///   by that level's `log2(count + 1)` share with a 1 px floor
+///   so rare severities never round away. Colours come from the
+///   theme's row background (`ThemeControl::BackgroundFor`), which
+///   also respects the "high contrast levels" preference; unstyled
+///   levels fall back to `QPalette::PlaceholderText`.
+/// - **Match / anchor overlays** repaint the full content width
+///   for buckets that carry a hit. Anchors > matches so a user
+///   marker wins over live search state.
+/// - **Viewport indicator** — anti-aliased translucent fill with
+///   a cosmetic outline, tracking the attached view's scrollbar
+///   (the "glass thumb" look).
+///
+/// Width is DPI-fluent: `sizeHint()` uses
+/// `2 × max(PM_ScrollBarExtent, font 'M')` scaled by the active
+/// width mode (Narrow 1.0 / Medium 1.5 / Wide 2.0). Repositioning
+/// is `LogTableView`'s job; the widget only paints and forwards
+/// mouse events.
 class OverviewRailWidget : public QWidget
 {
     Q_OBJECT
@@ -115,11 +97,7 @@ public:
         return mWidthMode;
     }
 
-    /// Retrieve the widget's currently-cached DPI-fluent width.
-    /// Kept as a helper (over `sizeHint().width()`) because
-    /// `sizeHint()` is const and re-runs the platform-metric
-    /// query on every call. Returns `mCachedRailWidth`, refreshed
-    /// as a side-effect of `sizeHint()`. Test-only.
+    /// Cached DPI-fluent width from the last `sizeHint()`. Test-only.
     [[nodiscard]] int RailWidthForTest() const;
 
     /// Rail rect for the viewport indicator overlay. Empty
@@ -142,23 +120,15 @@ public:
     /// the widget. Test-only.
     [[nodiscard]] static int WidthForCountForTest(std::uint32_t count, std::uint32_t maxCount, int columnWidth);
 
-    /// Single content rect inside the usable underlay. Returned
-    /// with `.left / .width` populated and `.top / .height` zero
-    /// because each bucket's paint pass fills its own Y slice
-    /// on top of this. The bin bar, match overlay, and anchor
-    /// overlay all share this same horizontal slot -- the old
-    /// three-column layout collapsed into a single slot with
-    /// paint order handling overlap. Test-only.
+    /// Content rect (`.left / .width` set, `.top / .height` zero).
+    /// Bin bar, match overlay, and anchor overlay all share this
+    /// horizontal slot; paint order handles overlap. Test-only.
     [[nodiscard]] static QRect ContentRectForTest(int underlayLeft, int underlayWidth);
 
 signals:
-    /// Emitted after the widget resolves a click / drag Y to a
-    /// proxy row. `MainWindow` connects this to
-    /// `ScrollToProxyRow`; @p replaceSelection is `true` on a
-    /// fresh click (the user is committing to that row, so it's
-    /// safe to replace the existing selection) and `false`
-    /// during a drag scrub (the user is exploring, so any
-    /// existing multi-selection is preserved).
+    /// Emitted after resolving a click / drag Y to a proxy row.
+    /// @p replaceSelection is `true` on a fresh click (commit) and
+    /// `false` during a drag scrub (leave the selection alone).
     void proxyRowClicked(int proxyRow, bool replaceSelection);
 
 protected:
@@ -170,37 +140,24 @@ protected:
     void resizeEvent(QResizeEvent *event) override;
     void changeEvent(QEvent *event) override;
 
-    /// Re-sync the model's bucket count on every show. Needed
-    /// because `MainWindow::SetOverviewRailVisible(false)` drops
-    /// the bucket vector to skip rebuilds while the rail is
-    /// hidden — a subsequent show whose viewport height didn't
-    /// change would not re-fire `resizeEvent`, and the rail
-    /// would paint blank against a zero-bucket model.
-    ///
-    /// Runs synchronously (bypasses `mBucketSyncTimer`) so the
-    /// first paint after a show already has correct bucket
-    /// geometry. The debounce is only there to coalesce interactive
-    /// window-resize storms; a show event is a discrete user action
-    /// and should feel instant.
+    /// Re-sync the model's bucket count on show. Needed because
+    /// `MainWindow::SetOverviewRailVisible(false)` drops the
+    /// bucket vector, and a same-height re-show wouldn't fire
+    /// `resizeEvent`. Runs synchronously so the first paint has
+    /// correct geometry.
     void showEvent(QShowEvent *event) override;
 
-    /// Cancel any pending debounced bucket-sync when the widget
-    /// hides. `MainWindow::SetOverviewRailVisible(false)` also
-    /// drops the model's bucket vector to skip rebuild cost while
-    /// hidden; without cancelling the timer, a queued
-    /// `SyncBucketCountToHeight()` firing right after the hide
-    /// would immediately re-populate the buckets against the
-    /// widget's persisted height, undoing the visibility-toggle
-    /// optimisation.
+    /// Cancel any pending debounced bucket-sync on hide. Without
+    /// this, a queued `SyncBucketCountToHeight()` firing after
+    /// `SetOverviewRailVisible(false)` would immediately
+    /// re-populate the buckets and undo the toggle optimisation.
     void hideEvent(QHideEvent *event) override;
 
 #ifdef LOGAPP_BUILD_TESTING
 public:
     /// Flush any pending debounced `SyncBucketCountToHeight()`
-    /// call now. Tests that resize the widget after `show()` and
-    /// expect the bucket vector to update before the next paint
-    /// call this to skip the debounce wait. No-op when no sync is
-    /// pending.
+    /// now. Lets tests skip the debounce wait after resizing.
+    /// No-op when no sync is pending.
     void FlushPendingBucketSyncForTest();
 #endif
 
@@ -214,71 +171,49 @@ private:
     /// rail, or an empty rect when the row count is 0.
     [[nodiscard]] QRect ComputeViewportIndicatorRect() const;
 
-    /// Push the current widget height into the model so the
-    /// bucket vector matches the rail's usable pixel count.
-    /// Idempotent when the height matches. Called synchronously
-    /// from `showEvent` and via `mBucketSyncTimer` from
-    /// `resizeEvent` so a drag-resize storm coalesces to a
-    /// single `SetBucketCount(H)` call (see
-    /// `BUCKET_SYNC_DEBOUNCE_MS` in the .cpp for the rationale).
+    /// Push the current widget height into the model. Idempotent
+    /// when the height matches. Called synchronously on `showEvent`
+    /// and coalesced via `mBucketSyncTimer` on `resizeEvent` (see
+    /// `BUCKET_SYNC_DEBOUNCE_MS`).
     void SyncBucketCountToHeight();
 
-    /// Resolve mouse Y to a proxy row and emit
-    /// `proxyRowClicked`. Filters out consecutive same-row
-    /// emissions during a drag so downstream handlers aren't
-    /// spammed with duplicate scrolls. @p replaceSelection is
-    /// forwarded to the signal so the initial click and the
-    /// scrubbing moves can request different selection policies.
+    /// Resolve mouse Y to a proxy row and emit `proxyRowClicked`.
+    /// De-duplicates consecutive same-row emissions during a drag.
     void EmitProxyRowForY(int y, bool replaceSelection);
 
     QPointer<OverviewRailModel> mModel;
     QPointer<ThemeControl> mTheme;
     QPointer<QAbstractItemView> mTableView;
 
-    /// Last emitted proxy row during an active drag. Sentinel
-    /// `INT_MIN` while idle so the first click still emits.
-    /// Default-initialised in-class so a future ctor overload
-    /// that forgets the init list can't leak an indeterminate
-    /// value into the first `EmitProxyRowForY` comparison.
+    /// Last emitted proxy row during an active drag; `INT_MIN`
+    /// while idle so the first click still emits.
     int mLastEmittedRow = INT_MIN;
 
-    /// True while the user is holding the left button on the
-    /// rail. Used to differentiate a wheel-through-rail scroll
-    /// (idle state, forward to scrollbar) from a drag scrub
-    /// (active state, do not forward).
+    /// True while the left button is held on the rail. Used to
+    /// route wheel events (forward to scrollbar when idle; swallow
+    /// during a drag scrub).
     bool mDragging = false;
 
-    /// Active width preset. Default Medium matches the
-    /// Preferences / `QSettings` default so a brand-new widget
-    /// agrees with a first-launch MainWindow before settings load.
+    /// Active width preset (default matches Preferences /
+    /// `QSettings` default so a brand-new widget agrees with a
+    /// first-launch MainWindow before settings load).
     OverviewRailWidthMode mWidthMode = OverviewRailWidthMode::Medium;
 
-    /// Last DPI-fluent width computed by `sizeHint()`. Mutable so
-    /// `sizeHint() const` can refresh it as a side-effect, and
-    /// `RailWidthForTest()` can return it without re-running the
-    /// platform-metric query.
+    /// Last DPI-fluent width computed by `sizeHint()`. `mutable`
+    /// so the `const` `sizeHint()` can refresh it.
     mutable int mCachedRailWidth = 0;
 
-    /// Bucket-edge Y-coordinates cache (one entry per bucket edge,
-    /// so `nBuckets + 1` entries). Recomputed only when the
-    /// `(nBuckets, railTop, railHeight)` triple changes. Drag-scroll
-    /// bursts trigger many paints per second and this vector would
-    /// otherwise allocate `~2 KB` per paint on a 500-px rail — a
-    /// small win in isolation, but on the hot path it shows up
-    /// under a profiler at heavy tail-append cadence.
+    /// Bucket-edge Y cache (`nBuckets + 1` entries). Recomputed
+    /// only when `(nBuckets, railTop, railHeight)` changes so
+    /// drag-scroll bursts skip the ~2 KB alloc per paint.
     std::vector<int> mCachedYEdges;
     std::size_t mCachedYEdgesBuckets = 0;
     int mCachedYEdgesRailTop = INT_MIN;
     int mCachedYEdgesRailHeight = INT_MIN;
 
-    /// Debounce timer for `SyncBucketCountToHeight()` on
-    /// `resizeEvent`. Interactive window-drag resizes fire a
-    /// resize event per changed pixel, and each `SetBucketCount(H)`
-    /// call reallocates buckets, drops the durable find-match
-    /// counts (sizes disagree), and forces a synchronous
-    /// full-table rescan through the `MainWindow`
-    /// `bucketsChanged` -> `PushFindMatchesToOverviewRail`
-    /// lambda. Coalescing collapses a drag burst into one
-    /// bucket-count update + one rescan.
+    /// Debounce for `SyncBucketCountToHeight()` on `resizeEvent`.
+    /// Each `SetBucketCount(H)` invalidates the durable find-match
+    /// counts and (with Find open) forces a full rescan, so a
+    /// per-pixel drag burst needs to be coalesced.
     QTimer *mBucketSyncTimer = nullptr;
 };

--- a/app/include/overview_rail_widget.hpp
+++ b/app/include/overview_rail_widget.hpp
@@ -188,4 +188,16 @@ private:
     /// `RailWidthForTest()` can return it without re-running the
     /// platform-metric query.
     mutable int mCachedRailWidth = 0;
+
+    /// Bucket-edge Y-coordinates cache (one entry per bucket edge,
+    /// so `nBuckets + 1` entries). Recomputed only when the
+    /// `(nBuckets, railTop, railHeight)` triple changes. Drag-scroll
+    /// bursts trigger many paints per second and this vector would
+    /// otherwise allocate `~2 KB` per paint on a 500-px rail — a
+    /// small win in isolation, but on the hot path it shows up
+    /// under a profiler at heavy tail-append cadence.
+    std::vector<int> mCachedYEdges;
+    std::size_t mCachedYEdgesBuckets = 0;
+    int mCachedYEdgesRailTop = INT_MIN;
+    int mCachedYEdgesRailHeight = INT_MIN;
 };

--- a/app/include/preferences_editor.hpp
+++ b/app/include/preferences_editor.hpp
@@ -1,5 +1,7 @@
 #pragma once
 
+#include "overview_rail_widget.hpp"
+
 #include <QCheckBox>
 #include <QComboBox>
 #include <QLabel>
@@ -61,6 +63,13 @@ signals:
     /// `themeChanged()` repaint path.
     void highContrastLevelsChanged(bool on);
 
+    /// Fired on every overview-rail width combo change (live
+    /// preview) and again on Cancel/close to revert. `MainWindow`
+    /// applies the mode to the rail widget and refreshes the
+    /// reserved viewport margin. `QSettings` is written only on
+    /// Ok when the value actually changed.
+    void overviewRailWidthChanged(OverviewRailWidthMode mode);
+
 private:
     /// Refill the theme combo from `ThemeControl::AvailableThemes`
     /// and select the active entry (Auto is the first entry).
@@ -93,6 +102,7 @@ private:
     QCheckBox *mStaticNewestFirstCheckBox;
     QCheckBox *mShowLevelIconsCheckBox;
     QCheckBox *mHighContrastLevelsCheckBox;
+    QComboBox *mOverviewRailWidthComboBox;
     QCheckBox *mRestoreLastSessionCheckBox;
     QSpinBox *mRecentSessionsMaxSpinBox;
 
@@ -111,4 +121,5 @@ private:
     /// initial values.
     bool mInitialShowLevelIcons = true;
     bool mInitialHighContrastLevels = false;
+    OverviewRailWidthMode mInitialOverviewRailWidth = OverviewRailWidthMode::Medium;
 };

--- a/app/include/preferences_editor.hpp
+++ b/app/include/preferences_editor.hpp
@@ -63,10 +63,8 @@ signals:
     /// `themeChanged()` repaint path.
     void highContrastLevelsChanged(bool on);
 
-    /// Fired on every overview-rail width combo change (live
-    /// preview) and again on Cancel/close to revert. `MainWindow`
-    /// applies the mode to the rail widget and refreshes the
-    /// reserved viewport margin. `QSettings` is written only on
+    /// Fired on every combo change (live preview) and on
+    /// Cancel/close to revert. `QSettings` is only written on
     /// Ok when the value actually changed.
     void overviewRailWidthChanged(OverviewRailWidthMode mode);
 

--- a/app/src/find_record_widget.cpp
+++ b/app/src/find_record_widget.cpp
@@ -187,10 +187,14 @@ FindRecordWidget::FindRecordWidget(QWidget *parent)
     connect(mButtonNext, &QToolButton::clicked, this, &FindRecordWidget::FindNext);
     connect(mButtonPrevious, &QToolButton::clicked, this, &FindRecordWidget::FindPrevious);
 
-    // Plain Return -> find-next. Shift+Return -> find-prev is wired
-    // in `eventFilter`: `returnPressed` is modifier-agnostic and
-    // `QLineEdit::keyPressEvent` accepts the event without bubbling.
-    connect(mEdit, &QLineEdit::returnPressed, this, &FindRecordWidget::FindNext);
+    // Return / Shift+Return on the search field are handled in
+    // `eventFilter` (not via `returnPressed`). `QLineEdit` emits
+    // `returnPressed` then *ignores* the key event, so a
+    // `returnPressed` -> FindNext hook plus the parent
+    // `keyPressEvent` FindNext path would double-advance and skip
+    // every other match. Consuming the key in the filter keeps a
+    // single jump; `keyPressEvent` still covers Enter when focus
+    // is on a toggle / arrow button.
     mEdit->installEventFilter(this);
 
     // `objectName`s on both timers let tests probe trailing vs max-age
@@ -341,8 +345,8 @@ void FindRecordWidget::DismissBar()
 void FindRecordWidget::keyPressEvent(QKeyEvent *event)
 {
     // Only reaches us when focus is on a toggle / arrow button. For
-    // `mEdit`, the line edit handles Return itself and `eventFilter`
-    // handles Shift+Return.
+    // `mEdit`, `eventFilter` consumes Return / Shift+Return so they
+    // never bubble here (a bubble would double-fire FindNext).
     if (event->key() == Qt::Key_Return || event->key() == Qt::Key_Enter)
     {
         if (event->modifiers().testFlag(Qt::ShiftModifier))
@@ -366,12 +370,22 @@ bool FindRecordWidget::eventFilter(QObject *watched, QEvent *event)
         // `QEvent::KeyPress` guarantees the dynamic type; Qt doesn't
         // enable RTTI on `QEvent`.
         auto *ke = static_cast<QKeyEvent *>(event); // NOLINT(cppcoreguidelines-pro-type-static-cast-downcast)
-        if ((ke->key() == Qt::Key_Return || ke->key() == Qt::Key_Enter) && ke->modifiers().testFlag(Qt::ShiftModifier))
+        if (ke->key() == Qt::Key_Return || ke->key() == Qt::Key_Enter)
         {
-            // Intercept before `QLineEdit::keyPressEvent`, which
-            // would otherwise emit `returnPressed` (-> FindNext)
-            // and swallow the shift-modified variant.
-            FindPrevious();
+            // Consume before `QLineEdit::keyPressEvent`: it emits
+            // `returnPressed` then ignores the event, which would
+            // bubble into `FindRecordWidget::keyPressEvent` and
+            // fire FindNext a second time (skipping every other
+            // match). Shift+Return is find-prev; plain Return is
+            // find-next.
+            if (ke->modifiers().testFlag(Qt::ShiftModifier))
+            {
+                FindPrevious();
+            }
+            else
+            {
+                FindNext();
+            }
             return true;
         }
     }

--- a/app/src/find_record_widget.cpp
+++ b/app/src/find_record_widget.cpp
@@ -278,12 +278,10 @@ void FindRecordWidget::SetMatchInfo(int current, int total, bool overflowed)
     // the user narrows the search.
     if (overflowed)
     {
-        mMatchCountLabel->setToolTip(
-            tr("Match count is a lower bound (the scan bails once every rail bucket "
-               "has a hit and the internal cursor cache is full). The current-match "
-               "index may read as 0 for a match past the cache. The overview rail "
-               "still shows every bucket that carries a hit.")
-        );
+        mMatchCountLabel->setToolTip(tr("Match count is a lower bound (the scan bails once every rail bucket "
+                                        "has a hit and the internal cursor cache is full). The current-match "
+                                        "index may read as 0 for a match past the cache. The overview rail "
+                                        "still shows every bucket that carries a hit."));
     }
     else
     {

--- a/app/src/find_record_widget.cpp
+++ b/app/src/find_record_widget.cpp
@@ -375,12 +375,23 @@ void FindRecordWidget::RequestMatchCountSoon()
 {
     if (mEdit->text().isEmpty())
     {
-        // Empty needle: clear immediately and cancel any in-flight
-        // tick so a stale needle can't overwrite the cleared state.
-        // No emit; the parent has nothing to recount.
+        // Empty needle: clear the label immediately, cancel any
+        // in-flight debounce so a stale needle can't overwrite
+        // the cleared state, and *also* signal the parent so it
+        // can drop dependent match state that lives outside this
+        // widget (find-match cache and overview-rail tick
+        // vector). We used to skip the emit here on the
+        // reasoning that "the parent has nothing to recount",
+        // but the emit is what resets the rail highlight --
+        // without it a cleared find bar would leave the last
+        // needle's ticks stranded on the rail. `MainWindow::
+        // UpdateFindMatchCount` short-circuits on empty text
+        // and calls `InvalidateFindMatchCache`, which in turn
+        // pushes an empty match list into the rail.
         mMatchCountTimer->stop();
         mMatchCountMaxAgeTimer->stop();
         SetMatchInfo(0, 0);
+        emit MatchCountRequested(mEdit->text(), mWildcardsAction->isChecked(), mRegexAction->isChecked());
         return;
     }
     mMatchCountTimer->start();

--- a/app/src/find_record_widget.cpp
+++ b/app/src/find_record_widget.cpp
@@ -248,9 +248,15 @@ void FindRecordWidget::SetMatchInfo(int current, int total, bool overflowed)
     {
         // Blank label, slot stays reserved (see `MATCH_LABEL_MIN_WIDTH`).
         mMatchCountLabel->clear();
+        mMatchCountLabel->setToolTip(QString());
         return;
     }
     // Locale-grouped digits; "+" suffix surfaces the parent's hit cap.
+    // Under `overflowed` the scan may have early-exited once the
+    // rail's presence fold was settled, so `total` is a lower bound;
+    // the tooltip below spells out the caveat (visible text alone
+    // used to be ambiguous — was it "at least N" or "exactly N but
+    // I can't find your cursor position"?).
     const QLocale locale = QLocale::system();
     const QString totalText =
         locale.toString(static_cast<qlonglong>(total)) + (overflowed ? QStringLiteral("+") : QString());
@@ -267,6 +273,25 @@ void FindRecordWidget::SetMatchInfo(int current, int total, bool overflowed)
         text = overflowed ? tr("%1 matches").arg(totalText) : tr("%Ln matches", nullptr, total);
     }
     mMatchCountLabel->setText(text);
+    // Tooltip: only meaningful under `overflowed`, when the "+" on
+    // its own reads as either "at least N" or "cursor position
+    // capped". Spell out both effects so a user who cares can tell
+    // whether the label undercount matters. Clear the tooltip
+    // otherwise so a stale one from a previous overflow doesn't
+    // linger after the user narrows the search.
+    if (overflowed)
+    {
+        mMatchCountLabel->setToolTip(
+            tr("Match count is a lower bound (the scan bails once every rail bucket "
+               "has a hit and the internal cursor cache is full). The current-match "
+               "index may read as 0 for a match past the cache. The overview rail "
+               "still shows every bucket that carries a hit.")
+        );
+    }
+    else
+    {
+        mMatchCountLabel->setToolTip(QString());
+    }
 }
 
 void FindRecordWidget::BumpMatchCountDebounce()

--- a/app/src/find_record_widget.cpp
+++ b/app/src/find_record_widget.cpp
@@ -188,13 +188,10 @@ FindRecordWidget::FindRecordWidget(QWidget *parent)
     connect(mButtonPrevious, &QToolButton::clicked, this, &FindRecordWidget::FindPrevious);
 
     // Return / Shift+Return on the search field are handled in
-    // `eventFilter` (not via `returnPressed`). `QLineEdit` emits
-    // `returnPressed` then *ignores* the key event, so a
-    // `returnPressed` -> FindNext hook plus the parent
-    // `keyPressEvent` FindNext path would double-advance and skip
-    // every other match. Consuming the key in the filter keeps a
-    // single jump; `keyPressEvent` still covers Enter when focus
-    // is on a toggle / arrow button.
+    // `eventFilter`, not via `returnPressed`: `QLineEdit` emits
+    // `returnPressed` then ignores the key, so wiring both would
+    // double-advance and skip every other match. `keyPressEvent`
+    // still handles Enter when focus is on a toggle / arrow button.
     mEdit->installEventFilter(this);
 
     // `objectName`s on both timers let tests probe trailing vs max-age
@@ -255,12 +252,10 @@ void FindRecordWidget::SetMatchInfo(int current, int total, bool overflowed)
         mMatchCountLabel->setToolTip(QString());
         return;
     }
-    // Locale-grouped digits; "+" suffix surfaces the parent's hit cap.
-    // Under `overflowed` the scan may have early-exited once the
-    // rail's presence fold was settled, so `total` is a lower bound;
-    // the tooltip below spells out the caveat (visible text alone
-    // used to be ambiguous — was it "at least N" or "exactly N but
-    // I can't find your cursor position"?).
+    // Locale-grouped digits; "+" suffix on `overflowed` signals
+    // that `total` is a lower bound (scan may have early-exited
+    // once every rail bucket had a hit). The tooltip below spells
+    // out the caveat about the position lookup.
     const QLocale locale = QLocale::system();
     const QString totalText =
         locale.toString(static_cast<qlonglong>(total)) + (overflowed ? QStringLiteral("+") : QString());
@@ -277,12 +272,10 @@ void FindRecordWidget::SetMatchInfo(int current, int total, bool overflowed)
         text = overflowed ? tr("%1 matches").arg(totalText) : tr("%Ln matches", nullptr, total);
     }
     mMatchCountLabel->setText(text);
-    // Tooltip: only meaningful under `overflowed`, when the "+" on
-    // its own reads as either "at least N" or "cursor position
-    // capped". Spell out both effects so a user who cares can tell
-    // whether the label undercount matters. Clear the tooltip
-    // otherwise so a stale one from a previous overflow doesn't
-    // linger after the user narrows the search.
+    // Tooltip is only meaningful under `overflowed` — the "+" alone
+    // is ambiguous between "at least N" and "position lookup capped".
+    // Clear it otherwise so a stale tooltip doesn't linger after
+    // the user narrows the search.
     if (overflowed)
     {
         mMatchCountLabel->setToolTip(
@@ -344,9 +337,8 @@ void FindRecordWidget::DismissBar()
 
 void FindRecordWidget::keyPressEvent(QKeyEvent *event)
 {
-    // Only reaches us when focus is on a toggle / arrow button. For
-    // `mEdit`, `eventFilter` consumes Return / Shift+Return so they
-    // never bubble here (a bubble would double-fire FindNext).
+    // Only reaches us when focus is on a toggle / arrow button;
+    // `eventFilter` consumes Return / Shift+Return on `mEdit`.
     if (event->key() == Qt::Key_Return || event->key() == Qt::Key_Enter)
     {
         if (event->modifiers().testFlag(Qt::ShiftModifier))
@@ -372,12 +364,10 @@ bool FindRecordWidget::eventFilter(QObject *watched, QEvent *event)
         auto *ke = static_cast<QKeyEvent *>(event); // NOLINT(cppcoreguidelines-pro-type-static-cast-downcast)
         if (ke->key() == Qt::Key_Return || ke->key() == Qt::Key_Enter)
         {
-            // Consume before `QLineEdit::keyPressEvent`: it emits
-            // `returnPressed` then ignores the event, which would
-            // bubble into `FindRecordWidget::keyPressEvent` and
-            // fire FindNext a second time (skipping every other
-            // match). Shift+Return is find-prev; plain Return is
-            // find-next.
+            // Consume before `QLineEdit::keyPressEvent` so it
+            // can't bubble into `keyPressEvent` and double-fire
+            // FindNext. Shift+Return → find-prev; plain Return
+            // → find-next.
             if (ke->modifiers().testFlag(Qt::ShiftModifier))
             {
                 FindPrevious();
@@ -415,18 +405,10 @@ void FindRecordWidget::RequestMatchCountSoon()
     if (mEdit->text().isEmpty())
     {
         // Empty needle: clear the label immediately, cancel any
-        // in-flight debounce so a stale needle can't overwrite
-        // the cleared state, and *also* signal the parent so it
-        // can drop dependent match state that lives outside this
-        // widget (find-match cache and overview-rail tick
-        // vector). We used to skip the emit here on the
-        // reasoning that "the parent has nothing to recount",
-        // but the emit is what resets the rail highlight --
-        // without it a cleared find bar would leave the last
-        // needle's ticks stranded on the rail. `MainWindow::
-        // UpdateFindMatchCount` short-circuits on empty text
-        // and calls `InvalidateFindMatchCache`, which in turn
-        // pushes an empty match list into the rail.
+        // in-flight debounce, and signal the parent so it can drop
+        // dependent match state (find cache + overview-rail ticks).
+        // Without the emit a cleared find bar would leave the last
+        // needle's ticks stranded on the rail.
         mMatchCountTimer->stop();
         mMatchCountMaxAgeTimer->stop();
         SetMatchInfo(0, 0);

--- a/app/src/log_filter_model.cpp
+++ b/app/src/log_filter_model.cpp
@@ -1228,18 +1228,10 @@ QList<QModelIndex> LogFilterModel::MatchRow(
     {
         result.reserve(hits);
     }
-    ForEachMatchingRow(
-        start,
-        role,
-        value,
-        flags,
-        forward,
-        skipFirstN,
-        [&](const QModelIndex &proxyIndex) -> bool {
-            result.append(proxyIndex);
-            return unlimited || result.size() < hits;
-        }
-    );
+    ForEachMatchingRow(start, role, value, flags, forward, skipFirstN, [&](const QModelIndex &proxyIndex) -> bool {
+        result.append(proxyIndex);
+        return unlimited || result.size() < hits;
+    });
     return result;
 }
 

--- a/app/src/log_filter_model.cpp
+++ b/app/src/log_filter_model.cpp
@@ -1145,9 +1145,7 @@ void LogFilterModel::ForEachMatchingRow(
         return idx < columnsForVisibility->size() && !(*columnsForVisibility)[idx].visible;
     };
 
-    // Returns true iff the caller asked us to stop (`onMatch` returned
-    // false). A match without stop-request still returns false so the
-    // outer walk continues on to the next row.
+    // Returns true iff `onMatch` returned false (stop requested).
     auto scanRow = [&](int actualRow) -> bool {
         int logRowCached = LOG_ROW_UNRESOLVED;
         for (int col = 0; col < columnCount; ++col)
@@ -1222,15 +1220,9 @@ QList<QModelIndex> LogFilterModel::MatchRow(
 ) const
 {
     QList<QModelIndex> result;
-    // `hits == 0` is nonsensical (asking for zero results is a
-    // programming error) and would silently stop after the first
-    // match under the `size < hits` ceiling below. Fail loudly in
-    // debug so a regression surfaces at the call site; release
-    // builds fall through to the `size < hits` branch which stops
-    // after one match — same as the assert's implicit contract.
+    // `hits == 0` would silently stop after the first match under
+    // the `size < hits` ceiling; require a real value.
     Q_ASSERT(hits == UNLIMITED_HITS || hits >= 1);
-    // `UNLIMITED_HITS` (-1) means "return every match"; represent it
-    // as "no ceiling" so the callback never signals stop on its own.
     const bool unlimited = (hits == UNLIMITED_HITS);
     if (!unlimited && hits > 0)
     {
@@ -1245,9 +1237,6 @@ QList<QModelIndex> LogFilterModel::MatchRow(
         skipFirstN,
         [&](const QModelIndex &proxyIndex) -> bool {
             result.append(proxyIndex);
-            // Stop as soon as we've reached the caller's cap; the
-            // unlimited branch keeps walking until the row space is
-            // exhausted.
             return unlimited || result.size() < hits;
         }
     );

--- a/app/src/log_filter_model.cpp
+++ b/app/src/log_filter_model.cpp
@@ -1084,17 +1084,16 @@ const loglib::EnumDictRank *LogFilterModel::EnumRankFor(int columnIndex) const
     return &it->second.rank;
 }
 
-QList<QModelIndex> LogFilterModel::MatchRow(
+void LogFilterModel::ForEachMatchingRow(
     const QModelIndex &start,
     int role,
     const QVariant &value,
-    int hits,
     Qt::MatchFlags flags,
     bool forward,
-    int skipFirstN
+    int skipFirstN,
+    const MatchRowCallback &onMatch
 ) const
 {
-    QList<QModelIndex> result;
     const int rowCount = this->rowCount(start.parent());
     const int columnCount = this->columnCount(start.parent());
 
@@ -1146,6 +1145,9 @@ QList<QModelIndex> LogFilterModel::MatchRow(
         return idx < columnsForVisibility->size() && !(*columnsForVisibility)[idx].visible;
     };
 
+    // Returns true iff the caller asked us to stop (`onMatch` returned
+    // false). A match without stop-request still returns false so the
+    // outer walk continues on to the next row.
     auto scanRow = [&](int actualRow) -> bool {
         int logRowCached = LOG_ROW_UNRESOLVED;
         for (int col = 0; col < columnCount; ++col)
@@ -1159,8 +1161,7 @@ QList<QModelIndex> LogFilterModel::MatchRow(
             resolveLogRow(proxyIndex, logRowCached);
             if (probeCell(proxyIndex, logRowCached))
             {
-                result.append(proxyIndex);
-                if (result.size() == hits)
+                if (!onMatch(proxyIndex))
                 {
                     return true;
                 }
@@ -1185,7 +1186,7 @@ QList<QModelIndex> LogFilterModel::MatchRow(
             }
             if (scanRow(actualRow))
             {
-                return result;
+                return;
             }
         }
     }
@@ -1204,11 +1205,52 @@ QList<QModelIndex> LogFilterModel::MatchRow(
             }
             if (scanRow(actualRow))
             {
-                return result;
+                return;
             }
         }
     }
+}
 
+QList<QModelIndex> LogFilterModel::MatchRow(
+    const QModelIndex &start,
+    int role,
+    const QVariant &value,
+    int hits,
+    Qt::MatchFlags flags,
+    bool forward,
+    int skipFirstN
+) const
+{
+    QList<QModelIndex> result;
+    // `hits == 0` is nonsensical (asking for zero results is a
+    // programming error) and would silently stop after the first
+    // match under the `size < hits` ceiling below. Fail loudly in
+    // debug so a regression surfaces at the call site; release
+    // builds fall through to the `size < hits` branch which stops
+    // after one match — same as the assert's implicit contract.
+    Q_ASSERT(hits == UNLIMITED_HITS || hits >= 1);
+    // `UNLIMITED_HITS` (-1) means "return every match"; represent it
+    // as "no ceiling" so the callback never signals stop on its own.
+    const bool unlimited = (hits == UNLIMITED_HITS);
+    if (!unlimited && hits > 0)
+    {
+        result.reserve(hits);
+    }
+    ForEachMatchingRow(
+        start,
+        role,
+        value,
+        flags,
+        forward,
+        skipFirstN,
+        [&](const QModelIndex &proxyIndex) -> bool {
+            result.append(proxyIndex);
+            // Stop as soon as we've reached the caller's cap; the
+            // unlimited branch keeps walking until the row space is
+            // exhausted.
+            return unlimited || result.size() < hits;
+        }
+    );
     return result;
 }
 

--- a/app/src/log_table_view.cpp
+++ b/app/src/log_table_view.cpp
@@ -649,22 +649,26 @@ void LogTableView::AttachOverviewRail(QWidget *rail)
     if (rail == nullptr)
     {
         mReservedRightMargin = 0;
-        // `setViewportMargins` is protected on QAbstractScrollArea;
-        // we're a subclass so calling it is legal.
-        setViewportMargins(0, 0, 0, 0);
+        // Trigger a geometry pass so the reclaimed margin lands
+        // (our `updateGeometries` override propagates the zero
+        // margin, driving `layoutChildren` to re-expand the
+        // viewport to the frame edge).
+        updateGeometries();
         return;
     }
     rail->setParent(this);
-    // Cache the width so `changeEvent` can refresh it on DPI /
-    // style / font changes without querying the rail on every
-    // geometry pass. Prefer `sizeHint` (the widget's own DPI-fluent
-    // width) but fall back to `minimumSizeHint` and then the
-    // current `width` so callers that ship a fixed-width rail
-    // (`setFixedWidth`, `setMinimumWidth`) still reserve margin.
+    // Cache the rail's width so every subsequent
+    // `updateGeometries` pass can re-apply the same reservation
+    // without re-querying `sizeHint`. `QAbstractScrollArea`
+    // already reserves `PM_ScrollBarExtent` on the right for the
+    // scrollbar itself, so this margin is JUST the rail width --
+    // adding the scrollbar extent here would leave a gap between
+    // the rail and the scrollbar. See `updateGeometries()` for
+    // the fight against `QTableView::updateGeometries()` wiping
+    // this margin back to zero.
     mReservedRightMargin = ResolvedRailWidth(rail);
-    setViewportMargins(0, 0, mReservedRightMargin, 0);
     rail->show();
-    UpdateOverviewRailGeometry();
+    updateGeometries();
 }
 
 int LogTableView::ResolvedRailWidth(const QWidget *rail)
@@ -692,6 +696,59 @@ void LogTableView::resizeEvent(QResizeEvent *event)
     UpdateOverviewRailGeometry();
 }
 
+void LogTableView::updateGeometries()
+{
+    // Base implementation calls `setViewportMargins(vHeaderW,
+    // hHeaderH, 0, 0)` unconditionally (qtableview.cpp line 2330),
+    // wiping any right margin we set from `AttachOverviewRail`.
+    QTableView::updateGeometries();
+
+    if (mReservedRightMargin > 0)
+    {
+        const QMargins current = viewportMargins();
+        if (current.right() != mReservedRightMargin)
+        {
+            // Applying the margin here triggers `layoutChildren`,
+            // which fires a viewport `Resize` event that would
+            // otherwise cascade into `updateGeometries()` again
+            // via `QAbstractItemView::resizeEvent` -- creating an
+            // infinite ping-pong with the base's margin reset.
+            // `viewportEvent()` overrides swallow that resize
+            // during the flag window so the layout settles in
+            // one pass. After settling, re-position the
+            // horizontal header against the shrunken viewport
+            // (the base captured its width against the pre-shrink
+            // rect and would otherwise let the header extend into
+            // the rail's slot).
+            mApplyingRailMargin = true;
+            setViewportMargins(current.left(), current.top(), mReservedRightMargin, current.bottom());
+            mApplyingRailMargin = false;
+            if (QHeaderView *hh = horizontalHeader(); hh != nullptr)
+            {
+                const QRect vg = viewport()->geometry();
+                hh->setGeometry(vg.left(), hh->y(), vg.width(), hh->height());
+            }
+        }
+    }
+
+    UpdateOverviewRailGeometry();
+}
+
+bool LogTableView::viewportEvent(QEvent *event)
+{
+    // Suppress the viewport `Resize` event that our own
+    // `setViewportMargins()` call triggers during margin
+    // re-application. Without this, `QAbstractItemView::resizeEvent`
+    // (invoked via the viewport filter's `QFrame::event` dispatch)
+    // would re-enter `updateGeometries()`, whose first step wipes
+    // the right margin back to zero -- undoing the reservation.
+    if (mApplyingRailMargin && event != nullptr && event->type() == QEvent::Resize)
+    {
+        return true;
+    }
+    return QTableView::viewportEvent(event);
+}
+
 void LogTableView::changeEvent(QEvent *event)
 {
     QTableView::changeEvent(event);
@@ -700,7 +757,7 @@ void LogTableView::changeEvent(QEvent *event)
         return;
     }
     // Refresh the reserved margin on events that can change the
-    // rail's DPI-fluent width or its wash / colour palette.
+    // rail's DPI-fluent width.
     // `ScreenChangeInternal` is a private Qt enum; we accept the
     // one-time deprecation risk because it's the only signal that
     // reliably fires on a monitor DPR change across the Qt
@@ -715,13 +772,14 @@ void LogTableView::changeEvent(QEvent *event)
     case QEvent::ApplicationFontChange:
     case QEvent::ScreenChangeInternal:
     {
-        const int freshWidth = ResolvedRailWidth(mOverviewRail);
-        if (freshWidth != mReservedRightMargin)
+        const int freshRailWidth = ResolvedRailWidth(mOverviewRail);
+        if (freshRailWidth != mReservedRightMargin)
         {
-            mReservedRightMargin = freshWidth;
-            setViewportMargins(0, 0, mReservedRightMargin, 0);
+            mReservedRightMargin = freshRailWidth;
         }
-        UpdateOverviewRailGeometry();
+        // `updateGeometries()` re-applies `mReservedRightMargin`
+        // after the base wipes it, and repositions the rail.
+        updateGeometries();
         break;
     }
     default:
@@ -742,7 +800,8 @@ void LogTableView::UpdateOverviewRailGeometry()
         if (mReservedRightMargin > 0)
         {
             mReservedRightMargin = 0;
-            setViewportMargins(0, 0, 0, 0);
+            const QMargins m = viewportMargins();
+            setViewportMargins(m.left(), m.top(), 0, m.bottom());
         }
         return;
     }
@@ -751,17 +810,30 @@ void LogTableView::UpdateOverviewRailGeometry()
     {
         return;
     }
-    // Rail sits immediately to the right of the viewport,
-    // spanning the viewport's Y range. Anchor to the viewport
-    // (not the widget) so header / horizontal-scrollbar chrome
-    // gets subtracted for free.
+    // Rail sits immediately to the right of the viewport. The
+    // remaining right-edge slice (past `vpGeom.right() +
+    // reservedMargin`) belongs to `QAbstractScrollArea`'s
+    // auto-placed vertical scrollbar -- Qt reserves
+    // `PM_ScrollBarExtent` there independently of viewport
+    // margins, so we don't have to leave room ourselves.
+    //
+    // Vertical span: from the top of the frame (Y=0, level with
+    // the horizontal header's top edge) down to the bottom of
+    // the viewport, so the strip reads as one continuous piece
+    // of chrome from the header down to the scrollbar corner.
+    // The rail widget's paint pass restricts the level bars and
+    // the viewport indicator to the viewport-Y slice of the
+    // widget (see `OverviewRailWidget::InteractiveRailRect`), so
+    // a bar for a visible row lines up horizontally with that
+    // row's table entry -- the header-Y slice above stays as
+    // wash chrome.
     const QRect vpGeom = vp->geometry();
     const int width = mReservedRightMargin;
     if (width <= 0)
     {
         return;
     }
-    mOverviewRail->setGeometry(vpGeom.right() + 1, vpGeom.top(), width, vpGeom.height());
+    mOverviewRail->setGeometry(vpGeom.right() + 1, 0, width, vpGeom.bottom() + 1);
     mOverviewRail->raise();
 }
 

--- a/app/src/log_table_view.cpp
+++ b/app/src/log_table_view.cpp
@@ -690,6 +690,24 @@ int LogTableView::ResolvedRailWidth(const QWidget *rail)
     return std::max(0, rail->width());
 }
 
+void LogTableView::RefreshOverviewRailMargin()
+{
+    if (mOverviewRail == nullptr)
+    {
+        return;
+    }
+    const int fresh = ResolvedRailWidth(mOverviewRail);
+    if (fresh == mReservedRightMargin)
+    {
+        // Width unchanged; still reposition in case geometry
+        // drifted, but skip the heavier margin rewrite.
+        UpdateOverviewRailGeometry();
+        return;
+    }
+    mReservedRightMargin = fresh;
+    updateGeometries();
+}
+
 void LogTableView::resizeEvent(QResizeEvent *event)
 {
     QTableView::resizeEvent(event);
@@ -821,12 +839,10 @@ void LogTableView::UpdateOverviewRailGeometry()
     // the horizontal header's top edge) down to the bottom of
     // the viewport, so the strip reads as one continuous piece
     // of chrome from the header down to the scrollbar corner.
-    // The rail widget's paint pass restricts the level bars and
-    // the viewport indicator to the viewport-Y slice of the
-    // widget (see `OverviewRailWidget::InteractiveRailRect`), so
-    // a bar for a visible row lines up horizontally with that
-    // row's table entry -- the header-Y slice above stays as
-    // wash chrome.
+    // The rail paints a whole-file overview across that full
+    // height (`OverviewRailWidget::InteractiveRailRect`); the
+    // viewport indicator overlay shows which proxy rows are
+    // currently visible.
     const QRect vpGeom = vp->geometry();
     const int width = mReservedRightMargin;
     if (width <= 0)

--- a/app/src/log_table_view.cpp
+++ b/app/src/log_table_view.cpp
@@ -701,6 +701,12 @@ void LogTableView::changeEvent(QEvent *event)
     }
     // Refresh the reserved margin on events that can change the
     // rail's DPI-fluent width or its wash / colour palette.
+    // `ScreenChangeInternal` is a private Qt enum; we accept the
+    // one-time deprecation risk because it's the only signal that
+    // reliably fires on a monitor DPR change across the Qt
+    // versions the project supports (6.1+). Qt 6.6+ ships the
+    // public `DevicePixelRatioChange` — once the minimum bumps
+    // that far, replace this case with the newer event.
     switch (event->type())
     {
     case QEvent::StyleChange:

--- a/app/src/log_table_view.cpp
+++ b/app/src/log_table_view.cpp
@@ -733,6 +733,17 @@ void LogTableView::UpdateOverviewRailGeometry()
 {
     if (mOverviewRail == nullptr)
     {
+        // Defensive: `mOverviewRail` is a `QPointer` and can be
+        // silently cleared if the rail widget is destroyed
+        // through a path other than `AttachOverviewRail(nullptr)`
+        // (an external `delete`, its parent being torn down,
+        // ...). Reclaim the reserved margin so the viewport
+        // doesn't keep a phantom gap on its right edge.
+        if (mReservedRightMargin > 0)
+        {
+            mReservedRightMargin = 0;
+            setViewportMargins(0, 0, 0, 0);
+        }
         return;
     }
     const QWidget *vp = viewport();

--- a/app/src/log_table_view.cpp
+++ b/app/src/log_table_view.cpp
@@ -636,10 +636,9 @@ void LogTableView::AttachOverviewRail(QWidget *rail)
     {
         return;
     }
-    // Detach the old rail (hide + drop from margin) without
-    // deleting it — ownership stays with the caller. Reparent
-    // to nullptr so a later attach against a different table
-    // view is legal.
+    // Detach the old rail without deleting it — ownership stays
+    // with the caller. Reparent to nullptr so a later attach
+    // against a different view is legal.
     if (mOverviewRail != nullptr)
     {
         mOverviewRail->hide();
@@ -649,23 +648,14 @@ void LogTableView::AttachOverviewRail(QWidget *rail)
     if (rail == nullptr)
     {
         mReservedRightMargin = 0;
-        // Trigger a geometry pass so the reclaimed margin lands
-        // (our `updateGeometries` override propagates the zero
-        // margin, driving `layoutChildren` to re-expand the
-        // viewport to the frame edge).
         updateGeometries();
         return;
     }
     rail->setParent(this);
-    // Cache the rail's width so every subsequent
-    // `updateGeometries` pass can re-apply the same reservation
-    // without re-querying `sizeHint`. `QAbstractScrollArea`
-    // already reserves `PM_ScrollBarExtent` on the right for the
-    // scrollbar itself, so this margin is JUST the rail width --
-    // adding the scrollbar extent here would leave a gap between
-    // the rail and the scrollbar. See `updateGeometries()` for
-    // the fight against `QTableView::updateGeometries()` wiping
-    // this margin back to zero.
+    // Cache the rail width so `updateGeometries` doesn't re-query
+    // `sizeHint` on every pass. `QAbstractScrollArea` already
+    // reserves `PM_ScrollBarExtent` for the scrollbar, so this
+    // margin is *just* the rail width.
     mReservedRightMargin = ResolvedRailWidth(rail);
     rail->show();
     updateGeometries();
@@ -699,8 +689,7 @@ void LogTableView::RefreshOverviewRailMargin()
     const int fresh = ResolvedRailWidth(mOverviewRail);
     if (fresh == mReservedRightMargin)
     {
-        // Width unchanged; still reposition in case geometry
-        // drifted, but skip the heavier margin rewrite.
+        // Width unchanged; reposition only, skip the margin rewrite.
         UpdateOverviewRailGeometry();
         return;
     }
@@ -716,9 +705,8 @@ void LogTableView::resizeEvent(QResizeEvent *event)
 
 void LogTableView::updateGeometries()
 {
-    // Base implementation calls `setViewportMargins(vHeaderW,
-    // hHeaderH, 0, 0)` unconditionally (qtableview.cpp line 2330),
-    // wiping any right margin we set from `AttachOverviewRail`.
+    // `QTableView::updateGeometries` unconditionally resets the
+    // right margin to zero, so we re-apply ours after the base.
     QTableView::updateGeometries();
 
     if (mReservedRightMargin > 0)
@@ -726,21 +714,17 @@ void LogTableView::updateGeometries()
         const QMargins current = viewportMargins();
         if (current.right() != mReservedRightMargin)
         {
-            // Applying the margin here triggers `layoutChildren`,
-            // which fires a viewport `Resize` event that would
-            // otherwise cascade into `updateGeometries()` again
-            // via `QAbstractItemView::resizeEvent` -- creating an
-            // infinite ping-pong with the base's margin reset.
-            // `viewportEvent()` overrides swallow that resize
+            // `setViewportMargins` fires a viewport `Resize` that
+            // would re-enter `updateGeometries` and wipe our
+            // margin. `viewportEvent()` swallows that resize
             // during the flag window so the layout settles in
-            // one pass. After settling, re-position the
-            // horizontal header against the shrunken viewport
-            // (the base captured its width against the pre-shrink
-            // rect and would otherwise let the header extend into
-            // the rail's slot).
+            // one pass.
             mApplyingRailMargin = true;
             setViewportMargins(current.left(), current.top(), mReservedRightMargin, current.bottom());
             mApplyingRailMargin = false;
+            // Re-position the horizontal header against the
+            // shrunken viewport; the base captured its width
+            // against the pre-shrink rect.
             if (QHeaderView *hh = horizontalHeader(); hh != nullptr)
             {
                 const QRect vg = viewport()->geometry();
@@ -754,12 +738,9 @@ void LogTableView::updateGeometries()
 
 bool LogTableView::viewportEvent(QEvent *event)
 {
-    // Suppress the viewport `Resize` event that our own
-    // `setViewportMargins()` call triggers during margin
-    // re-application. Without this, `QAbstractItemView::resizeEvent`
-    // (invoked via the viewport filter's `QFrame::event` dispatch)
-    // would re-enter `updateGeometries()`, whose first step wipes
-    // the right margin back to zero -- undoing the reservation.
+    // Swallow the viewport `Resize` triggered by our own
+    // `setViewportMargins()` — otherwise it would re-enter
+    // `updateGeometries()` and wipe the margin.
     if (mApplyingRailMargin && event != nullptr && event->type() == QEvent::Resize)
     {
         return true;
@@ -775,13 +756,9 @@ void LogTableView::changeEvent(QEvent *event)
         return;
     }
     // Refresh the reserved margin on events that can change the
-    // rail's DPI-fluent width.
-    // `ScreenChangeInternal` is a private Qt enum; we accept the
-    // one-time deprecation risk because it's the only signal that
-    // reliably fires on a monitor DPR change across the Qt
-    // versions the project supports (6.1+). Qt 6.6+ ships the
-    // public `DevicePixelRatioChange` — once the minimum bumps
-    // that far, replace this case with the newer event.
+    // rail's DPI-fluent width. `ScreenChangeInternal` is a private
+    // Qt enum used as a DPR-change proxy; once Qt 6.6+ becomes the
+    // minimum, replace with the public `DevicePixelRatioChange`.
     switch (event->type())
     {
     case QEvent::StyleChange:
@@ -795,8 +772,6 @@ void LogTableView::changeEvent(QEvent *event)
         {
             mReservedRightMargin = freshRailWidth;
         }
-        // `updateGeometries()` re-applies `mReservedRightMargin`
-        // after the base wipes it, and repositions the rail.
         updateGeometries();
         break;
     }
@@ -809,12 +784,10 @@ void LogTableView::UpdateOverviewRailGeometry()
 {
     if (mOverviewRail == nullptr)
     {
-        // Defensive: `mOverviewRail` is a `QPointer` and can be
-        // silently cleared if the rail widget is destroyed
-        // through a path other than `AttachOverviewRail(nullptr)`
-        // (an external `delete`, its parent being torn down,
-        // ...). Reclaim the reserved margin so the viewport
-        // doesn't keep a phantom gap on its right edge.
+        // `mOverviewRail` is a `QPointer` and can be silently
+        // cleared if the rail was destroyed outside
+        // `AttachOverviewRail(nullptr)`. Reclaim the margin so the
+        // viewport doesn't keep a phantom gap on the right edge.
         if (mReservedRightMargin > 0)
         {
             mReservedRightMargin = 0;
@@ -828,21 +801,11 @@ void LogTableView::UpdateOverviewRailGeometry()
     {
         return;
     }
-    // Rail sits immediately to the right of the viewport. The
-    // remaining right-edge slice (past `vpGeom.right() +
-    // reservedMargin`) belongs to `QAbstractScrollArea`'s
-    // auto-placed vertical scrollbar -- Qt reserves
-    // `PM_ScrollBarExtent` there independently of viewport
-    // margins, so we don't have to leave room ourselves.
-    //
-    // Vertical span: from the top of the frame (Y=0, level with
-    // the horizontal header's top edge) down to the bottom of
-    // the viewport, so the strip reads as one continuous piece
-    // of chrome from the header down to the scrollbar corner.
-    // The rail paints a whole-file overview across that full
-    // height (`OverviewRailWidget::InteractiveRailRect`); the
-    // viewport indicator overlay shows which proxy rows are
-    // currently visible.
+    // Rail sits immediately to the right of the viewport, spanning
+    // from Y=0 (level with the horizontal header) to the bottom of
+    // the viewport. The strip past the rail is Qt's auto-placed
+    // vertical scrollbar (`PM_ScrollBarExtent`, reserved
+    // independently of viewport margins).
     const QRect vpGeom = vp->geometry();
     const int width = mReservedRightMargin;
     if (width <= 0)

--- a/app/src/log_table_view.cpp
+++ b/app/src/log_table_view.cpp
@@ -655,13 +655,35 @@ void LogTableView::AttachOverviewRail(QWidget *rail)
         return;
     }
     rail->setParent(this);
-    // Cache the width from `sizeHint` so `changeEvent` can
-    // refresh it on DPI / style / font changes without querying
-    // the rail on every geometry pass.
-    mReservedRightMargin = std::max(0, rail->sizeHint().width());
+    // Cache the width so `changeEvent` can refresh it on DPI /
+    // style / font changes without querying the rail on every
+    // geometry pass. Prefer `sizeHint` (the widget's own DPI-fluent
+    // width) but fall back to `minimumSizeHint` and then the
+    // current `width` so callers that ship a fixed-width rail
+    // (`setFixedWidth`, `setMinimumWidth`) still reserve margin.
+    mReservedRightMargin = ResolvedRailWidth(rail);
     setViewportMargins(0, 0, mReservedRightMargin, 0);
     rail->show();
     UpdateOverviewRailGeometry();
+}
+
+int LogTableView::ResolvedRailWidth(const QWidget *rail)
+{
+    if (rail == nullptr)
+    {
+        return 0;
+    }
+    const int hint = rail->sizeHint().width();
+    if (hint > 0)
+    {
+        return hint;
+    }
+    const int minHint = rail->minimumSizeHint().width();
+    if (minHint > 0)
+    {
+        return minHint;
+    }
+    return std::max(0, rail->width());
 }
 
 void LogTableView::resizeEvent(QResizeEvent *event)
@@ -687,7 +709,7 @@ void LogTableView::changeEvent(QEvent *event)
     case QEvent::ApplicationFontChange:
     case QEvent::ScreenChangeInternal:
     {
-        const int freshWidth = std::max(0, mOverviewRail->sizeHint().width());
+        const int freshWidth = ResolvedRailWidth(mOverviewRail);
         if (freshWidth != mReservedRightMargin)
         {
             mReservedRightMargin = freshWidth;

--- a/app/src/log_table_view.cpp
+++ b/app/src/log_table_view.cpp
@@ -630,6 +630,102 @@ bool LogTableView::eventFilter(QObject *watched, QEvent *event)
     return QTableView::eventFilter(watched, event);
 }
 
+void LogTableView::AttachOverviewRail(QWidget *rail)
+{
+    if (mOverviewRail == rail)
+    {
+        return;
+    }
+    // Detach the old rail (hide + drop from margin) without
+    // deleting it — ownership stays with the caller. Reparent
+    // to nullptr so a later attach against a different table
+    // view is legal.
+    if (mOverviewRail != nullptr)
+    {
+        mOverviewRail->hide();
+        mOverviewRail->setParent(nullptr);
+    }
+    mOverviewRail = rail;
+    if (rail == nullptr)
+    {
+        mReservedRightMargin = 0;
+        // `setViewportMargins` is protected on QAbstractScrollArea;
+        // we're a subclass so calling it is legal.
+        setViewportMargins(0, 0, 0, 0);
+        return;
+    }
+    rail->setParent(this);
+    // Cache the width from `sizeHint` so `changeEvent` can
+    // refresh it on DPI / style / font changes without querying
+    // the rail on every geometry pass.
+    mReservedRightMargin = std::max(0, rail->sizeHint().width());
+    setViewportMargins(0, 0, mReservedRightMargin, 0);
+    rail->show();
+    UpdateOverviewRailGeometry();
+}
+
+void LogTableView::resizeEvent(QResizeEvent *event)
+{
+    QTableView::resizeEvent(event);
+    UpdateOverviewRailGeometry();
+}
+
+void LogTableView::changeEvent(QEvent *event)
+{
+    QTableView::changeEvent(event);
+    if (event == nullptr || mOverviewRail == nullptr)
+    {
+        return;
+    }
+    // Refresh the reserved margin on events that can change the
+    // rail's DPI-fluent width or its wash / colour palette.
+    switch (event->type())
+    {
+    case QEvent::StyleChange:
+    case QEvent::PaletteChange:
+    case QEvent::FontChange:
+    case QEvent::ApplicationFontChange:
+    case QEvent::ScreenChangeInternal:
+    {
+        const int freshWidth = std::max(0, mOverviewRail->sizeHint().width());
+        if (freshWidth != mReservedRightMargin)
+        {
+            mReservedRightMargin = freshWidth;
+            setViewportMargins(0, 0, mReservedRightMargin, 0);
+        }
+        UpdateOverviewRailGeometry();
+        break;
+    }
+    default:
+        break;
+    }
+}
+
+void LogTableView::UpdateOverviewRailGeometry()
+{
+    if (mOverviewRail == nullptr)
+    {
+        return;
+    }
+    const QWidget *vp = viewport();
+    if (vp == nullptr)
+    {
+        return;
+    }
+    // Rail sits immediately to the right of the viewport,
+    // spanning the viewport's Y range. Anchor to the viewport
+    // (not the widget) so header / horizontal-scrollbar chrome
+    // gets subtracted for free.
+    const QRect vpGeom = vp->geometry();
+    const int width = mReservedRightMargin;
+    if (width <= 0)
+    {
+        return;
+    }
+    mOverviewRail->setGeometry(vpGeom.right() + 1, vpGeom.top(), width, vpGeom.height());
+    mOverviewRail->raise();
+}
+
 void LogTableView::CopySelectedRowsToClipboard()
 {
     const QModelIndexList selectedRows = this->selectionModel()->selectedRows();

--- a/app/src/main_window.cpp
+++ b/app/src/main_window.cpp
@@ -1093,14 +1093,24 @@ MainWindow::MainWindow(
         PushFindMatchesToOverviewRail();
     });
 
-    // Dropping the find bar drops the rail's match ticks too —
-    // matching the "*i* of *N*" indicator which is only shown
-    // while the bar is visible. The cache itself survives so a
-    // later reveal can restore ticks without re-scanning.
-    connect(mFindDock, &FindDock::closed, this, [this]() {
+    // Dropping the find bar (or tabbing it away) drops the rail's
+    // match ticks too — matching the "*i* of *N*" indicator which
+    // is only shown while the bar is visible. `closed` covers the
+    // X-button / Escape dismissal; `visibilityChanged(false)` also
+    // covers tab inactivation in a tabified bottom dock group,
+    // where `closed` does not fire. The cache itself survives so a
+    // later `revealed` can restore ticks without re-scanning.
+    const auto clearOverviewRailMatchTicks = [this]() {
         if (mOverviewRailModel != nullptr)
         {
             mOverviewRailModel->SetMatchProxyRows({});
+        }
+    };
+    connect(mFindDock, &FindDock::closed, this, clearOverviewRailMatchTicks);
+    connect(mFindDock, &QDockWidget::visibilityChanged, this, [clearOverviewRailMatchTicks](bool visible) {
+        if (!visible)
+        {
+            clearOverviewRailMatchTicks();
         }
     });
 
@@ -1248,6 +1258,26 @@ MainWindow::MainWindow(
         }
         mTheme->SetHighContrast(on);
     });
+
+    // Overview-rail width preset (live preview from Preferences).
+    // Apply to the widget then refresh the table's reserved margin
+    // so the viewport shrinks/grows with the new sizeHint.
+    connect(
+        mPreferencesEditor,
+        &PreferencesEditor::overviewRailWidthChanged,
+        this,
+        [this](OverviewRailWidthMode mode) {
+            if (mOverviewRailWidget == nullptr)
+            {
+                return;
+            }
+            mOverviewRailWidget->SetWidthMode(mode);
+            if (mTableView != nullptr)
+            {
+                mTableView->RefreshOverviewRailMargin();
+            }
+        }
+    );
 
     // Anchor hotkeys (programmatic so the .ui isn't bloated):
     //   Ctrl+1..8     anchor selection at colour N
@@ -1594,9 +1624,17 @@ MainWindow::MainWindow(
     // (default on, per the ROADMAP guidance for item 13).
     // Routing through `SetOverviewRailVisible` keeps the QAction,
     // the attach state, and the settings write in one place.
+    // Width mode is applied before attach so the first
+    // `ResolvedRailWidth` already sees the scaled sizeHint.
     if (mActionToggleOverviewRail != nullptr)
     {
         const QSettings settings;
+        if (mOverviewRailWidget != nullptr)
+        {
+            mOverviewRailWidget->SetWidthMode(ParseOverviewRailWidthMode(
+                settings.value(QStringLiteral("ui/overviewRailWidth"), QStringLiteral("medium")).toString()
+            ));
+        }
         const bool showOverviewRail = settings.value(QStringLiteral("ui/showOverviewRail"), true).toBool();
         SetOverviewRailVisible(showOverviewRail);
     }
@@ -5845,6 +5883,15 @@ void MainWindow::PushFindMatchesToOverviewRail()
     {
         return;
     }
+    // Match ticks mirror the find indicator: only while the bar
+    // is visible. The cache still survives a close / tab-hide so
+    // `FindDock::revealed` can restore without re-scanning; do
+    // not re-apply ticks from a stale cache while the bar is
+    // hidden (e.g. rail toggled off→on after find was closed).
+    if (!IsFindBarVisible())
+    {
+        return;
+    }
     const std::size_t nBuckets = mOverviewRailModel->BucketCount();
     if (nBuckets == 0)
     {
@@ -5863,7 +5910,7 @@ void MainWindow::PushFindMatchesToOverviewRail()
     // Bucket counts missing (scan ran while rail was hidden) or
     // size-mismatched (H changed since the scan). Prefer a full
     // recount so the rail never paints a top-biased capped strip.
-    if (IsFindBarVisible() && !cache.needle.isEmpty())
+    if (!cache.needle.isEmpty())
     {
         const QString text = cache.needle;
         const bool wildcards = cache.wildcards;
@@ -5876,8 +5923,8 @@ void MainWindow::PushFindMatchesToOverviewRail()
         return;
     }
 
-    // Find bar unavailable: best-effort restore from the capped
-    // row list (may be top-biased when overflowed).
+    // Empty needle with a surviving cache: best-effort restore
+    // from the capped row list (may be top-biased when overflowed).
     mOverviewRailModel->SetMatchProxyRows(cache.sortedRows);
 }
 
@@ -6184,6 +6231,16 @@ void MainWindow::ScrollToProxyRow(int proxyRow, bool replaceSelection)
     {
         return;
     }
+    // Rail click / scrub is intentional browsing. Disengage Follow
+    // newest so a subsequent live-tail batch cannot yank the
+    // viewport back to the tail mid-exploration. `scrollTo` is
+    // programmatic and would not fire `userScrolledAwayFromTail`
+    // on its own; handle Follow here instead of relying on the
+    // scrollbar attribution path.
+    if (ui != nullptr && ui->actionFollowTail->isChecked())
+    {
+        ui->actionFollowTail->setChecked(false);
+    }
     mTableView->scrollTo(proxyIdx, QAbstractItemView::PositionAtCenter);
     if (replaceSelection)
     {
@@ -6237,11 +6294,19 @@ void MainWindow::SetOverviewRailVisible(bool visible)
         // wasted O(rowCount) walk (and, worse, a duplicate paint
         // on the widget's first show).
         mTableView->AttachOverviewRail(mOverviewRailWidget);
-        // If find is active, re-push match ticks. Same-H hide→show
-        // already restores via durable model state; a height change
-        // (or a scan that ran while the rail was hidden) needs
+        // Re-push match ticks only while find is visible — same
+        // contract as the find-dock close / tab-hide handlers.
+        // Same-H hide→show already restores via durable model
+        // state when find is still open; a height change (or a
+        // scan that ran while the rail was hidden) needs
         // `PushFindMatchesToOverviewRail` to re-bucket / rescan.
-        PushFindMatchesToOverviewRail();
+        // Unconditional push would resurrect stale ticks from
+        // `mFindMatchCache` after the user closed find then
+        // toggled the rail.
+        if (IsFindBarVisible())
+        {
+            PushFindMatchesToOverviewRail();
+        }
     }
     else
     {

--- a/app/src/main_window.cpp
+++ b/app/src/main_window.cpp
@@ -714,16 +714,11 @@ MainWindow::MainWindow(
     mTableView->setSortingEnabled(true);
     mTableView->sortByColumn(-1, Qt::SortOrder::AscendingOrder);
 
-    // Overview rail (ROADMAP item 13). Constructed after the
-    // proxy chain because the model buckets `mSortFilterProxyModel`
-    // rows and the widget derives its viewport indicator from
-    // `mTableView`'s scrollbar.
-    //
-    // The rail's lifetime is bound to the window: the model
-    // stays live even while the rail is hidden so the toggle
-    // is instant on both edges. The widget is owned by `this`
-    // while detached and reparents to `mTableView` inside
-    // `LogTableView::AttachOverviewRail` when visible.
+    // Overview rail (ROADMAP item 13). Constructed after the proxy
+    // chain: the model buckets `mSortFilterProxyModel` rows and
+    // the widget's viewport indicator reads `mTableView`'s
+    // scrollbar. The model stays live even while the rail is
+    // hidden so the toggle is instant on both edges.
     mOverviewRailModel = new OverviewRailModel(mSortFilterProxyModel, mModel, mAnchors, this);
     mOverviewRailWidget = new OverviewRailWidget(mOverviewRailModel, mTheme, mTableView, this);
     mOverviewRailWidget->hide();
@@ -753,11 +748,10 @@ MainWindow::MainWindow(
     mActionToggleOverviewRail = new QAction(tr("Overview rail"), this);
     mActionToggleOverviewRail->setObjectName(QStringLiteral("actionToggleOverviewRail"));
     mActionToggleOverviewRail->setCheckable(true);
-    // Ctrl+Shift+O sits next to the histogram's Ctrl+H in the
-    // View menu. Ctrl+O opens files, so we differentiate with
-    // the Shift modifier; Ctrl+Shift+A and Ctrl+Shift+S are
-    // already taken by the anchor / session shortcuts.
-    mActionToggleOverviewRail->setShortcut(QKeySequence(Qt::CTRL | Qt::SHIFT | Qt::Key_O));
+    // `R` for Rail. `Ctrl+Shift+O` belongs to `actionOpenLogStream`
+    // (see `main_window.ui`); binding it here as well produced a
+    // Qt "ambiguous shortcut overload" warning at runtime.
+    mActionToggleOverviewRail->setShortcut(QKeySequence(Qt::CTRL | Qt::SHIFT | Qt::Key_R));
     addAction(mActionToggleOverviewRail);
     connect(mActionToggleOverviewRail, &QAction::toggled, this, &MainWindow::SetOverviewRailVisible);
 
@@ -1087,19 +1081,17 @@ MainWindow::MainWindow(
         }
         // Restore rail ticks from the surviving cache. Prefer
         // unbiased `bucketCounts` over the capped `sortedRows`
-        // list — a naive `SetMatchProxyRows(sortedRows)` would
-        // paint only the first 10 000 hits after a common-needle
-        // reopen, and a cache-hit debounce would never re-scan.
+        // list; a naive push would paint only the first 10 000
+        // hits after a common-needle reopen.
         PushFindMatchesToOverviewRail();
     });
 
-    // Dropping the find bar (or tabbing it away) drops the rail's
-    // match ticks too — matching the "*i* of *N*" indicator which
-    // is only shown while the bar is visible. `closed` covers the
-    // X-button / Escape dismissal; `visibilityChanged(false)` also
-    // covers tab inactivation in a tabified bottom dock group,
-    // where `closed` does not fire. The cache itself survives so a
-    // later `revealed` can restore ticks without re-scanning.
+    // Dropping the find bar clears the rail's match ticks (they
+    // mirror the "*i* of *N*" indicator, which is only shown while
+    // the bar is visible). `closed` covers X-button / Escape;
+    // `visibilityChanged(false)` also covers tab inactivation in a
+    // tabified dock group where `closed` doesn't fire. The cache
+    // survives so a later reveal can restore without re-scanning.
     const auto clearOverviewRailMatchTicks = [this]() {
         if (mOverviewRailModel != nullptr)
         {
@@ -1260,8 +1252,8 @@ MainWindow::MainWindow(
     });
 
     // Overview-rail width preset (live preview from Preferences).
-    // Apply to the widget then refresh the table's reserved margin
-    // so the viewport shrinks/grows with the new sizeHint.
+    // Refresh the table's reserved margin after applying so the
+    // viewport tracks the new sizeHint.
     connect(
         mPreferencesEditor,
         &PreferencesEditor::overviewRailWidthChanged,
@@ -1620,12 +1612,11 @@ MainWindow::MainWindow(
         mModel->SetShowLevelIcons(showLevelIcons);
     }
 
-    // Seed the overview rail from the persisted preference
-    // (default on, per the ROADMAP guidance for item 13).
-    // Routing through `SetOverviewRailVisible` keeps the QAction,
-    // the attach state, and the settings write in one place.
-    // Width mode is applied before attach so the first
-    // `ResolvedRailWidth` already sees the scaled sizeHint.
+    // Seed the overview rail from the persisted preference (default
+    // on). Routing through `SetOverviewRailVisible` keeps the
+    // QAction, attach state, and settings write in one place. Width
+    // mode is applied before attach so the first `ResolvedRailWidth`
+    // sees the scaled sizeHint.
     if (mActionToggleOverviewRail != nullptr)
     {
         const QSettings settings;
@@ -5675,12 +5666,11 @@ void MainWindow::UpdateFindMatchCount(const QString &text, bool wildcards, bool 
     }
     if (text.isEmpty())
     {
-        // Reached both programmatically (find bar not yet used) and
-        // via `FindRecordWidget::RequestMatchCountSoon`, which emits
-        // `MatchCountRequested("")` after the user clears the field
-        // so downstream match state (this cache + the overview rail's
-        // tick vector) drops in one round-trip. `InvalidateFindMatchCache`
-        // is what pushes the empty match list into the rail.
+        // Reached both programmatically and via
+        // `FindRecordWidget::RequestMatchCountSoon` after the user
+        // cleared the field. `InvalidateFindMatchCache` drops the
+        // cache and pushes an empty list into the rail so its ticks
+        // clear in one round-trip.
         InvalidateFindMatchCache();
         mFindRecord->SetMatchInfo(0, 0);
         return;
@@ -5704,44 +5694,33 @@ void MainWindow::UpdateFindMatchCount(const QString &text, bool wildcards, bool 
         }
         const QVariant value = QVariant::fromValue(text);
         const int proxyRowCount = mSortFilterProxyModel->rowCount();
-        // Ask the rail for its live bucket count so we can fold
-        // per-hit counters straight into a fixed-size vector as
-        // the scan runs. The rail is dropped to zero buckets while
-        // hidden (see `SetOverviewRailVisible`), in which case we
-        // skip the bucket-counter fold entirely and let the rail
-        // reattach via its own rebuild path.
+        // Read the rail's live bucket count so per-hit counters can
+        // fold straight into a fixed-size vector during the scan.
+        // Zero when the rail is hidden — the bucket fold is skipped
+        // in that case.
         const std::size_t nBuckets =
             (mOverviewRailModel != nullptr) ? mOverviewRailModel->BucketCount() : std::size_t{0};
 
-        // Single-walk accumulator. `sortedRows` caps out at
-        // `MAX_FIND_MATCH_COUNT` (see field doc): the vector feeds
-        // the `Next / Previous` binary search and needs to fit in
-        // predictable memory. The rail is fed via `bucketCounts`
-        // (fixed-size at `nBuckets`). Paint only needs presence
-        // (`matchCount > 0`), so once every bucket has a tick and
-        // the navigator list is past the cap we can stop — a
-        // common needle on a huge proxy must not force a full
-        // synchronous walk. Sparse needles still scan to the end
-        // (not every bucket lights up early).
+        // Single-walk accumulator. `sortedRows` is capped at
+        // `MAX_FIND_MATCH_COUNT` for the Next / Previous binary
+        // search; the rail is fed via `bucketCounts`. Once every
+        // bucket has a tick and the navigator list is past the cap
+        // we can stop: further hits only change density, and paint
+        // is presence-only. Sparse needles still scan to the end.
         std::vector<int> sortedRows;
-        // Clamp against a possible pathological `rowCount() == -1`
-        // (some `QAbstractItemModel` overrides return -1 to signal
-        // "unknown"). Without the `max(0, ...)`, casting a negative
-        // value to `size_t` would ask `reserve` for a multi-EB
-        // allocation and throw `std::length_error` on the GUI
-        // thread. `MAX_FIND_MATCH_COUNT` is also the hard cap on
-        // the walk, so oversizing beyond it wastes memory.
+        // Clamp against `rowCount() == -1` (some models return -1
+        // for "unknown"); a negative cast to size_t would trigger
+        // a multi-EB `reserve` and throw on the GUI thread.
         const int reserveHint = std::min(std::max(0, proxyRowCount), MAX_FIND_MATCH_COUNT);
         sortedRows.reserve(static_cast<size_t>(reserveHint));
         std::vector<uint32_t> bucketCounts(nBuckets, uint32_t{0});
         uint32_t totalMatches = 0;
         std::size_t bucketsHit = 0;
         bool scanExhausted = true;
-        // `ForEachMatchingRow` streams matches to the callback
-        // without allocating a `QList<QModelIndex>`. Contract:
-        // one invocation per matching row, in ascending row order
-        // (forward, no wrap), so `sortedRows` stays sorted-unique
-        // for the downstream binary search.
+        // `ForEachMatchingRow` streams matches without allocating a
+        // `QList<QModelIndex>`. Ascending row order + no duplicates
+        // is contracted, so `sortedRows` stays sorted-unique for
+        // the binary search.
         mSortFilterProxyModel->ForEachMatchingRow(
             start,
             Qt::DisplayRole,
@@ -5767,14 +5746,10 @@ void MainWindow::UpdateFindMatchCount(const QString &text, bool wildcards, bool 
                 {
                     sortedRows.push_back(proxyRow);
                 }
-                // Early-exit once overflow is proven (one past the
-                // navigator cap) and the rail either is hidden or
-                // already has a presence tick in every bucket.
-                // Further hits only change density / the exact
-                // total; the label shows "+" and paint ignores
-                // density. Mirrors the pre-rail `hits = MAX+1`
-                // freeze guard without re-biasing the rail strip
-                // for dense needles.
+                // Early-exit once overflow is proven and the rail
+                // is either hidden or has a tick in every bucket.
+                // Further hits only change density, which paint
+                // ignores; the label reads "+" past the cap.
                 if (totalMatches > static_cast<uint32_t>(MAX_FIND_MATCH_COUNT) &&
                     (nBuckets == 0 || bucketsHit >= nBuckets))
                 {
@@ -5787,11 +5762,9 @@ void MainWindow::UpdateFindMatchCount(const QString &text, bool wildcards, bool 
 
         const bool overflowed =
             !scanExhausted || totalMatches > static_cast<uint32_t>(MAX_FIND_MATCH_COUNT);
-        // Defensive sort/dedup: `ForEachMatchingRow` is contracted
-        // to yield rows in ascending order without duplicates, but
-        // a future contract drift can't be allowed to silently
-        // corrupt the binary search. `qWarning` mirrors the assert
-        // so release builds still leave a breadcrumb.
+        // Defensive sort/dedup: contract violations would silently
+        // corrupt the binary search. Assert in debug, warn in
+        // release, still recover so the caller doesn't see garbage.
         const bool sortedAsExpected = std::ranges::is_sorted(sortedRows);
         Q_ASSERT(sortedAsExpected);
         if (!sortedAsExpected)
@@ -5815,23 +5788,16 @@ void MainWindow::UpdateFindMatchCount(const QString &text, bool wildcards, bool 
             .overflowed = overflowed,
             .sortedRows = std::move(sortedRows),
             .totalMatches = totalMatches,
-            // Keep a copy for find-dock reveal / rail re-show so a
-            // cache-hit path can still push unbiased ticks without
-            // re-walking the proxy. Empty when the rail had zero
-            // buckets during this scan (hidden).
+            // Keep a copy so a find-dock reveal / rail re-show can
+            // push unbiased ticks without re-walking the proxy.
+            // Empty when the rail had zero buckets (hidden).
             .bucketCounts = (nBuckets > 0) ? bucketCounts : std::vector<uint32_t>{},
         };
-        // Push the fresh match state into the overview rail. The
-        // bucket-counts path is preferred when the rail has an
-        // active bucket vector: it feeds every hit into the rail's
-        // paint without the O(matches) allocation, and it never
-        // biases toward the top of the log even when the sorted-
-        // rows vector is capped. When the rail is hidden
-        // (`nBuckets == 0`), fall back to the row-list path so
-        // the cached list survives a later re-show via
-        // `SetBucketCount(H)` triggering a fresh rebuild (and
-        // `PushFindMatchesToOverviewRail` forces a recount when
-        // that list was capped).
+        // Prefer the bucket-counts path when the rail is armed: it
+        // avoids the O(matches) allocation and doesn't bias toward
+        // the top of the log when `sortedRows` is capped. Fall back
+        // to the row-list path when hidden so a later re-show can
+        // still restore ticks.
         if (mOverviewRailModel != nullptr)
         {
             if (nBuckets > 0)
@@ -5845,10 +5811,9 @@ void MainWindow::UpdateFindMatchCount(const QString &text, bool wildcards, bool 
         }
     }
 
-    // When `overflowed`, `totalMatches` is a lower bound (early
-    // exit or capped navigator) and the "+" suffix also signals
-    // that the position lookup below can return `0` for a current
-    // row past the cap.
+    // Under `overflowed` `totalMatches` is a lower bound and the
+    // position lookup below can return `0` for a cursor past the
+    // cap; the "+" suffix on the label signals both.
     const int total = static_cast<int>(mFindMatchCache->totalMatches);
     int currentOneBased = 0;
     if (total > 0 && mTableView != nullptr && !mFindMatchCache->sortedRows.empty())
@@ -5871,9 +5836,8 @@ void MainWindow::UpdateFindMatchCount(const QString &text, bool wildcards, bool 
 void MainWindow::InvalidateFindMatchCache()
 {
     mFindMatchCache.reset();
-    // Rail ticks are keyed on the cached match state; drop
-    // them alongside the cache so a stale find selection can't
-    // strand ticks on rows the current filter no longer accepts.
+    // Drop rail ticks alongside the cache so a stale find selection
+    // can't strand ticks on rows the current filter rejects.
     if (mOverviewRailModel != nullptr)
     {
         mOverviewRailModel->SetMatchProxyRows({});
@@ -5910,24 +5874,23 @@ void MainWindow::PushFindMatchesToOverviewRail()
         return;
     }
 
-    // Bucket counts missing (scan ran while rail was hidden) or
-    // size-mismatched (H changed since the scan). Prefer a full
-    // recount so the rail never paints a top-biased capped strip.
+    // Bucket counts missing or size-mismatched (rail was hidden
+    // during the scan, or H changed since). Prefer a fresh recount
+    // so the rail never paints a top-biased capped strip.
     if (!cache.needle.isEmpty())
     {
         const QString text = cache.needle;
         const bool wildcards = cache.wildcards;
         const bool regularExpressions = cache.regularExpressions;
-        // Soft-invalidate: drop the cache so UpdateFindMatchCount
-        // rescans, but do not clear the rail first — the recount
-        // below replaces ticks in one shot.
+        // Soft-invalidate: drop the cache so `UpdateFindMatchCount`
+        // rescans, but leave the rail alone — the recount replaces
+        // ticks in one shot.
         mFindMatchCache.reset();
         UpdateFindMatchCount(text, wildcards, regularExpressions);
         return;
     }
 
-    // Empty needle with a surviving cache: best-effort restore
-    // from the capped row list (may be top-biased when overflowed).
+    // Empty needle: best-effort restore from the capped row list.
     mOverviewRailModel->SetMatchProxyRows(cache.sortedRows);
 }
 
@@ -6225,8 +6188,8 @@ void MainWindow::ScrollToProxyRow(int proxyRow, bool replaceSelection)
     }
     if (proxyRow < 0 || proxyRow >= mSortFilterProxyModel->rowCount())
     {
-        // Row can be transiently stale during an insert / filter
-        // change race — silently no-op so a drag scrub stays smooth.
+        // Silently no-op on a transient out-of-range so a drag
+        // scrub stays smooth during insert / filter races.
         return;
     }
     const QModelIndex proxyIdx = mSortFilterProxyModel->index(proxyRow, 0);
@@ -6234,14 +6197,10 @@ void MainWindow::ScrollToProxyRow(int proxyRow, bool replaceSelection)
     {
         return;
     }
-    // Rail click / scrub is intentional browsing. Disengage Follow
-    // newest so a subsequent live-tail batch cannot yank the
-    // viewport back to the tail mid-exploration. `scrollTo` is
-    // programmatic and would not fire `userScrolledAwayFromTail`
-    // on its own; handle Follow here instead of relying on the
-    // scrollbar attribution path. Null-check both handles: a partial
-    // UI setup (early failure path in `setupUi`) can leave the
-    // action pointer null even when `ui` itself is valid.
+    // Rail navigation is intentional browsing; disengage Follow
+    // newest so a live-tail batch can't yank the viewport back to
+    // the tail. `scrollTo` is programmatic and wouldn't fire
+    // `userScrolledAwayFromTail` on its own.
     if (ui != nullptr && ui->actionFollowTail != nullptr && ui->actionFollowTail->isChecked())
     {
         ui->actionFollowTail->setChecked(false);
@@ -6250,16 +6209,13 @@ void MainWindow::ScrollToProxyRow(int proxyRow, bool replaceSelection)
     if (replaceSelection)
     {
         // Fresh click: same "commit to row" semantics as
-        // `SelectSourceRow` (anchors dock, histogram bucket click).
+        // `SelectSourceRow`.
         mTableView->clearSelection();
         mTableView->selectionModel()->select(proxyIdx, QItemSelectionModel::Select | QItemSelectionModel::Rows);
         mTableView->selectionModel()->setCurrentIndex(proxyIdx, QItemSelectionModel::NoUpdate);
     }
-    // Drag scrub (`replaceSelection == false`): scroll only, so
-    // the user's existing selection survives the exploration
-    // pass. Deliberately do not update the current index either
-    // — advancing it would clobber the last-clicked row for the
-    // next arrow-key press.
+    // Drag scrub: scroll only, leave selection + current index
+    // untouched so exploration doesn't clobber the last-clicked row.
 }
 
 void MainWindow::SetOverviewRailVisible(bool visible)
@@ -6269,21 +6225,17 @@ void MainWindow::SetOverviewRailVisible(bool visible)
         return;
     }
     // Persist immediately so the next launch honours the current
-    // preference regardless of how we got here (user toggle,
-    // load-time seed, session reload). Guarded so the load-time
-    // seed (which replays the persisted value verbatim) doesn't
-    // round-trip through QSettings for no reason — that's a
-    // registry write on Windows, and we call it on every window
-    // construction.
+    // preference. Guarded to skip the redundant write on the
+    // load-time seed (replaying the persisted value verbatim) —
+    // avoids a Windows registry write on every window construction.
     QSettings settings;
     if (settings.value(QStringLiteral("ui/showOverviewRail"), true).toBool() != visible)
     {
         settings.setValue(QStringLiteral("ui/showOverviewRail"), visible);
     }
 
-    // Keep the QAction's check state consistent when the slot is
-    // driven programmatically (load-time seed). `QSignalBlocker`
-    // stops the mirroring from re-triggering us.
+    // Mirror the QAction check state for programmatic callers;
+    // block the signal so this doesn't re-enter us.
     if (mActionToggleOverviewRail != nullptr && mActionToggleOverviewRail->isChecked() != visible)
     {
         const QSignalBlocker blocker(mActionToggleOverviewRail);
@@ -6293,21 +6245,14 @@ void MainWindow::SetOverviewRailVisible(bool visible)
     if (visible)
     {
         // Attach reparents + shows the widget; its `resizeEvent`
-        // then calls `SetBucketCount(H)` on the model which runs a
-        // synchronous rebuild, so we do NOT need to invoke
-        // `Rebuild()` here. A second rebuild would only produce a
-        // wasted O(rowCount) walk (and, worse, a duplicate paint
-        // on the widget's first show).
+        // then calls `SetBucketCount(H)` on the model (synchronous
+        // rebuild), so we don't need `Rebuild()` here.
         mTableView->AttachOverviewRail(mOverviewRailWidget);
         // Re-push match ticks only while find is visible — same
-        // contract as the find-dock close / tab-hide handlers.
-        // Same-H hide→show already restores via durable model
-        // state when find is still open; a height change (or a
-        // scan that ran while the rail was hidden) needs
-        // `PushFindMatchesToOverviewRail` to re-bucket / rescan.
-        // Unconditional push would resurrect stale ticks from
-        // `mFindMatchCache` after the user closed find then
-        // toggled the rail.
+        // contract as the find-dock hide handlers. Same-H hide→show
+        // restores via durable model state; a height change (or a
+        // scan that ran while the rail was hidden) needs the
+        // re-bucket / rescan path in `PushFindMatchesToOverviewRail`.
         if (IsFindBarVisible())
         {
             PushFindMatchesToOverviewRail();
@@ -6316,17 +6261,13 @@ void MainWindow::SetOverviewRailVisible(bool visible)
     else
     {
         mTableView->AttachOverviewRail(nullptr);
-        // Reparent to `this` so the widget survives the detach
-        // and Qt cleanup remains ours. `AttachOverviewRail(null)`
-        // already dropped the parent.
+        // Reparent to `this` so the widget survives the detach.
+        // `AttachOverviewRail(null)` already dropped the parent.
         mOverviewRailWidget->setParent(this);
         mOverviewRailWidget->hide();
-        // Drop the model's bucket vector so `RebuildInternal`
-        // short-circuits on every incoming proxy signal while the
-        // rail is hidden. Without this, live-tail bursts would
-        // pay the full O(rowCount) walk even though nothing is
-        // painted. `SetBucketCount(H)` from the widget's next
-        // `resizeEvent` re-arms the model on the toggle back on.
+        // Drop the bucket vector so `RebuildInternal` short-circuits
+        // on incoming proxy signals while the rail is hidden.
+        // `SetBucketCount(H)` on the next `showEvent` re-arms it.
         if (mOverviewRailModel != nullptr)
         {
             mOverviewRailModel->SetBucketCount(0);

--- a/app/src/main_window.cpp
+++ b/app/src/main_window.cpp
@@ -5643,12 +5643,38 @@ void MainWindow::UpdateFindMatchCount(const QString &text, bool wildcards, bool 
             return;
         }
         const QVariant value = QVariant::fromValue(text);
-        // Cap + 1: the extra hit lets us distinguish "exactly at the
-        // cap" from "ran off the end". Keeps the GUI bounded on huge
-        // tables with a common needle.
+        // Scan the whole proxy for matches (bounded by proxy row
+        // count, not by a fixed hit cap). We used to stop after
+        // `MAX_FIND_MATCH_COUNT + 1` hits, which is fine for the
+        // i-of-N label but *biased* the returned row list to
+        // the first N matching rows -- so the overview rail (which
+        // consumes the same list) drew highlight ticks only in
+        // the top slice of the log and appeared "broken" whenever
+        // a common needle produced >10 000 hits. The debounce
+        // upstream (`FindRecordWidget::mMatchCountTimer`, ~200 ms
+        // trailing + max-age cap) already coalesces per-keystroke
+        // bursts, so paying the full scan cost is acceptable per
+        // finalised query. The scan itself is O(rows * cols) with
+        // an early-exit-per-row on the first cell match, which
+        // matches the previous cost for common needles that hit
+        // the cap; only rare-needle scans (which walked the whole
+        // proxy before too) see any additional work here.
+        const int proxyRowCount = mSortFilterProxyModel->rowCount();
+        // Use `proxyRowCount` as the ceiling so `MatchRow` still
+        // stops as soon as every row has been visited. A zero
+        // row count would fall through with an empty match list
+        // as it always did.
+        const int scanCap = std::max(1, proxyRowCount);
         const QModelIndexList matches =
-            mSortFilterProxyModel->MatchRow(start, Qt::DisplayRole, value, MAX_FIND_MATCH_COUNT + 1, flags, true, 0);
-        const bool overflowed = matches.size() > MAX_FIND_MATCH_COUNT;
+            mSortFilterProxyModel->MatchRow(start, Qt::DisplayRole, value, scanCap, flags, true, 0);
+        // The scan is uncapped so the returned list is exhaustive
+        // (no "we stopped after N hits" lower-bound semantics).
+        // `overflowed` -> `false` disables the "+" suffix on the
+        // "*i* of *N*" label; the exact count is fine to display
+        // and no longer misleadingly reads as a lower bound.
+        // Kept as a cache field for backward-compat with the
+        // struct's existing consumers.
+        const bool overflowed = false;
         // `MatchRow` is contracted to return one entry per row in
         // ascending order. Sort + unique defensively so a future
         // contract drift can't silently corrupt the binary search;
@@ -5679,13 +5705,15 @@ void MainWindow::UpdateFindMatchCount(const QString &text, bool wildcards, bool 
                           "deduplicating defensively. This is a contract violation worth investigating.";
         }
         rows.erase(std::ranges::unique(rows).begin(), rows.end());
-        // Trim only when there's surplus -- the dedup above can drop
-        // entries below the cap, and a blind `resize(cap)` would then
-        // grow the vector with zeros that look like matches at row 0.
-        if (rows.size() > static_cast<size_t>(MAX_FIND_MATCH_COUNT))
-        {
-            rows.resize(static_cast<size_t>(MAX_FIND_MATCH_COUNT));
-        }
+        // No truncation: `rows` already holds every match found
+        // by the uncapped scan above, and both consumers (the
+        // overview rail's bucket-folder and the Next / Previous
+        // binary search) benefit from an exact list. The old
+        // `resize(MAX_FIND_MATCH_COUNT)` truncation was the
+        // second half of the "highlight stops working with many
+        // hits" bug -- combined with the capped `MatchRow`, it
+        // left the rail's tick vector contiguous from row 0 and
+        // silently missing every match past the first N.
         mFindMatchCache = FindMatchCache{
             .needle = text,
             .wildcards = wildcards,

--- a/app/src/main_window.cpp
+++ b/app/src/main_window.cpp
@@ -6021,7 +6021,7 @@ void MainWindow::JumpToFirstRowInBucket(std::size_t bucketIndex)
     SelectSourceRow(sourceRow);
 }
 
-void MainWindow::ScrollToProxyRow(int proxyRow)
+void MainWindow::ScrollToProxyRow(int proxyRow, bool replaceSelection)
 {
     if (mTableView == nullptr || mSortFilterProxyModel == nullptr)
     {
@@ -6038,10 +6038,20 @@ void MainWindow::ScrollToProxyRow(int proxyRow)
     {
         return;
     }
-    mTableView->clearSelection();
     mTableView->scrollTo(proxyIdx, QAbstractItemView::PositionAtCenter);
-    mTableView->selectionModel()->select(proxyIdx, QItemSelectionModel::Select | QItemSelectionModel::Rows);
-    mTableView->selectionModel()->setCurrentIndex(proxyIdx, QItemSelectionModel::NoUpdate);
+    if (replaceSelection)
+    {
+        // Fresh click: same "commit to row" semantics as
+        // `SelectSourceRow` (anchors dock, histogram bucket click).
+        mTableView->clearSelection();
+        mTableView->selectionModel()->select(proxyIdx, QItemSelectionModel::Select | QItemSelectionModel::Rows);
+        mTableView->selectionModel()->setCurrentIndex(proxyIdx, QItemSelectionModel::NoUpdate);
+    }
+    // Drag scrub (`replaceSelection == false`): scroll only, so
+    // the user's existing selection survives the exploration
+    // pass. Deliberately do not update the current index either
+    // — advancing it would clobber the last-clicked row for the
+    // next arrow-key press.
 }
 
 void MainWindow::SetOverviewRailVisible(bool visible)
@@ -6067,14 +6077,13 @@ void MainWindow::SetOverviewRailVisible(bool visible)
 
     if (visible)
     {
+        // Attach reparents + shows the widget; its `resizeEvent`
+        // then calls `SetBucketCount(H)` on the model which runs a
+        // synchronous rebuild, so we do NOT need to invoke
+        // `Rebuild()` here. A second rebuild would only produce a
+        // wasted O(rowCount) walk (and, worse, a duplicate paint
+        // on the widget's first show).
         mTableView->AttachOverviewRail(mOverviewRailWidget);
-        // Rebuild once on attach so buckets reflect the current
-        // row count (the model was quiet while the widget stayed
-        // hidden and had a zero-height sizeHint).
-        if (mOverviewRailModel != nullptr)
-        {
-            mOverviewRailModel->Rebuild();
-        }
     }
     else
     {
@@ -6084,6 +6093,16 @@ void MainWindow::SetOverviewRailVisible(bool visible)
         // already dropped the parent.
         mOverviewRailWidget->setParent(this);
         mOverviewRailWidget->hide();
+        // Drop the model's bucket vector so `RebuildInternal`
+        // short-circuits on every incoming proxy signal while the
+        // rail is hidden. Without this, live-tail bursts would
+        // pay the full O(rowCount) walk even though nothing is
+        // painted. `SetBucketCount(H)` from the widget's next
+        // `resizeEvent` re-arms the model on the toggle back on.
+        if (mOverviewRailModel != nullptr)
+        {
+            mOverviewRailModel->SetBucketCount(0);
+        }
     }
 }
 

--- a/app/src/main_window.cpp
+++ b/app/src/main_window.cpp
@@ -714,6 +714,32 @@ MainWindow::MainWindow(
     mTableView->setSortingEnabled(true);
     mTableView->sortByColumn(-1, Qt::SortOrder::AscendingOrder);
 
+    // Overview rail (ROADMAP item 13). Constructed after the
+    // proxy chain because the model buckets `mSortFilterProxyModel`
+    // rows and the widget derives its viewport indicator from
+    // `mTableView`'s scrollbar.
+    //
+    // The rail's lifetime is bound to the window: the model
+    // stays live even while the rail is hidden so the toggle
+    // is instant on both edges. The widget is owned by `this`
+    // while detached and reparents to `mTableView` inside
+    // `LogTableView::AttachOverviewRail` when visible.
+    mOverviewRailModel = new OverviewRailModel(mSortFilterProxyModel, mModel, mAnchors, this);
+    mOverviewRailWidget = new OverviewRailWidget(mOverviewRailModel, mTheme, mTableView, this);
+    mOverviewRailWidget->hide();
+    connect(mOverviewRailWidget, &OverviewRailWidget::proxyRowClicked, this, &MainWindow::ScrollToProxyRow);
+
+    mActionToggleOverviewRail = new QAction(tr("Overview rail"), this);
+    mActionToggleOverviewRail->setObjectName(QStringLiteral("actionToggleOverviewRail"));
+    mActionToggleOverviewRail->setCheckable(true);
+    // Ctrl+Shift+O sits next to the histogram's Ctrl+H in the
+    // View menu. Ctrl+O opens files, so we differentiate with
+    // the Shift modifier; Ctrl+Shift+A and Ctrl+Shift+S are
+    // already taken by the anchor / session shortcuts.
+    mActionToggleOverviewRail->setShortcut(QKeySequence(Qt::CTRL | Qt::SHIFT | Qt::Key_O));
+    addAction(mActionToggleOverviewRail);
+    connect(mActionToggleOverviewRail, &QAction::toggled, this, &MainWindow::SetOverviewRailVisible);
+
     // Icon-pill delegate is created only when we have a
     // `ThemeControl`; the no-theme test fixture keeps the standard
     // text delegate (`IsLevelIconModeActive` is always false there).
@@ -1037,6 +1063,25 @@ MainWindow::MainWindow(
         if (mFindRecord != nullptr)
         {
             mFindRecord->BumpMatchCountDebounce();
+        }
+        // Repopulate the rail's match ticks from the current
+        // cache. Without this, closing and reopening the find
+        // bar would leave the rail blank until the user typed
+        // again.
+        if (mOverviewRailModel != nullptr && mFindMatchCache.has_value())
+        {
+            mOverviewRailModel->SetMatchProxyRows(mFindMatchCache->sortedRows);
+        }
+    });
+
+    // Dropping the find bar drops the rail's match ticks too —
+    // matching the "*i* of *N*" indicator which is only shown
+    // while the bar is visible. The cache itself survives so a
+    // later reveal can restore ticks without re-scanning.
+    connect(mFindDock, &FindDock::closed, this, [this]() {
+        if (mOverviewRailModel != nullptr)
+        {
+            mOverviewRailModel->SetMatchProxyRows({});
         }
     });
 
@@ -1524,6 +1569,17 @@ MainWindow::MainWindow(
         const QSettings settings;
         const bool showLevelIcons = settings.value(QStringLiteral("ui/showLevelIcons"), true).toBool();
         mModel->SetShowLevelIcons(showLevelIcons);
+    }
+
+    // Seed the overview rail from the persisted preference
+    // (default on, per the ROADMAP guidance for item 13).
+    // Routing through `SetOverviewRailVisible` keeps the QAction,
+    // the attach state, and the settings write in one place.
+    if (mActionToggleOverviewRail != nullptr)
+    {
+        const QSettings settings;
+        const bool showOverviewRail = settings.value(QStringLiteral("ui/showOverviewRail"), true).toBool();
+        SetOverviewRailVisible(showOverviewRail);
     }
 
     // Run after every action is wired so they can all be decorated in one pass.
@@ -4057,6 +4113,7 @@ void MainWindow::BuildMainToolbar()
     tag(ui->actionToggleRecordDetails, mMainToolbar, QStringLiteral(":/icons/panel-right-open.svg"));
     tag(mActionToggleAnchors, mMainToolbar, QStringLiteral(":/icons/bookmark.svg"));
     tag(mActionToggleHistogram, mMainToolbar, QStringLiteral(":/icons/bar-chart-3.svg"));
+    tag(mActionToggleOverviewRail, mMainToolbar, QStringLiteral(":/icons/bar-chart-horizontal.svg"));
     tag(ui->actionPreferences, mMainToolbar, QStringLiteral(":/icons/settings-2.svg"));
     // Stream toolbar gets the same treatment so the combined strip
     // looks uniform when both bars are visible. Pause is the one
@@ -4200,6 +4257,10 @@ void MainWindow::BuildMainToolbar()
     if (mActionToggleHistogram != nullptr)
     {
         mMainToolbar->addAction(mActionToggleHistogram);
+    }
+    if (mActionToggleOverviewRail != nullptr)
+    {
+        mMainToolbar->addAction(mActionToggleOverviewRail);
     }
 
     // Expanding spacer pushes Preferences to the far right edge,
@@ -5632,6 +5693,15 @@ void MainWindow::UpdateFindMatchCount(const QString &text, bool wildcards, bool 
             .overflowed = overflowed,
             .sortedRows = std::move(rows),
         };
+        // Push the fresh match rows into the overview rail so its
+        // find-tick band matches the "*i* of *N*" indicator. The
+        // rail's model coalesces the bucket recompute but emits
+        // `matchesChanged` immediately so the widget repaints on
+        // the next event loop pass.
+        if (mOverviewRailModel != nullptr)
+        {
+            mOverviewRailModel->SetMatchProxyRows(mFindMatchCache->sortedRows);
+        }
     }
 
     const int total = static_cast<int>(mFindMatchCache->sortedRows.size());
@@ -5656,6 +5726,13 @@ void MainWindow::UpdateFindMatchCount(const QString &text, bool wildcards, bool 
 void MainWindow::InvalidateFindMatchCache()
 {
     mFindMatchCache.reset();
+    // Rail ticks are keyed on the cached proxy-row list; drop
+    // them alongside the cache so a stale find selection can't
+    // strand ticks on rows the current filter no longer accepts.
+    if (mOverviewRailModel != nullptr)
+    {
+        mOverviewRailModel->SetMatchProxyRows({});
+    }
 }
 
 void MainWindow::OnFindCacheInvalidated()
@@ -5942,6 +6019,72 @@ void MainWindow::JumpToFirstRowInBucket(std::size_t bucketIndex)
         return;
     }
     SelectSourceRow(sourceRow);
+}
+
+void MainWindow::ScrollToProxyRow(int proxyRow)
+{
+    if (mTableView == nullptr || mSortFilterProxyModel == nullptr)
+    {
+        return;
+    }
+    if (proxyRow < 0 || proxyRow >= mSortFilterProxyModel->rowCount())
+    {
+        // Row can be transiently stale during an insert / filter
+        // change race — silently no-op so a drag scrub stays smooth.
+        return;
+    }
+    const QModelIndex proxyIdx = mSortFilterProxyModel->index(proxyRow, 0);
+    if (!proxyIdx.isValid())
+    {
+        return;
+    }
+    mTableView->clearSelection();
+    mTableView->scrollTo(proxyIdx, QAbstractItemView::PositionAtCenter);
+    mTableView->selectionModel()->select(proxyIdx, QItemSelectionModel::Select | QItemSelectionModel::Rows);
+    mTableView->selectionModel()->setCurrentIndex(proxyIdx, QItemSelectionModel::NoUpdate);
+}
+
+void MainWindow::SetOverviewRailVisible(bool visible)
+{
+    if (mTableView == nullptr || mOverviewRailWidget == nullptr)
+    {
+        return;
+    }
+    // Persist immediately so the next launch honours the current
+    // preference regardless of how we got here (user toggle,
+    // load-time seed, session reload).
+    QSettings settings;
+    settings.setValue(QStringLiteral("ui/showOverviewRail"), visible);
+
+    // Keep the QAction's check state consistent when the slot is
+    // driven programmatically (load-time seed). `QSignalBlocker`
+    // stops the mirroring from re-triggering us.
+    if (mActionToggleOverviewRail != nullptr && mActionToggleOverviewRail->isChecked() != visible)
+    {
+        const QSignalBlocker blocker(mActionToggleOverviewRail);
+        mActionToggleOverviewRail->setChecked(visible);
+    }
+
+    if (visible)
+    {
+        mTableView->AttachOverviewRail(mOverviewRailWidget);
+        // Rebuild once on attach so buckets reflect the current
+        // row count (the model was quiet while the widget stayed
+        // hidden and had a zero-height sizeHint).
+        if (mOverviewRailModel != nullptr)
+        {
+            mOverviewRailModel->Rebuild();
+        }
+    }
+    else
+    {
+        mTableView->AttachOverviewRail(nullptr);
+        // Reparent to `this` so the widget survives the detach
+        // and Qt cleanup remains ours. `AttachOverviewRail(null)`
+        // already dropped the parent.
+        mOverviewRailWidget->setParent(this);
+        mOverviewRailWidget->hide();
+    }
 }
 
 void MainWindow::AddTimeRangeFilterFromHistogram(qint64 fromEpochMicros, qint64 toEpochMicros)
@@ -7974,6 +8117,12 @@ void MainWindow::RebuildViewMenu()
     if (mActionToggleHistogram != nullptr)
     {
         viewMenu->addAction(mActionToggleHistogram);
+    }
+
+    // Overview rail toggle; same pattern.
+    if (mActionToggleOverviewRail != nullptr)
+    {
+        viewMenu->addAction(mActionToggleOverviewRail);
     }
 
     // Primary toolbar toggle. `QToolBar::toggleViewAction` returns a

--- a/app/src/main_window.cpp
+++ b/app/src/main_window.cpp
@@ -6062,9 +6062,16 @@ void MainWindow::SetOverviewRailVisible(bool visible)
     }
     // Persist immediately so the next launch honours the current
     // preference regardless of how we got here (user toggle,
-    // load-time seed, session reload).
+    // load-time seed, session reload). Guarded so the load-time
+    // seed (which replays the persisted value verbatim) doesn't
+    // round-trip through QSettings for no reason — that's a
+    // registry write on Windows, and we call it on every window
+    // construction.
     QSettings settings;
-    settings.setValue(QStringLiteral("ui/showOverviewRail"), visible);
+    if (settings.value(QStringLiteral("ui/showOverviewRail"), true).toBool() != visible)
+    {
+        settings.setValue(QStringLiteral("ui/showOverviewRail"), visible);
+    }
 
     // Keep the QAction's check state consistent when the slot is
     // driven programmatically (load-time seed). `QSignalBlocker`

--- a/app/src/main_window.cpp
+++ b/app/src/main_window.cpp
@@ -728,6 +728,27 @@ MainWindow::MainWindow(
     mOverviewRailWidget = new OverviewRailWidget(mOverviewRailModel, mTheme, mTableView, this);
     mOverviewRailWidget->hide();
     connect(mOverviewRailWidget, &OverviewRailWidget::proxyRowClicked, this, &MainWindow::ScrollToProxyRow);
+    // A height change reallocates buckets and drops size-mismatched
+    // durable match counts. When find is open, re-push / rescan so
+    // ticks don't vanish until the next keystroke.
+    connect(mOverviewRailModel, &OverviewRailModel::bucketsChanged, this, [this]() {
+        if (!IsFindBarVisible() || !mFindMatchCache.has_value() || mOverviewRailModel == nullptr)
+        {
+            return;
+        }
+        const std::size_t n = mOverviewRailModel->BucketCount();
+        if (n == 0)
+        {
+            return;
+        }
+        // Same H and ticks already present: RebuildInternal
+        // re-applied durable counts; nothing to do.
+        if (mFindMatchCache->bucketCounts.size() == n && mOverviewRailModel->HasMatchTicks())
+        {
+            return;
+        }
+        PushFindMatchesToOverviewRail();
+    });
 
     mActionToggleOverviewRail = new QAction(tr("Overview rail"), this);
     mActionToggleOverviewRail->setObjectName(QStringLiteral("actionToggleOverviewRail"));
@@ -1064,14 +1085,12 @@ MainWindow::MainWindow(
         {
             mFindRecord->BumpMatchCountDebounce();
         }
-        // Repopulate the rail's match ticks from the current
-        // cache. Without this, closing and reopening the find
-        // bar would leave the rail blank until the user typed
-        // again.
-        if (mOverviewRailModel != nullptr && mFindMatchCache.has_value())
-        {
-            mOverviewRailModel->SetMatchProxyRows(mFindMatchCache->sortedRows);
-        }
+        // Restore rail ticks from the surviving cache. Prefer
+        // unbiased `bucketCounts` over the capped `sortedRows`
+        // list — a naive `SetMatchProxyRows(sortedRows)` would
+        // paint only the first 10 000 hits after a common-needle
+        // reopen, and a cache-hit debounce would never re-scan.
+        PushFindMatchesToOverviewRail();
     });
 
     // Dropping the find bar drops the rail's match ticks too —
@@ -5643,98 +5662,155 @@ void MainWindow::UpdateFindMatchCount(const QString &text, bool wildcards, bool 
             return;
         }
         const QVariant value = QVariant::fromValue(text);
-        // Scan the whole proxy for matches (bounded by proxy row
-        // count, not by a fixed hit cap). We used to stop after
-        // `MAX_FIND_MATCH_COUNT + 1` hits, which is fine for the
-        // i-of-N label but *biased* the returned row list to
-        // the first N matching rows -- so the overview rail (which
-        // consumes the same list) drew highlight ticks only in
-        // the top slice of the log and appeared "broken" whenever
-        // a common needle produced >10 000 hits. The debounce
-        // upstream (`FindRecordWidget::mMatchCountTimer`, ~200 ms
-        // trailing + max-age cap) already coalesces per-keystroke
-        // bursts, so paying the full scan cost is acceptable per
-        // finalised query. The scan itself is O(rows * cols) with
-        // an early-exit-per-row on the first cell match, which
-        // matches the previous cost for common needles that hit
-        // the cap; only rare-needle scans (which walked the whole
-        // proxy before too) see any additional work here.
         const int proxyRowCount = mSortFilterProxyModel->rowCount();
-        // Use `proxyRowCount` as the ceiling so `MatchRow` still
-        // stops as soon as every row has been visited. A zero
-        // row count would fall through with an empty match list
-        // as it always did.
-        const int scanCap = std::max(1, proxyRowCount);
-        const QModelIndexList matches =
-            mSortFilterProxyModel->MatchRow(start, Qt::DisplayRole, value, scanCap, flags, true, 0);
-        // The scan is uncapped so the returned list is exhaustive
-        // (no "we stopped after N hits" lower-bound semantics).
-        // `overflowed` -> `false` disables the "+" suffix on the
-        // "*i* of *N*" label; the exact count is fine to display
-        // and no longer misleadingly reads as a lower bound.
-        // Kept as a cache field for backward-compat with the
-        // struct's existing consumers.
-        const bool overflowed = false;
-        // `MatchRow` is contracted to return one entry per row in
-        // ascending order. Sort + unique defensively so a future
-        // contract drift can't silently corrupt the binary search;
-        // asserts catch the regression at the source in debug builds.
-        std::vector<int> rows;
-        rows.reserve(static_cast<size_t>(matches.size()));
-        for (const QModelIndex &m : matches)
-        {
-            rows.push_back(m.row());
-        }
-        // Sort check must precede dedup check: `adjacent_find` only
-        // spots adjacent dupes, so unsorted input with non-adjacent
-        // duplicates would slip through. `qWarning` mirrors the
-        // assert because release builds compile it out.
-        const bool sortedAsExpected = std::ranges::is_sorted(rows);
+        // Ask the rail for its live bucket count so we can fold
+        // per-hit counters straight into a fixed-size vector as
+        // the scan runs. The rail is dropped to zero buckets while
+        // hidden (see `SetOverviewRailVisible`), in which case we
+        // skip the bucket-counter fold entirely and let the rail
+        // reattach via its own rebuild path.
+        const std::size_t nBuckets =
+            (mOverviewRailModel != nullptr) ? mOverviewRailModel->BucketCount() : std::size_t{0};
+
+        // Single-walk accumulator. `sortedRows` caps out at
+        // `MAX_FIND_MATCH_COUNT` (see field doc): the vector feeds
+        // the `Next / Previous` binary search and needs to fit in
+        // predictable memory. The rail is fed via `bucketCounts`
+        // (fixed-size at `nBuckets`). Paint only needs presence
+        // (`matchCount > 0`), so once every bucket has a tick and
+        // the navigator list is past the cap we can stop — a
+        // common needle on a huge proxy must not force a full
+        // synchronous walk. Sparse needles still scan to the end
+        // (not every bucket lights up early).
+        std::vector<int> sortedRows;
+        // Clamp against a possible pathological `rowCount() == -1`
+        // (some `QAbstractItemModel` overrides return -1 to signal
+        // "unknown"). Without the `max(0, ...)`, casting a negative
+        // value to `size_t` would ask `reserve` for a multi-EB
+        // allocation and throw `std::length_error` on the GUI
+        // thread. `MAX_FIND_MATCH_COUNT` is also the hard cap on
+        // the walk, so oversizing beyond it wastes memory.
+        const int reserveHint = std::min(std::max(0, proxyRowCount), MAX_FIND_MATCH_COUNT);
+        sortedRows.reserve(static_cast<size_t>(reserveHint));
+        std::vector<uint32_t> bucketCounts(nBuckets, uint32_t{0});
+        uint32_t totalMatches = 0;
+        std::size_t bucketsHit = 0;
+        bool scanExhausted = true;
+        // `ForEachMatchingRow` streams matches to the callback
+        // without allocating a `QList<QModelIndex>`. Contract:
+        // one invocation per matching row, in ascending row order
+        // (forward, no wrap), so `sortedRows` stays sorted-unique
+        // for the downstream binary search.
+        mSortFilterProxyModel->ForEachMatchingRow(
+            start,
+            Qt::DisplayRole,
+            value,
+            flags,
+            /*forward=*/true,
+            /*skipFirstN=*/0,
+            [&](const QModelIndex &matchIndex) -> bool {
+                ++totalMatches;
+                const int proxyRow = matchIndex.row();
+                if (nBuckets > 0 && proxyRowCount > 0 && proxyRow >= 0)
+                {
+                    const std::size_t bucketIdx =
+                        (static_cast<std::size_t>(proxyRow) * nBuckets) / static_cast<std::size_t>(proxyRowCount);
+                    uint32_t &slot = bucketCounts[std::min(bucketIdx, nBuckets - 1)];
+                    if (slot == 0)
+                    {
+                        ++bucketsHit;
+                    }
+                    ++slot;
+                }
+                if (static_cast<int>(sortedRows.size()) < MAX_FIND_MATCH_COUNT)
+                {
+                    sortedRows.push_back(proxyRow);
+                }
+                // Early-exit once overflow is proven (one past the
+                // navigator cap) and the rail either is hidden or
+                // already has a presence tick in every bucket.
+                // Further hits only change density / the exact
+                // total; the label shows "+" and paint ignores
+                // density. Mirrors the pre-rail `hits = MAX+1`
+                // freeze guard without re-biasing the rail strip
+                // for dense needles.
+                if (totalMatches > static_cast<uint32_t>(MAX_FIND_MATCH_COUNT) &&
+                    (nBuckets == 0 || bucketsHit >= nBuckets))
+                {
+                    scanExhausted = false;
+                    return false;
+                }
+                return true;
+            }
+        );
+
+        const bool overflowed =
+            !scanExhausted || totalMatches > static_cast<uint32_t>(MAX_FIND_MATCH_COUNT);
+        // Defensive sort/dedup: `ForEachMatchingRow` is contracted
+        // to yield rows in ascending order without duplicates, but
+        // a future contract drift can't be allowed to silently
+        // corrupt the binary search. `qWarning` mirrors the assert
+        // so release builds still leave a breadcrumb.
+        const bool sortedAsExpected = std::ranges::is_sorted(sortedRows);
         Q_ASSERT(sortedAsExpected);
         if (!sortedAsExpected)
         {
-            qWarning() << "MainWindow::UpdateFindMatchCount: MatchRow returned unsorted rows; "
+            qWarning() << "MainWindow::UpdateFindMatchCount: ForEachMatchingRow returned unsorted rows; "
                           "sorting defensively. This is a contract violation worth investigating.";
-            std::ranges::sort(rows);
+            std::ranges::sort(sortedRows);
         }
-        const bool dedupedAsExpected = std::ranges::adjacent_find(rows) == rows.end();
+        const bool dedupedAsExpected = std::ranges::adjacent_find(sortedRows) == sortedRows.end();
         Q_ASSERT(dedupedAsExpected);
         if (!dedupedAsExpected)
         {
-            qWarning() << "MainWindow::UpdateFindMatchCount: MatchRow returned duplicate rows; "
+            qWarning() << "MainWindow::UpdateFindMatchCount: ForEachMatchingRow returned duplicate rows; "
                           "deduplicating defensively. This is a contract violation worth investigating.";
+            sortedRows.erase(std::ranges::unique(sortedRows).begin(), sortedRows.end());
         }
-        rows.erase(std::ranges::unique(rows).begin(), rows.end());
-        // No truncation: `rows` already holds every match found
-        // by the uncapped scan above, and both consumers (the
-        // overview rail's bucket-folder and the Next / Previous
-        // binary search) benefit from an exact list. The old
-        // `resize(MAX_FIND_MATCH_COUNT)` truncation was the
-        // second half of the "highlight stops working with many
-        // hits" bug -- combined with the capped `MatchRow`, it
-        // left the rail's tick vector contiguous from row 0 and
-        // silently missing every match past the first N.
         mFindMatchCache = FindMatchCache{
             .needle = text,
             .wildcards = wildcards,
             .regularExpressions = regularExpressions,
             .overflowed = overflowed,
-            .sortedRows = std::move(rows),
+            .sortedRows = std::move(sortedRows),
+            .totalMatches = totalMatches,
+            // Keep a copy for find-dock reveal / rail re-show so a
+            // cache-hit path can still push unbiased ticks without
+            // re-walking the proxy. Empty when the rail had zero
+            // buckets during this scan (hidden).
+            .bucketCounts = (nBuckets > 0) ? bucketCounts : std::vector<uint32_t>{},
         };
-        // Push the fresh match rows into the overview rail so its
-        // find-tick band matches the "*i* of *N*" indicator. The
-        // rail's model coalesces the bucket recompute but emits
-        // `matchesChanged` immediately so the widget repaints on
-        // the next event loop pass.
+        // Push the fresh match state into the overview rail. The
+        // bucket-counts path is preferred when the rail has an
+        // active bucket vector: it feeds every hit into the rail's
+        // paint without the O(matches) allocation, and it never
+        // biases toward the top of the log even when the sorted-
+        // rows vector is capped. When the rail is hidden
+        // (`nBuckets == 0`), fall back to the row-list path so
+        // the cached list survives a later re-show via
+        // `SetBucketCount(H)` triggering a fresh rebuild (and
+        // `PushFindMatchesToOverviewRail` forces a recount when
+        // that list was capped).
         if (mOverviewRailModel != nullptr)
         {
-            mOverviewRailModel->SetMatchProxyRows(mFindMatchCache->sortedRows);
+            if (nBuckets > 0)
+            {
+                mOverviewRailModel->SetMatchBucketCounts(std::move(bucketCounts), totalMatches);
+            }
+            else
+            {
+                mOverviewRailModel->SetMatchProxyRows(mFindMatchCache->sortedRows);
+            }
         }
     }
 
-    const int total = static_cast<int>(mFindMatchCache->sortedRows.size());
+    // When `overflowed`, `totalMatches` is a lower bound (early
+    // exit or capped navigator) and the "+" suffix also signals
+    // that the position lookup below can return `0` for a current
+    // row past the cap.
+    const int total = static_cast<int>(mFindMatchCache->totalMatches);
     int currentOneBased = 0;
-    if (total > 0 && mTableView != nullptr)
+    if (total > 0 && mTableView != nullptr && !mFindMatchCache->sortedRows.empty())
     {
         const QModelIndex currentIdx = mTableView->currentIndex();
         if (currentIdx.isValid())
@@ -5754,13 +5830,55 @@ void MainWindow::UpdateFindMatchCount(const QString &text, bool wildcards, bool 
 void MainWindow::InvalidateFindMatchCache()
 {
     mFindMatchCache.reset();
-    // Rail ticks are keyed on the cached proxy-row list; drop
+    // Rail ticks are keyed on the cached match state; drop
     // them alongside the cache so a stale find selection can't
     // strand ticks on rows the current filter no longer accepts.
     if (mOverviewRailModel != nullptr)
     {
         mOverviewRailModel->SetMatchProxyRows({});
     }
+}
+
+void MainWindow::PushFindMatchesToOverviewRail()
+{
+    if (mOverviewRailModel == nullptr || !mFindMatchCache.has_value())
+    {
+        return;
+    }
+    const std::size_t nBuckets = mOverviewRailModel->BucketCount();
+    if (nBuckets == 0)
+    {
+        // Rail hidden: durable model state (row list or stored
+        // bucket counts) is enough for the next SetBucketCount(H).
+        return;
+    }
+
+    const FindMatchCache &cache = *mFindMatchCache;
+    if (cache.bucketCounts.size() == nBuckets)
+    {
+        mOverviewRailModel->SetMatchBucketCounts(cache.bucketCounts, cache.totalMatches);
+        return;
+    }
+
+    // Bucket counts missing (scan ran while rail was hidden) or
+    // size-mismatched (H changed since the scan). Prefer a full
+    // recount so the rail never paints a top-biased capped strip.
+    if (IsFindBarVisible() && !cache.needle.isEmpty())
+    {
+        const QString text = cache.needle;
+        const bool wildcards = cache.wildcards;
+        const bool regularExpressions = cache.regularExpressions;
+        // Soft-invalidate: drop the cache so UpdateFindMatchCount
+        // rescans, but do not clear the rail first — the recount
+        // below replaces ticks in one shot.
+        mFindMatchCache.reset();
+        UpdateFindMatchCount(text, wildcards, regularExpressions);
+        return;
+    }
+
+    // Find bar unavailable: best-effort restore from the capped
+    // row list (may be top-biased when overflowed).
+    mOverviewRailModel->SetMatchProxyRows(cache.sortedRows);
 }
 
 void MainWindow::OnFindCacheInvalidated()
@@ -6119,6 +6237,11 @@ void MainWindow::SetOverviewRailVisible(bool visible)
         // wasted O(rowCount) walk (and, worse, a duplicate paint
         // on the widget's first show).
         mTableView->AttachOverviewRail(mOverviewRailWidget);
+        // If find is active, re-push match ticks. Same-H hide→show
+        // already restores via durable model state; a height change
+        // (or a scan that ran while the rail was hidden) needs
+        // `PushFindMatchesToOverviewRail` to re-bucket / rescan.
+        PushFindMatchesToOverviewRail();
     }
     else
     {

--- a/app/src/main_window.cpp
+++ b/app/src/main_window.cpp
@@ -1254,22 +1254,17 @@ MainWindow::MainWindow(
     // Overview-rail width preset (live preview from Preferences).
     // Refresh the table's reserved margin after applying so the
     // viewport tracks the new sizeHint.
-    connect(
-        mPreferencesEditor,
-        &PreferencesEditor::overviewRailWidthChanged,
-        this,
-        [this](OverviewRailWidthMode mode) {
-            if (mOverviewRailWidget == nullptr)
-            {
-                return;
-            }
-            mOverviewRailWidget->SetWidthMode(mode);
-            if (mTableView != nullptr)
-            {
-                mTableView->RefreshOverviewRailMargin();
-            }
+    connect(mPreferencesEditor, &PreferencesEditor::overviewRailWidthChanged, this, [this](OverviewRailWidthMode mode) {
+        if (mOverviewRailWidget == nullptr)
+        {
+            return;
         }
-    );
+        mOverviewRailWidget->SetWidthMode(mode);
+        if (mTableView != nullptr)
+        {
+            mTableView->RefreshOverviewRailMargin();
+        }
+    });
 
     // Anchor hotkeys (programmatic so the .ui isn't bloated):
     //   Ctrl+1..8     anchor selection at colour N
@@ -5760,8 +5755,7 @@ void MainWindow::UpdateFindMatchCount(const QString &text, bool wildcards, bool 
             }
         );
 
-        const bool overflowed =
-            !scanExhausted || totalMatches > static_cast<uint32_t>(MAX_FIND_MATCH_COUNT);
+        const bool overflowed = !scanExhausted || totalMatches > static_cast<uint32_t>(MAX_FIND_MATCH_COUNT);
         // Defensive sort/dedup: contract violations would silently
         // corrupt the binary search. Assert in debug, warn in
         // release, still recover so the caller doesn't see garbage.

--- a/app/src/main_window.cpp
+++ b/app/src/main_window.cpp
@@ -5675,9 +5675,12 @@ void MainWindow::UpdateFindMatchCount(const QString &text, bool wildcards, bool 
     }
     if (text.isEmpty())
     {
-        // Only reachable via a programmatic call (the widget
-        // suppresses the signal on empty text). Keep the label
-        // clear in case the cache was previously populated.
+        // Reached both programmatically (find bar not yet used) and
+        // via `FindRecordWidget::RequestMatchCountSoon`, which emits
+        // `MatchCountRequested("")` after the user clears the field
+        // so downstream match state (this cache + the overview rail's
+        // tick vector) drops in one round-trip. `InvalidateFindMatchCache`
+        // is what pushes the empty match list into the rail.
         InvalidateFindMatchCache();
         mFindRecord->SetMatchInfo(0, 0);
         return;
@@ -6236,8 +6239,10 @@ void MainWindow::ScrollToProxyRow(int proxyRow, bool replaceSelection)
     // viewport back to the tail mid-exploration. `scrollTo` is
     // programmatic and would not fire `userScrolledAwayFromTail`
     // on its own; handle Follow here instead of relying on the
-    // scrollbar attribution path.
-    if (ui != nullptr && ui->actionFollowTail->isChecked())
+    // scrollbar attribution path. Null-check both handles: a partial
+    // UI setup (early failure path in `setupUi`) can leave the
+    // action pointer null even when `ui` itself is valid.
+    if (ui != nullptr && ui->actionFollowTail != nullptr && ui->actionFollowTail->isChecked())
     {
         ui->actionFollowTail->setChecked(false);
     }

--- a/app/src/overview_rail_model.cpp
+++ b/app/src/overview_rail_model.cpp
@@ -191,10 +191,14 @@ loglib::LogLevel OverviewRailModel::DominantLevel(std::size_t bucket) const noex
         return loglib::LogLevel::Unknown;
     }
     const auto &counts = mBuckets[bucket].levels.counts;
-    // Pick the entry with the highest count, tie-broken by
-    // severity rank (Fatal wins over Error wins over Warn, ...).
-    // `Unknown` (slot 0) contributes to the paint like any other
-    // level so unresolved rows still tint the rail.
+    // Majority-count level, tie-broken by severity (Fatal wins
+    // over Error wins over Warn, ...). Retained for callers that
+    // want a *single* colour per bucket (e.g. the anchor tick
+    // legend, tests). The widget's level histogram no longer
+    // relies on this method -- it iterates the per-level counts
+    // and paints stacked severity segments so a bucket with 200
+    // Trace + 1 Fatal shows both the grey volume *and* a visible
+    // red anomaly pixel, which majority-count alone erases.
     std::size_t bestSlot = 0;
     uint32_t bestCount = 0;
     int bestSeverity = -1;

--- a/app/src/overview_rail_model.cpp
+++ b/app/src/overview_rail_model.cpp
@@ -8,7 +8,9 @@
 
 #include <QAbstractItemModel>
 #include <QAbstractProxyModel>
+#include <QDebug>
 #include <QModelIndex>
+#include <QPointer>
 #include <QTimer>
 
 #include <algorithm>
@@ -592,8 +594,16 @@ int OverviewRailModel::ProxyToSourceRow(int proxyRow) const noexcept
         return -1;
     }
     QModelIndex idx = mProxyModel->index(proxyRow, 0);
-    for (QAbstractProxyModel *proxy : mProxyChain)
+    for (const QPointer<QAbstractProxyModel> &proxy : mProxyChain)
     {
+        // A `QPointer` slot can zero if the referenced proxy was
+        // destroyed under us without the outermost proxy firing
+        // `modelReset`. Short-circuit rather than dereferencing a
+        // null slot; the caller treats `-1` as "row not resolvable".
+        if (proxy.isNull())
+        {
+            return -1;
+        }
         idx = proxy->mapToSource(idx);
     }
     if (!idx.isValid())
@@ -604,13 +614,28 @@ int OverviewRailModel::ProxyToSourceRow(int proxyRow) const noexcept
     // swaps its `sourceModel()` after our cache is populated and
     // the outer proxy doesn't emit `modelReset`, the walk lands on
     // an alien model and we'd fold rows from the wrong table. Cheap
-    // pointer compare so we can afford it in debug; skipped in
-    // release because a single misattributed bucket is preferable
-    // to spinning `qWarning` per row.
+    // pointer compare so we can afford it in debug; release emits a
+    // one-shot `qWarning` (see below) so the shipped build isn't
+    // silent about it, then falls through with the (wrong) row —
+    // that's still better than crashing on a `nullptr` dereference.
     Q_ASSERT_X(
         idx.model() == mSourceModel, "OverviewRailModel::ProxyToSourceRow",
         "proxy chain no longer terminates at the cached source model"
     );
+    if (idx.model() != mSourceModel)
+    {
+        // Once-per-model-instance breadcrumb. `qWarning` per row
+        // would drown the log at 1M-row-scan cadence; the flag keeps
+        // it to a single line per drift event.
+        if (!mProxyChainDriftWarned)
+        {
+            mProxyChainDriftWarned = true;
+            qWarning() << "OverviewRailModel::ProxyToSourceRow: proxy chain no longer terminates at the "
+                          "cached source model. Bucket counts may misattribute rows until the next "
+                          "modelReset refreshes the chain cache.";
+        }
+        return -1;
+    }
     return idx.row();
 }
 
@@ -618,6 +643,12 @@ void OverviewRailModel::RebuildProxyChainCache()
 {
     mProxyChain.clear();
     mProxyChainTerminatesAtSource = false;
+    // Fresh cache: arm the drift warning again so a *new* chain
+    // drift after this rebuild still surfaces its one-shot
+    // `qWarning`. Without the reset, once-warned-per-lifetime
+    // would silently swallow a second drift event after e.g. a
+    // dictionary rebuild that emitted `modelReset`.
+    mProxyChainDriftWarned = false;
     if (mProxyModel == nullptr || mSourceModel == nullptr)
     {
         return;
@@ -631,7 +662,7 @@ void OverviewRailModel::RebuildProxyChainCache()
     QAbstractItemModel *current = mProxyModel;
     while (auto *proxy = qobject_cast<QAbstractProxyModel *>(current))
     {
-        mProxyChain.push_back(proxy);
+        mProxyChain.push_back(QPointer<QAbstractProxyModel>(proxy));
         current = proxy->sourceModel();
         if (current == nullptr)
         {

--- a/app/src/overview_rail_model.cpp
+++ b/app/src/overview_rail_model.cpp
@@ -1,0 +1,438 @@
+#include "overview_rail_model.hpp"
+
+#include "log_model.hpp"
+
+#include <loglib/log_configuration.hpp>
+#include <loglib/log_level.hpp>
+#include <loglib/log_table.hpp>
+
+#include <QAbstractItemModel>
+#include <QAbstractProxyModel>
+#include <QModelIndex>
+#include <QTimer>
+
+#include <algorithm>
+#include <array>
+#include <cstddef>
+#include <cstdint>
+
+namespace
+{
+
+/// Coalesce cadence for `bucketsChanged`. Matches the histogram's
+/// 50 ms cadence and the table's live-tail batch cadence so a
+/// row burst yields at most one repaint.
+constexpr int EMIT_COALESCE_MS = 50;
+
+/// Severity ranking for the dominant-level tie-break. Higher
+/// value == more severe, so ties go to the row colour users are
+/// more likely to want to see. Indexed by
+/// `static_cast<size_t>(LogLevel)`.
+constexpr std::array<int, loglib::CANONICAL_LEVEL_COUNT + 1> LEVEL_SEVERITY_RANK = {
+    0, // Unknown
+    1, // Trace
+    2, // Debug
+    3, // Info
+    4, // Warn
+    5, // Error
+    6, // Fatal
+};
+
+} // namespace
+
+OverviewRailModel::OverviewRailModel(
+    QAbstractItemModel *proxyModel, LogModel *sourceModel, AnchorManager *anchors, QObject *parent
+)
+    : QObject(parent), mProxyModel(proxyModel), mSourceModel(sourceModel), mAnchors(anchors)
+{
+    mEmitTimer = new QTimer(this);
+    mEmitTimer->setSingleShot(true);
+    mEmitTimer->setInterval(EMIT_COALESCE_MS);
+    connect(mEmitTimer, &QTimer::timeout, this, &OverviewRailModel::bucketsChanged);
+
+    if (mProxyModel != nullptr)
+    {
+        connect(mProxyModel, &QAbstractItemModel::rowsInserted, this, &OverviewRailModel::OnRowsInserted);
+        connect(mProxyModel, &QAbstractItemModel::rowsRemoved, this, &OverviewRailModel::OnRowsRemoved);
+        connect(mProxyModel, &QAbstractItemModel::modelReset, this, &OverviewRailModel::OnModelReset);
+        // A filter/sort change lands as `layoutChanged` on
+        // `LogFilterModel`; row inserts are rare after that, so we
+        // rebuild here to pick up the new proxy row set.
+        connect(mProxyModel, &QAbstractItemModel::layoutChanged, this, &OverviewRailModel::OnLayoutChanged);
+        // Column shape changes may move the level column even
+        // when no rows insert. Not coalesced with `columnsMoved`
+        // because both funnel to the same rebuild anyway.
+        connect(mProxyModel, &QAbstractItemModel::columnsMoved, this, &OverviewRailModel::OnColumnsChanged);
+        connect(mProxyModel, &QAbstractItemModel::columnsInserted, this, &OverviewRailModel::OnColumnsChanged);
+        connect(mProxyModel, &QAbstractItemModel::columnsRemoved, this, &OverviewRailModel::OnColumnsChanged);
+    }
+
+    if (mSourceModel != nullptr)
+    {
+        // Level column can promote / demote mid-stream. Refresh
+        // the cache and rebuild so pre-promotion `Unknown` rows
+        // get re-attributed to their canonical level.
+        connect(
+            mSourceModel,
+            &LogModel::enumColumnsChanged,
+            this,
+            [this](EnumColumnsChangeReason, int) { OnEnumColumnsChanged(); }
+        );
+    }
+
+    if (mAnchors != nullptr)
+    {
+        connect(mAnchors, &AnchorManager::anchorChanged, this, &OverviewRailModel::OnAnchorChanged);
+        connect(mAnchors, &AnchorManager::anchorsReset, this, &OverviewRailModel::OnAnchorsReset);
+    }
+
+    // Prime the cached column index and bucket vector.
+    mLevelColumnIndex = ComputeLevelColumnIndex();
+}
+
+void OverviewRailModel::SetBucketCount(std::size_t nBuckets)
+{
+    if (mBuckets.size() == nBuckets)
+    {
+        return;
+    }
+    mBuckets.assign(nBuckets, Bucket{});
+    // Bit count is preserved separately because the fresh buckets
+    // start at zero; recompute inside RebuildInternal.
+    RebuildInternal();
+    // Rail widget consumes the change immediately on the next
+    // paint tick, so avoid the coalesce delay here.
+    emit bucketsChanged();
+}
+
+void OverviewRailModel::SetMatchProxyRows(std::vector<int> proxyRows)
+{
+    mMatchProxyRows = std::move(proxyRows);
+    // Match counts overlay the existing per-level bucket data;
+    // rebuild to fold the fresh rows into the bucket vector.
+    RebuildInternal();
+    emit matchesChanged();
+    emit bucketsChanged();
+}
+
+void OverviewRailModel::Rebuild()
+{
+    RebuildInternal();
+    ScheduleEmit();
+}
+
+loglib::LogLevel OverviewRailModel::DominantLevel(std::size_t bucket) const noexcept
+{
+    if (bucket >= mBuckets.size())
+    {
+        return loglib::LogLevel::Unknown;
+    }
+    const auto &counts = mBuckets[bucket].levels.counts;
+    // Pick the entry with the highest count, tie-broken by
+    // severity rank (Fatal wins over Error wins over Warn, ...).
+    // `Unknown` (slot 0) contributes to the paint like any other
+    // level so unresolved rows still tint the rail.
+    std::size_t bestSlot = 0;
+    uint32_t bestCount = 0;
+    int bestSeverity = -1;
+    for (std::size_t i = 0; i < counts.size(); ++i)
+    {
+        const uint32_t count = counts[i];
+        if (count == 0)
+        {
+            continue;
+        }
+        const int severity = LEVEL_SEVERITY_RANK[i];
+        if (count > bestCount || (count == bestCount && severity > bestSeverity))
+        {
+            bestSlot = i;
+            bestCount = count;
+            bestSeverity = severity;
+        }
+    }
+    return static_cast<loglib::LogLevel>(bestSlot);
+}
+
+int OverviewRailModel::FirstProxyRowInBucket(std::size_t bucket) const noexcept
+{
+    if (mProxyRowCount <= 0 || mBuckets.empty() || bucket >= mBuckets.size())
+    {
+        return -1;
+    }
+    // Inverse of the linear map `bucket = row * N / M`: the first
+    // row landing in `bucket` is ceil(bucket * M / N).
+    const std::size_t nBuckets = mBuckets.size();
+    const long long numerator = static_cast<long long>(bucket) * static_cast<long long>(mProxyRowCount);
+    long long firstRow = (numerator + static_cast<long long>(nBuckets) - 1) / static_cast<long long>(nBuckets);
+    firstRow = std::clamp<long long>(firstRow, 0, mProxyRowCount - 1);
+    return static_cast<int>(firstRow);
+}
+
+int OverviewRailModel::ProxyRowForYPixel(int y, int railHeight) const noexcept
+{
+    if (mProxyRowCount <= 0)
+    {
+        return -1;
+    }
+    if (railHeight <= 0)
+    {
+        return 0;
+    }
+    // Clamp Y into the rail's usable range.
+    const int clampedY = std::clamp(y, 0, railHeight - 1);
+    // Linear map: bucket = (y * bucketCount) / railHeight, then
+    // return the first proxy row in that bucket (matches paint
+    // math so click-and-scroll lands on the row the user sees).
+    if (mBuckets.empty())
+    {
+        // No bucket vector yet — approximate directly with row
+        // math so clicks work even before the first `SetBucketCount`.
+        const long long row = (static_cast<long long>(clampedY) * static_cast<long long>(mProxyRowCount)) /
+                              static_cast<long long>(railHeight);
+        return static_cast<int>(std::clamp<long long>(row, 0, mProxyRowCount - 1));
+    }
+    const long long bucket = (static_cast<long long>(clampedY) * static_cast<long long>(mBuckets.size())) /
+                             static_cast<long long>(railHeight);
+    const int clampedBucket = static_cast<int>(std::clamp<long long>(bucket, 0, static_cast<long long>(mBuckets.size()) - 1));
+    const int firstRow = FirstProxyRowInBucket(static_cast<std::size_t>(clampedBucket));
+    return firstRow >= 0 ? firstRow : 0;
+}
+
+void OverviewRailModel::OnRowsInserted(const QModelIndex &parent, int first, int last)
+{
+    (void)parent;
+    (void)first;
+    (void)last;
+    Rebuild();
+}
+
+void OverviewRailModel::OnRowsRemoved(const QModelIndex &parent, int first, int last)
+{
+    (void)parent;
+    (void)first;
+    (void)last;
+    Rebuild();
+}
+
+void OverviewRailModel::OnModelReset()
+{
+    mLevelColumnIndex = ComputeLevelColumnIndex();
+    Rebuild();
+}
+
+void OverviewRailModel::OnLayoutChanged()
+{
+    Rebuild();
+}
+
+void OverviewRailModel::OnColumnsChanged()
+{
+    const int fresh = ComputeLevelColumnIndex();
+    if (fresh == mLevelColumnIndex)
+    {
+        return;
+    }
+    mLevelColumnIndex = fresh;
+    Rebuild();
+}
+
+void OverviewRailModel::OnEnumColumnsChanged()
+{
+    const int fresh = ComputeLevelColumnIndex();
+    if (fresh == mLevelColumnIndex)
+    {
+        // A grow / demote of an unrelated column: skip the
+        // rebuild to keep append hot paths cheap.
+        return;
+    }
+    mLevelColumnIndex = fresh;
+    Rebuild();
+}
+
+void OverviewRailModel::OnAnchorChanged(const AnchorManager::Key & /*key*/)
+{
+    // Anchor edits are rare; a full rebuild costs the same
+    // O(rowCount) as folding a single anchor into its bucket, and
+    // keeps the running popcount trivially in sync.
+    Rebuild();
+}
+
+void OverviewRailModel::OnAnchorsReset()
+{
+    Rebuild();
+}
+
+void OverviewRailModel::RebuildInternal()
+{
+    const std::size_t previousBitsSet = mAnchorBucketBitsSet;
+
+    // Zero everything except the vector capacity.
+    for (auto &bucket : mBuckets)
+    {
+        bucket.levels.counts.fill(0);
+        bucket.matchCount = 0;
+        bucket.anchorSlots.reset();
+    }
+    mAnchorBucketBitsSet = 0;
+
+    if (mProxyModel == nullptr)
+    {
+        mProxyRowCount = 0;
+        EmitAnchorChangeIfDifferent(previousBitsSet);
+        return;
+    }
+    mProxyRowCount = mProxyModel->rowCount();
+    if (mBuckets.empty() || mProxyRowCount <= 0)
+    {
+        EmitAnchorChangeIfDifferent(previousBitsSet);
+        return;
+    }
+
+    const bool trackAnchors = mAnchors != nullptr && !mAnchors->Empty();
+    const std::size_t nBuckets = mBuckets.size();
+
+    // One linear walk over the proxy: bucket per row, mapped
+    // to source once for the level lookup and (optionally) the
+    // anchor slot lookup. On a 1M-row session with 500 buckets
+    // this is a handful of ms — dominated by the source-mapping
+    // walk, not by the bucket increment.
+    for (int proxyRow = 0; proxyRow < mProxyRowCount; ++proxyRow)
+    {
+        const std::size_t bucketIdx =
+            (static_cast<std::size_t>(proxyRow) * nBuckets) / static_cast<std::size_t>(mProxyRowCount);
+        const std::size_t bounded = std::min(bucketIdx, nBuckets - 1);
+        auto &bucket = mBuckets[bounded];
+
+        const int sourceRow = ProxyToSourceRow(proxyRow);
+        if (sourceRow < 0)
+        {
+            // Proxy chain hides this row on the way down. Count
+            // it as `Unknown` so the rail still shows *something*
+            // where the row is — better than a gap that hides
+            // the fact that a row is present.
+            ++bucket.levels.counts[static_cast<std::size_t>(loglib::LogLevel::Unknown)];
+            continue;
+        }
+        const loglib::LogLevel level = LevelForSourceRow(sourceRow);
+        ++bucket.levels.counts[static_cast<std::size_t>(level)];
+
+        if (trackAnchors)
+        {
+            const auto slot = mSourceModel->AnchorSlotForRow(sourceRow);
+            if (slot.has_value())
+            {
+                auto &mask = bucket.anchorSlots;
+                if (!mask.test(*slot))
+                {
+                    mask.set(*slot);
+                    ++mAnchorBucketBitsSet;
+                }
+            }
+        }
+    }
+
+    // Fold match rows in. `mFindMatchCache->sortedRows` is a
+    // sorted, deduplicated proxy-row list — bucket assignment
+    // matches the row pass above.
+    for (const int proxyRow : mMatchProxyRows)
+    {
+        if (proxyRow < 0 || proxyRow >= mProxyRowCount)
+        {
+            continue;
+        }
+        const std::size_t bucketIdx =
+            (static_cast<std::size_t>(proxyRow) * nBuckets) / static_cast<std::size_t>(mProxyRowCount);
+        const std::size_t bounded = std::min(bucketIdx, nBuckets - 1);
+        ++mBuckets[bounded].matchCount;
+    }
+
+    EmitAnchorChangeIfDifferent(previousBitsSet);
+}
+
+void OverviewRailModel::ScheduleEmit()
+{
+    if (!mEmitTimer->isActive())
+    {
+        mEmitTimer->start();
+    }
+}
+
+int OverviewRailModel::BucketForProxyRow(int proxyRow) const noexcept
+{
+    if (mProxyRowCount <= 0 || mBuckets.empty() || proxyRow < 0 || proxyRow >= mProxyRowCount)
+    {
+        return -1;
+    }
+    const std::size_t bucketIdx =
+        (static_cast<std::size_t>(proxyRow) * mBuckets.size()) / static_cast<std::size_t>(mProxyRowCount);
+    return static_cast<int>(std::min(bucketIdx, mBuckets.size() - 1));
+}
+
+int OverviewRailModel::ProxyToSourceRow(int proxyRow) const noexcept
+{
+    if (mProxyModel == nullptr || mSourceModel == nullptr)
+    {
+        return -1;
+    }
+    QModelIndex idx = mProxyModel->index(proxyRow, 0);
+    QAbstractItemModel *current = mProxyModel;
+    // Walk through however many `QAbstractProxyModel` layers the
+    // chain has (in production it's LogFilterModel ->
+    // RowOrderProxyModel -> LogModel).
+    while (auto *proxy = qobject_cast<QAbstractProxyModel *>(current))
+    {
+        idx = proxy->mapToSource(idx);
+        current = proxy->sourceModel();
+        if (current == nullptr)
+        {
+            return -1;
+        }
+    }
+    if (current != mSourceModel || !idx.isValid())
+    {
+        return -1;
+    }
+    return idx.row();
+}
+
+loglib::LogLevel OverviewRailModel::LevelForSourceRow(int sourceRow) const noexcept
+{
+    if (mSourceModel == nullptr || mLevelColumnIndex < 0)
+    {
+        return loglib::LogLevel::Unknown;
+    }
+    // Prefer LogTable::GetLevelForRow directly over
+    // `LogModel::LevelForRow`: the private helper caches
+    // `mFirstLevelColumnCache` inside LogModel, which self-repairs
+    // during `AppendBatch`. Reading through our own cached index
+    // sidesteps the race the histogram model documents.
+    const auto level = mSourceModel->Table().GetLevelForRow(
+        static_cast<std::size_t>(sourceRow), static_cast<std::size_t>(mLevelColumnIndex)
+    );
+    return level.value_or(loglib::LogLevel::Unknown);
+}
+
+int OverviewRailModel::ComputeLevelColumnIndex() const noexcept
+{
+    if (mSourceModel == nullptr)
+    {
+        return -1;
+    }
+    const auto &config = mSourceModel->Configuration();
+    for (std::size_t i = 0; i < config.columns.size(); ++i)
+    {
+        if (config.columns[i].type == loglib::LogConfiguration::Type::Level)
+        {
+            return static_cast<int>(i);
+        }
+    }
+    return -1;
+}
+
+void OverviewRailModel::EmitAnchorChangeIfDifferent(std::size_t previousBitsSet)
+{
+    if (previousBitsSet != mAnchorBucketBitsSet)
+    {
+        emit anchorBucketsChanged();
+    }
+}

--- a/app/src/overview_rail_model.cpp
+++ b/app/src/overview_rail_model.cpp
@@ -147,6 +147,11 @@ void OverviewRailModel::SetBucketCount(std::size_t nBuckets)
 void OverviewRailModel::SetMatchProxyRows(std::vector<int> proxyRows)
 {
     mMatchProxyRows = std::move(proxyRows);
+    // Row-list path owns match state; drop any durable bucket
+    // counts so a later rebuild can't re-apply a stale fold on
+    // top of (or instead of) the rows we just installed.
+    mMatchBucketCounts.clear();
+    mMatchBucketTotal = 0;
     // Normalise: sort + unique. `FoldMatchTicksIntoBuckets`
     // increments per entry, so a duplicated row would double-
     // count into its bucket and inflate `mBucketedMatchCount`.
@@ -157,6 +162,24 @@ void OverviewRailModel::SetMatchProxyRows(std::vector<int> proxyRows)
     // upstream).
     std::sort(mMatchProxyRows.begin(), mMatchProxyRows.end());
     mMatchProxyRows.erase(std::unique(mMatchProxyRows.begin(), mMatchProxyRows.end()), mMatchProxyRows.end());
+    // Refresh the cached row count from the live proxy before
+    // folding. `mProxyRowCount` is otherwise only written inside
+    // `RebuildInternal` and lags reality by up to one coalesce
+    // window (~50 ms); during live-tail inserts the caller has
+    // already scanned against the current row count and passed
+    // us match rows referenced to it. Using the stale (smaller)
+    // denominator would either drop tail-row hits (proxy index
+    // >= `mProxyRowCount`) or fold them into the last bucket via
+    // a divide-by-smaller-M — both visible as ticks vanishing
+    // or bunching after a live-tail append. The level counts
+    // and anchor bits keep their old `mProxyRowCount` bucketing
+    // for one coalesce interval; that mismatch is invisible on
+    // the timescale a user perceives and self-heals on the next
+    // rebuild.
+    if (mProxyModel != nullptr)
+    {
+        mProxyRowCount = mProxyModel->rowCount();
+    }
     // Match ticks live in `matchCount` only; level counts and
     // anchor bits are unaffected. Refresh just the tick field so
     // a find-bar keystroke doesn't re-walk the whole proxy.
@@ -166,6 +189,45 @@ void OverviewRailModel::SetMatchProxyRows(std::vector<int> proxyRows)
     // signals with the same `update()` slot — an extra
     // `bucketsChanged` would only trigger a redundant repaint
     // request that Qt would immediately coalesce out again.
+    emit matchesChanged();
+}
+
+void OverviewRailModel::SetMatchBucketCounts(std::vector<uint32_t> perBucketCounts, uint32_t totalMatches)
+{
+    // Size mismatch: the rail resized (or the caller has stale
+    // bucket-count info) between the caller computing its counts
+    // and this call landing. Drop the update silently rather than
+    // half-applying a mismatched vector — the resize will trigger
+    // its own synchronous rebuild via `SetBucketCount` and the
+    // next find-bar debounce recomputes cleanly against the new
+    // bucket count. Validate BEFORE mutating any local state so a
+    // dropped update leaves the model bit-for-bit untouched (the
+    // previous ordering refreshed `mProxyRowCount` speculatively
+    // even in the drop path — harmless today but a landmine for
+    // any future consumer that reads `mProxyRowCount` between
+    // this call and the next rebuild).
+    if (perBucketCounts.size() != mBuckets.size())
+    {
+        return;
+    }
+    // Refresh the cached row count for the same reason as
+    // `SetMatchProxyRows`: the caller has already scanned against
+    // the live proxy, and any subsequent rail math (e.g.
+    // `HasMatchTicks`, `BucketForProxyRow` on paint) needs the
+    // denominator that matches.
+    if (mProxyModel != nullptr)
+    {
+        mProxyRowCount = mProxyModel->rowCount();
+    }
+    // Clear the raw-rows path so the next coalesced full rebuild
+    // doesn't double-count a stale row-list fold on top of the
+    // pre-bucketed values. Retain the counts themselves so
+    // `RebuildInternal` can re-apply them (anchor edits, hide→show
+    // at the same H) without the caller re-pushing.
+    mMatchProxyRows.clear();
+    mMatchBucketCounts = std::move(perBucketCounts);
+    mMatchBucketTotal = totalMatches;
+    ApplyStoredMatchBucketCounts();
     emit matchesChanged();
 }
 
@@ -415,8 +477,15 @@ void OverviewRailModel::RebuildInternal()
     // Fold current match rows in as part of the same walk so
     // the caller doesn't have to invoke `RefreshMatchTicks`
     // separately. Path is O(nMatchRows) on top of the O(rowCount)
-    // proxy walk above.
+    // proxy walk above. When the bucketed API owns match state
+    // (`mMatchProxyRows` empty, durable counts retained), re-apply
+    // those counts so anchor edits / hide→show / same-H resize
+    // don't wipe find highlights.
     FoldMatchTicksIntoBuckets();
+    if (mMatchProxyRows.empty())
+    {
+        ApplyStoredMatchBucketCounts();
+    }
 
     EmitAnchorChangeIfDifferent(previousBitsSet);
 }
@@ -484,6 +553,19 @@ void OverviewRailModel::FoldMatchTicksIntoBuckets()
     }
 }
 
+void OverviewRailModel::ApplyStoredMatchBucketCounts()
+{
+    if (mMatchBucketCounts.size() != mBuckets.size() || mBuckets.empty())
+    {
+        return;
+    }
+    mBucketedMatchCount = mMatchBucketTotal;
+    for (std::size_t i = 0; i < mBuckets.size(); ++i)
+    {
+        mBuckets[i].matchCount = mMatchBucketCounts[i];
+    }
+}
+
 int OverviewRailModel::BucketForProxyRow(int proxyRow) const noexcept
 {
     if (mProxyRowCount <= 0 || mBuckets.empty() || proxyRow < 0 || proxyRow >= mProxyRowCount)
@@ -518,6 +600,17 @@ int OverviewRailModel::ProxyToSourceRow(int proxyRow) const noexcept
     {
         return -1;
     }
+    // Debug-only guard against chain drift: if a mid-chain proxy
+    // swaps its `sourceModel()` after our cache is populated and
+    // the outer proxy doesn't emit `modelReset`, the walk lands on
+    // an alien model and we'd fold rows from the wrong table. Cheap
+    // pointer compare so we can afford it in debug; skipped in
+    // release because a single misattributed bucket is preferable
+    // to spinning `qWarning` per row.
+    Q_ASSERT_X(
+        idx.model() == mSourceModel, "OverviewRailModel::ProxyToSourceRow",
+        "proxy chain no longer terminates at the cached source model"
+    );
     return idx.row();
 }
 

--- a/app/src/overview_rail_model.cpp
+++ b/app/src/overview_rail_model.cpp
@@ -73,19 +73,13 @@ OverviewRailModel::OverviewRailModel(
         // get re-attributed. Skip dictionary `Grew` events — they
         // can't move the level column, and every batch of a wide
         // log would otherwise pay an `O(nColumns)` scan.
-        connect(
-            mSourceModel,
-            &LogModel::enumColumnsChanged,
-            this,
-            [this](EnumColumnsChangeReason reason, int)
+        connect(mSourceModel, &LogModel::enumColumnsChanged, this, [this](EnumColumnsChangeReason reason, int) {
+            if (reason == EnumColumnsChangeReason::Grew)
             {
-                if (reason == EnumColumnsChangeReason::Grew)
-                {
-                    return;
-                }
-                OnEnumColumnsChanged();
+                return;
             }
-        );
+            OnEnumColumnsChanged();
+        });
     }
 
     if (mAnchors != nullptr)
@@ -522,7 +516,8 @@ int OverviewRailModel::ProxyToSourceRow(int proxyRow) const noexcept
     // and we'd fold rows from the wrong table. Assert in debug,
     // one-shot warn in release, and refuse the row.
     Q_ASSERT_X(
-        idx.model() == mSourceModel, "OverviewRailModel::ProxyToSourceRow",
+        idx.model() == mSourceModel,
+        "OverviewRailModel::ProxyToSourceRow",
         "proxy chain no longer terminates at the cached source model"
     );
     if (idx.model() != mSourceModel)

--- a/app/src/overview_rail_model.cpp
+++ b/app/src/overview_rail_model.cpp
@@ -19,10 +19,12 @@
 namespace
 {
 
-/// Coalesce cadence for `bucketsChanged`. Matches the histogram's
-/// 50 ms cadence and the table's live-tail batch cadence so a
-/// row burst yields at most one repaint.
-constexpr int EMIT_COALESCE_MS = 50;
+/// Coalesce cadence for the full-rebuild + `bucketsChanged`
+/// emit. Matches the histogram's 50 ms cadence and the table's
+/// live-tail batch cadence, so a per-row `rowsInserted` volley
+/// (LogFilterModel's active-sort branch) collapses to one
+/// O(rowCount) walk instead of one per row.
+constexpr int REBUILD_COALESCE_MS = 50;
 
 /// Severity ranking for the dominant-level tie-break. Higher
 /// value == more severe, so ties go to the row colour users are
@@ -45,10 +47,10 @@ OverviewRailModel::OverviewRailModel(
 )
     : QObject(parent), mProxyModel(proxyModel), mSourceModel(sourceModel), mAnchors(anchors)
 {
-    mEmitTimer = new QTimer(this);
-    mEmitTimer->setSingleShot(true);
-    mEmitTimer->setInterval(EMIT_COALESCE_MS);
-    connect(mEmitTimer, &QTimer::timeout, this, &OverviewRailModel::bucketsChanged);
+    mRebuildTimer = new QTimer(this);
+    mRebuildTimer->setSingleShot(true);
+    mRebuildTimer->setInterval(REBUILD_COALESCE_MS);
+    connect(mRebuildTimer, &QTimer::timeout, this, &OverviewRailModel::OnRebuildTimeout);
 
     if (mProxyModel != nullptr)
     {
@@ -97,28 +99,49 @@ void OverviewRailModel::SetBucketCount(std::size_t nBuckets)
         return;
     }
     mBuckets.assign(nBuckets, Bucket{});
-    // Bit count is preserved separately because the fresh buckets
-    // start at zero; recompute inside RebuildInternal.
+    // Zero-bucket case (rail hidden) is the fast-path the
+    // visibility toggle relies on: `RebuildInternal` short-
+    // circuits on `mBuckets.empty()` so subsequent proxy signals
+    // cost only the timer restart.
+    //
+    // Non-zero case: called from the widget's `resizeEvent`, which
+    // triggers a paint on return. Rebuild synchronously so the
+    // widget sees fresh bucket geometry on the next paint tick
+    // instead of the coalesce timer's stale buckets.
+    if (mRebuildTimer != nullptr && mRebuildTimer->isActive())
+    {
+        // A coalesced rebuild was in flight; the sync rebuild
+        // below supersedes it.
+        mRebuildTimer->stop();
+    }
     RebuildInternal();
-    // Rail widget consumes the change immediately on the next
-    // paint tick, so avoid the coalesce delay here.
     emit bucketsChanged();
 }
 
 void OverviewRailModel::SetMatchProxyRows(std::vector<int> proxyRows)
 {
     mMatchProxyRows = std::move(proxyRows);
-    // Match counts overlay the existing per-level bucket data;
-    // rebuild to fold the fresh rows into the bucket vector.
-    RebuildInternal();
+    // Match ticks live in `matchCount` only; level counts and
+    // anchor bits are unaffected. Refresh just the tick field so
+    // a find-bar keystroke doesn't re-walk the whole proxy.
+    RefreshMatchTicks();
     emit matchesChanged();
     emit bucketsChanged();
 }
 
 void OverviewRailModel::Rebuild()
 {
+    ScheduleRebuild();
+}
+
+void OverviewRailModel::RebuildNow()
+{
+    if (mRebuildTimer != nullptr && mRebuildTimer->isActive())
+    {
+        mRebuildTimer->stop();
+    }
     RebuildInternal();
-    ScheduleEmit();
+    emit bucketsChanged();
 }
 
 loglib::LogLevel OverviewRailModel::DominantLevel(std::size_t bucket) const noexcept
@@ -178,39 +201,31 @@ int OverviewRailModel::ProxyRowForYPixel(int y, int railHeight) const noexcept
     {
         return 0;
     }
-    // Clamp Y into the rail's usable range.
+    // Clamp Y into the rail's usable range, then map directly to
+    // proxy rows: `row = y * rowCount / railHeight`. This gives
+    // sub-bucket precision so scrubbing a bucket that spans many
+    // rows still moves the viewport smoothly. The bucket-based
+    // mapping is only relevant to the paint pass, not to click
+    // resolution — a user clicking the middle of a bucket wants
+    // to land on the middle row, not the bucket's first row.
     const int clampedY = std::clamp(y, 0, railHeight - 1);
-    // Linear map: bucket = (y * bucketCount) / railHeight, then
-    // return the first proxy row in that bucket (matches paint
-    // math so click-and-scroll lands on the row the user sees).
-    if (mBuckets.empty())
-    {
-        // No bucket vector yet — approximate directly with row
-        // math so clicks work even before the first `SetBucketCount`.
-        const long long row = (static_cast<long long>(clampedY) * static_cast<long long>(mProxyRowCount)) /
-                              static_cast<long long>(railHeight);
-        return static_cast<int>(std::clamp<long long>(row, 0, mProxyRowCount - 1));
-    }
-    const long long bucket = (static_cast<long long>(clampedY) * static_cast<long long>(mBuckets.size())) /
-                             static_cast<long long>(railHeight);
-    const int clampedBucket = static_cast<int>(std::clamp<long long>(bucket, 0, static_cast<long long>(mBuckets.size()) - 1));
-    const int firstRow = FirstProxyRowInBucket(static_cast<std::size_t>(clampedBucket));
-    return firstRow >= 0 ? firstRow : 0;
+    const long long row = (static_cast<long long>(clampedY) * static_cast<long long>(mProxyRowCount)) /
+                          static_cast<long long>(railHeight);
+    return static_cast<int>(std::clamp<long long>(row, 0, mProxyRowCount - 1));
 }
 
-void OverviewRailModel::OnRowsInserted(const QModelIndex &parent, int first, int last)
+void OverviewRailModel::OnRowsInserted(const QModelIndex & /*parent*/, int /*first*/, int /*last*/)
 {
-    (void)parent;
-    (void)first;
-    (void)last;
+    // Rebuild is coalesced through the 50 ms timer, so a burst
+    // (per-row inserts under an active sort in `LogFilterModel`)
+    // collapses to one walk. The `first` / `last` range is
+    // ignored today; keeping the slot signature intact leaves
+    // room for a tail-append fast path later.
     Rebuild();
 }
 
-void OverviewRailModel::OnRowsRemoved(const QModelIndex &parent, int first, int last)
+void OverviewRailModel::OnRowsRemoved(const QModelIndex & /*parent*/, int /*first*/, int /*last*/)
 {
-    (void)parent;
-    (void)first;
-    (void)last;
     Rebuild();
 }
 
@@ -274,6 +289,7 @@ void OverviewRailModel::RebuildInternal()
         bucket.anchorSlots.reset();
     }
     mAnchorBucketBitsSet = 0;
+    mBucketedMatchCount = 0;
 
     if (mProxyModel == nullptr)
     {
@@ -331,9 +347,53 @@ void OverviewRailModel::RebuildInternal()
         }
     }
 
-    // Fold match rows in. `mFindMatchCache->sortedRows` is a
-    // sorted, deduplicated proxy-row list — bucket assignment
-    // matches the row pass above.
+    // Fold current match rows in as part of the same walk so
+    // the caller doesn't have to invoke `RefreshMatchTicks`
+    // separately. Path is O(nMatchRows) on top of the O(rowCount)
+    // proxy walk above.
+    FoldMatchTicksIntoBuckets();
+
+    EmitAnchorChangeIfDifferent(previousBitsSet);
+}
+
+void OverviewRailModel::RefreshMatchTicks()
+{
+    mBucketedMatchCount = 0;
+    for (auto &bucket : mBuckets)
+    {
+        bucket.matchCount = 0;
+    }
+    // No-op when the rail has no bucket vector (hidden) or the
+    // proxy is empty — `mBucketedMatchCount` is already zero and
+    // there's nothing to fold into.
+    if (mBuckets.empty() || mProxyRowCount <= 0)
+    {
+        return;
+    }
+    FoldMatchTicksIntoBuckets();
+}
+
+void OverviewRailModel::ScheduleRebuild()
+{
+    if (mRebuildTimer != nullptr && !mRebuildTimer->isActive())
+    {
+        mRebuildTimer->start();
+    }
+}
+
+void OverviewRailModel::OnRebuildTimeout()
+{
+    RebuildInternal();
+    emit bucketsChanged();
+}
+
+void OverviewRailModel::FoldMatchTicksIntoBuckets()
+{
+    if (mBuckets.empty() || mProxyRowCount <= 0)
+    {
+        return;
+    }
+    const std::size_t nBuckets = mBuckets.size();
     for (const int proxyRow : mMatchProxyRows)
     {
         if (proxyRow < 0 || proxyRow >= mProxyRowCount)
@@ -344,16 +404,7 @@ void OverviewRailModel::RebuildInternal()
             (static_cast<std::size_t>(proxyRow) * nBuckets) / static_cast<std::size_t>(mProxyRowCount);
         const std::size_t bounded = std::min(bucketIdx, nBuckets - 1);
         ++mBuckets[bounded].matchCount;
-    }
-
-    EmitAnchorChangeIfDifferent(previousBitsSet);
-}
-
-void OverviewRailModel::ScheduleEmit()
-{
-    if (!mEmitTimer->isActive())
-    {
-        mEmitTimer->start();
+        ++mBucketedMatchCount;
     }
 }
 

--- a/app/src/overview_rail_model.cpp
+++ b/app/src/overview_rail_model.cpp
@@ -73,12 +73,23 @@ OverviewRailModel::OverviewRailModel(
     {
         // Level column can promote / demote mid-stream. Refresh
         // the cache and rebuild so pre-promotion `Unknown` rows
-        // get re-attributed to their canonical level.
+        // get re-attributed to their canonical level. Dictionary
+        // `Grew` events can't move the level column (only
+        // `Promoted` / `Demoted` can), so short-circuit them --
+        // otherwise every batch of a wide log pays an
+        // `O(nColumns)` scan for a null result.
         connect(
             mSourceModel,
             &LogModel::enumColumnsChanged,
             this,
-            [this](EnumColumnsChangeReason, int) { OnEnumColumnsChanged(); }
+            [this](EnumColumnsChangeReason reason, int)
+            {
+                if (reason == EnumColumnsChangeReason::Grew)
+                {
+                    return;
+                }
+                OnEnumColumnsChanged();
+            }
         );
     }
 
@@ -90,6 +101,7 @@ OverviewRailModel::OverviewRailModel(
 
     // Prime the cached column index and bucket vector.
     mLevelColumnIndex = ComputeLevelColumnIndex();
+    RebuildProxyChainCache();
 }
 
 void OverviewRailModel::SetBucketCount(std::size_t nBuckets)
@@ -98,6 +110,17 @@ void OverviewRailModel::SetBucketCount(std::size_t nBuckets)
     {
         return;
     }
+    // Capture whether the pre-transition state carried anything
+    // the widget could have been painting. When we're dropping
+    // to zero buckets from a state with no proxy rows, no match
+    // ticks, and no anchor bits, there is nothing new for the
+    // widget to invalidate, and we can skip the emit (which
+    // otherwise queues a paint through the widget's `update()`
+    // slot). Guarded so the hide-during-idle path costs zero
+    // downstream work.
+    const bool preStateHadContent =
+        !mBuckets.empty() && (mProxyRowCount > 0 || mBucketedMatchCount > 0 || mAnchorBucketBitsSet > 0);
+
     mBuckets.assign(nBuckets, Bucket{});
     // Zero-bucket case (rail hidden) is the fast-path the
     // visibility toggle relies on: `RebuildInternal` short-
@@ -115,12 +138,25 @@ void OverviewRailModel::SetBucketCount(std::size_t nBuckets)
         mRebuildTimer->stop();
     }
     RebuildInternal();
-    emit bucketsChanged();
+    if (nBuckets != 0 || preStateHadContent)
+    {
+        emit bucketsChanged();
+    }
 }
 
 void OverviewRailModel::SetMatchProxyRows(std::vector<int> proxyRows)
 {
     mMatchProxyRows = std::move(proxyRows);
+    // Normalise: sort + unique. `FoldMatchTicksIntoBuckets`
+    // increments per entry, so a duplicated row would double-
+    // count into its bucket and inflate `mBucketedMatchCount`.
+    // Today's only caller (`MainWindow::UpdateFindMatchCount`)
+    // already passes a sorted-unique set, so this is O(n) in the
+    // happy path and cheap enough to keep even in the pathological
+    // case (repeated find-bar keystrokes are already debounced
+    // upstream).
+    std::sort(mMatchProxyRows.begin(), mMatchProxyRows.end());
+    mMatchProxyRows.erase(std::unique(mMatchProxyRows.begin(), mMatchProxyRows.end()), mMatchProxyRows.end());
     // Match ticks live in `matchCount` only; level counts and
     // anchor bits are unaffected. Refresh just the tick field so
     // a find-bar keystroke doesn't re-walk the whole proxy.
@@ -236,6 +272,10 @@ void OverviewRailModel::OnRowsRemoved(const QModelIndex & /*parent*/, int /*firs
 void OverviewRailModel::OnModelReset()
 {
     mLevelColumnIndex = ComputeLevelColumnIndex();
+    // A model reset may swap the terminal source or drop / add a
+    // proxy layer under us (e.g. clearAllFilters -> proxy reset).
+    // Refresh the cached chain before the next rebuild walks it.
+    RebuildProxyChainCache();
     Rebuild();
 }
 
@@ -270,9 +310,16 @@ void OverviewRailModel::OnEnumColumnsChanged()
 
 void OverviewRailModel::OnAnchorChanged(const AnchorManager::Key & /*key*/)
 {
-    // Anchor edits are rare; a full rebuild costs the same
-    // O(rowCount) as folding a single anchor into its bucket, and
-    // keeps the running popcount trivially in sync.
+    // Anchor edits are rare (user-driven, single-key at a time),
+    // so we rebuild in bulk rather than maintaining a per-key
+    // fold path. A targeted fold would need a source-row ->
+    // proxy-row inverse mapping we don't maintain today: given a
+    // key we can find its source row via
+    // `SourceRowForAnchorKey` (O(1)), but locating that row in
+    // the outer proxy under an active sort/filter is O(rowCount).
+    // A full rebuild is the same worst case and keeps the
+    // running popcount trivially in sync -- worth revisiting if
+    // anchor bulk-edit ever becomes hot.
     Rebuild();
 }
 
@@ -295,8 +342,13 @@ void OverviewRailModel::RebuildInternal()
     mAnchorBucketBitsSet = 0;
     mBucketedMatchCount = 0;
 
-    if (mProxyModel == nullptr)
+    if (mProxyModel == nullptr || mSourceModel == nullptr)
     {
+        // `mSourceModel` is a `QPointer`; if the underlying
+        // `LogModel` has been destroyed under us, bail cleanly
+        // instead of dereferencing a cleared pointer. The zeroed
+        // buckets already leave the rail in a well-defined "no
+        // data" state.
         mProxyRowCount = 0;
         EmitAnchorChangeIfDifferent(previousBitsSet);
         return;
@@ -316,6 +368,7 @@ void OverviewRailModel::RebuildInternal()
     // anchor slot lookup. On a 1M-row session with 500 buckets
     // this is a handful of ms — dominated by the source-mapping
     // walk, not by the bucket increment.
+    LogModel *const sourceModel = mSourceModel;
     for (int proxyRow = 0; proxyRow < mProxyRowCount; ++proxyRow)
     {
         const std::size_t bucketIdx =
@@ -326,11 +379,15 @@ void OverviewRailModel::RebuildInternal()
         const int sourceRow = ProxyToSourceRow(proxyRow);
         if (sourceRow < 0)
         {
-            // Proxy chain hides this row on the way down. Count
-            // it as `Unknown` so the rail still shows *something*
-            // where the row is — better than a gap that hides
-            // the fact that a row is present.
-            ++bucket.levels.counts[static_cast<std::size_t>(loglib::LogLevel::Unknown)];
+            // The outermost proxy exposed a row whose chain walk
+            // yields no source row -- an inner proxy hiding a row
+            // the outer proxy accepted breaks the invariant that
+            // the two agree on visibility. In production the
+            // outermost proxy is `LogFilterModel`, so this
+            // branch is dead code; assert in debug and skip in
+            // release rather than painting a phantom Unknown row
+            // that hides the invariant break.
+            Q_ASSERT_X(false, "OverviewRailModel::RebuildInternal", "proxy row has no reachable source row");
             continue;
         }
         const loglib::LogLevel level = LevelForSourceRow(sourceRow);
@@ -338,7 +395,7 @@ void OverviewRailModel::RebuildInternal()
 
         if (trackAnchors)
         {
-            const auto slot = mSourceModel->AnchorSlotForRow(sourceRow);
+            const auto slot = sourceModel->AnchorSlotForRow(sourceRow);
             if (slot.has_value())
             {
                 auto &mask = bucket.anchorSlots;
@@ -440,25 +497,56 @@ int OverviewRailModel::ProxyToSourceRow(int proxyRow) const noexcept
     {
         return -1;
     }
+    // The cache is populated once from `RebuildProxyChainCache`;
+    // if the chain doesn't terminate at `mSourceModel` we can't
+    // safely resolve a source row. Short-circuit rather than
+    // silently miscount.
+    if (!mProxyChainTerminatesAtSource)
+    {
+        return -1;
+    }
     QModelIndex idx = mProxyModel->index(proxyRow, 0);
-    QAbstractItemModel *current = mProxyModel;
-    // Walk through however many `QAbstractProxyModel` layers the
-    // chain has (in production it's LogFilterModel ->
-    // RowOrderProxyModel -> LogModel).
-    while (auto *proxy = qobject_cast<QAbstractProxyModel *>(current))
+    for (QAbstractProxyModel *proxy : mProxyChain)
     {
         idx = proxy->mapToSource(idx);
-        current = proxy->sourceModel();
-        if (current == nullptr)
-        {
-            return -1;
-        }
     }
-    if (current != mSourceModel || !idx.isValid())
+    if (!idx.isValid())
     {
         return -1;
     }
     return idx.row();
+}
+
+void OverviewRailModel::RebuildProxyChainCache()
+{
+    mProxyChain.clear();
+    mProxyChainTerminatesAtSource = false;
+    if (mProxyModel == nullptr || mSourceModel == nullptr)
+    {
+        return;
+    }
+    // Trivial case: the "proxy" already IS the source model.
+    if (mProxyModel == mSourceModel)
+    {
+        mProxyChainTerminatesAtSource = true;
+        return;
+    }
+    QAbstractItemModel *current = mProxyModel;
+    while (auto *proxy = qobject_cast<QAbstractProxyModel *>(current))
+    {
+        mProxyChain.push_back(proxy);
+        current = proxy->sourceModel();
+        if (current == nullptr)
+        {
+            mProxyChain.clear();
+            return;
+        }
+    }
+    mProxyChainTerminatesAtSource = (current == mSourceModel);
+    if (!mProxyChainTerminatesAtSource)
+    {
+        mProxyChain.clear();
+    }
 }
 
 loglib::LogLevel OverviewRailModel::LevelForSourceRow(int sourceRow) const noexcept

--- a/app/src/overview_rail_model.cpp
+++ b/app/src/overview_rail_model.cpp
@@ -357,7 +357,7 @@ void OverviewRailModel::RebuildInternal()
     // Single linear walk over the proxy: one source-row mapping
     // per row for the level (and optional anchor) lookup. Cost is
     // dominated by the source mapping, not the bucket increment.
-    LogModel *const sourceModel = mSourceModel;
+    const LogModel *const sourceModel = mSourceModel;
     for (int proxyRow = 0; proxyRow < mProxyRowCount; ++proxyRow)
     {
         const std::size_t bucketIdx =
@@ -555,7 +555,7 @@ void OverviewRailModel::RebuildProxyChainCache()
     QAbstractItemModel *current = mProxyModel;
     while (auto *proxy = qobject_cast<QAbstractProxyModel *>(current))
     {
-        mProxyChain.push_back(QPointer<QAbstractProxyModel>(proxy));
+        mProxyChain.emplace_back(proxy);
         current = proxy->sourceModel();
         if (current == nullptr)
         {

--- a/app/src/overview_rail_model.cpp
+++ b/app/src/overview_rail_model.cpp
@@ -21,17 +21,14 @@
 namespace
 {
 
-/// Coalesce cadence for the full-rebuild + `bucketsChanged`
-/// emit. Matches the histogram's 50 ms cadence and the table's
-/// live-tail batch cadence, so a per-row `rowsInserted` volley
-/// (LogFilterModel's active-sort branch) collapses to one
-/// O(rowCount) walk instead of one per row.
+/// Coalesce cadence for the full rebuild + `bucketsChanged`
+/// emit. Matches the histogram and live-tail batch cadence, so a
+/// per-row `rowsInserted` volley collapses to one O(rowCount)
+/// walk instead of one per row.
 constexpr int REBUILD_COALESCE_MS = 50;
 
-/// Severity ranking for the dominant-level tie-break. Higher
-/// value == more severe, so ties go to the row colour users are
-/// more likely to want to see. Indexed by
-/// `static_cast<size_t>(LogLevel)`.
+/// Severity ranking for the dominant-level tie-break; higher =
+/// more severe. Indexed by `static_cast<size_t>(LogLevel)`.
 constexpr std::array<int, loglib::CANONICAL_LEVEL_COUNT + 1> LEVEL_SEVERITY_RANK = {
     0, // Unknown
     1, // Trace
@@ -60,12 +57,10 @@ OverviewRailModel::OverviewRailModel(
         connect(mProxyModel, &QAbstractItemModel::rowsRemoved, this, &OverviewRailModel::OnRowsRemoved);
         connect(mProxyModel, &QAbstractItemModel::modelReset, this, &OverviewRailModel::OnModelReset);
         // A filter/sort change lands as `layoutChanged` on
-        // `LogFilterModel`; row inserts are rare after that, so we
-        // rebuild here to pick up the new proxy row set.
+        // `LogFilterModel`; rebuild to pick up the new row set.
         connect(mProxyModel, &QAbstractItemModel::layoutChanged, this, &OverviewRailModel::OnLayoutChanged);
         // Column shape changes may move the level column even
-        // when no rows insert. Not coalesced with `columnsMoved`
-        // because both funnel to the same rebuild anyway.
+        // when no rows insert.
         connect(mProxyModel, &QAbstractItemModel::columnsMoved, this, &OverviewRailModel::OnColumnsChanged);
         connect(mProxyModel, &QAbstractItemModel::columnsInserted, this, &OverviewRailModel::OnColumnsChanged);
         connect(mProxyModel, &QAbstractItemModel::columnsRemoved, this, &OverviewRailModel::OnColumnsChanged);
@@ -73,13 +68,11 @@ OverviewRailModel::OverviewRailModel(
 
     if (mSourceModel != nullptr)
     {
-        // Level column can promote / demote mid-stream. Refresh
+        // Level column can promote / demote mid-stream; refresh
         // the cache and rebuild so pre-promotion `Unknown` rows
-        // get re-attributed to their canonical level. Dictionary
-        // `Grew` events can't move the level column (only
-        // `Promoted` / `Demoted` can), so short-circuit them --
-        // otherwise every batch of a wide log pays an
-        // `O(nColumns)` scan for a null result.
+        // get re-attributed. Skip dictionary `Grew` events — they
+        // can't move the level column, and every batch of a wide
+        // log would otherwise pay an `O(nColumns)` scan.
         connect(
             mSourceModel,
             &LogModel::enumColumnsChanged,
@@ -112,33 +105,23 @@ void OverviewRailModel::SetBucketCount(std::size_t nBuckets)
     {
         return;
     }
-    // Capture whether the pre-transition state carried anything
-    // the widget could have been painting. When we're dropping
-    // to zero buckets from a state with no proxy rows, no match
-    // ticks, and no anchor bits, there is nothing new for the
-    // widget to invalidate, and we can skip the emit (which
-    // otherwise queues a paint through the widget's `update()`
-    // slot). Guarded so the hide-during-idle path costs zero
-    // downstream work.
+    // Track whether the previous state had anything the widget
+    // could have painted. Dropping to zero from an already-empty
+    // state means no repaint is needed downstream.
     const bool preStateHadContent =
         !mBuckets.empty() && (mProxyRowCount > 0 || mBucketedMatchCount > 0 || mAnchorBucketBitsSet > 0);
 
     mBuckets.assign(nBuckets, Bucket{});
-    // Zero-bucket case (rail hidden) is the fast-path the
-    // visibility toggle relies on: `RebuildInternal` short-
-    // circuits on `mBuckets.empty()` so subsequent proxy signals
-    // cost only the timer restart.
-    //
-    // Non-zero case: called from the widget's `resizeEvent`, which
-    // triggers a paint on return. Rebuild synchronously so the
-    // widget sees fresh bucket geometry on the next paint tick
-    // instead of the coalesce timer's stale buckets.
+    // Supersede any in-flight coalesced rebuild; the sync one
+    // below is fresher.
     if (mRebuildTimer != nullptr && mRebuildTimer->isActive())
     {
-        // A coalesced rebuild was in flight; the sync rebuild
-        // below supersedes it.
         mRebuildTimer->stop();
     }
+    // Synchronous so the widget's next paint sees fresh geometry.
+    // Zero-bucket state is the fast-path: `RebuildInternal`
+    // short-circuits on `mBuckets.empty()` and subsequent proxy
+    // signals stay cheap while the rail is hidden.
     RebuildInternal();
     if (nBuckets != 0 || preStateHadContent)
     {
@@ -149,83 +132,50 @@ void OverviewRailModel::SetBucketCount(std::size_t nBuckets)
 void OverviewRailModel::SetMatchProxyRows(std::vector<int> proxyRows)
 {
     mMatchProxyRows = std::move(proxyRows);
-    // Row-list path owns match state; drop any durable bucket
-    // counts so a later rebuild can't re-apply a stale fold on
-    // top of (or instead of) the rows we just installed.
+    // Row-list path owns match state; drop the durable bucket
+    // counts so a later rebuild can't re-apply a stale fold.
     mMatchBucketCounts.clear();
     mMatchBucketTotal = 0;
-    // Normalise: sort + unique. `FoldMatchTicksIntoBuckets`
-    // increments per entry, so a duplicated row would double-
-    // count into its bucket and inflate `mBucketedMatchCount`.
-    // Today's only caller (`MainWindow::UpdateFindMatchCount`)
-    // already passes a sorted-unique set, so this is O(n) in the
-    // happy path and cheap enough to keep even in the pathological
-    // case (repeated find-bar keystrokes are already debounced
-    // upstream).
+    // Sort + unique so `FoldMatchTicksIntoBuckets` (which
+    // increments per entry) doesn't double-count a duplicated row.
     std::sort(mMatchProxyRows.begin(), mMatchProxyRows.end());
     mMatchProxyRows.erase(std::unique(mMatchProxyRows.begin(), mMatchProxyRows.end()), mMatchProxyRows.end());
-    // Refresh the cached row count from the live proxy before
-    // folding. `mProxyRowCount` is otherwise only written inside
-    // `RebuildInternal` and lags reality by up to one coalesce
-    // window (~50 ms); during live-tail inserts the caller has
-    // already scanned against the current row count and passed
-    // us match rows referenced to it. Using the stale (smaller)
-    // denominator would either drop tail-row hits (proxy index
-    // >= `mProxyRowCount`) or fold them into the last bucket via
-    // a divide-by-smaller-M — both visible as ticks vanishing
-    // or bunching after a live-tail append. The level counts
-    // and anchor bits keep their old `mProxyRowCount` bucketing
-    // for one coalesce interval; that mismatch is invisible on
-    // the timescale a user perceives and self-heals on the next
-    // rebuild.
+    // Refresh `mProxyRowCount` from the live proxy — it can lag
+    // by one coalesce window under live-tail inserts, and folding
+    // with a stale (smaller) denominator would drop tail-row hits
+    // or bunch them into the last bucket.
     if (mProxyModel != nullptr)
     {
         mProxyRowCount = mProxyModel->rowCount();
     }
-    // Match ticks live in `matchCount` only; level counts and
-    // anchor bits are unaffected. Refresh just the tick field so
-    // a find-bar keystroke doesn't re-walk the whole proxy.
     RefreshMatchTicks();
-    // Only `matchesChanged` fires here: bucket geometry (levels,
-    // anchor bits) is unchanged, and the widget listens to both
-    // signals with the same `update()` slot — an extra
-    // `bucketsChanged` would only trigger a redundant repaint
-    // request that Qt would immediately coalesce out again.
+    // Only `matchesChanged`: level counts / anchor bits are
+    // unchanged, so an extra `bucketsChanged` would just queue a
+    // duplicate paint request.
     emit matchesChanged();
 }
 
 void OverviewRailModel::SetMatchBucketCounts(std::vector<uint32_t> perBucketCounts, uint32_t totalMatches)
 {
-    // Size mismatch: the rail resized (or the caller has stale
-    // bucket-count info) between the caller computing its counts
-    // and this call landing. Drop the update silently rather than
-    // half-applying a mismatched vector — the resize will trigger
-    // its own synchronous rebuild via `SetBucketCount` and the
-    // next find-bar debounce recomputes cleanly against the new
-    // bucket count. Validate BEFORE mutating any local state so a
-    // dropped update leaves the model bit-for-bit untouched (the
-    // previous ordering refreshed `mProxyRowCount` speculatively
-    // even in the drop path — harmless today but a landmine for
-    // any future consumer that reads `mProxyRowCount` between
-    // this call and the next rebuild).
+    // Size mismatch → rail resized between the caller computing
+    // counts and this call landing. Drop the update; the resize
+    // triggers its own rebuild and the next find debounce
+    // recomputes. Validate BEFORE mutating so a dropped update
+    // leaves the model untouched.
     if (perBucketCounts.size() != mBuckets.size())
     {
         return;
     }
-    // Refresh the cached row count for the same reason as
-    // `SetMatchProxyRows`: the caller has already scanned against
-    // the live proxy, and any subsequent rail math (e.g.
-    // `HasMatchTicks`, `BucketForProxyRow` on paint) needs the
-    // denominator that matches.
+    // Same reasoning as in `SetMatchProxyRows`: the caller scanned
+    // against the live proxy, and subsequent rail math needs the
+    // matching denominator.
     if (mProxyModel != nullptr)
     {
         mProxyRowCount = mProxyModel->rowCount();
     }
-    // Clear the raw-rows path so the next coalesced full rebuild
-    // doesn't double-count a stale row-list fold on top of the
-    // pre-bucketed values. Retain the counts themselves so
-    // `RebuildInternal` can re-apply them (anchor edits, hide→show
-    // at the same H) without the caller re-pushing.
+    // Clear the raw-rows path so a rebuild doesn't double-fold on
+    // top of these pre-bucketed values. Retain the counts as
+    // durable state for `RebuildInternal` to re-apply.
     mMatchProxyRows.clear();
     mMatchBucketCounts = std::move(perBucketCounts);
     mMatchBucketTotal = totalMatches;
@@ -255,14 +205,10 @@ loglib::LogLevel OverviewRailModel::DominantLevel(std::size_t bucket) const noex
         return loglib::LogLevel::Unknown;
     }
     const auto &counts = mBuckets[bucket].levels.counts;
-    // Majority-count level, tie-broken by severity (Fatal wins
-    // over Error wins over Warn, ...). Retained for callers that
-    // want a *single* colour per bucket (e.g. the anchor tick
-    // legend, tests). The widget's level histogram no longer
-    // relies on this method -- it iterates the per-level counts
-    // and paints stacked severity segments so a bucket with 200
-    // Trace + 1 Fatal shows both the grey volume *and* a visible
-    // red anomaly pixel, which majority-count alone erases.
+    // Majority-count level, tie-broken by severity. Retained for
+    // callers that want a single colour per bucket; the widget's
+    // paint pass instead stacks per-level segments so rare
+    // high-severity anomalies stay visible.
     std::size_t bestSlot = 0;
     uint32_t bestCount = 0;
     int bestSeverity = -1;
@@ -309,13 +255,9 @@ int OverviewRailModel::ProxyRowForYPixel(int y, int railHeight) const noexcept
     {
         return 0;
     }
-    // Clamp Y into the rail's usable range, then map directly to
-    // proxy rows: `row = y * rowCount / railHeight`. This gives
-    // sub-bucket precision so scrubbing a bucket that spans many
-    // rows still moves the viewport smoothly. The bucket-based
-    // mapping is only relevant to the paint pass, not to click
-    // resolution — a user clicking the middle of a bucket wants
-    // to land on the middle row, not the bucket's first row.
+    // Direct pixel-to-row map (`row = y * rowCount / railHeight`)
+    // gives sub-bucket precision, so scrubbing a bucket that spans
+    // many rows still moves smoothly. Bucket mapping is paint-only.
     const int clampedY = std::clamp(y, 0, railHeight - 1);
     const long long row = (static_cast<long long>(clampedY) * static_cast<long long>(mProxyRowCount)) /
                           static_cast<long long>(railHeight);
@@ -324,11 +266,9 @@ int OverviewRailModel::ProxyRowForYPixel(int y, int railHeight) const noexcept
 
 void OverviewRailModel::OnRowsInserted(const QModelIndex & /*parent*/, int /*first*/, int /*last*/)
 {
-    // Rebuild is coalesced through the 50 ms timer, so a burst
-    // (per-row inserts under an active sort in `LogFilterModel`)
-    // collapses to one walk. The `first` / `last` range is
-    // ignored today; keeping the slot signature intact leaves
-    // room for a tail-append fast path later.
+    // `first` / `last` are ignored today — a burst of per-row
+    // inserts coalesces via `Rebuild()`. Signature is kept intact
+    // to leave room for a future tail-append fast path.
     Rebuild();
 }
 
@@ -340,9 +280,8 @@ void OverviewRailModel::OnRowsRemoved(const QModelIndex & /*parent*/, int /*firs
 void OverviewRailModel::OnModelReset()
 {
     mLevelColumnIndex = ComputeLevelColumnIndex();
-    // A model reset may swap the terminal source or drop / add a
-    // proxy layer under us (e.g. clearAllFilters -> proxy reset).
-    // Refresh the cached chain before the next rebuild walks it.
+    // A reset may swap the terminal source or drop / add a proxy
+    // layer under us; refresh the chain cache before rebuilding.
     RebuildProxyChainCache();
     Rebuild();
 }
@@ -368,8 +307,7 @@ void OverviewRailModel::OnEnumColumnsChanged()
     const int fresh = ComputeLevelColumnIndex();
     if (fresh == mLevelColumnIndex)
     {
-        // A grow / demote of an unrelated column: skip the
-        // rebuild to keep append hot paths cheap.
+        // Unrelated column changed; skip the rebuild.
         return;
     }
     mLevelColumnIndex = fresh;
@@ -378,16 +316,10 @@ void OverviewRailModel::OnEnumColumnsChanged()
 
 void OverviewRailModel::OnAnchorChanged(const AnchorManager::Key & /*key*/)
 {
-    // Anchor edits are rare (user-driven, single-key at a time),
-    // so we rebuild in bulk rather than maintaining a per-key
-    // fold path. A targeted fold would need a source-row ->
-    // proxy-row inverse mapping we don't maintain today: given a
-    // key we can find its source row via
-    // `SourceRowForAnchorKey` (O(1)), but locating that row in
-    // the outer proxy under an active sort/filter is O(rowCount).
-    // A full rebuild is the same worst case and keeps the
-    // running popcount trivially in sync -- worth revisiting if
-    // anchor bulk-edit ever becomes hot.
+    // Anchor edits are user-driven and rare, so rebuild in bulk
+    // rather than fold per key. A targeted fold would need a
+    // source-row → proxy-row inverse mapping we don't maintain;
+    // the worst case is the same O(rowCount).
     Rebuild();
 }
 
@@ -412,11 +344,8 @@ void OverviewRailModel::RebuildInternal()
 
     if (mProxyModel == nullptr || mSourceModel == nullptr)
     {
-        // `mSourceModel` is a `QPointer`; if the underlying
-        // `LogModel` has been destroyed under us, bail cleanly
-        // instead of dereferencing a cleared pointer. The zeroed
-        // buckets already leave the rail in a well-defined "no
-        // data" state.
+        // `QPointer` may have zeroed under us; the pre-zeroed
+        // buckets already leave the rail in a "no data" state.
         mProxyRowCount = 0;
         EmitAnchorChangeIfDifferent(previousBitsSet);
         return;
@@ -431,11 +360,9 @@ void OverviewRailModel::RebuildInternal()
     const bool trackAnchors = mAnchors != nullptr && !mAnchors->Empty();
     const std::size_t nBuckets = mBuckets.size();
 
-    // One linear walk over the proxy: bucket per row, mapped
-    // to source once for the level lookup and (optionally) the
-    // anchor slot lookup. On a 1M-row session with 500 buckets
-    // this is a handful of ms — dominated by the source-mapping
-    // walk, not by the bucket increment.
+    // Single linear walk over the proxy: one source-row mapping
+    // per row for the level (and optional anchor) lookup. Cost is
+    // dominated by the source mapping, not the bucket increment.
     LogModel *const sourceModel = mSourceModel;
     for (int proxyRow = 0; proxyRow < mProxyRowCount; ++proxyRow)
     {
@@ -447,14 +374,9 @@ void OverviewRailModel::RebuildInternal()
         const int sourceRow = ProxyToSourceRow(proxyRow);
         if (sourceRow < 0)
         {
-            // The outermost proxy exposed a row whose chain walk
-            // yields no source row -- an inner proxy hiding a row
-            // the outer proxy accepted breaks the invariant that
-            // the two agree on visibility. In production the
-            // outermost proxy is `LogFilterModel`, so this
-            // branch is dead code; assert in debug and skip in
-            // release rather than painting a phantom Unknown row
-            // that hides the invariant break.
+            // Outer proxy exposes a row an inner proxy hides —
+            // breaks the visibility invariant. In production
+            // (`LogFilterModel` outermost) this is dead code.
             Q_ASSERT_X(false, "OverviewRailModel::RebuildInternal", "proxy row has no reachable source row");
             continue;
         }
@@ -476,13 +398,10 @@ void OverviewRailModel::RebuildInternal()
         }
     }
 
-    // Fold current match rows in as part of the same walk so
-    // the caller doesn't have to invoke `RefreshMatchTicks`
-    // separately. Path is O(nMatchRows) on top of the O(rowCount)
-    // proxy walk above. When the bucketed API owns match state
-    // (`mMatchProxyRows` empty, durable counts retained), re-apply
-    // those counts so anchor edits / hide→show / same-H resize
-    // don't wipe find highlights.
+    // Fold current match rows in as part of the same walk. When
+    // the bucketed API owns match state (row list empty, durable
+    // counts retained), re-apply those counts so anchor edits /
+    // hide→show / same-H resize don't wipe find highlights.
     FoldMatchTicksIntoBuckets();
     if (mMatchProxyRows.empty())
     {
@@ -499,9 +418,6 @@ void OverviewRailModel::RefreshMatchTicks()
     {
         bucket.matchCount = 0;
     }
-    // No-op when the rail has no bucket vector (hidden) or the
-    // proxy is empty — `mBucketedMatchCount` is already zero and
-    // there's nothing to fold into.
     if (mBuckets.empty() || mProxyRowCount <= 0)
     {
         return;
@@ -511,13 +427,10 @@ void OverviewRailModel::RefreshMatchTicks()
 
 void OverviewRailModel::ScheduleRebuild()
 {
-    // While the rail is hidden, `SetBucketCount(0)` drops the
-    // bucket vector; a rebuild would fully short-circuit and
-    // emit a redundant `bucketsChanged` that fans out into
-    // queued widget `update()` calls (each a no-op on the
-    // hidden widget, but not free). Skip the timer entirely
-    // instead — the next `SetBucketCount(H)` on re-show runs
-    // its own synchronous rebuild against fresh proxy state.
+    // Rail hidden → skip the timer. A rebuild would short-circuit
+    // and emit a redundant `bucketsChanged` that fans out to
+    // queued widget updates (each a no-op, but not free). The
+    // next `SetBucketCount(H)` on re-show runs its own rebuild.
     if (mBuckets.empty())
     {
         return;
@@ -585,10 +498,6 @@ int OverviewRailModel::ProxyToSourceRow(int proxyRow) const noexcept
     {
         return -1;
     }
-    // The cache is populated once from `RebuildProxyChainCache`;
-    // if the chain doesn't terminate at `mSourceModel` we can't
-    // safely resolve a source row. Short-circuit rather than
-    // silently miscount.
     if (!mProxyChainTerminatesAtSource)
     {
         return -1;
@@ -596,10 +505,9 @@ int OverviewRailModel::ProxyToSourceRow(int proxyRow) const noexcept
     QModelIndex idx = mProxyModel->index(proxyRow, 0);
     for (const QPointer<QAbstractProxyModel> &proxy : mProxyChain)
     {
-        // A `QPointer` slot can zero if the referenced proxy was
-        // destroyed under us without the outermost proxy firing
-        // `modelReset`. Short-circuit rather than dereferencing a
-        // null slot; the caller treats `-1` as "row not resolvable".
+        // A `QPointer` slot may zero if the referenced proxy was
+        // destroyed without a `modelReset`; return `-1` rather
+        // than crash.
         if (proxy.isNull())
         {
             return -1;
@@ -610,23 +518,16 @@ int OverviewRailModel::ProxyToSourceRow(int proxyRow) const noexcept
     {
         return -1;
     }
-    // Debug-only guard against chain drift: if a mid-chain proxy
-    // swaps its `sourceModel()` after our cache is populated and
-    // the outer proxy doesn't emit `modelReset`, the walk lands on
-    // an alien model and we'd fold rows from the wrong table. Cheap
-    // pointer compare so we can afford it in debug; release emits a
-    // one-shot `qWarning` (see below) so the shipped build isn't
-    // silent about it, then falls through with the (wrong) row —
-    // that's still better than crashing on a `nullptr` dereference.
+    // Chain drift: a mid-chain proxy silently swapped its source
+    // and we'd fold rows from the wrong table. Assert in debug,
+    // one-shot warn in release, and refuse the row.
     Q_ASSERT_X(
         idx.model() == mSourceModel, "OverviewRailModel::ProxyToSourceRow",
         "proxy chain no longer terminates at the cached source model"
     );
     if (idx.model() != mSourceModel)
     {
-        // Once-per-model-instance breadcrumb. `qWarning` per row
-        // would drown the log at 1M-row-scan cadence; the flag keeps
-        // it to a single line per drift event.
+        // Flag prevents log spam at scan cadence (~1 M rows).
         if (!mProxyChainDriftWarned)
         {
             mProxyChainDriftWarned = true;
@@ -643,11 +544,8 @@ void OverviewRailModel::RebuildProxyChainCache()
 {
     mProxyChain.clear();
     mProxyChainTerminatesAtSource = false;
-    // Fresh cache: arm the drift warning again so a *new* chain
-    // drift after this rebuild still surfaces its one-shot
-    // `qWarning`. Without the reset, once-warned-per-lifetime
-    // would silently swallow a second drift event after e.g. a
-    // dictionary rebuild that emitted `modelReset`.
+    // Fresh cache re-arms the one-shot drift warning so a
+    // subsequent drift after e.g. a dictionary rebuild still logs.
     mProxyChainDriftWarned = false;
     if (mProxyModel == nullptr || mSourceModel == nullptr)
     {
@@ -683,11 +581,10 @@ loglib::LogLevel OverviewRailModel::LevelForSourceRow(int sourceRow) const noexc
     {
         return loglib::LogLevel::Unknown;
     }
-    // Prefer LogTable::GetLevelForRow directly over
-    // `LogModel::LevelForRow`: the private helper caches
-    // `mFirstLevelColumnCache` inside LogModel, which self-repairs
-    // during `AppendBatch`. Reading through our own cached index
-    // sidesteps the race the histogram model documents.
+    // Read `LogTable::GetLevelForRow` directly instead of going
+    // through `LogModel::LevelForRow`; our own cached index
+    // sidesteps the `AppendBatch` cache race the histogram
+    // model documents.
     const auto level = mSourceModel->Table().GetLevelForRow(
         static_cast<std::size_t>(sourceRow), static_cast<std::size_t>(mLevelColumnIndex)
     );

--- a/app/src/overview_rail_model.cpp
+++ b/app/src/overview_rail_model.cpp
@@ -125,8 +125,12 @@ void OverviewRailModel::SetMatchProxyRows(std::vector<int> proxyRows)
     // anchor bits are unaffected. Refresh just the tick field so
     // a find-bar keystroke doesn't re-walk the whole proxy.
     RefreshMatchTicks();
+    // Only `matchesChanged` fires here: bucket geometry (levels,
+    // anchor bits) is unchanged, and the widget listens to both
+    // signals with the same `update()` slot — an extra
+    // `bucketsChanged` would only trigger a redundant repaint
+    // request that Qt would immediately coalesce out again.
     emit matchesChanged();
-    emit bucketsChanged();
 }
 
 void OverviewRailModel::Rebuild()
@@ -375,6 +379,17 @@ void OverviewRailModel::RefreshMatchTicks()
 
 void OverviewRailModel::ScheduleRebuild()
 {
+    // While the rail is hidden, `SetBucketCount(0)` drops the
+    // bucket vector; a rebuild would fully short-circuit and
+    // emit a redundant `bucketsChanged` that fans out into
+    // queued widget `update()` calls (each a no-op on the
+    // hidden widget, but not free). Skip the timer entirely
+    // instead — the next `SetBucketCount(H)` on re-show runs
+    // its own synchronous rebuild against fresh proxy state.
+    if (mBuckets.empty())
+    {
+        return;
+    }
     if (mRebuildTimer != nullptr && !mRebuildTimer->isActive())
     {
         mRebuildTimer->start();

--- a/app/src/overview_rail_widget.cpp
+++ b/app/src/overview_rail_widget.cpp
@@ -175,9 +175,9 @@ QColor ColorForAnchorSlot(const ThemeControl *theme, std::uint8_t colorIndex, co
 {
     if (underlayWidth <= 0)
     {
-        return QRect(underlayLeft, 0, 0, 0);
+        return {underlayLeft, 0, 0, 0};
     }
-    return QRect(underlayLeft, 0, underlayWidth, 0);
+    return {underlayLeft, 0, underlayWidth, 0};
 }
 
 [[nodiscard]] double WidthScaleForMode(OverviewRailWidthMode mode) noexcept
@@ -358,7 +358,7 @@ int OverviewRailWidget::WidthForCountForTest(std::uint32_t count, std::uint32_t 
         return 0;
     }
     const double intensity = IntensityForCount(count, maxCount);
-    int barWidth = static_cast<int>(std::round(intensity * static_cast<double>(columnWidth)));
+    const int barWidth = static_cast<int>(std::round(intensity * static_cast<double>(columnWidth)));
     return std::clamp(barWidth, MIN_BAR_WIDTH_PX, columnWidth);
 }
 
@@ -559,7 +559,7 @@ void OverviewRailWidget::paintEvent(QPaintEvent * /*event*/)
             int reserved = 0;
             for (std::size_t s = 0; s < SEVERITY_DESCENDING.size(); ++s)
             {
-                const std::size_t levelIdx = static_cast<std::size_t>(SEVERITY_DESCENDING[s]);
+                const auto levelIdx = static_cast<std::size_t>(SEVERITY_DESCENDING[s]);
                 const std::uint32_t levelCount = bucket.levels.counts[levelIdx];
                 if (levelCount > 0)
                 {
@@ -585,7 +585,7 @@ void OverviewRailWidget::paintEvent(QPaintEvent * /*event*/)
                 // the bar ends exactly at `barWidth` and the
                 // dominant severity wins the visual tie-break.
                 int allocated = 0;
-                for (int w : segWidths)
+                for (const int w : segWidths)
                 {
                     allocated += w;
                 }
@@ -953,7 +953,7 @@ QRect OverviewRailWidget::ComputeViewportIndicatorRect() const
     const long long yBottom = (static_cast<long long>(bottomRow + 1) * static_cast<long long>(railHeight)) /
                               static_cast<long long>(totalRows);
     const int naturalHeight = static_cast<int>(yBottom - yTop);
-    int indicatorHeight = std::max(naturalHeight, INDICATOR_MIN_HEIGHT_PX);
+    const int indicatorHeight = std::max(naturalHeight, INDICATOR_MIN_HEIGHT_PX);
     // When the natural span is shorter than the min-height floor
     // (common on tall logs), expand around the centre of the
     // visible range so a mid-viewport row lines up with the
@@ -968,7 +968,7 @@ QRect OverviewRailWidget::ComputeViewportIndicatorRect() const
     }
     indicatorTop = std::max(indicatorTop, rail.top());
 
-    return QRect(rail.left(), indicatorTop, rail.width(), indicatorHeight);
+    return {rail.left(), indicatorTop, rail.width(), indicatorHeight};
 }
 
 void OverviewRailWidget::SyncBucketCountToHeight()

--- a/app/src/overview_rail_widget.cpp
+++ b/app/src/overview_rail_widget.cpp
@@ -48,144 +48,77 @@
 namespace
 {
 
-/// Vertical pixel inset on the rail. Keeps tick outlines from
-/// clipping against the widget's top / bottom edges and gives
-/// the wash a visible frame line.
+/// Vertical inset so tick outlines don't clip against the widget's
+/// top / bottom edges.
 constexpr int RAIL_VERTICAL_INSET = 2;
 
-/// Horizontal pixel inset for the level-underlay column. The
-/// wash background paints edge-to-edge; the coloured underlay
-/// steps in 1 px so the two reads as concentric bands rather
-/// than a single flat fill.
+/// Horizontal inset for the level-underlay column. Steps in 1 px
+/// from the wash so the two read as concentric bands.
 constexpr int RAIL_UNDERLAY_INSET = 1;
 
-/// Minimum bar width for a non-empty level bucket. Guarantees a
-/// 1-row bucket still paints as a visible 2-px tick, so sparse
-/// activity zones don't visually vanish in a mostly-empty log.
+/// Minimum bar width for a non-empty bucket; guarantees a single
+/// row still paints as a visible tick.
 constexpr int MIN_BAR_WIDTH_PX = 2;
 
-/// Alpha applied to the *fallback* segment colour when the
-/// theme leaves a level unstyled (see `ColorForLevel`). Keeps
-/// Info-heavy rails from washing out by compositing the
-/// neutral placeholder-text tone semi-transparently over
-/// `QPalette::Base`. Styled levels (Fatal, Error, Warn, ...)
-/// paint fully opaque and take their colour from the theme's
-/// row *background* which is designed as a subtle severity
-/// tint on Base -- see `ColorForLevel` for the rationale.
+/// Fallback alpha when the theme leaves a level unstyled.
+/// Composites over `QPalette::Base` so Info-heavy rails don't
+/// wash out.
 constexpr int LEVEL_FALLBACK_ALPHA = 96;
 
-/// Minimum horizontal width for one severity segment inside a
-/// bucket's bar. Keeps a rare-but-present level (e.g. one Fatal
-/// in a 500-row bucket) from rounding away to zero pixels. Kept
-/// tiny (1 px) so the floor doesn't manufacture a bright band
-/// on the rail's left edge -- combined with the dark row-
-/// background palette in `ColorForLevel`, even every-bucket
-/// severity segments composite to a subtle tint, not a stripe.
+/// Minimum width per severity segment. Keeps a rare level from
+/// rounding to zero; 1 px so the floor doesn't manufacture a
+/// bright band on the left edge.
 constexpr int MIN_SEGMENT_WIDTH_PX = 1;
 
-/// Alpha on the 1 px separator line drawn at the rail's left
-/// edge. Gives the rail a hard boundary against the table body
-/// so the eye can find it even when the palette Window colour
-/// is close to Base. `QPalette::Dark` (window's shadow tone)
-/// reads as a divider on both Light and Dark themes.
+/// Alpha for the 1 px separator at the rail's left edge.
 constexpr int SEPARATOR_ALPHA = 255;
 
-/// Alpha on the viewport-indicator glass fill. Higher than
-/// the wash so the indicator reads as an overlay marker;
-/// lower than opaque so the wash still shows through.
+/// Viewport-indicator fill alpha; overlay marker without erasing
+/// the underlying wash.
 constexpr int INDICATOR_FILL_ALPHA = 60;
 
-/// Alpha on the viewport-indicator outline. Solid pen with
-/// palette Highlight so the indicator reads as focused UI
-/// chrome, not a decoration.
+/// Viewport-indicator outline alpha (`QPalette::Highlight`).
 constexpr int INDICATOR_OUTLINE_ALPHA = 200;
 
-/// Corner radius (device-independent px) on the viewport
-/// indicator. Matches the platform's rounded-thumb aesthetic
-/// without pretending to be the actual scrollbar thumb.
+/// Corner radius on the viewport indicator; matches the platform's
+/// rounded-thumb look.
 constexpr int INDICATOR_CORNER_RADIUS = 3;
 
-/// Minimum viewport-indicator height. Ensures a very-tall
-/// session still exposes a hittable indicator; without this a
-/// 1 M row session would collapse the indicator to sub-pixel.
+/// Minimum indicator height so a tall session still has a hittable
+/// target.
 constexpr int INDICATOR_MIN_HEIGHT_PX = 12;
 
-/// Minimum rail width in device-independent px. Guarantees a
-/// hittable target at very small font sizes; the single-column
-/// bin section still stays readable at this width because the
-/// stacked severity segments compress down to 1 px per level
-/// (which is enough to spot a rare Fatal streak).
+/// Minimum rail width in DP; hittable at small font sizes.
 constexpr int RAIL_MIN_WIDTH_PX = 24;
 
-/// Maximum rail width in device-independent px after the
-/// width-mode scale is applied. Headroom for Wide (`2 ×` base)
-/// when accessibility themes advertise a large
-/// `PM_ScrollBarExtent` (base can already sit near 60). A lower
-/// cap (e.g. 96) would collapse Wide into Medium on those
-/// setups. Typical Win11 Wide lands around ~72 and never hits
-/// this ceiling.
+/// Maximum rail width post-scaling. Sized for `Wide × 2` on
+/// accessibility themes with a large `PM_ScrollBarExtent`.
 constexpr int RAIL_MAX_WIDTH_PX = 128;
 
-/// Scale factors applied to the DPI-fluent base width for each
-/// `OverviewRailWidthMode`. Narrow is today's unscaled formula.
+/// Scale factors per `OverviewRailWidthMode`.
 constexpr double RAIL_WIDTH_SCALE_NARROW = 1.0;
 constexpr double RAIL_WIDTH_SCALE_MEDIUM = 1.5;
 constexpr double RAIL_WIDTH_SCALE_WIDE = 2.0;
 
-/// Extra width added to the DPI-fluent metric. Nudges the
-/// rail slightly wider than the scrollbar so it doesn't merge
-/// visually with a scrollbar rendered in the same theme.
+/// Extra pixels on the DPI-fluent base so the rail doesn't visually
+/// merge with the scrollbar.
 constexpr int RAIL_WIDTH_PADDING = 2;
 
 /// Trailing-edge debounce for `SyncBucketCountToHeight()` on
-/// `resizeEvent`. A live drag-resize storm fires a resize event
-/// per pixel of height change, and each `SetBucketCount(H)` call
-/// on the model reallocates buckets, invalidates the durable
-/// per-bucket find-match counts (`ApplyStoredMatchBucketCounts`
-/// no-ops on size mismatch), and forces the `MainWindow`
-/// `bucketsChanged` -> `PushFindMatchesToOverviewRail` wiring
-/// to run a synchronous full-table find rescan. Without
-/// debouncing, dragging the window edge with the Find bar open
-/// and a moderately broad needle on a large log freezes the UI
-/// for seconds. 100 ms is above typical human-perceptible
-/// resize latency yet short enough that the rail settles into
-/// the new geometry the moment the drag stops. `showEvent`
-/// bypasses the timer so the first paint after a show is never
-/// delayed.
+/// resize. Each `SetBucketCount(H)` reallocates buckets and,
+/// with Find open, forces a full rescan; a per-pixel drag storm
+/// would freeze the UI without coalescing. `showEvent` bypasses
+/// the timer.
 constexpr int BUCKET_SYNC_DEBOUNCE_MS = 100;
 
 QColor ColorForLevel(const ThemeControl *theme, loglib::LogLevel level, const QPalette &palette)
 {
-    // Rail bars use the active theme's row *background* wash
-    // rather than its row *foreground* text tone. Foregrounds
-    // (Warn `#FCD34D`, Error `#FCA5A5`, Fatal `#FECACA` on Dark)
-    // are tuned for legible contrast against the row background
-    // and read as *bright pastels* when painted directly on Base
-    // -- multiple such bright tones stacked across the rail then
-    // composite to a washed-out "light band" (the regression the
-    // "rail is still too light" report was about). Row
-    // backgrounds are the opposite: theme designers pick them as
-    // *subtle* severity tints layered on Base, so a rail bin
-    // painted with a level's row background matches exactly what
-    // the eye sees on the corresponding table row -- a mini-map
-    // of the file's severity pattern.
-    //
-    // `ThemeControl::BackgroundFor` reads from `BuildStyleCache`,
-    // which resolves per-level styles through
-    // `StyleForLevel(theme, level, mHighContrast)` -- so this
-    // call automatically picks up the theme's
-    // `levelsHighContrast` block when the user has the
-    // Preferences "high contrast levels" checkbox on. No extra
-    // wiring is needed here; toggling the setting rebuilds the
-    // cache and repaints the rail with the loud variants.
-    //
-    // Themes intentionally leave some levels unstyled (built-in
-    // Dark / Light leave `Info` blank so Info rows read as
-    // ordinary chrome). For those, fall back to
-    // `QPalette::PlaceholderText` composited at
-    // `LEVEL_FALLBACK_ALPHA` -- a dim theme-driven grey that
-    // keeps the rail readable without overwhelming it when the
-    // unstyled level dominates the bucket totals.
+    // Row *background* wash (not foreground): foreground is tuned
+    // for contrast on top of this background and would read as a
+    // bright pastel band on the rail. Makes the rail a mini-map
+    // of the row-tinted table. `BackgroundFor` respects the
+    // "high contrast levels" preference through the style cache.
+    // Unstyled levels fall through to `QPalette::PlaceholderText`.
     if (theme != nullptr)
     {
         const QBrush brush = theme->BackgroundFor(level);
@@ -201,19 +134,9 @@ QColor ColorForLevel(const ThemeControl *theme, loglib::LogLevel level, const QP
 
 QColor ColorForAnchorSlot(const ThemeControl *theme, std::uint8_t colorIndex, const QPalette &palette)
 {
-    // Anchor colours come from the theme's per-slot anchor
-    // palette (`theme.anchorPalette` in each JSON, resolved by
-    // `ThemeControl::AnchorBrushFor`). The API accepts either
-    // `Qt::BackgroundRole` (slot fill) or `Qt::ForegroundRole`
-    // (contrast text); every other caller in the app --
-    // `log_model.cpp` (row rendering), `histogram_widget.cpp`,
-    // `anchors_dock.cpp`, and `main_window.cpp` -- passes
-    // `Qt::BackgroundRole` to get the anchor's fill colour, and
-    // the rail must do the same or `AnchorBrushFor` returns an
-    // invalid brush and every anchor collapses to the fallback
-    // `QPalette::Highlight` regardless of slot. Bug repro:
-    // set three anchors on different palette slots and observe
-    // the rail paint them all in the same accent colour.
+    // Anchor colours come from `theme.anchorPalette`. Passing
+    // `Qt::BackgroundRole` returns the slot fill; the wrong role
+    // yields an invalid brush and collapses to `Highlight`.
     if (theme != nullptr)
     {
         const QBrush brush = theme->AnchorBrushFor(colorIndex, static_cast<int>(Qt::BackgroundRole));
@@ -225,17 +148,11 @@ QColor ColorForAnchorSlot(const ThemeControl *theme, std::uint8_t colorIndex, co
     return palette.color(QPalette::Highlight);
 }
 
-/// Log-scaled intensity in [0, 1] for a bucket with @p count
-/// rows against a rail-wide max of @p maxCount. Uses
-/// `log2(count + 1) / log2(maxCount + 1)` so a 1-row bucket
-/// still returns a positive intensity (no `log2(0)` trap) and a
-/// max-count bucket saturates to 1.0. The log compresses the
-/// dynamic range so small bins stay visible next to hot spots
-/// on power-law distributions -- a bucket with 10 rows against
-/// a max of 10k still gets ~30 % of the level column instead of
-/// the ~0.1 % a linear map would give it. Log base is irrelevant
-/// to the shape; `log2` chosen for readability. Returns 0 for
-/// an empty bucket, and clamps to `[0, 1]` for defence.
+/// Log-scaled intensity in `[0, 1]` for a bucket with @p count
+/// against rail-wide max @p maxCount. `log2(count + 1) /
+/// log2(maxCount + 1)` keeps small bins visible next to hot
+/// spots on power-law distributions (10 vs 10k reads ~30 %
+/// instead of the linear 0.1 %). Returns 0 for an empty bucket.
 [[nodiscard]] double IntensityForCount(std::uint32_t count, std::uint32_t maxCount) noexcept
 {
     if (count == 0 || maxCount == 0)
@@ -251,12 +168,9 @@ QColor ColorForAnchorSlot(const ThemeControl *theme, std::uint8_t colorIndex, co
     return std::clamp(num / den, 0.0, 1.0);
 }
 
-/// Single content rect: the horizontal slot the paint passes
-/// draw into. Reflects the widget's move from a three-column
-/// layout (level / match / anchor side-by-side) to a single
-/// full-width bin section that match and anchor ticks *overlay*
-/// on top of. Returned with a zero Y span; each bucket's paint
-/// pass fills its own Y slice.
+/// Horizontal slot every paint pass draws into (bins, match
+/// overlay, anchor overlay share it). Zero Y span; each bucket
+/// fills its own slice.
 [[nodiscard]] QRect ComputeContentRect(int underlayLeft, int underlayWidth) noexcept
 {
     if (underlayWidth <= 0)
@@ -315,20 +229,11 @@ OverviewRailWidget::OverviewRailWidget(
 )
     : QWidget(parent), mModel(model), mTheme(theme), mTableView(tableView)
 {
-    // Opaque `QPalette::Base` background -- the same role the
-    // viewport and the histogram widget paint their content on.
-    // On Dark Fusion (Base #232629 vs Window #31363B) this makes
-    // the rail read as a *narrow extension of the table's data
-    // area*, not as chrome next to the scrollbar. The practical
-    // win is contrast: the per-level colours the theme returns
-    // via `ColorForLevel` are tuned for legibility on Base
-    // (that's where the row backgrounds live), so Info-heavy
-    // buckets paint a visible blue instead of a Window-blended
-    // ghost. `WA_OpaquePaintEvent` tells Qt we cover every
-    // pixel opaquely so it can skip the auto-fill call before
-    // our paintEvent -- combined with the explicit background
-    // fill at the top of paintEvent this keeps scroll-drag
-    // repaints artefact-free.
+    // Opaque `QPalette::Base` — same role the viewport and
+    // histogram paint on. Level colours are tuned for this
+    // background. `WA_OpaquePaintEvent` skips Qt's auto-fill;
+    // `paintEvent` does its own fill to avoid scroll-drag
+    // artefacts.
     setAttribute(Qt::WA_OpaquePaintEvent, true);
     setFocusPolicy(Qt::NoFocus);
     setMouseTracking(false);
@@ -353,9 +258,7 @@ OverviewRailWidget::OverviewRailWidget(
         }
     }
 
-    // Trailing-edge debounce so a drag-resize storm collapses to
-    // one `SetBucketCount(H)` call. See `BUCKET_SYNC_DEBOUNCE_MS`
-    // for the perf rationale. Object-named for tests.
+    // Debounce for drag-resize storms; see `BUCKET_SYNC_DEBOUNCE_MS`.
     mBucketSyncTimer = new QTimer(this);
     mBucketSyncTimer->setObjectName(QStringLiteral("overviewRailBucketSyncTimer"));
     mBucketSyncTimer->setSingleShot(true);
@@ -371,7 +274,7 @@ void OverviewRailWidget::SetWidthMode(OverviewRailWidthMode mode)
     }
     mWidthMode = mode;
     mCachedRailWidth = 0;
-    // Notify the layout system so `LogTableView` re-reads
+    // Nudges the layout system so `LogTableView` re-reads
     // `sizeHint()` and refreshes the reserved right margin.
     updateGeometry();
     update();
@@ -379,31 +282,15 @@ void OverviewRailWidget::SetWidthMode(OverviewRailWidthMode mode)
 
 QSize OverviewRailWidget::sizeHint() const
 {
-    // DPI-fluent base: twice the platform scrollbar extent so
-    // the rail scales with the same DPI metric users already
-    // recognise, but stays wide enough that the stacked-
-    // severity bin bar remains readable. Fall back to the
-    // font's `M` advance when the style returns a degenerate 0
-    // (offscreen QPA in tests). Floor at `RAIL_MIN_WIDTH_PX`.
-    //
-    // The 2x factor was tuned against the "invisible bars"
-    // report on Windows 11: a raw scrollbar extent of 17 px
-    // left the content strip too narrow at typical viewing
-    // distance. Doubling lands around ~36 px of base width
-    // before the width-mode scale is applied.
-    //
-    // Width mode then multiplies that base (Narrow 1.0 /
-    // Medium 1.5 / Wide 2.0) and the result is clamped into
-    // `[RAIL_MIN_WIDTH_PX, RAIL_MAX_WIDTH_PX]`.
+    // Base = `2 × max(PM_ScrollBarExtent, font 'M') + padding`,
+    // floored at `RAIL_MIN_WIDTH_PX`. Width mode scales it, then
+    // clamp into `[RAIL_MIN_WIDTH_PX, RAIL_MAX_WIDTH_PX]`.
     const QStyle *s = style();
     const int scrollbarExtent = (s != nullptr) ? s->pixelMetric(QStyle::PM_ScrollBarExtent, nullptr, this) : 0;
     const int fontExtent = fontMetrics().horizontalAdvance(QLatin1Char('M'));
     const int base = std::max({2 * scrollbarExtent, 2 * fontExtent, RAIL_MIN_WIDTH_PX}) + RAIL_WIDTH_PADDING;
     const double scaled = static_cast<double>(base) * WidthScaleForMode(mWidthMode);
     const int extent = std::clamp(static_cast<int>(std::lround(scaled)), RAIL_MIN_WIDTH_PX, RAIL_MAX_WIDTH_PX);
-    // Cache so `RailWidthForTest` (and any future non-const
-    // helper that wants the last DPI-fluent width) doesn't have
-    // to re-run the platform-metric query.
     mCachedRailWidth = extent;
     return {extent, 0};
 }
@@ -415,8 +302,7 @@ QSize OverviewRailWidget::minimumSizeHint() const
 
 int OverviewRailWidget::RailWidthForTest() const
 {
-    // Warm the cache when a test asks before the first
-    // `sizeHint()` roundtrip, then return the cached value.
+    // Warm the cache for tests that ask before the first paint.
     if (mCachedRailWidth == 0)
     {
         (void)sizeHint();
@@ -467,10 +353,8 @@ int OverviewRailWidget::YForBucketForTest(std::size_t bucket) const
 
 int OverviewRailWidget::WidthForCountForTest(std::uint32_t count, std::uint32_t maxCount, int columnWidth)
 {
-    // Mirrors the paint pass: clamp column width to non-negative,
-    // scale by the log-based intensity, then clamp into
-    // `[MIN_BAR_WIDTH_PX, columnWidth]`. An empty bucket returns
-    // zero so tests can distinguish "no bar" from "min-width bar".
+    // Mirrors the paint pass. Empty bucket returns 0 so tests
+    // can distinguish "no bar" from "min-width bar".
     if (columnWidth <= 0 || count == 0 || maxCount == 0)
     {
         return 0;
@@ -493,25 +377,14 @@ void OverviewRailWidget::paintEvent(QPaintEvent * /*event*/)
     const QPalette pal = palette();
     const QRect widgetRect = rect();
 
-    // Fully repaint the widget's background on every paint pass.
-    // Qt::WA_OpaquePaintEvent (set in the ctor) tells Qt we cover
-    // every pixel, which *disables* `autoFillBackground` -- so
-    // without this explicit fill the previous paint's content
-    // would leak through (visible as smearing / trails when the
-    // user drags the scrollbar and successive paints don't fully
-    // overwrite the old level bar / viewport indicator paint).
-    // Using `QPalette::Base` matches the viewport's / histogram's
-    // background tone so the level bar colours (which are tuned
-    // for legibility on Base) show at the expected contrast.
+    // Explicit background fill: `WA_OpaquePaintEvent` disables
+    // Qt's auto-fill; without this the previous paint smears
+    // during scrollbar drags.
     painter.fillRect(widgetRect, pal.color(QPalette::Base));
 
-    // Draw a 1 px `QPalette::Dark` separator at the left edge
-    // so the rail's boundary against the viewport is crisp
-    // regardless of how close Window and Base ended up under
-    // the user's palette. Kept as a painter line rather than
-    // a stylesheet border so it survives style overrides that
-    // strip the widget's frame (Windows 11 Fusion, some
-    // accessibility themes).
+    // 1 px `Dark` separator at the left edge so the boundary
+    // against the viewport reads on any palette. Painted (not
+    // stylesheet) so it survives style overrides.
     if (widgetRect.width() > 0)
     {
         QColor sepColor = pal.color(QPalette::Dark);
@@ -543,28 +416,18 @@ void OverviewRailWidget::paintEvent(QPaintEvent * /*event*/)
     const int underlayWidth = std::max(1, rail.width() - (2 * RAIL_UNDERLAY_INSET));
     const QColor highlightColor = pal.color(QPalette::Highlight);
 
-    // Single content slot: the whole underlay. Match and anchor
-    // ticks *overlay* the level bins in the same slot (previously
-    // each channel got its own sub-column, which fractured a
-    // small rail into three near-invisible strips). Paint order
-    // guarantees anchors > matches > bins so a bucket that
-    // carries all three still surfaces the user-set anchor.
+    // Single content slot shared by bins + overlays. Paint order
+    // anchors > matches > bins so a bucket with all three still
+    // surfaces the user-set anchor.
     const QRect content = ComputeContentRect(underlayLeft, underlayWidth);
     const int contentLeft = content.left();
     const int contentWidth = content.width();
 
-    // Precompute the Y coordinate of every bucket edge once.
-    // Each of the paint passes below picks the top from
-    // `yEdges[i]` and the bottom from `yEdges[i+1]` -- avoids
-    // recomputing the same integer division per bucket on tall
-    // rails and keeps the seam-rounding ("bottom == next
-    // bucket's top") consistent across passes.
-    //
-    // Cached on `(nBuckets, railTop, railHeight)` so a drag-scroll
-    // burst (many paints per second, geometry unchanged between
-    // them) reuses the same vector instead of re-allocating
-    // `nBuckets + 1` ints per paint. Invalidated implicitly on
-    // resize / bucket-count change / style-driven inset shift.
+    // Precompute every bucket-edge Y once. Each paint pass reads
+    // top from `yEdges[i]` and bottom from `yEdges[i+1]`, keeping
+    // seams consistent across passes. Cached on
+    // `(nBuckets, railTop, railHeight)` so drag-scroll bursts
+    // skip the alloc.
     if (mCachedYEdgesBuckets != nBuckets || mCachedYEdgesRailTop != railTop ||
         mCachedYEdgesRailHeight != railHeight)
     {
@@ -580,14 +443,9 @@ void OverviewRailWidget::paintEvent(QPaintEvent * /*event*/)
     }
     const std::vector<int> &yEdges = mCachedYEdges;
 
-    // Rail-wide max bucket total. Drives the log-scaled bar
-    // width in Pass 1 so density is expressed as bar length
-    // relative to the busiest bucket. Computed in one linear
-    // walk over `buckets` (nBuckets = railHeight ~= 600, so
-    // trivial); recomputed on every paint because the model
-    // has no rail-wide max cache and the alternative (subscribe
-    // to a "maxChanged" signal) buys us microseconds we don't
-    // need.
+    // Rail-wide max bucket total; drives the log-scaled bar
+    // width in Pass 1. `nBuckets` ≈ 600, so recomputing per paint
+    // is trivial and cheaper than plumbing a "maxChanged" signal.
     std::uint32_t maxCount = 0;
     std::size_t nonEmptyBuckets = 0;
     for (const auto &bucket : buckets)
@@ -600,19 +458,11 @@ void OverviewRailWidget::paintEvent(QPaintEvent * /*event*/)
         }
     }
 
-    // Gated diagnostic: with `LOGAPP_RAIL_TRACE=1` in the
-    // environment (paired with `QT_FORCE_STDERR_LOGGING=1` on
-    // Windows so the GUI subsystem output routes to stderr),
-    // log the rail's paint state to `qInfo`. Rate-limited to
-    // once per second so drag-repaint bursts don't flood the
-    // console. This is scaffolding for future "invisible bars"
-    // regressions -- see run_diag.ps1 for the end-to-end reproducer
-    // (launch the app, capture the window via PrintWindow, parse
-    // pixels for expected colours).
+    // Gated diagnostic: `LOGAPP_RAIL_TRACE=1` in the environment
+    // (paired with `QT_FORCE_STDERR_LOGGING=1` on Windows) logs
+    // the rail's paint state to `qInfo` at 1 Hz. Scaffolding for
+    // future "invisible bars" regressions.
     static const bool RAIL_TRACE_ENABLED = qEnvironmentVariableIntValue("LOGAPP_RAIL_TRACE") != 0;
-    // 1 Hz throttle window: fast enough to see live buckets fill in
-    // during streaming, slow enough that drag-repaint bursts don't
-    // flood the console with duplicate lines.
     constexpr int RAIL_TRACE_THROTTLE_MS = 1000;
     if (RAIL_TRACE_ENABLED)
     {
@@ -656,43 +506,21 @@ void OverviewRailWidget::paintEvent(QPaintEvent * /*event*/)
         }
     }
 
-    // Pass 1 (base layer): one bin bar per non-empty bucket,
-    // split into a stack of severity segments (Fatal / Error /
-    // Warn / Info / Debug / Trace / Unknown left-to-right in
-    // severity-descending order). Bar *width* encodes total row
-    // density (log-scaled -- small bins still show a visible
-    // tick, hot spots saturate to the full content width); each
-    // segment's width inside the bar is proportional to that
-    // level's share of the bucket.
+    // Pass 1 (base): one bin bar per non-empty bucket, split into
+    // severity segments in descending order (Fatal → Unknown).
+    // Bar width = log-scaled total density; per-segment width =
+    // that level's share of the bucket. Every non-zero level gets
+    // `MIN_SEGMENT_WIDTH_PX` so a rare Fatal in a 500-Trace bucket
+    // still lights a pixel.
     //
-    // Every non-zero level gets `MIN_SEGMENT_WIDTH_PX` (1 px) so
-    // a rare Fatal in a 500-Trace bucket still lights up a
-    // pixel. This was previously the source of a "left-edge
-    // bright stripe" regression when the paint used row
-    // *foreground* colours (Warn `#FCD34D`, Fatal `#FECACA`,
-    // ...) -- one bright pixel per bucket became a continuous
-    // vertical light band on real logs. `ColorForLevel` now
-    // resolves to the row *background* wash instead, which is a
-    // subtle severity tint on Base, so even every-bucket
-    // segments composite to a soft mini-map rather than a
-    // stripe. `BackgroundFor` also respects
-    // `mHighContrast` automatically (via `BuildStyleCache`), so
-    // toggling the Preferences "high contrast levels" checkbox
-    // recolours the rail with the loud
-    // `levelsHighContrast` variants without any extra plumbing.
+    // Match ticks (Pass 2) and anchor ticks (Pass 3) overlay this
+    // base for buckets that carry them, so their signal wins over
+    // the level painting.
     //
-    // Match ticks (Pass 2) and anchor ticks (Pass 3) later
-    // *overlay* this base layer for buckets that carry them, so
-    // the "you have a match here" / "you have an anchor here"
-    // signal wins for hit-testing purposes even though the base
-    // layer painted the same slot first.
-    //
-    // Kept as a hard-coded severity-descending list (rather than
-    // reaching into the model's `LEVEL_SEVERITY_RANK`) so the
-    // widget's paint pass has no cross-file coupling. If the
-    // canonical level list ever grows the initialiser has to
-    // grow alongside `LEVEL_SEVERITY_RANK` in the model or the
-    // paint pass will silently miss the new level.
+    // Hard-coded severity list rather than reading from the model
+    // so the widget's paint has no cross-file coupling; grow this
+    // alongside `LEVEL_SEVERITY_RANK` if the canonical list ever
+    // grows.
     constexpr std::size_t SEVERITY_LEVEL_COUNT = loglib::CANONICAL_LEVEL_COUNT + 1;
     constexpr std::array<loglib::LogLevel, SEVERITY_LEVEL_COUNT> SEVERITY_DESCENDING{
         loglib::LogLevel::Fatal,
@@ -721,28 +549,13 @@ void OverviewRailWidget::paintEvent(QPaintEvent * /*event*/)
             barWidth = std::clamp(barWidth, MIN_BAR_WIDTH_PX, contentWidth);
 
             // Two-pass segment sizing:
-            //   1) assign every non-zero level a
-            //      `MIN_SEGMENT_WIDTH_PX` floor and total the
-            //      reserved pixels;
-            //   2) distribute the remaining `barWidth -
-            //      reserved` proportionally to each level's
-            //      *log-weighted* share of the bucket.
-            //
-            // Weights use `log2(count + 1)` (the same
-            // transform `IntensityForCount` applies to the
-            // bar's total density). Linear proportions
-            // effectively hide rare severities: a bucket of
-            // 500 Trace + 1 Fatal gives Fatal 1/501 = 0.2 % of
-            // the bar, floored to a single pixel that reads
-            // as noise on a Trace-dominated rail. Log-weighted
-            // shares raise that Fatal slice to
-            // log2(2) / (log2(501) + log2(2)) ~= 7 %, which is
-            // a visibly readable band without letting the
-            // majority level lose its "this is the dominant
-            // one" cue. Both scales point in the same
-            // direction (bigger count -> bigger slice), just
-            // with a compressed dynamic range that matches
-            // human contrast sensitivity better.
+            //   1. Assign every non-zero level a
+            //      `MIN_SEGMENT_WIDTH_PX` floor.
+            //   2. Distribute the remainder proportionally to each
+            //      level's `log2(count + 1)` weight.
+            // Log weights compress the dynamic range so a rare
+            // Fatal in a Trace-heavy bucket gets a readable slice
+            // (~7 % vs 0.2 % linear) without erasing the majority.
             std::array<int, SEVERITY_LEVEL_COUNT> segWidths{};
             std::array<double, SEVERITY_LEVEL_COUNT> segWeights{};
             double totalWeight = 0.0;
@@ -772,11 +585,9 @@ void OverviewRailWidget::paintEvent(QPaintEvent * /*event*/)
                         static_cast<int>((segWeights[s] / totalWeight) * static_cast<double>(extra));
                     segWidths[s] += share;
                 }
-                // Rounding leftovers: hand them to the level
-                // that carries the largest weight (the
-                // majority in log space), so the bar's right
-                // edge lands on `barWidth` exactly and the
-                // dominant severity gets the visual tie-break.
+                // Rounding leftovers go to the heaviest level so
+                // the bar ends exactly at `barWidth` and the
+                // dominant severity wins the visual tie-break.
                 int allocated = 0;
                 for (int w : segWidths)
                 {
@@ -820,13 +631,9 @@ void OverviewRailWidget::paintEvent(QPaintEvent * /*event*/)
         }
     }
 
-    // Pass 2 (overlay): match ticks. Repaint the *entire content
-    // width* for every bucket that carries at least one match
-    // row so the "there is a match here" signal is a solid,
-    // high-contrast Highlight-colour bar that unambiguously
-    // wins over the base-layer bin painting. Full-width instead
-    // of an accent column so a search hit in an otherwise-quiet
-    // bucket still catches the eye at a glance.
+    // Pass 2 (overlay): match ticks. Repaint the full content
+    // width for every bucket with at least one match so the
+    // "there is a match here" signal is unambiguously visible.
     if (mModel->HasMatchTicks() && contentWidth > 0)
     {
         for (std::size_t i = 0; i < nBuckets; ++i)
@@ -841,13 +648,9 @@ void OverviewRailWidget::paintEvent(QPaintEvent * /*event*/)
         }
     }
 
-    // Pass 3 (overlay): anchor ticks. Repaint the *entire content
-    // width* for every bucket that carries at least one anchor
-    // row. Painted after matches so a bucket that is both an
-    // anchor and a search hit reads as an anchor -- user-set
-    // markers outrank live search state. Anchor colour comes
-    // from `ThemeControl::AnchorBrushFor` (theme's
-    // `anchorPalette`).
+    // Pass 3 (overlay): anchor ticks. Full content width for
+    // every bucket with an anchor. Drawn after matches so
+    // user-set markers outrank live search state.
     if (mModel->HasAnchorTicks() && contentWidth > 0)
     {
         for (std::size_t i = 0; i < nBuckets; ++i)
@@ -860,8 +663,8 @@ void OverviewRailWidget::paintEvent(QPaintEvent * /*event*/)
             const int y = yEdges[i];
             const int height = std::max(1, yEdges[i + 1] - y);
             // Paint the lowest-index set slot: multiple anchor
-            // colours in one bucket collapse to the first-set
-            // (deterministic, and rare for a small rail).
+            // colours in one bucket collapse to first-set
+            // (deterministic; rare on a small rail).
             for (std::size_t s = 0; s < mask.size(); ++s)
             {
                 if (mask.test(s))
@@ -874,9 +677,9 @@ void OverviewRailWidget::paintEvent(QPaintEvent * /*event*/)
         }
     }
 
-    // Pass 4: viewport indicator. Rounded, translucent fill
-    // with a solid outline so the visible range reads as
-    // interactive chrome over the level / tick painting.
+    // Pass 4: viewport indicator. Rounded translucent fill with a
+    // solid outline so the visible range reads as interactive
+    // chrome over the level / tick painting.
     const QRect indicator = ComputeViewportIndicatorRect();
     if (!indicator.isEmpty())
     {
@@ -890,9 +693,9 @@ void OverviewRailWidget::paintEvent(QPaintEvent * /*event*/)
         pen.setCosmetic(true);
         pen.setWidth(1);
         painter.setPen(pen);
-        // Inset by 0.5 px so the cosmetic pen lands on a whole
-        // pixel row and the rounded corners anti-alias cleanly.
-        const QRectF rounded(
+    // Half-pixel inset so the cosmetic pen lands on whole rows
+    // and the rounded corners anti-alias cleanly.
+    const QRectF rounded(
             indicator.left() + 0.5, indicator.top() + 0.5, indicator.width() - 1.0, indicator.height() - 1.0
         );
         painter.drawRoundedRect(rounded, INDICATOR_CORNER_RADIUS, INDICATOR_CORNER_RADIUS);
@@ -910,10 +713,9 @@ void OverviewRailWidget::mousePressEvent(QMouseEvent *event)
     }
     mDragging = true;
     mLastEmittedRow = INT_MIN;
-    // A fresh click commits the user to that row: the downstream
-    // handler is allowed to replace the current selection with
-    // just this row (matches the "click to jump" idiom used by
-    // the histogram tick strip and the anchors dock).
+    // Fresh click commits: allow the handler to replace the
+    // current selection with just this row (same idiom as the
+    // histogram tick strip and anchors dock).
     EmitProxyRowForY(static_cast<int>(event->position().y()), /*replaceSelection=*/true);
     event->accept();
 }
@@ -925,8 +727,7 @@ void OverviewRailWidget::mouseMoveEvent(QMouseEvent *event)
         QWidget::mouseMoveEvent(event);
         return;
     }
-    // Scrubbing: the user is exploring, not committing. Ask the
-    // handler to scroll without touching the selection so a
+    // Scrubbing: scroll without touching the selection so a
     // carefully-built multi-row selection survives a rail scrub.
     EmitProxyRowForY(static_cast<int>(event->position().y()), /*replaceSelection=*/false);
     event->accept();
@@ -946,10 +747,9 @@ void OverviewRailWidget::mouseReleaseEvent(QMouseEvent *event)
 
 void OverviewRailWidget::wheelEvent(QWheelEvent *event)
 {
-    // While actively dragging, swallow the wheel so a fumbled
-    // scroll doesn't fight the drag scrub. Otherwise forward
-    // by injecting a matching delta into the table's scrollbar
-    // so the rail behaves like an extension of the scrollbar.
+    // Swallow wheel during a drag so a fumbled scroll doesn't
+    // fight the scrub. Otherwise forward to the table's
+    // scrollbar so the rail behaves like an extension of it.
     if (mDragging)
     {
         event->accept();
@@ -966,38 +766,26 @@ void OverviewRailWidget::wheelEvent(QWheelEvent *event)
         event->ignore();
         return;
     }
-    // Translate the wheel event's local position into the
-    // scrollbar's coordinate space before forwarding. The
-    // original `event->position()` is in this widget's coords,
-    // which sit past the scrollbar's rect on the horizontal
-    // axis; forwarding verbatim would leave any style /
-    // accessibility layer that inspects the point looking at
-    // coordinates outside `vbar`. `QAbstractSlider::wheelEvent`
-    // currently reads only `angleDelta` (so the mismatch was
-    // invisible in production), but the translation is cheap
-    // and future-proofs the wiring against a style that ever
-    // starts caring — e.g. a hover indicator or a hit-test
-    // for click-past-thumb page behaviour. Global position
-    // stays as-is so screen-space consumers see the same
-    // point the user pointed at.
-    // Attribute the forthcoming scrollbar `valueChanged` as
-    // user-driven. Forwarding via `sendEvent` bypasses
-    // `LogTableView::wheelEvent`, which is the normal path that
-    // sets this flag. Qt's `QAbstractSlider::wheelEvent` usually
-    // goes through `triggerAction` (so `actionTriggered` would
-    // also set the flag), but attributing explicitly keeps Follow
-    // newest disengage correct even if a style / platform path
-    // calls `setValue` directly.
+    // Translate local position into the scrollbar's coord space
+    // before forwarding. `QAbstractSlider::wheelEvent` only reads
+    // `angleDelta` today, but a future style / accessibility
+    // layer inspecting the point would see coords outside `vbar`
+    // without this. Global position stays as-is.
+    //
+    // Attribute the forthcoming `valueChanged` as user-driven:
+    // `sendEvent` bypasses `LogTableView::wheelEvent` (the
+    // normal attribution path), so we set the flag explicitly to
+    // keep Follow-newest disengage correct even if a style /
+    // platform path bypasses `triggerAction`.
     auto *logView = qobject_cast<LogTableView *>(mTableView.data());
     if (logView != nullptr)
     {
         logView->AttributeNextScrollToUser();
     }
-    // Snapshot the scrollbar value so we can detect the pinned-
-    // edge case (wheel forwarded but the scrollbar was already at
-    // `minimum()` / `maximum()` in the wheel's direction, so no
-    // `valueChanged` fires and the attribution flag would survive
-    // until the next — possibly programmatic — value change).
+    // Snapshot so we can detect the pinned-edge case: wheel
+    // forwarded but scrollbar already at `minimum()` /
+    // `maximum()`, so `valueChanged` never fires and the
+    // attribution flag would survive until the next value change.
     const int valueBefore = vbar->value();
     const QPointF globalPos = event->globalPosition();
     const QPointF localPos = vbar->mapFromGlobal(globalPos.toPoint());
@@ -1014,50 +802,34 @@ void OverviewRailWidget::wheelEvent(QWheelEvent *event)
         event->pointingDevice()
     );
     QApplication::sendEvent(vbar, &translated);
-    // Pinned-edge case: value didn't move, so `OnVerticalScrollValue
-    // Changed` never fired and the user-attribution flag we set
-    // above is still true. Clear it so a later programmatic
-    // `setValue` (e.g. anchor-restore on the next batch) isn't
-    // mistakenly reported as a user scroll.
+    // Pinned-edge cleanup: value didn't move, so
+    // `OnVerticalScrollValueChanged` never fired and the flag we
+    // set is stranded. Clear it so a later programmatic
+    // `setValue` isn't misattributed as a user scroll.
     if (logView != nullptr && vbar->value() == valueBefore)
     {
         logView->ClearNextScrollUserAttribution();
     }
-    // Mark accepted so the parent scroll area doesn't double-
-    // process the wheel event.
     event->accept();
 }
 
 void OverviewRailWidget::resizeEvent(QResizeEvent *event)
 {
     QWidget::resizeEvent(event);
-    // Debounce: an interactive window drag fires a resize event
-    // per pixel of height change, and each `SyncBucketCountToHeight`
-    // would call `SetBucketCount(H±1)` on the model, which drops
-    // the durable per-bucket find-match counts and (with the Find
-    // bar open) forces `MainWindow` to run a full synchronous
-    // find rescan through the `bucketsChanged` lambda. Coalescing
-    // through `mBucketSyncTimer` collapses the burst to one
-    // bucket update + one rescan when the drag settles.
-    //
-    // Paints during the debounce window use the previous
-    // bucket count against the current widget height, so the
-    // rail's proportions stretch slightly for up to
-    // `BUCKET_SYNC_DEBOUNCE_MS` — visually indistinguishable
-    // from the settled state given the rail is a summary
-    // strip, not a pixel-accurate view. Click / drag / wheel
-    // still resolve against the live widget height + live
-    // model row count (see `ProxyRowForYPixel`), so hit-testing
-    // stays correct.
+    // Debounce: a window drag fires one resize per pixel of
+    // height change; each `SetBucketCount(H±1)` drops the durable
+    // per-bucket match counts and forces a full find rescan.
+    // Coalescing collapses the burst to one update + one rescan
+    // when the drag settles. Paints during the window use the
+    // previous bucket count against the current height (slight
+    // stretch, visually indistinguishable); hit-testing resolves
+    // against the live widget height regardless.
     if (mBucketSyncTimer != nullptr)
     {
         mBucketSyncTimer->start();
     }
     else
     {
-        // Defensive: constructor guarantees the timer exists,
-        // but if a future refactor moves timer construction out
-        // of the ctor keep the widget functional.
         SyncBucketCountToHeight();
     }
 }
@@ -1065,13 +837,10 @@ void OverviewRailWidget::resizeEvent(QResizeEvent *event)
 void OverviewRailWidget::hideEvent(QHideEvent *event)
 {
     QWidget::hideEvent(event);
-    // Cancel any pending debounced sync. `MainWindow::
-    // SetOverviewRailVisible(false)` drops the model's bucket
-    // vector immediately after this hide fires; a queued
-    // `SyncBucketCountToHeight()` firing right after would
-    // re-populate the vector against the widget's persisted
-    // height and undo the visibility-toggle optimisation
-    // (paying rebuild cost while the rail is invisible).
+    // Cancel pending sync: `SetOverviewRailVisible(false)` drops
+    // the model's bucket vector right after; a queued
+    // `SyncBucketCountToHeight` would re-populate it and undo the
+    // hidden-rail rebuild-cost optimisation.
     if (mBucketSyncTimer != nullptr)
     {
         mBucketSyncTimer->stop();
@@ -1082,22 +851,11 @@ void OverviewRailWidget::showEvent(QShowEvent *event)
 {
     QWidget::showEvent(event);
     // Re-arm the model after a hide-toggle dropped its bucket
-    // vector. Idempotent when the height matches — `SetBucketCount`
-    // is a no-op on a matching count.
-    //
-    // Skip the call when the widget hasn't been sized yet (first
-    // show, before the hosting `LogTableView::UpdateOverviewRail
-    // Geometry` runs). Calling `SetBucketCount(0)` here would
-    // fire a redundant no-op transition; the follow-up
-    // `resizeEvent` immediately supersedes it with the real
-    // height.
-    //
-    // A show is a discrete user action (toggle, tab switch, first
-    // appearance) and must not wait on the resize debounce — the
-    // first paint after the show has to see correct bucket
-    // geometry. Cancel any pending resize-debounce so we don't
-    // double-fire `SetBucketCount` on the same H after this call
-    // returns.
+    // vector. Skip when unsized (first show before geometry
+    // runs) — `resizeEvent` supersedes with the real height.
+    // Show is a discrete user action and must not wait on the
+    // resize debounce; cancel any pending sync to avoid a
+    // double-fire on the same H.
     if (height() > 0)
     {
         if (mBucketSyncTimer != nullptr)
@@ -1111,16 +869,11 @@ void OverviewRailWidget::showEvent(QShowEvent *event)
 void OverviewRailWidget::changeEvent(QEvent *event)
 {
     QWidget::changeEvent(event);
-    // Style / palette / font change may shift the DPI-fluent
-    // width and the wash colour. Force a fresh sizeHint so the
-    // hosting `LogTableView` reserves the right margin.
-    // `ScreenChangeInternal` is a private Qt enum today; we
-    // rely on it as the most reliable cross-version proxy for a
-    // DPR change (Qt 6.6+ ships public `DevicePixelRatioChange`,
-    // but the project targets Qt 6.1+). Both events go through
-    // this switch so the newer one is picked up for free once we
-    // raise the floor. See LogTableView::changeEvent for the
-    // matching comment.
+    // Style / palette / font changes shift DPI-fluent width and
+    // the wash colour. Force a fresh sizeHint so the host view
+    // re-reserves the right margin. `ScreenChangeInternal` acts
+    // as a Qt 6.1+ proxy for DPR change; `DevicePixelRatioChange`
+    // (Qt 6.6+) will pick up automatically when the floor rises.
     switch (event->type())
     {
     case QEvent::StyleChange:
@@ -1138,22 +891,11 @@ void OverviewRailWidget::changeEvent(QEvent *event)
 
 QRect OverviewRailWidget::InteractiveRailRect() const
 {
-    // The rail is a whole-file overview: rail top = first row,
-    // rail bottom = last row, bars fill the entire widget
-    // height. Following klogg / glogg / VS Code minimap, the
-    // vertical position within the rail is a linear projection
-    // of the file's row index -- *not* of the viewport's Y
-    // range. That means the bar for row 0 sits at the top edge
-    // of the rail widget (level with the header's top edge),
-    // and the currently visible viewport is drawn as a movable
-    // highlight box (`ComputeViewportIndicatorRect`) *inside*
-    // the rail.
-    //
-    // Restricting the rail to the viewport-Y strip only was
-    // tried; users read that as "the rail is broken -- half of
-    // it is empty chrome". A whole-widget projection gives the
-    // full file overview at a glance and reserves the "where am
-    // I" answer to the highlight box.
+    // Whole-file overview: rail top = first row, rail bottom =
+    // last row, bars fill the widget height. Follows klogg /
+    // VS Code minimap — vertical position is a linear projection
+    // of file row index, not viewport Y. Restricting to viewport
+    // Y was tried; users read it as "the rail is broken".
     QRect r = rect();
     r.adjust(0, RAIL_VERTICAL_INSET, 0, -RAIL_VERTICAL_INSET);
     return r;
@@ -1197,16 +939,16 @@ QRect OverviewRailWidget::ComputeViewportIndicatorRect() const
     }
     const QRect viewport = mTableView->viewport()->rect();
     const int topRow = mTableView->indexAt(QPoint(0, 0)).row();
-    // `indexAt(bottom)` returns -1 when the bottom is past the
-    // last row; use the row count in that case so the indicator
-    // extends to the tail as the user scrolls into the last page.
+    // `indexAt(bottom)` returns -1 past the last row; fall back
+    // to the row count so the indicator extends to the tail on
+    // the last page.
     const int bottomIdxRow = mTableView->indexAt(QPoint(0, std::max(0, viewport.height() - 1))).row();
     int bottomRow = (bottomIdxRow >= 0) ? bottomIdxRow : (totalRows - 1);
 
     int visibleTop = (topRow >= 0) ? topRow : 0;
     bottomRow = std::max(bottomRow, visibleTop);
-    // Clamp into `[0, totalRows)` so the indicator never runs
-    // past the rail even under a transient row-count mismatch.
+    // Clamp so the indicator can't run past the rail under a
+    // transient row-count mismatch.
     visibleTop = std::clamp(visibleTop, 0, totalRows - 1);
     bottomRow = std::clamp(bottomRow, visibleTop, totalRows - 1);
 
@@ -1217,21 +959,14 @@ QRect OverviewRailWidget::ComputeViewportIndicatorRect() const
                               static_cast<long long>(totalRows);
     const int naturalHeight = static_cast<int>(yBottom - yTop);
     int indicatorHeight = std::max(naturalHeight, INDICATOR_MIN_HEIGHT_PX);
-    // When the natural viewport-Y span is shorter than the
-    // `INDICATOR_MIN_HEIGHT_PX` floor (the common case for tall
-    // logs -- a 50 k-row session with 20 visible rows maps to
-    // sub-pixel on the rail), expand around the *centre* of the
-    // visible range instead of pinning to the top. Otherwise a
-    // row selected in the middle of the viewport would appear
-    // at the top edge of the min-height-inflated indicator on
-    // the rail, misaligned with where the user sees the row in
-    // the table (regression report: "the anchor is showed in
-    // the middle of the tableview but the rail marks it at the
-    // top of the current-view preview").
+    // When the natural span is shorter than the min-height floor
+    // (common on tall logs), expand around the centre of the
+    // visible range so a mid-viewport row lines up with the
+    // indicator's middle rather than its top edge.
     const long long yCenter = (yTop + yBottom) / 2;
     int indicatorTop = rail.top() + static_cast<int>(yCenter) - (indicatorHeight / 2);
-    // Clamp to the rail so the centering + min-height boost
-    // don't push the indicator past either inset.
+    // Clamp so centring + min-height boost can't push the
+    // indicator past either inset.
     if (indicatorTop + indicatorHeight > rail.bottom() + 1)
     {
         indicatorTop = rail.bottom() + 1 - indicatorHeight;
@@ -1249,9 +984,9 @@ void OverviewRailWidget::SyncBucketCountToHeight()
     }
     const QRect rail = InteractiveRailRect();
     const int height = std::max(0, rail.height());
-    // One bucket per pixel row keeps the rail's paint math
-    // trivial (fillRect at each Y). SetBucketCount is a no-op
-    // when the count matches.
+    // One bucket per pixel row keeps the paint math trivial
+    // (fillRect at each Y). `SetBucketCount` is a no-op on a
+    // matching count.
     mModel->SetBucketCount(static_cast<std::size_t>(height));
 }
 
@@ -1262,8 +997,8 @@ void OverviewRailWidget::FlushPendingBucketSyncForTest()
     {
         return;
     }
-    // Stop first so the timer's own `timeout` can't race the
-    // sync we're about to run manually and double-fire.
+    // Stop first so the timer's `timeout` can't race the manual
+    // sync and double-fire.
     mBucketSyncTimer->stop();
     SyncBucketCountToHeight();
 }

--- a/app/src/overview_rail_widget.cpp
+++ b/app/src/overview_rail_widget.cpp
@@ -29,10 +29,15 @@
 #include <QWidget>
 #include <Qt>
 
+#include <QElapsedTimer>
+
 #include <algorithm>
+#include <array>
 #include <bitset>
 #include <climits>
+#include <cmath>
 #include <cstddef>
+#include <cstdint>
 #include <vector>
 
 namespace
@@ -49,20 +54,36 @@ constexpr int RAIL_VERTICAL_INSET = 2;
 /// than a single flat fill.
 constexpr int RAIL_UNDERLAY_INSET = 1;
 
-/// Fractional width of the match tick band inside the rail.
-/// The band paints centred; ~55 % width reads as a clear
-/// vertical marker without dominating the level wash beside
-/// it.
-constexpr double MATCH_TICK_WIDTH_FRACTION = 0.55;
+/// Minimum bar width for a non-empty level bucket. Guarantees a
+/// 1-row bucket still paints as a visible 2-px tick, so sparse
+/// activity zones don't visually vanish in a mostly-empty log.
+constexpr int MIN_BAR_WIDTH_PX = 2;
 
-/// Alpha on the level underlay. Muted enough that anchor and
-/// match ticks stay legible when painted over the same bucket.
-constexpr int LEVEL_UNDERLAY_ALPHA = 110;
+/// Alpha applied to the *fallback* segment colour when the
+/// theme leaves a level unstyled (see `ColorForLevel`). Keeps
+/// Info-heavy rails from washing out by compositing the
+/// neutral placeholder-text tone semi-transparently over
+/// `QPalette::Base`. Styled levels (Fatal, Error, Warn, ...)
+/// paint fully opaque and take their colour from the theme's
+/// row *background* which is designed as a subtle severity
+/// tint on Base -- see `ColorForLevel` for the rationale.
+constexpr int LEVEL_FALLBACK_ALPHA = 96;
 
-/// Alpha on the rail wash. Subtle — a hint of separation,
-/// not a slab. Applied over `QPalette::Base` so a Dark theme
-/// dims and a Light theme lifts by the same delta.
-constexpr int WASH_ALPHA = 24;
+/// Minimum horizontal width for one severity segment inside a
+/// bucket's bar. Keeps a rare-but-present level (e.g. one Fatal
+/// in a 500-row bucket) from rounding away to zero pixels. Kept
+/// tiny (1 px) so the floor doesn't manufacture a bright band
+/// on the rail's left edge -- combined with the dark row-
+/// background palette in `ColorForLevel`, even every-bucket
+/// severity segments composite to a subtle tint, not a stripe.
+constexpr int MIN_SEGMENT_WIDTH_PX = 1;
+
+/// Alpha on the 1 px separator line drawn at the rail's left
+/// edge. Gives the rail a hard boundary against the table body
+/// so the eye can find it even when the palette Window colour
+/// is close to Base. `QPalette::Dark` (window's shadow tone)
+/// reads as a divider on both Light and Dark themes.
+constexpr int SEPARATOR_ALPHA = 255;
 
 /// Alpha on the viewport-indicator glass fill. Higher than
 /// the wash so the indicator reads as an overlay marker;
@@ -85,25 +106,61 @@ constexpr int INDICATOR_CORNER_RADIUS = 3;
 constexpr int INDICATOR_MIN_HEIGHT_PX = 12;
 
 /// Minimum rail width in device-independent px. Guarantees a
-/// hittable target at very small font sizes.
-constexpr int RAIL_MIN_WIDTH_PX = 10;
+/// hittable target at very small font sizes; the single-column
+/// bin section still stays readable at this width because the
+/// stacked severity segments compress down to 1 px per level
+/// (which is enough to spot a rare Fatal streak).
+constexpr int RAIL_MIN_WIDTH_PX = 24;
 
 /// Maximum rail width in device-independent px. Some styles
 /// (accessibility themes on Windows, GTK "chunky-scrollbar"
 /// setups) advertise very large `PM_ScrollBarExtent` values —
 /// mirroring them 1:1 would cover a large fraction of the
-/// viewport with a nearly-empty rail. The cap keeps the rail
-/// at klogg-parity density; ticks + indicator remain crisp
-/// above this width so raising it further wastes pixels.
-constexpr int RAIL_MAX_WIDTH_PX = 22;
+/// viewport with a nearly-empty rail. The cap is deliberately
+/// wide so per-level stacked-segment colours are
+/// unmistakably readable even on 4K displays where 14 px bars
+/// were near-invisible in user reports. Klogg's overview strip
+/// is 16 px; we run wider because we also show anchors + match
+/// ticks in dedicated columns, not just matches.
+constexpr int RAIL_MAX_WIDTH_PX = 60;
 
 /// Extra width added to the DPI-fluent metric. Nudges the
 /// rail slightly wider than the scrollbar so it doesn't merge
 /// visually with a scrollbar rendered in the same theme.
 constexpr int RAIL_WIDTH_PADDING = 2;
 
-QColor ColorForLevelWithFallback(const ThemeControl *theme, loglib::LogLevel level, const QPalette &palette)
+QColor ColorForLevel(const ThemeControl *theme, loglib::LogLevel level, const QPalette &palette)
 {
+    // Rail bars use the active theme's row *background* wash
+    // rather than its row *foreground* text tone. Foregrounds
+    // (Warn `#FCD34D`, Error `#FCA5A5`, Fatal `#FECACA` on Dark)
+    // are tuned for legible contrast against the row background
+    // and read as *bright pastels* when painted directly on Base
+    // -- multiple such bright tones stacked across the rail then
+    // composite to a washed-out "light band" (the regression the
+    // "rail is still too light" report was about). Row
+    // backgrounds are the opposite: theme designers pick them as
+    // *subtle* severity tints layered on Base, so a rail bin
+    // painted with a level's row background matches exactly what
+    // the eye sees on the corresponding table row -- a mini-map
+    // of the file's severity pattern.
+    //
+    // `ThemeControl::BackgroundFor` reads from `BuildStyleCache`,
+    // which resolves per-level styles through
+    // `StyleForLevel(theme, level, mHighContrast)` -- so this
+    // call automatically picks up the theme's
+    // `levelsHighContrast` block when the user has the
+    // Preferences "high contrast levels" checkbox on. No extra
+    // wiring is needed here; toggling the setting rebuilds the
+    // cache and repaints the rail with the loud variants.
+    //
+    // Themes intentionally leave some levels unstyled (built-in
+    // Dark / Light leave `Info` blank so Info rows read as
+    // ordinary chrome). For those, fall back to
+    // `QPalette::PlaceholderText` composited at
+    // `LEVEL_FALLBACK_ALPHA` -- a dim theme-driven grey that
+    // keeps the rail readable without overwhelming it when the
+    // unstyled level dominates the bucket totals.
     if (theme != nullptr)
     {
         const QBrush brush = theme->BackgroundFor(level);
@@ -112,36 +169,76 @@ QColor ColorForLevelWithFallback(const ThemeControl *theme, loglib::LogLevel lev
             return brush.color();
         }
     }
-    // Fallback: use palette Highlight for higher severities,
-    // Mid for lower. Consistent with the "no-theme test fixture"
-    // path used by `HistogramWidget`.
-    switch (level)
-    {
-    case loglib::LogLevel::Fatal:
-    case loglib::LogLevel::Error:
-    case loglib::LogLevel::Warn:
-        return palette.color(QPalette::Highlight);
-    case loglib::LogLevel::Info:
-    case loglib::LogLevel::Debug:
-    case loglib::LogLevel::Trace:
-        return palette.color(QPalette::Mid);
-    case loglib::LogLevel::Unknown:
-    default:
-        return palette.color(QPalette::Midlight);
-    }
+    QColor c = palette.color(QPalette::PlaceholderText);
+    c.setAlpha(LEVEL_FALLBACK_ALPHA);
+    return c;
 }
 
 QColor ColorForAnchorSlot(const ThemeControl *theme, std::uint8_t colorIndex, const QPalette &palette)
 {
+    // Anchor colours come from the theme's per-slot anchor
+    // palette (`theme.anchorPalette` in each JSON, resolved by
+    // `ThemeControl::AnchorBrushFor`). The API accepts either
+    // `Qt::BackgroundRole` (slot fill) or `Qt::ForegroundRole`
+    // (contrast text); every other caller in the app --
+    // `log_model.cpp` (row rendering), `histogram_widget.cpp`,
+    // `anchors_dock.cpp`, and `main_window.cpp` -- passes
+    // `Qt::BackgroundRole` to get the anchor's fill colour, and
+    // the rail must do the same or `AnchorBrushFor` returns an
+    // invalid brush and every anchor collapses to the fallback
+    // `QPalette::Highlight` regardless of slot. Bug repro:
+    // set three anchors on different palette slots and observe
+    // the rail paint them all in the same accent colour.
     if (theme != nullptr)
     {
-        const QBrush brush = theme->AnchorBrushFor(colorIndex, static_cast<int>(QPalette::Highlight));
+        const QBrush brush = theme->AnchorBrushFor(colorIndex, static_cast<int>(Qt::BackgroundRole));
         if (brush.style() != Qt::NoBrush)
         {
             return brush.color();
         }
     }
     return palette.color(QPalette::Highlight);
+}
+
+/// Log-scaled intensity in [0, 1] for a bucket with @p count
+/// rows against a rail-wide max of @p maxCount. Uses
+/// `log2(count + 1) / log2(maxCount + 1)` so a 1-row bucket
+/// still returns a positive intensity (no `log2(0)` trap) and a
+/// max-count bucket saturates to 1.0. The log compresses the
+/// dynamic range so small bins stay visible next to hot spots
+/// on power-law distributions -- a bucket with 10 rows against
+/// a max of 10k still gets ~30 % of the level column instead of
+/// the ~0.1 % a linear map would give it. Log base is irrelevant
+/// to the shape; `log2` chosen for readability. Returns 0 for
+/// an empty bucket, and clamps to `[0, 1]` for defence.
+[[nodiscard]] double IntensityForCount(std::uint32_t count, std::uint32_t maxCount) noexcept
+{
+    if (count == 0 || maxCount == 0)
+    {
+        return 0.0;
+    }
+    const double num = std::log2(static_cast<double>(count) + 1.0);
+    const double den = std::log2(static_cast<double>(maxCount) + 1.0);
+    if (den <= 0.0)
+    {
+        return 0.0;
+    }
+    return std::clamp(num / den, 0.0, 1.0);
+}
+
+/// Single content rect: the horizontal slot the paint passes
+/// draw into. Reflects the widget's move from a three-column
+/// layout (level / match / anchor side-by-side) to a single
+/// full-width bin section that match and anchor ticks *overlay*
+/// on top of. Returned with a zero Y span; each bucket's paint
+/// pass fills its own Y slice.
+[[nodiscard]] QRect ComputeContentRect(int underlayLeft, int underlayWidth) noexcept
+{
+    if (underlayWidth <= 0)
+    {
+        return QRect(underlayLeft, 0, 0, 0);
+    }
+    return QRect(underlayLeft, 0, underlayWidth, 0);
 }
 
 } // namespace
@@ -151,12 +248,27 @@ OverviewRailWidget::OverviewRailWidget(
 )
     : QWidget(parent), mModel(model), mTheme(theme), mTableView(tableView)
 {
-    setAttribute(Qt::WA_OpaquePaintEvent, false);
+    // Opaque `QPalette::Base` background -- the same role the
+    // viewport and the histogram widget paint their content on.
+    // On Dark Fusion (Base #232629 vs Window #31363B) this makes
+    // the rail read as a *narrow extension of the table's data
+    // area*, not as chrome next to the scrollbar. The practical
+    // win is contrast: the per-level colours the theme returns
+    // via `ColorForLevel` are tuned for legibility on Base
+    // (that's where the row backgrounds live), so Info-heavy
+    // buckets paint a visible blue instead of a Window-blended
+    // ghost. `WA_OpaquePaintEvent` tells Qt we cover every
+    // pixel opaquely so it can skip the auto-fill call before
+    // our paintEvent -- combined with the explicit background
+    // fill at the top of paintEvent this keeps scroll-drag
+    // repaints artefact-free.
+    setAttribute(Qt::WA_OpaquePaintEvent, true);
     setFocusPolicy(Qt::NoFocus);
     setMouseTracking(false);
     setCursor(Qt::ArrowCursor);
     setSizePolicy(QSizePolicy::Fixed, QSizePolicy::Expanding);
-    setAutoFillBackground(false);
+    setAutoFillBackground(true);
+    setBackgroundRole(QPalette::Base);
 
     if (mModel != nullptr)
     {
@@ -177,21 +289,30 @@ OverviewRailWidget::OverviewRailWidget(
 
 QSize OverviewRailWidget::sizeHint() const
 {
-    // DPI-fluent width: anchor to the platform scrollbar extent
-    // so the rail scales with the same metric users already
-    // recognise. Add a small padding so the rail doesn't look
-    // like a duplicate scrollbar when the two sit next to each
-    // other. Fall back to the font's `M` advance when the style
-    // returns a degenerate 0 (offscreen QPA in tests). Clamp
-    // into `[RAIL_MIN_WIDTH_PX, RAIL_MAX_WIDTH_PX]` so a themed
-    // style with a giant scrollbar extent doesn't inflate the
-    // rail past the point where extra pixels stop conveying
-    // information.
+    // DPI-fluent width: anchor to twice the platform scrollbar
+    // extent so the rail scales with the same DPI metric users
+    // already recognise, but stays wide enough that the three
+    // internal columns (level / match / anchor) each get several
+    // clearly visible pixels. Fall back to the font's `M` advance
+    // when the style returns a degenerate 0 (offscreen QPA in
+    // tests). Clamp into `[RAIL_MIN_WIDTH_PX, RAIL_MAX_WIDTH_PX]`
+    // so a themed style with a giant scrollbar extent doesn't
+    // inflate the rail past the point where extra pixels stop
+    // conveying information, and a tiny extent (accessibility
+    // narrow-scrollbar setups) can't collapse the level column
+    // to a single-pixel streak.
+    //
+    // The 2x factor was tuned against the "invisible bars"
+    // report on Windows 11: a raw scrollbar extent of 17 px
+    // collapsed the level column to ~10 px, which reads as a
+    // hair-thin line at typical viewing distance. Doubling puts
+    // the level column at ~19 px -- comfortably readable per
+    // level colour.
     const QStyle *s = style();
     const int scrollbarExtent = (s != nullptr) ? s->pixelMetric(QStyle::PM_ScrollBarExtent, nullptr, this) : 0;
     const int fontExtent = fontMetrics().horizontalAdvance(QLatin1Char('M'));
-    const int raw = std::max({scrollbarExtent, fontExtent, RAIL_MIN_WIDTH_PX}) + RAIL_WIDTH_PADDING;
-    const int extent = std::min(raw, RAIL_MAX_WIDTH_PX);
+    const int raw = std::max({2 * scrollbarExtent, 2 * fontExtent, RAIL_MIN_WIDTH_PX}) + RAIL_WIDTH_PADDING;
+    const int extent = std::clamp(raw, RAIL_MIN_WIDTH_PX, RAIL_MAX_WIDTH_PX);
     // Cache so `RailWidthForTest` (and any future non-const
     // helper that wants the last DPI-fluent width) doesn't have
     // to re-run the platform-metric query.
@@ -256,6 +377,26 @@ int OverviewRailWidget::YForBucketForTest(std::size_t bucket) const
     return y;
 }
 
+int OverviewRailWidget::WidthForCountForTest(std::uint32_t count, std::uint32_t maxCount, int columnWidth)
+{
+    // Mirrors the paint pass: clamp column width to non-negative,
+    // scale by the log-based intensity, then clamp into
+    // `[MIN_BAR_WIDTH_PX, columnWidth]`. An empty bucket returns
+    // zero so tests can distinguish "no bar" from "min-width bar".
+    if (columnWidth <= 0 || count == 0 || maxCount == 0)
+    {
+        return 0;
+    }
+    const double intensity = IntensityForCount(count, maxCount);
+    int barWidth = static_cast<int>(std::round(intensity * static_cast<double>(columnWidth)));
+    return std::clamp(barWidth, MIN_BAR_WIDTH_PX, columnWidth);
+}
+
+QRect OverviewRailWidget::ContentRectForTest(int underlayLeft, int underlayWidth)
+{
+    return ComputeContentRect(underlayLeft, underlayWidth);
+}
+
 void OverviewRailWidget::paintEvent(QPaintEvent * /*event*/)
 {
     QPainter painter(this);
@@ -264,14 +405,31 @@ void OverviewRailWidget::paintEvent(QPaintEvent * /*event*/)
     const QPalette pal = palette();
     const QRect widgetRect = rect();
 
-    // Wash background: base tinted a hair toward Window so the
-    // rail reads as an edge frame. Painted edge-to-edge; the
-    // interactive rail rect insets from this by
-    // `RAIL_VERTICAL_INSET` for tick / indicator geometry.
-    QColor washColor = pal.color(QPalette::Window);
-    washColor.setAlpha(WASH_ALPHA);
+    // Fully repaint the widget's background on every paint pass.
+    // Qt::WA_OpaquePaintEvent (set in the ctor) tells Qt we cover
+    // every pixel, which *disables* `autoFillBackground` -- so
+    // without this explicit fill the previous paint's content
+    // would leak through (visible as smearing / trails when the
+    // user drags the scrollbar and successive paints don't fully
+    // overwrite the old level bar / viewport indicator paint).
+    // Using `QPalette::Base` matches the viewport's / histogram's
+    // background tone so the level bar colours (which are tuned
+    // for legibility on Base) show at the expected contrast.
     painter.fillRect(widgetRect, pal.color(QPalette::Base));
-    painter.fillRect(widgetRect, washColor);
+
+    // Draw a 1 px `QPalette::Dark` separator at the left edge
+    // so the rail's boundary against the viewport is crisp
+    // regardless of how close Window and Base ended up under
+    // the user's palette. Kept as a painter line rather than
+    // a stylesheet border so it survives style overrides that
+    // strip the widget's frame (Windows 11 Fusion, some
+    // accessibility themes).
+    if (widgetRect.width() > 0)
+    {
+        QColor sepColor = pal.color(QPalette::Dark);
+        sepColor.setAlpha(SEPARATOR_ALPHA);
+        painter.fillRect(QRect(widgetRect.left(), widgetRect.top(), 1, widgetRect.height()), sepColor);
+    }
 
     if (mModel == nullptr || mModel->BucketCount() == 0)
     {
@@ -297,12 +455,22 @@ void OverviewRailWidget::paintEvent(QPaintEvent * /*event*/)
     const int underlayWidth = std::max(1, rail.width() - (2 * RAIL_UNDERLAY_INSET));
     const QColor highlightColor = pal.color(QPalette::Highlight);
 
+    // Single content slot: the whole underlay. Match and anchor
+    // ticks *overlay* the level bins in the same slot (previously
+    // each channel got its own sub-column, which fractured a
+    // small rail into three near-invisible strips). Paint order
+    // guarantees anchors > matches > bins so a bucket that
+    // carries all three still surfaces the user-set anchor.
+    const QRect content = ComputeContentRect(underlayLeft, underlayWidth);
+    const int contentLeft = content.left();
+    const int contentWidth = content.width();
+
     // Precompute the Y coordinate of every bucket edge once.
-    // Each of the three paint passes below picks the top from
+    // Each of the paint passes below picks the top from
     // `yEdges[i]` and the bottom from `yEdges[i+1]` -- avoids
-    // recomputing the same integer division three times per
-    // bucket on tall rails and keeps the seam-rounding
-    // ("bottom == next bucket's top") consistent across passes.
+    // recomputing the same integer division per bucket on tall
+    // rails and keeps the seam-rounding ("bottom == next
+    // bucket's top") consistent across passes.
     std::vector<int> yEdges(nBuckets + 1);
     for (std::size_t i = 0; i <= nBuckets; ++i)
     {
@@ -310,33 +478,255 @@ void OverviewRailWidget::paintEvent(QPaintEvent * /*event*/)
     }
     yEdges.back() = railTop + railHeight;
 
-    // Pass 1: dominant-level underlay per non-empty bucket.
-    // One pixel row per bucket by construction (buckets sized to
-    // rail height via `SetBucketCount`). Skip the expensive
-    // level lookup when the bucket is empty.
-    for (std::size_t i = 0; i < nBuckets; ++i)
+    // Rail-wide max bucket total. Drives the log-scaled bar
+    // width in Pass 1 so density is expressed as bar length
+    // relative to the busiest bucket. Computed in one linear
+    // walk over `buckets` (nBuckets = railHeight ~= 600, so
+    // trivial); recomputed on every paint because the model
+    // has no rail-wide max cache and the alternative (subscribe
+    // to a "maxChanged" signal) buys us microseconds we don't
+    // need.
+    std::uint32_t maxCount = 0;
+    std::size_t nonEmptyBuckets = 0;
+    for (const auto &bucket : buckets)
     {
-        const auto &bucket = buckets[i];
-        if (bucket.levels.Total() == 0)
+        const std::uint32_t total = bucket.levels.Total();
+        maxCount = std::max(maxCount, total);
+        if (total > 0)
         {
-            continue;
+            ++nonEmptyBuckets;
         }
-        const int y = yEdges[i];
-        const int height = std::max(1, yEdges[i + 1] - y);
-
-        const loglib::LogLevel dominant = mModel->DominantLevel(i);
-        QColor color = ColorForLevelWithFallback(mTheme, dominant, pal);
-        color.setAlpha(LEVEL_UNDERLAY_ALPHA);
-        painter.fillRect(QRect(underlayLeft, y, underlayWidth, height), color);
     }
 
-    // Pass 2: match ticks. Painted as a narrower band centred
-    // on the rail so it reads as an accent stripe separate
-    // from the level underlay.
-    if (mModel->HasMatchTicks())
+    // Gated diagnostic: with `LOGAPP_RAIL_TRACE=1` in the
+    // environment (paired with `QT_FORCE_STDERR_LOGGING=1` on
+    // Windows so the GUI subsystem output routes to stderr),
+    // log the rail's paint state to `qInfo`. Rate-limited to
+    // once per second so drag-repaint bursts don't flood the
+    // console. This is scaffolding for future "invisible bars"
+    // regressions -- see run_diag.ps1 for the end-to-end reproducer
+    // (launch the app, capture the window via PrintWindow, parse
+    // pixels for expected colours).
+    static const bool RAIL_TRACE_ENABLED = qEnvironmentVariableIntValue("LOGAPP_RAIL_TRACE") != 0;
+    // 1 Hz throttle window: fast enough to see live buckets fill in
+    // during streaming, slow enough that drag-repaint bursts don't
+    // flood the console with duplicate lines.
+    constexpr int RAIL_TRACE_THROTTLE_MS = 1000;
+    if (RAIL_TRACE_ENABLED)
     {
-        const int tickWidth = std::max(2, static_cast<int>(underlayWidth * MATCH_TICK_WIDTH_FRACTION));
-        const int tickLeft = underlayLeft + ((underlayWidth - tickWidth) / 2);
+        static QElapsedTimer traceGate;
+        if (!traceGate.isValid() || traceGate.hasExpired(RAIL_TRACE_THROTTLE_MS))
+        {
+            traceGate.restart();
+            loglib::LogLevel firstDominant = loglib::LogLevel::Unknown;
+            std::uint32_t firstBucketTotal = 0;
+            QColor firstBarColor = pal.color(QPalette::Base);
+            for (std::size_t i = 0; i < nBuckets; ++i)
+            {
+                if (buckets[i].levels.Total() > 0)
+                {
+                    firstBucketTotal = buckets[i].levels.Total();
+                    firstDominant = mModel->DominantLevel(i);
+                    firstBarColor = ColorForLevel(mTheme, firstDominant, pal);
+                    break;
+                }
+            }
+            const int proxyRows = mModel->ProxyRowCount();
+            const int levelColIdx = mModel->LevelColumnIndexForTest();
+            qInfo().noquote() << QStringLiteral(
+                                     "[rail-trace] widget=%1x%2 rail=%3x%4 content=%5 buckets=%6 non-empty=%7 "
+                                     "maxCount=%8 base=%9 firstBucket total=%10 dom=%11 color=%12 proxyRows=%13 "
+                                     "levelColIdx=%14")
+                                     .arg(widgetRect.width())
+                                     .arg(widgetRect.height())
+                                     .arg(rail.width())
+                                     .arg(rail.height())
+                                     .arg(contentWidth)
+                                     .arg(nBuckets)
+                                     .arg(nonEmptyBuckets)
+                                     .arg(maxCount)
+                                     .arg(pal.color(QPalette::Base).name())
+                                     .arg(firstBucketTotal)
+                                     .arg(static_cast<int>(firstDominant))
+                                     .arg(firstBarColor.name())
+                                     .arg(proxyRows)
+                                     .arg(levelColIdx);
+        }
+    }
+
+    // Pass 1 (base layer): one bin bar per non-empty bucket,
+    // split into a stack of severity segments (Fatal / Error /
+    // Warn / Info / Debug / Trace / Unknown left-to-right in
+    // severity-descending order). Bar *width* encodes total row
+    // density (log-scaled -- small bins still show a visible
+    // tick, hot spots saturate to the full content width); each
+    // segment's width inside the bar is proportional to that
+    // level's share of the bucket.
+    //
+    // Every non-zero level gets `MIN_SEGMENT_WIDTH_PX` (1 px) so
+    // a rare Fatal in a 500-Trace bucket still lights up a
+    // pixel. This was previously the source of a "left-edge
+    // bright stripe" regression when the paint used row
+    // *foreground* colours (Warn `#FCD34D`, Fatal `#FECACA`,
+    // ...) -- one bright pixel per bucket became a continuous
+    // vertical light band on real logs. `ColorForLevel` now
+    // resolves to the row *background* wash instead, which is a
+    // subtle severity tint on Base, so even every-bucket
+    // segments composite to a soft mini-map rather than a
+    // stripe. `BackgroundFor` also respects
+    // `mHighContrast` automatically (via `BuildStyleCache`), so
+    // toggling the Preferences "high contrast levels" checkbox
+    // recolours the rail with the loud
+    // `levelsHighContrast` variants without any extra plumbing.
+    //
+    // Match ticks (Pass 2) and anchor ticks (Pass 3) later
+    // *overlay* this base layer for buckets that carry them, so
+    // the "you have a match here" / "you have an anchor here"
+    // signal wins for hit-testing purposes even though the base
+    // layer painted the same slot first.
+    //
+    // Kept as a hard-coded severity-descending list (rather than
+    // reaching into the model's `LEVEL_SEVERITY_RANK`) so the
+    // widget's paint pass has no cross-file coupling. If the
+    // canonical level list ever grows the initialiser has to
+    // grow alongside `LEVEL_SEVERITY_RANK` in the model or the
+    // paint pass will silently miss the new level.
+    constexpr std::size_t SEVERITY_LEVEL_COUNT = loglib::CANONICAL_LEVEL_COUNT + 1;
+    constexpr std::array<loglib::LogLevel, SEVERITY_LEVEL_COUNT> SEVERITY_DESCENDING{
+        loglib::LogLevel::Fatal,
+        loglib::LogLevel::Error,
+        loglib::LogLevel::Warn,
+        loglib::LogLevel::Info,
+        loglib::LogLevel::Debug,
+        loglib::LogLevel::Trace,
+        loglib::LogLevel::Unknown,
+    };
+    if (contentWidth > 0)
+    {
+        for (std::size_t i = 0; i < nBuckets; ++i)
+        {
+            const auto &bucket = buckets[i];
+            const std::uint32_t count = bucket.levels.Total();
+            if (count == 0)
+            {
+                continue;
+            }
+            const int y = yEdges[i];
+            const int height = std::max(1, yEdges[i + 1] - y);
+
+            const double intensity = IntensityForCount(count, maxCount);
+            int barWidth = static_cast<int>(std::round(intensity * static_cast<double>(contentWidth)));
+            barWidth = std::clamp(barWidth, MIN_BAR_WIDTH_PX, contentWidth);
+
+            // Two-pass segment sizing:
+            //   1) assign every non-zero level a
+            //      `MIN_SEGMENT_WIDTH_PX` floor and total the
+            //      reserved pixels;
+            //   2) distribute the remaining `barWidth -
+            //      reserved` proportionally to each level's
+            //      *log-weighted* share of the bucket.
+            //
+            // Weights use `log2(count + 1)` (the same
+            // transform `IntensityForCount` applies to the
+            // bar's total density). Linear proportions
+            // effectively hide rare severities: a bucket of
+            // 500 Trace + 1 Fatal gives Fatal 1/501 = 0.2 % of
+            // the bar, floored to a single pixel that reads
+            // as noise on a Trace-dominated rail. Log-weighted
+            // shares raise that Fatal slice to
+            // log2(2) / (log2(501) + log2(2)) ~= 7 %, which is
+            // a visibly readable band without letting the
+            // majority level lose its "this is the dominant
+            // one" cue. Both scales point in the same
+            // direction (bigger count -> bigger slice), just
+            // with a compressed dynamic range that matches
+            // human contrast sensitivity better.
+            std::array<int, SEVERITY_LEVEL_COUNT> segWidths{};
+            std::array<double, SEVERITY_LEVEL_COUNT> segWeights{};
+            double totalWeight = 0.0;
+            int reserved = 0;
+            for (std::size_t s = 0; s < SEVERITY_DESCENDING.size(); ++s)
+            {
+                const std::size_t levelIdx = static_cast<std::size_t>(SEVERITY_DESCENDING[s]);
+                const std::uint32_t levelCount = bucket.levels.counts[levelIdx];
+                if (levelCount > 0)
+                {
+                    segWidths[s] = MIN_SEGMENT_WIDTH_PX;
+                    reserved += MIN_SEGMENT_WIDTH_PX;
+                    segWeights[s] = std::log2(static_cast<double>(levelCount) + 1.0);
+                    totalWeight += segWeights[s];
+                }
+            }
+            const int extra = std::max(0, barWidth - reserved);
+            if (extra > 0 && totalWeight > 0.0)
+            {
+                for (std::size_t s = 0; s < SEVERITY_DESCENDING.size(); ++s)
+                {
+                    if (segWeights[s] <= 0.0)
+                    {
+                        continue;
+                    }
+                    const int share =
+                        static_cast<int>((segWeights[s] / totalWeight) * static_cast<double>(extra));
+                    segWidths[s] += share;
+                }
+                // Rounding leftovers: hand them to the level
+                // that carries the largest weight (the
+                // majority in log space), so the bar's right
+                // edge lands on `barWidth` exactly and the
+                // dominant severity gets the visual tie-break.
+                int allocated = 0;
+                for (int w : segWidths)
+                {
+                    allocated += w;
+                }
+                if (allocated < barWidth)
+                {
+                    std::size_t heaviest = 0;
+                    double heaviestWeight = 0.0;
+                    for (std::size_t s = 0; s < SEVERITY_DESCENDING.size(); ++s)
+                    {
+                        if (segWeights[s] > heaviestWeight)
+                        {
+                            heaviestWeight = segWeights[s];
+                            heaviest = s;
+                        }
+                    }
+                    if (heaviestWeight > 0.0)
+                    {
+                        segWidths[heaviest] += (barWidth - allocated);
+                    }
+                }
+            }
+
+            int xCursor = contentLeft;
+            for (std::size_t s = 0; s < SEVERITY_DESCENDING.size(); ++s)
+            {
+                if (segWidths[s] == 0)
+                {
+                    continue;
+                }
+                const int w = std::min(segWidths[s], barWidth - (xCursor - contentLeft));
+                if (w <= 0)
+                {
+                    break;
+                }
+                const QColor color = ColorForLevel(mTheme, SEVERITY_DESCENDING[s], pal);
+                painter.fillRect(QRect(xCursor, y, w, height), color);
+                xCursor += w;
+            }
+        }
+    }
+
+    // Pass 2 (overlay): match ticks. Repaint the *entire content
+    // width* for every bucket that carries at least one match
+    // row so the "there is a match here" signal is a solid,
+    // high-contrast Highlight-colour bar that unambiguously
+    // wins over the base-layer bin painting. Full-width instead
+    // of an accent column so a search hit in an otherwise-quiet
+    // bucket still catches the eye at a glance.
+    if (mModel->HasMatchTicks() && contentWidth > 0)
+    {
         for (std::size_t i = 0; i < nBuckets; ++i)
         {
             if (buckets[i].matchCount == 0)
@@ -345,17 +735,19 @@ void OverviewRailWidget::paintEvent(QPaintEvent * /*event*/)
             }
             const int y = yEdges[i];
             const int height = std::max(1, yEdges[i + 1] - y);
-            painter.fillRect(QRect(tickLeft, y, tickWidth, height), highlightColor);
+            painter.fillRect(QRect(contentLeft, y, contentWidth, height), highlightColor);
         }
     }
 
-    // Pass 3: anchor ticks. One filled sub-band per set slot,
-    // aligned to the *right* edge so anchors and matches sit
-    // side-by-side and don't overlay each other.
-    if (mModel->HasAnchorTicks())
+    // Pass 3 (overlay): anchor ticks. Repaint the *entire content
+    // width* for every bucket that carries at least one anchor
+    // row. Painted after matches so a bucket that is both an
+    // anchor and a search hit reads as an anchor -- user-set
+    // markers outrank live search state. Anchor colour comes
+    // from `ThemeControl::AnchorBrushFor` (theme's
+    // `anchorPalette`).
+    if (mModel->HasAnchorTicks() && contentWidth > 0)
     {
-        const int anchorBandWidth = std::max(2, underlayWidth / 3);
-        const int anchorBandLeft = underlayLeft + underlayWidth - anchorBandWidth;
         for (std::size_t i = 0; i < nBuckets; ++i)
         {
             const auto &mask = buckets[i].anchorSlots;
@@ -373,7 +765,7 @@ void OverviewRailWidget::paintEvent(QPaintEvent * /*event*/)
                 if (mask.test(s))
                 {
                     const QColor c = ColorForAnchorSlot(mTheme, static_cast<std::uint8_t>(s), pal);
-                    painter.fillRect(QRect(anchorBandLeft, y, anchorBandWidth, height), c);
+                    painter.fillRect(QRect(contentLeft, y, contentWidth, height), c);
                     break;
                 }
             }
@@ -404,6 +796,7 @@ void OverviewRailWidget::paintEvent(QPaintEvent * /*event*/)
         painter.drawRoundedRect(rounded, INDICATOR_CORNER_RADIUS, INDICATOR_CORNER_RADIUS);
         painter.restore();
     }
+
 }
 
 void OverviewRailWidget::mousePressEvent(QMouseEvent *event)
@@ -540,6 +933,22 @@ void OverviewRailWidget::changeEvent(QEvent *event)
 
 QRect OverviewRailWidget::InteractiveRailRect() const
 {
+    // The rail is a whole-file overview: rail top = first row,
+    // rail bottom = last row, bars fill the entire widget
+    // height. Following klogg / glogg / VS Code minimap, the
+    // vertical position within the rail is a linear projection
+    // of the file's row index -- *not* of the viewport's Y
+    // range. That means the bar for row 0 sits at the top edge
+    // of the rail widget (level with the header's top edge),
+    // and the currently visible viewport is drawn as a movable
+    // highlight box (`ComputeViewportIndicatorRect`) *inside*
+    // the rail.
+    //
+    // Restricting the rail to the viewport-Y strip only was
+    // tried; users read that as "the rail is broken -- half of
+    // it is empty chrome". A whole-widget projection gives the
+    // full file overview at a glance and reserves the "where am
+    // I" answer to the highlight box.
     QRect r = rect();
     r.adjust(0, RAIL_VERTICAL_INSET, 0, -RAIL_VERTICAL_INSET);
     return r;
@@ -601,11 +1010,23 @@ QRect OverviewRailWidget::ComputeViewportIndicatorRect() const
                            static_cast<long long>(totalRows);
     const long long yBottom = (static_cast<long long>(bottomRow + 1) * static_cast<long long>(railHeight)) /
                               static_cast<long long>(totalRows);
-    int indicatorTop = rail.top() + static_cast<int>(yTop);
-    int indicatorHeight = static_cast<int>(yBottom - yTop);
-    indicatorHeight = std::max(indicatorHeight, INDICATOR_MIN_HEIGHT_PX);
-    // Clamp to the rail so the min-height boost doesn't push
-    // the indicator past the bottom insets.
+    const int naturalHeight = static_cast<int>(yBottom - yTop);
+    int indicatorHeight = std::max(naturalHeight, INDICATOR_MIN_HEIGHT_PX);
+    // When the natural viewport-Y span is shorter than the
+    // `INDICATOR_MIN_HEIGHT_PX` floor (the common case for tall
+    // logs -- a 50 k-row session with 20 visible rows maps to
+    // sub-pixel on the rail), expand around the *centre* of the
+    // visible range instead of pinning to the top. Otherwise a
+    // row selected in the middle of the viewport would appear
+    // at the top edge of the min-height-inflated indicator on
+    // the rail, misaligned with where the user sees the row in
+    // the table (regression report: "the anchor is showed in
+    // the middle of the tableview but the rail marks it at the
+    // top of the current-view preview").
+    const long long yCenter = (yTop + yBottom) / 2;
+    int indicatorTop = rail.top() + static_cast<int>(yCenter) - (indicatorHeight / 2);
+    // Clamp to the rail so the centering + min-height boost
+    // don't push the indicator past either inset.
     if (indicatorTop + indicatorHeight > rail.bottom() + 1)
     {
         indicatorTop = rail.bottom() + 1 - indicatorHeight;

--- a/app/src/overview_rail_widget.cpp
+++ b/app/src/overview_rail_widget.cpp
@@ -21,6 +21,7 @@
 #include <QRect>
 #include <QResizeEvent>
 #include <QScrollBar>
+#include <QShowEvent>
 #include <QSize>
 #include <QStyle>
 #include <QStyleOptionViewItem>
@@ -85,6 +86,15 @@ constexpr int INDICATOR_MIN_HEIGHT_PX = 12;
 /// Minimum rail width in device-independent px. Guarantees a
 /// hittable target at very small font sizes.
 constexpr int RAIL_MIN_WIDTH_PX = 10;
+
+/// Maximum rail width in device-independent px. Some styles
+/// (accessibility themes on Windows, GTK "chunky-scrollbar"
+/// setups) advertise very large `PM_ScrollBarExtent` values —
+/// mirroring them 1:1 would cover a large fraction of the
+/// viewport with a nearly-empty rail. The cap keeps the rail
+/// at klogg-parity density; ticks + indicator remain crisp
+/// above this width so raising it further wastes pixels.
+constexpr int RAIL_MAX_WIDTH_PX = 22;
 
 /// Extra width added to the DPI-fluent metric. Nudges the
 /// rail slightly wider than the scrollbar so it doesn't merge
@@ -171,11 +181,16 @@ QSize OverviewRailWidget::sizeHint() const
     // recognise. Add a small padding so the rail doesn't look
     // like a duplicate scrollbar when the two sit next to each
     // other. Fall back to the font's `M` advance when the style
-    // returns a degenerate 0 (offscreen QPA in tests).
+    // returns a degenerate 0 (offscreen QPA in tests). Clamp
+    // into `[RAIL_MIN_WIDTH_PX, RAIL_MAX_WIDTH_PX]` so a themed
+    // style with a giant scrollbar extent doesn't inflate the
+    // rail past the point where extra pixels stop conveying
+    // information.
     const QStyle *s = style();
     const int scrollbarExtent = (s != nullptr) ? s->pixelMetric(QStyle::PM_ScrollBarExtent, nullptr, this) : 0;
     const int fontExtent = fontMetrics().horizontalAdvance(QLatin1Char('M'));
-    const int extent = std::max({scrollbarExtent, fontExtent, RAIL_MIN_WIDTH_PX}) + RAIL_WIDTH_PADDING;
+    const int raw = std::max({scrollbarExtent, fontExtent, RAIL_MIN_WIDTH_PX}) + RAIL_WIDTH_PADDING;
+    const int extent = std::min(raw, RAIL_MAX_WIDTH_PX);
     return {extent, 0};
 }
 
@@ -390,7 +405,11 @@ void OverviewRailWidget::mousePressEvent(QMouseEvent *event)
     }
     mDragging = true;
     mLastEmittedRow = INT_MIN;
-    EmitProxyRowForY(static_cast<int>(event->position().y()));
+    // A fresh click commits the user to that row: the downstream
+    // handler is allowed to replace the current selection with
+    // just this row (matches the "click to jump" idiom used by
+    // the histogram tick strip and the anchors dock).
+    EmitProxyRowForY(static_cast<int>(event->position().y()), /*replaceSelection=*/true);
     event->accept();
 }
 
@@ -401,7 +420,10 @@ void OverviewRailWidget::mouseMoveEvent(QMouseEvent *event)
         QWidget::mouseMoveEvent(event);
         return;
     }
-    EmitProxyRowForY(static_cast<int>(event->position().y()));
+    // Scrubbing: the user is exploring, not committing. Ask the
+    // handler to scroll without touching the selection so a
+    // carefully-built multi-row selection survives a rail scrub.
+    EmitProxyRowForY(static_cast<int>(event->position().y()), /*replaceSelection=*/false);
     event->accept();
 }
 
@@ -451,12 +473,28 @@ void OverviewRailWidget::resizeEvent(QResizeEvent *event)
     SyncBucketCountToHeight();
 }
 
+void OverviewRailWidget::showEvent(QShowEvent *event)
+{
+    QWidget::showEvent(event);
+    // Re-arm the model after a hide-toggle dropped its bucket
+    // vector. Idempotent when the height matches — `SetBucketCount`
+    // is a no-op on a matching count.
+    SyncBucketCountToHeight();
+}
+
 void OverviewRailWidget::changeEvent(QEvent *event)
 {
     QWidget::changeEvent(event);
     // Style / palette / font change may shift the DPI-fluent
     // width and the wash colour. Force a fresh sizeHint so the
     // hosting `LogTableView` reserves the right margin.
+    // `ScreenChangeInternal` is a private Qt enum today; we
+    // rely on it as the most reliable cross-version proxy for a
+    // DPR change (Qt 6.6+ ships public `DevicePixelRatioChange`,
+    // but the project targets Qt 6.1+). Both events go through
+    // this switch so the newer one is picked up for free once we
+    // raise the floor. See LogTableView::changeEvent for the
+    // matching comment.
     switch (event->type())
     {
     case QEvent::StyleChange:
@@ -552,7 +590,7 @@ void OverviewRailWidget::SyncBucketCountToHeight()
     mModel->SetBucketCount(static_cast<std::size_t>(height));
 }
 
-void OverviewRailWidget::EmitProxyRowForY(int y)
+void OverviewRailWidget::EmitProxyRowForY(int y, bool replaceSelection)
 {
     if (mModel == nullptr)
     {
@@ -570,5 +608,5 @@ void OverviewRailWidget::EmitProxyRowForY(int y)
         return;
     }
     mLastEmittedRow = proxyRow;
-    emit proxyRowClicked(proxyRow);
+    emit proxyRowClicked(proxyRow, replaceSelection);
 }

--- a/app/src/overview_rail_widget.cpp
+++ b/app/src/overview_rail_widget.cpp
@@ -988,10 +988,17 @@ void OverviewRailWidget::wheelEvent(QWheelEvent *event)
     // also set the flag), but attributing explicitly keeps Follow
     // newest disengage correct even if a style / platform path
     // calls `setValue` directly.
-    if (auto *logView = qobject_cast<LogTableView *>(mTableView.data()); logView != nullptr)
+    auto *logView = qobject_cast<LogTableView *>(mTableView.data());
+    if (logView != nullptr)
     {
         logView->AttributeNextScrollToUser();
     }
+    // Snapshot the scrollbar value so we can detect the pinned-
+    // edge case (wheel forwarded but the scrollbar was already at
+    // `minimum()` / `maximum()` in the wheel's direction, so no
+    // `valueChanged` fires and the attribution flag would survive
+    // until the next — possibly programmatic — value change).
+    const int valueBefore = vbar->value();
     const QPointF globalPos = event->globalPosition();
     const QPointF localPos = vbar->mapFromGlobal(globalPos.toPoint());
     QWheelEvent translated(
@@ -1007,6 +1014,15 @@ void OverviewRailWidget::wheelEvent(QWheelEvent *event)
         event->pointingDevice()
     );
     QApplication::sendEvent(vbar, &translated);
+    // Pinned-edge case: value didn't move, so `OnVerticalScrollValue
+    // Changed` never fired and the user-attribution flag we set
+    // above is still true. Clear it so a later programmatic
+    // `setValue` (e.g. anchor-restore on the next batch) isn't
+    // mistakenly reported as a user scroll.
+    if (logView != nullptr && vbar->value() == valueBefore)
+    {
+        logView->ClearNextScrollUserAttribution();
+    }
     // Mark accepted so the parent scroll area doesn't double-
     // process the wheel event.
     event->accept();

--- a/app/src/overview_rail_widget.cpp
+++ b/app/src/overview_rail_widget.cpp
@@ -33,6 +33,7 @@
 #include <bitset>
 #include <climits>
 #include <cstddef>
+#include <vector>
 
 namespace
 {
@@ -191,6 +192,10 @@ QSize OverviewRailWidget::sizeHint() const
     const int fontExtent = fontMetrics().horizontalAdvance(QLatin1Char('M'));
     const int raw = std::max({scrollbarExtent, fontExtent, RAIL_MIN_WIDTH_PX}) + RAIL_WIDTH_PADDING;
     const int extent = std::min(raw, RAIL_MAX_WIDTH_PX);
+    // Cache so `RailWidthForTest` (and any future non-const
+    // helper that wants the last DPI-fluent width) doesn't have
+    // to re-run the platform-metric query.
+    mCachedRailWidth = extent;
     return {extent, 0};
 }
 
@@ -201,7 +206,13 @@ QSize OverviewRailWidget::minimumSizeHint() const
 
 int OverviewRailWidget::RailWidthForTest() const
 {
-    return sizeHint().width();
+    // Warm the cache when a test asks before the first
+    // `sizeHint()` roundtrip, then return the cached value.
+    if (mCachedRailWidth == 0)
+    {
+        (void)sizeHint();
+    }
+    return mCachedRailWidth;
 }
 
 QRect OverviewRailWidget::ViewportIndicatorRectForTest() const
@@ -286,6 +297,19 @@ void OverviewRailWidget::paintEvent(QPaintEvent * /*event*/)
     const int underlayWidth = std::max(1, rail.width() - (2 * RAIL_UNDERLAY_INSET));
     const QColor highlightColor = pal.color(QPalette::Highlight);
 
+    // Precompute the Y coordinate of every bucket edge once.
+    // Each of the three paint passes below picks the top from
+    // `yEdges[i]` and the bottom from `yEdges[i+1]` -- avoids
+    // recomputing the same integer division three times per
+    // bucket on tall rails and keeps the seam-rounding
+    // ("bottom == next bucket's top") consistent across passes.
+    std::vector<int> yEdges(nBuckets + 1);
+    for (std::size_t i = 0; i <= nBuckets; ++i)
+    {
+        yEdges[i] = railTop + static_cast<int>((i * static_cast<std::size_t>(railHeight)) / nBuckets);
+    }
+    yEdges.back() = railTop + railHeight;
+
     // Pass 1: dominant-level underlay per non-empty bucket.
     // One pixel row per bucket by construction (buckets sized to
     // rail height via `SetBucketCount`). Skip the expensive
@@ -297,14 +321,8 @@ void OverviewRailWidget::paintEvent(QPaintEvent * /*event*/)
         {
             continue;
         }
-        const int y = railTop + static_cast<int>((i * static_cast<std::size_t>(railHeight)) / nBuckets);
-        // Height of at least 1 px so the row is always visible.
-        // Rounding via next-bucket-start avoids gaps at the
-        // seams while keeping the layout tight.
-        const int nextY = (i + 1 < nBuckets)
-                              ? railTop + static_cast<int>(((i + 1) * static_cast<std::size_t>(railHeight)) / nBuckets)
-                              : (railTop + railHeight);
-        const int height = std::max(1, nextY - y);
+        const int y = yEdges[i];
+        const int height = std::max(1, yEdges[i + 1] - y);
 
         const loglib::LogLevel dominant = mModel->DominantLevel(i);
         QColor color = ColorForLevelWithFallback(mTheme, dominant, pal);
@@ -325,12 +343,8 @@ void OverviewRailWidget::paintEvent(QPaintEvent * /*event*/)
             {
                 continue;
             }
-            const int y = railTop + static_cast<int>((i * static_cast<std::size_t>(railHeight)) / nBuckets);
-            const int nextY =
-                (i + 1 < nBuckets)
-                    ? railTop + static_cast<int>(((i + 1) * static_cast<std::size_t>(railHeight)) / nBuckets)
-                    : (railTop + railHeight);
-            const int height = std::max(1, nextY - y);
+            const int y = yEdges[i];
+            const int height = std::max(1, yEdges[i + 1] - y);
             painter.fillRect(QRect(tickLeft, y, tickWidth, height), highlightColor);
         }
     }
@@ -349,12 +363,8 @@ void OverviewRailWidget::paintEvent(QPaintEvent * /*event*/)
             {
                 continue;
             }
-            const int y = railTop + static_cast<int>((i * static_cast<std::size_t>(railHeight)) / nBuckets);
-            const int nextY =
-                (i + 1 < nBuckets)
-                    ? railTop + static_cast<int>(((i + 1) * static_cast<std::size_t>(railHeight)) / nBuckets)
-                    : (railTop + railHeight);
-            const int height = std::max(1, nextY - y);
+            const int y = yEdges[i];
+            const int height = std::max(1, yEdges[i + 1] - y);
             // Paint the lowest-index set slot: multiple anchor
             // colours in one bucket collapse to the first-set
             // (deterministic, and rare for a small rail).
@@ -461,6 +471,14 @@ void OverviewRailWidget::wheelEvent(QWheelEvent *event)
         event->ignore();
         return;
     }
+    // TODO: `event->position()` is in this widget's coordinate
+    // system, not the scrollbar's. `QAbstractSlider::wheelEvent`
+    // only reads `angleDelta` today so the mismatch is
+    // invisible, but any style / accessibility layer that
+    // inspects position sees rail-widget coordinates. Consider
+    // translating with `QWheelEvent` cloned at `vbar->mapFromGlobal
+    // (event->globalPosition().toPoint())` once we hit a case
+    // that cares.
     QApplication::sendEvent(vbar, event);
     // Mark accepted so the parent scroll area doesn't double-
     // process the wheel event.
@@ -479,7 +497,17 @@ void OverviewRailWidget::showEvent(QShowEvent *event)
     // Re-arm the model after a hide-toggle dropped its bucket
     // vector. Idempotent when the height matches — `SetBucketCount`
     // is a no-op on a matching count.
-    SyncBucketCountToHeight();
+    //
+    // Skip the call when the widget hasn't been sized yet (first
+    // show, before the hosting `LogTableView::UpdateOverviewRail
+    // Geometry` runs). Calling `SetBucketCount(0)` here would
+    // fire a redundant no-op transition; the follow-up
+    // `resizeEvent` immediately supersedes it with the real
+    // height.
+    if (height() > 0)
+    {
+        SyncBucketCountToHeight();
+    }
 }
 
 void OverviewRailWidget::changeEvent(QEvent *event)
@@ -523,23 +551,33 @@ QRect OverviewRailWidget::ComputeViewportIndicatorRect() const
     {
         return {};
     }
-    const int totalRows = mModel->ProxyRowCount();
-    if (totalRows <= 0)
-    {
-        return {};
-    }
-    const QRect rail = InteractiveRailRect();
-    if (rail.isEmpty())
-    {
-        return {};
-    }
-
     // The visible range is best expressed via `indexAt` on the
     // table (top + bottom of the viewport). `indexAt` already
     // tolerates a null model (returns an invalid index whose
     // `.row()` is `-1`), which the row-resolution branch below
     // treats the same as "empty layout".
     if (mTableView->model() == nullptr)
+    {
+        return {};
+    }
+    // Prefer the *live* row count from the attached table's model
+    // over `mModel->ProxyRowCount()`. The latter is a snapshot
+    // from the last rebuild -- between rebuilds during a heavy
+    // stream it can lag the true count by a batch, and the
+    // indicator would size against the stale value. Fall back to
+    // the cached count when the live query returns 0 (rare, but
+    // guards against a torn read during teardown).
+    int totalRows = mTableView->model()->rowCount();
+    if (totalRows <= 0)
+    {
+        totalRows = mModel->ProxyRowCount();
+    }
+    if (totalRows <= 0)
+    {
+        return {};
+    }
+    const QRect rail = InteractiveRailRect();
+    if (rail.isEmpty())
     {
         return {};
     }

--- a/app/src/overview_rail_widget.cpp
+++ b/app/src/overview_rail_widget.cpp
@@ -1,0 +1,574 @@
+#include "overview_rail_widget.hpp"
+
+#include "overview_rail_model.hpp"
+#include "theme_control.hpp"
+
+#include <loglib/log_level.hpp>
+#include <loglib/theme.hpp>
+
+#include <QAbstractItemView>
+#include <QAbstractProxyModel>
+#include <QApplication>
+#include <QBrush>
+#include <QColor>
+#include <QEvent>
+#include <QFontMetrics>
+#include <QMouseEvent>
+#include <QPaintEvent>
+#include <QPainter>
+#include <QPalette>
+#include <QPen>
+#include <QRect>
+#include <QResizeEvent>
+#include <QScrollBar>
+#include <QSize>
+#include <QStyle>
+#include <QStyleOptionViewItem>
+#include <QWheelEvent>
+#include <QWidget>
+#include <Qt>
+
+#include <algorithm>
+#include <bitset>
+#include <climits>
+#include <cstddef>
+
+namespace
+{
+
+/// Vertical pixel inset on the rail. Keeps tick outlines from
+/// clipping against the widget's top / bottom edges and gives
+/// the wash a visible frame line.
+constexpr int RAIL_VERTICAL_INSET = 2;
+
+/// Horizontal pixel inset for the level-underlay column. The
+/// wash background paints edge-to-edge; the coloured underlay
+/// steps in 1 px so the two reads as concentric bands rather
+/// than a single flat fill.
+constexpr int RAIL_UNDERLAY_INSET = 1;
+
+/// Fractional width of the match tick band inside the rail.
+/// The band paints centred; ~55 % width reads as a clear
+/// vertical marker without dominating the level wash beside
+/// it.
+constexpr double MATCH_TICK_WIDTH_FRACTION = 0.55;
+
+/// Alpha on the level underlay. Muted enough that anchor and
+/// match ticks stay legible when painted over the same bucket.
+constexpr int LEVEL_UNDERLAY_ALPHA = 110;
+
+/// Alpha on the rail wash. Subtle — a hint of separation,
+/// not a slab. Applied over `QPalette::Base` so a Dark theme
+/// dims and a Light theme lifts by the same delta.
+constexpr int WASH_ALPHA = 24;
+
+/// Alpha on the viewport-indicator glass fill. Higher than
+/// the wash so the indicator reads as an overlay marker;
+/// lower than opaque so the wash still shows through.
+constexpr int INDICATOR_FILL_ALPHA = 60;
+
+/// Alpha on the viewport-indicator outline. Solid pen with
+/// palette Highlight so the indicator reads as focused UI
+/// chrome, not a decoration.
+constexpr int INDICATOR_OUTLINE_ALPHA = 200;
+
+/// Corner radius (device-independent px) on the viewport
+/// indicator. Matches the platform's rounded-thumb aesthetic
+/// without pretending to be the actual scrollbar thumb.
+constexpr int INDICATOR_CORNER_RADIUS = 3;
+
+/// Minimum viewport-indicator height. Ensures a very-tall
+/// session still exposes a hittable indicator; without this a
+/// 1 M row session would collapse the indicator to sub-pixel.
+constexpr int INDICATOR_MIN_HEIGHT_PX = 12;
+
+/// Minimum rail width in device-independent px. Guarantees a
+/// hittable target at very small font sizes.
+constexpr int RAIL_MIN_WIDTH_PX = 10;
+
+/// Extra width added to the DPI-fluent metric. Nudges the
+/// rail slightly wider than the scrollbar so it doesn't merge
+/// visually with a scrollbar rendered in the same theme.
+constexpr int RAIL_WIDTH_PADDING = 2;
+
+QColor ColorForLevelWithFallback(const ThemeControl *theme, loglib::LogLevel level, const QPalette &palette)
+{
+    if (theme != nullptr)
+    {
+        const QBrush brush = theme->BackgroundFor(level);
+        if (brush.style() != Qt::NoBrush)
+        {
+            return brush.color();
+        }
+    }
+    // Fallback: use palette Highlight for higher severities,
+    // Mid for lower. Consistent with the "no-theme test fixture"
+    // path used by `HistogramWidget`.
+    switch (level)
+    {
+    case loglib::LogLevel::Fatal:
+    case loglib::LogLevel::Error:
+    case loglib::LogLevel::Warn:
+        return palette.color(QPalette::Highlight);
+    case loglib::LogLevel::Info:
+    case loglib::LogLevel::Debug:
+    case loglib::LogLevel::Trace:
+        return palette.color(QPalette::Mid);
+    case loglib::LogLevel::Unknown:
+    default:
+        return palette.color(QPalette::Midlight);
+    }
+}
+
+QColor ColorForAnchorSlot(const ThemeControl *theme, std::uint8_t colorIndex, const QPalette &palette)
+{
+    if (theme != nullptr)
+    {
+        const QBrush brush = theme->AnchorBrushFor(colorIndex, static_cast<int>(QPalette::Highlight));
+        if (brush.style() != Qt::NoBrush)
+        {
+            return brush.color();
+        }
+    }
+    return palette.color(QPalette::Highlight);
+}
+
+} // namespace
+
+OverviewRailWidget::OverviewRailWidget(
+    OverviewRailModel *model, ThemeControl *theme, QAbstractItemView *tableView, QWidget *parent
+)
+    : QWidget(parent), mModel(model), mTheme(theme), mTableView(tableView), mLastEmittedRow(INT_MIN)
+{
+    setAttribute(Qt::WA_OpaquePaintEvent, false);
+    setFocusPolicy(Qt::NoFocus);
+    setMouseTracking(false);
+    setCursor(Qt::ArrowCursor);
+    setSizePolicy(QSizePolicy::Fixed, QSizePolicy::Expanding);
+    setAutoFillBackground(false);
+
+    if (mModel != nullptr)
+    {
+        connect(mModel, &OverviewRailModel::bucketsChanged, this, qOverload<>(&QWidget::update));
+        connect(mModel, &OverviewRailModel::matchesChanged, this, qOverload<>(&QWidget::update));
+        connect(mModel, &OverviewRailModel::anchorBucketsChanged, this, qOverload<>(&QWidget::update));
+    }
+
+    if (mTableView != nullptr)
+    {
+        if (auto *vbar = mTableView->verticalScrollBar(); vbar != nullptr)
+        {
+            connect(vbar, &QAbstractSlider::valueChanged, this, qOverload<>(&QWidget::update));
+            connect(vbar, &QAbstractSlider::rangeChanged, this, [this](int, int) { update(); });
+        }
+    }
+}
+
+QSize OverviewRailWidget::sizeHint() const
+{
+    // DPI-fluent width: anchor to the platform scrollbar extent
+    // so the rail scales with the same metric users already
+    // recognise. Add a small padding so the rail doesn't look
+    // like a duplicate scrollbar when the two sit next to each
+    // other. Fall back to the font's `M` advance when the style
+    // returns a degenerate 0 (offscreen QPA in tests).
+    const QStyle *s = style();
+    const int scrollbarExtent = (s != nullptr) ? s->pixelMetric(QStyle::PM_ScrollBarExtent, nullptr, this) : 0;
+    const int fontExtent = fontMetrics().horizontalAdvance(QLatin1Char('M'));
+    const int extent = std::max({scrollbarExtent, fontExtent, RAIL_MIN_WIDTH_PX}) + RAIL_WIDTH_PADDING;
+    return {extent, 0};
+}
+
+QSize OverviewRailWidget::minimumSizeHint() const
+{
+    return {RAIL_MIN_WIDTH_PX, 0};
+}
+
+int OverviewRailWidget::RailWidthForTest() const
+{
+    return sizeHint().width();
+}
+
+QRect OverviewRailWidget::ViewportIndicatorRectForTest() const
+{
+    return ComputeViewportIndicatorRect();
+}
+
+int OverviewRailWidget::BucketAtYForTest(int y) const
+{
+    if (mModel == nullptr || mModel->BucketCount() == 0)
+    {
+        return -1;
+    }
+    const QRect rail = InteractiveRailRect();
+    if (rail.isEmpty())
+    {
+        return -1;
+    }
+    const int clampedY = std::clamp(y - rail.top(), 0, rail.height() - 1);
+    const std::size_t bucket = (static_cast<std::size_t>(clampedY) * mModel->BucketCount()) /
+                               static_cast<std::size_t>(rail.height());
+    return static_cast<int>(std::min(bucket, mModel->BucketCount() - 1));
+}
+
+int OverviewRailWidget::YForBucketForTest(std::size_t bucket) const
+{
+    if (mModel == nullptr || mModel->BucketCount() == 0)
+    {
+        return -1;
+    }
+    const QRect rail = InteractiveRailRect();
+    if (rail.isEmpty())
+    {
+        return -1;
+    }
+    const std::size_t nBuckets = mModel->BucketCount();
+    const std::size_t clampedBucket = std::min(bucket, nBuckets - 1);
+    const int y = rail.top() + static_cast<int>(
+                                   (clampedBucket * static_cast<std::size_t>(rail.height())) / nBuckets
+                               );
+    return y;
+}
+
+void OverviewRailWidget::paintEvent(QPaintEvent * /*event*/)
+{
+    QPainter painter(this);
+    painter.setRenderHint(QPainter::Antialiasing, true);
+
+    const QPalette pal = palette();
+    const QRect widgetRect = rect();
+
+    // Wash background: base tinted a hair toward Window so the
+    // rail reads as an edge frame. Painted edge-to-edge; the
+    // interactive rail rect insets from this by
+    // `RAIL_VERTICAL_INSET` for tick / indicator geometry.
+    QColor washColor = pal.color(QPalette::Window);
+    washColor.setAlpha(WASH_ALPHA);
+    painter.fillRect(widgetRect, pal.color(QPalette::Base));
+    painter.fillRect(widgetRect, washColor);
+
+    if (mModel == nullptr || mModel->BucketCount() == 0)
+    {
+        return;
+    }
+
+    const QRect rail = InteractiveRailRect();
+    if (rail.isEmpty())
+    {
+        return;
+    }
+
+    const auto buckets = mModel->Buckets();
+    const std::size_t nBuckets = buckets.size();
+    const int railTop = rail.top();
+    const int railHeight = rail.height();
+    if (railHeight <= 0 || nBuckets == 0)
+    {
+        return;
+    }
+
+    const int underlayLeft = rail.left() + RAIL_UNDERLAY_INSET;
+    const int underlayWidth = std::max(1, rail.width() - (2 * RAIL_UNDERLAY_INSET));
+    const QColor highlightColor = pal.color(QPalette::Highlight);
+
+    // Pass 1: dominant-level underlay per non-empty bucket.
+    // One pixel row per bucket by construction (buckets sized to
+    // rail height via `SetBucketCount`). Skip the expensive
+    // level lookup when the bucket is empty.
+    for (std::size_t i = 0; i < nBuckets; ++i)
+    {
+        const auto &bucket = buckets[i];
+        if (bucket.levels.Total() == 0)
+        {
+            continue;
+        }
+        const int y = railTop + static_cast<int>((i * static_cast<std::size_t>(railHeight)) / nBuckets);
+        // Height of at least 1 px so the row is always visible.
+        // Rounding via next-bucket-start avoids gaps at the
+        // seams while keeping the layout tight.
+        const int nextY = (i + 1 < nBuckets)
+                              ? railTop + static_cast<int>(((i + 1) * static_cast<std::size_t>(railHeight)) / nBuckets)
+                              : (railTop + railHeight);
+        const int height = std::max(1, nextY - y);
+
+        const loglib::LogLevel dominant = mModel->DominantLevel(i);
+        QColor color = ColorForLevelWithFallback(mTheme, dominant, pal);
+        color.setAlpha(LEVEL_UNDERLAY_ALPHA);
+        painter.fillRect(QRect(underlayLeft, y, underlayWidth, height), color);
+    }
+
+    // Pass 2: match ticks. Painted as a narrower band centred
+    // on the rail so it reads as an accent stripe separate
+    // from the level underlay.
+    if (mModel->HasMatchTicks())
+    {
+        const int tickWidth = std::max(2, static_cast<int>(underlayWidth * MATCH_TICK_WIDTH_FRACTION));
+        const int tickLeft = underlayLeft + ((underlayWidth - tickWidth) / 2);
+        for (std::size_t i = 0; i < nBuckets; ++i)
+        {
+            if (buckets[i].matchCount == 0)
+            {
+                continue;
+            }
+            const int y = railTop + static_cast<int>((i * static_cast<std::size_t>(railHeight)) / nBuckets);
+            const int nextY =
+                (i + 1 < nBuckets)
+                    ? railTop + static_cast<int>(((i + 1) * static_cast<std::size_t>(railHeight)) / nBuckets)
+                    : (railTop + railHeight);
+            const int height = std::max(1, nextY - y);
+            painter.fillRect(QRect(tickLeft, y, tickWidth, height), highlightColor);
+        }
+    }
+
+    // Pass 3: anchor ticks. One filled sub-band per set slot,
+    // aligned to the *right* edge so anchors and matches sit
+    // side-by-side and don't overlay each other.
+    if (mModel->HasAnchorTicks())
+    {
+        const int anchorBandWidth = std::max(2, underlayWidth / 3);
+        const int anchorBandLeft = underlayLeft + underlayWidth - anchorBandWidth;
+        for (std::size_t i = 0; i < nBuckets; ++i)
+        {
+            const auto &mask = buckets[i].anchorSlots;
+            if (mask.none())
+            {
+                continue;
+            }
+            const int y = railTop + static_cast<int>((i * static_cast<std::size_t>(railHeight)) / nBuckets);
+            const int nextY =
+                (i + 1 < nBuckets)
+                    ? railTop + static_cast<int>(((i + 1) * static_cast<std::size_t>(railHeight)) / nBuckets)
+                    : (railTop + railHeight);
+            const int height = std::max(1, nextY - y);
+            // Paint the lowest-index set slot: multiple anchor
+            // colours in one bucket collapse to the first-set
+            // (deterministic, and rare for a small rail).
+            for (std::size_t s = 0; s < mask.size(); ++s)
+            {
+                if (mask.test(s))
+                {
+                    const QColor c = ColorForAnchorSlot(mTheme, static_cast<std::uint8_t>(s), pal);
+                    painter.fillRect(QRect(anchorBandLeft, y, anchorBandWidth, height), c);
+                    break;
+                }
+            }
+        }
+    }
+
+    // Pass 4: viewport indicator. Rounded, translucent fill
+    // with a solid outline so the visible range reads as
+    // interactive chrome over the level / tick painting.
+    const QRect indicator = ComputeViewportIndicatorRect();
+    if (!indicator.isEmpty())
+    {
+        painter.save();
+        QColor fill = highlightColor;
+        fill.setAlpha(INDICATOR_FILL_ALPHA);
+        QColor outline = highlightColor;
+        outline.setAlpha(INDICATOR_OUTLINE_ALPHA);
+        painter.setBrush(fill);
+        QPen pen(outline);
+        pen.setCosmetic(true);
+        pen.setWidth(1);
+        painter.setPen(pen);
+        // Inset by 0.5 px so the cosmetic pen lands on a whole
+        // pixel row and the rounded corners anti-alias cleanly.
+        const QRectF rounded(
+            indicator.left() + 0.5, indicator.top() + 0.5, indicator.width() - 1.0, indicator.height() - 1.0
+        );
+        painter.drawRoundedRect(rounded, INDICATOR_CORNER_RADIUS, INDICATOR_CORNER_RADIUS);
+        painter.restore();
+    }
+}
+
+void OverviewRailWidget::mousePressEvent(QMouseEvent *event)
+{
+    if (event->button() != Qt::LeftButton)
+    {
+        QWidget::mousePressEvent(event);
+        return;
+    }
+    mDragging = true;
+    mLastEmittedRow = INT_MIN;
+    EmitProxyRowForY(static_cast<int>(event->position().y()));
+    event->accept();
+}
+
+void OverviewRailWidget::mouseMoveEvent(QMouseEvent *event)
+{
+    if (!mDragging)
+    {
+        QWidget::mouseMoveEvent(event);
+        return;
+    }
+    EmitProxyRowForY(static_cast<int>(event->position().y()));
+    event->accept();
+}
+
+void OverviewRailWidget::mouseReleaseEvent(QMouseEvent *event)
+{
+    if (event->button() != Qt::LeftButton)
+    {
+        QWidget::mouseReleaseEvent(event);
+        return;
+    }
+    mDragging = false;
+    mLastEmittedRow = INT_MIN;
+    event->accept();
+}
+
+void OverviewRailWidget::wheelEvent(QWheelEvent *event)
+{
+    // While actively dragging, swallow the wheel so a fumbled
+    // scroll doesn't fight the drag scrub. Otherwise forward
+    // by injecting a matching delta into the table's scrollbar
+    // so the rail behaves like an extension of the scrollbar.
+    if (mDragging)
+    {
+        event->accept();
+        return;
+    }
+    if (mTableView == nullptr)
+    {
+        event->ignore();
+        return;
+    }
+    auto *vbar = mTableView->verticalScrollBar();
+    if (vbar == nullptr)
+    {
+        event->ignore();
+        return;
+    }
+    QApplication::sendEvent(vbar, event);
+    // Mark accepted so the parent scroll area doesn't double-
+    // process the wheel event.
+    event->accept();
+}
+
+void OverviewRailWidget::resizeEvent(QResizeEvent *event)
+{
+    QWidget::resizeEvent(event);
+    SyncBucketCountToHeight();
+}
+
+void OverviewRailWidget::changeEvent(QEvent *event)
+{
+    QWidget::changeEvent(event);
+    // Style / palette / font change may shift the DPI-fluent
+    // width and the wash colour. Force a fresh sizeHint so the
+    // hosting `LogTableView` reserves the right margin.
+    switch (event->type())
+    {
+    case QEvent::StyleChange:
+    case QEvent::PaletteChange:
+    case QEvent::FontChange:
+    case QEvent::ApplicationFontChange:
+    case QEvent::ScreenChangeInternal:
+        updateGeometry();
+        update();
+        break;
+    default:
+        break;
+    }
+}
+
+QRect OverviewRailWidget::InteractiveRailRect() const
+{
+    QRect r = rect();
+    r.adjust(0, RAIL_VERTICAL_INSET, 0, -RAIL_VERTICAL_INSET);
+    return r;
+}
+
+QRect OverviewRailWidget::ComputeViewportIndicatorRect() const
+{
+    if (mTableView == nullptr || mModel == nullptr)
+    {
+        return {};
+    }
+    const int totalRows = mModel->ProxyRowCount();
+    if (totalRows <= 0)
+    {
+        return {};
+    }
+    const QRect rail = InteractiveRailRect();
+    if (rail.isEmpty())
+    {
+        return {};
+    }
+
+    // The visible range is best expressed via `rowAt`/`rowAt`+
+    // viewport height on the table. Fall back to scrollbar-based
+    // math when the view can't resolve rows (empty layout).
+    const QAbstractItemModel *proxy = mTableView->model();
+    if (proxy == nullptr)
+    {
+        return {};
+    }
+    const QRect viewport = mTableView->viewport()->rect();
+    const int topRow = mTableView->indexAt(QPoint(0, 0)).row();
+    // `indexAt(bottom)` returns -1 when the bottom is past the
+    // last row; use the row count in that case so the indicator
+    // extends to the tail as the user scrolls into the last page.
+    const int bottomIdxRow = mTableView->indexAt(QPoint(0, std::max(0, viewport.height() - 1))).row();
+    int bottomRow = (bottomIdxRow >= 0) ? bottomIdxRow : (totalRows - 1);
+
+    int visibleTop = (topRow >= 0) ? topRow : 0;
+    bottomRow = std::max(bottomRow, visibleTop);
+    // Clamp into `[0, totalRows)` so the indicator never runs
+    // past the rail even under a transient row-count mismatch.
+    visibleTop = std::clamp(visibleTop, 0, totalRows - 1);
+    bottomRow = std::clamp(bottomRow, visibleTop, totalRows - 1);
+
+    const int railHeight = rail.height();
+    const long long yTop = (static_cast<long long>(visibleTop) * static_cast<long long>(railHeight)) /
+                           static_cast<long long>(totalRows);
+    const long long yBottom = (static_cast<long long>(bottomRow + 1) * static_cast<long long>(railHeight)) /
+                              static_cast<long long>(totalRows);
+    int indicatorTop = rail.top() + static_cast<int>(yTop);
+    int indicatorHeight = static_cast<int>(yBottom - yTop);
+    indicatorHeight = std::max(indicatorHeight, INDICATOR_MIN_HEIGHT_PX);
+    // Clamp to the rail so the min-height boost doesn't push
+    // the indicator past the bottom insets.
+    if (indicatorTop + indicatorHeight > rail.bottom() + 1)
+    {
+        indicatorTop = rail.bottom() + 1 - indicatorHeight;
+    }
+    indicatorTop = std::max(indicatorTop, rail.top());
+
+    return QRect(rail.left(), indicatorTop, rail.width(), indicatorHeight);
+}
+
+void OverviewRailWidget::SyncBucketCountToHeight()
+{
+    if (mModel == nullptr)
+    {
+        return;
+    }
+    const QRect rail = InteractiveRailRect();
+    const int height = std::max(0, rail.height());
+    // One bucket per pixel row keeps the rail's paint math
+    // trivial (fillRect at each Y). SetBucketCount is a no-op
+    // when the count matches.
+    mModel->SetBucketCount(static_cast<std::size_t>(height));
+}
+
+void OverviewRailWidget::EmitProxyRowForY(int y)
+{
+    if (mModel == nullptr)
+    {
+        return;
+    }
+    const QRect rail = InteractiveRailRect();
+    if (rail.isEmpty())
+    {
+        return;
+    }
+    const int relativeY = y - rail.top();
+    const int proxyRow = mModel->ProxyRowForYPixel(relativeY, rail.height());
+    if (proxyRow < 0 || proxyRow == mLastEmittedRow)
+    {
+        return;
+    }
+    mLastEmittedRow = proxyRow;
+    emit proxyRowClicked(proxyRow);
+}

--- a/app/src/overview_rail_widget.cpp
+++ b/app/src/overview_rail_widget.cpp
@@ -471,12 +471,26 @@ void OverviewRailWidget::paintEvent(QPaintEvent * /*event*/)
     // recomputing the same integer division per bucket on tall
     // rails and keeps the seam-rounding ("bottom == next
     // bucket's top") consistent across passes.
-    std::vector<int> yEdges(nBuckets + 1);
-    for (std::size_t i = 0; i <= nBuckets; ++i)
+    //
+    // Cached on `(nBuckets, railTop, railHeight)` so a drag-scroll
+    // burst (many paints per second, geometry unchanged between
+    // them) reuses the same vector instead of re-allocating
+    // `nBuckets + 1` ints per paint. Invalidated implicitly on
+    // resize / bucket-count change / style-driven inset shift.
+    if (mCachedYEdgesBuckets != nBuckets || mCachedYEdgesRailTop != railTop ||
+        mCachedYEdgesRailHeight != railHeight)
     {
-        yEdges[i] = railTop + static_cast<int>((i * static_cast<std::size_t>(railHeight)) / nBuckets);
+        mCachedYEdges.assign(nBuckets + 1, 0);
+        for (std::size_t i = 0; i <= nBuckets; ++i)
+        {
+            mCachedYEdges[i] = railTop + static_cast<int>((i * static_cast<std::size_t>(railHeight)) / nBuckets);
+        }
+        mCachedYEdges.back() = railTop + railHeight;
+        mCachedYEdgesBuckets = nBuckets;
+        mCachedYEdgesRailTop = railTop;
+        mCachedYEdgesRailHeight = railHeight;
     }
-    yEdges.back() = railTop + railHeight;
+    const std::vector<int> &yEdges = mCachedYEdges;
 
     // Rail-wide max bucket total. Drives the log-scaled bar
     // width in Pass 1 so density is expressed as bar length

--- a/app/src/overview_rail_widget.cpp
+++ b/app/src/overview_rail_widget.cpp
@@ -1,5 +1,6 @@
 #include "overview_rail_widget.hpp"
 
+#include "log_table_view.hpp"
 #include "overview_rail_model.hpp"
 #include "theme_control.hpp"
 
@@ -13,11 +14,14 @@
 #include <QColor>
 #include <QEvent>
 #include <QFontMetrics>
+#include <QHideEvent>
 #include <QMouseEvent>
 #include <QPaintEvent>
 #include <QPainter>
 #include <QPalette>
 #include <QPen>
+#include <QPointF>
+#include <QPointingDevice>
 #include <QRect>
 #include <QResizeEvent>
 #include <QScrollBar>
@@ -25,6 +29,7 @@
 #include <QSize>
 #include <QStyle>
 #include <QStyleOptionViewItem>
+#include <QTimer>
 #include <QWheelEvent>
 #include <QWidget>
 #include <Qt>
@@ -112,22 +117,42 @@ constexpr int INDICATOR_MIN_HEIGHT_PX = 12;
 /// (which is enough to spot a rare Fatal streak).
 constexpr int RAIL_MIN_WIDTH_PX = 24;
 
-/// Maximum rail width in device-independent px. Some styles
-/// (accessibility themes on Windows, GTK "chunky-scrollbar"
-/// setups) advertise very large `PM_ScrollBarExtent` values —
-/// mirroring them 1:1 would cover a large fraction of the
-/// viewport with a nearly-empty rail. The cap is deliberately
-/// wide so per-level stacked-segment colours are
-/// unmistakably readable even on 4K displays where 14 px bars
-/// were near-invisible in user reports. Klogg's overview strip
-/// is 16 px; we run wider because we also show anchors + match
-/// ticks in dedicated columns, not just matches.
-constexpr int RAIL_MAX_WIDTH_PX = 60;
+/// Maximum rail width in device-independent px after the
+/// width-mode scale is applied. Headroom for Wide (`2 ×` base)
+/// when accessibility themes advertise a large
+/// `PM_ScrollBarExtent` (base can already sit near 60). A lower
+/// cap (e.g. 96) would collapse Wide into Medium on those
+/// setups. Typical Win11 Wide lands around ~72 and never hits
+/// this ceiling.
+constexpr int RAIL_MAX_WIDTH_PX = 128;
+
+/// Scale factors applied to the DPI-fluent base width for each
+/// `OverviewRailWidthMode`. Narrow is today's unscaled formula.
+constexpr double RAIL_WIDTH_SCALE_NARROW = 1.0;
+constexpr double RAIL_WIDTH_SCALE_MEDIUM = 1.5;
+constexpr double RAIL_WIDTH_SCALE_WIDE = 2.0;
 
 /// Extra width added to the DPI-fluent metric. Nudges the
 /// rail slightly wider than the scrollbar so it doesn't merge
 /// visually with a scrollbar rendered in the same theme.
 constexpr int RAIL_WIDTH_PADDING = 2;
+
+/// Trailing-edge debounce for `SyncBucketCountToHeight()` on
+/// `resizeEvent`. A live drag-resize storm fires a resize event
+/// per pixel of height change, and each `SetBucketCount(H)` call
+/// on the model reallocates buckets, invalidates the durable
+/// per-bucket find-match counts (`ApplyStoredMatchBucketCounts`
+/// no-ops on size mismatch), and forces the `MainWindow`
+/// `bucketsChanged` -> `PushFindMatchesToOverviewRail` wiring
+/// to run a synchronous full-table find rescan. Without
+/// debouncing, dragging the window edge with the Find bar open
+/// and a moderately broad needle on a large log freezes the UI
+/// for seconds. 100 ms is above typical human-perceptible
+/// resize latency yet short enough that the rail settles into
+/// the new geometry the moment the drag stops. `showEvent`
+/// bypasses the timer so the first paint after a show is never
+/// delayed.
+constexpr int BUCKET_SYNC_DEBOUNCE_MS = 100;
 
 QColor ColorForLevel(const ThemeControl *theme, loglib::LogLevel level, const QPalette &palette)
 {
@@ -241,7 +266,49 @@ QColor ColorForAnchorSlot(const ThemeControl *theme, std::uint8_t colorIndex, co
     return QRect(underlayLeft, 0, underlayWidth, 0);
 }
 
+[[nodiscard]] double WidthScaleForMode(OverviewRailWidthMode mode) noexcept
+{
+    switch (mode)
+    {
+    case OverviewRailWidthMode::Narrow:
+        return RAIL_WIDTH_SCALE_NARROW;
+    case OverviewRailWidthMode::Wide:
+        return RAIL_WIDTH_SCALE_WIDE;
+    case OverviewRailWidthMode::Medium:
+    default:
+        return RAIL_WIDTH_SCALE_MEDIUM;
+    }
+}
+
 } // namespace
+
+OverviewRailWidthMode ParseOverviewRailWidthMode(const QString &value)
+{
+    if (value == QLatin1String("narrow"))
+    {
+        return OverviewRailWidthMode::Narrow;
+    }
+    if (value == QLatin1String("wide"))
+    {
+        return OverviewRailWidthMode::Wide;
+    }
+    // Default / unknown / "medium" → Medium (shipped default).
+    return OverviewRailWidthMode::Medium;
+}
+
+QString OverviewRailWidthModeToSettingsString(OverviewRailWidthMode mode)
+{
+    switch (mode)
+    {
+    case OverviewRailWidthMode::Narrow:
+        return QStringLiteral("narrow");
+    case OverviewRailWidthMode::Wide:
+        return QStringLiteral("wide");
+    case OverviewRailWidthMode::Medium:
+    default:
+        return QStringLiteral("medium");
+    }
+}
 
 OverviewRailWidget::OverviewRailWidget(
     OverviewRailModel *model, ThemeControl *theme, QAbstractItemView *tableView, QWidget *parent
@@ -285,34 +352,55 @@ OverviewRailWidget::OverviewRailWidget(
             connect(vbar, &QAbstractSlider::rangeChanged, this, [this](int, int) { update(); });
         }
     }
+
+    // Trailing-edge debounce so a drag-resize storm collapses to
+    // one `SetBucketCount(H)` call. See `BUCKET_SYNC_DEBOUNCE_MS`
+    // for the perf rationale. Object-named for tests.
+    mBucketSyncTimer = new QTimer(this);
+    mBucketSyncTimer->setObjectName(QStringLiteral("overviewRailBucketSyncTimer"));
+    mBucketSyncTimer->setSingleShot(true);
+    mBucketSyncTimer->setInterval(BUCKET_SYNC_DEBOUNCE_MS);
+    connect(mBucketSyncTimer, &QTimer::timeout, this, &OverviewRailWidget::SyncBucketCountToHeight);
+}
+
+void OverviewRailWidget::SetWidthMode(OverviewRailWidthMode mode)
+{
+    if (mWidthMode == mode)
+    {
+        return;
+    }
+    mWidthMode = mode;
+    mCachedRailWidth = 0;
+    // Notify the layout system so `LogTableView` re-reads
+    // `sizeHint()` and refreshes the reserved right margin.
+    updateGeometry();
+    update();
 }
 
 QSize OverviewRailWidget::sizeHint() const
 {
-    // DPI-fluent width: anchor to twice the platform scrollbar
-    // extent so the rail scales with the same DPI metric users
-    // already recognise, but stays wide enough that the three
-    // internal columns (level / match / anchor) each get several
-    // clearly visible pixels. Fall back to the font's `M` advance
-    // when the style returns a degenerate 0 (offscreen QPA in
-    // tests). Clamp into `[RAIL_MIN_WIDTH_PX, RAIL_MAX_WIDTH_PX]`
-    // so a themed style with a giant scrollbar extent doesn't
-    // inflate the rail past the point where extra pixels stop
-    // conveying information, and a tiny extent (accessibility
-    // narrow-scrollbar setups) can't collapse the level column
-    // to a single-pixel streak.
+    // DPI-fluent base: twice the platform scrollbar extent so
+    // the rail scales with the same DPI metric users already
+    // recognise, but stays wide enough that the stacked-
+    // severity bin bar remains readable. Fall back to the
+    // font's `M` advance when the style returns a degenerate 0
+    // (offscreen QPA in tests). Floor at `RAIL_MIN_WIDTH_PX`.
     //
     // The 2x factor was tuned against the "invisible bars"
     // report on Windows 11: a raw scrollbar extent of 17 px
-    // collapsed the level column to ~10 px, which reads as a
-    // hair-thin line at typical viewing distance. Doubling puts
-    // the level column at ~19 px -- comfortably readable per
-    // level colour.
+    // left the content strip too narrow at typical viewing
+    // distance. Doubling lands around ~36 px of base width
+    // before the width-mode scale is applied.
+    //
+    // Width mode then multiplies that base (Narrow 1.0 /
+    // Medium 1.5 / Wide 2.0) and the result is clamped into
+    // `[RAIL_MIN_WIDTH_PX, RAIL_MAX_WIDTH_PX]`.
     const QStyle *s = style();
     const int scrollbarExtent = (s != nullptr) ? s->pixelMetric(QStyle::PM_ScrollBarExtent, nullptr, this) : 0;
     const int fontExtent = fontMetrics().horizontalAdvance(QLatin1Char('M'));
-    const int raw = std::max({2 * scrollbarExtent, 2 * fontExtent, RAIL_MIN_WIDTH_PX}) + RAIL_WIDTH_PADDING;
-    const int extent = std::clamp(raw, RAIL_MIN_WIDTH_PX, RAIL_MAX_WIDTH_PX);
+    const int base = std::max({2 * scrollbarExtent, 2 * fontExtent, RAIL_MIN_WIDTH_PX}) + RAIL_WIDTH_PADDING;
+    const double scaled = static_cast<double>(base) * WidthScaleForMode(mWidthMode);
+    const int extent = std::clamp(static_cast<int>(std::lround(scaled)), RAIL_MIN_WIDTH_PX, RAIL_MAX_WIDTH_PX);
     // Cache so `RailWidthForTest` (and any future non-const
     // helper that wants the last DPI-fluent width) doesn't have
     // to re-run the platform-metric query.
@@ -878,15 +966,47 @@ void OverviewRailWidget::wheelEvent(QWheelEvent *event)
         event->ignore();
         return;
     }
-    // TODO: `event->position()` is in this widget's coordinate
-    // system, not the scrollbar's. `QAbstractSlider::wheelEvent`
-    // only reads `angleDelta` today so the mismatch is
-    // invisible, but any style / accessibility layer that
-    // inspects position sees rail-widget coordinates. Consider
-    // translating with `QWheelEvent` cloned at `vbar->mapFromGlobal
-    // (event->globalPosition().toPoint())` once we hit a case
-    // that cares.
-    QApplication::sendEvent(vbar, event);
+    // Translate the wheel event's local position into the
+    // scrollbar's coordinate space before forwarding. The
+    // original `event->position()` is in this widget's coords,
+    // which sit past the scrollbar's rect on the horizontal
+    // axis; forwarding verbatim would leave any style /
+    // accessibility layer that inspects the point looking at
+    // coordinates outside `vbar`. `QAbstractSlider::wheelEvent`
+    // currently reads only `angleDelta` (so the mismatch was
+    // invisible in production), but the translation is cheap
+    // and future-proofs the wiring against a style that ever
+    // starts caring — e.g. a hover indicator or a hit-test
+    // for click-past-thumb page behaviour. Global position
+    // stays as-is so screen-space consumers see the same
+    // point the user pointed at.
+    // Attribute the forthcoming scrollbar `valueChanged` as
+    // user-driven. Forwarding via `sendEvent` bypasses
+    // `LogTableView::wheelEvent`, which is the normal path that
+    // sets this flag. Qt's `QAbstractSlider::wheelEvent` usually
+    // goes through `triggerAction` (so `actionTriggered` would
+    // also set the flag), but attributing explicitly keeps Follow
+    // newest disengage correct even if a style / platform path
+    // calls `setValue` directly.
+    if (auto *logView = qobject_cast<LogTableView *>(mTableView.data()); logView != nullptr)
+    {
+        logView->AttributeNextScrollToUser();
+    }
+    const QPointF globalPos = event->globalPosition();
+    const QPointF localPos = vbar->mapFromGlobal(globalPos.toPoint());
+    QWheelEvent translated(
+        localPos,
+        globalPos,
+        event->pixelDelta(),
+        event->angleDelta(),
+        event->buttons(),
+        event->modifiers(),
+        event->phase(),
+        event->inverted(),
+        event->source(),
+        event->pointingDevice()
+    );
+    QApplication::sendEvent(vbar, &translated);
     // Mark accepted so the parent scroll area doesn't double-
     // process the wheel event.
     event->accept();
@@ -895,7 +1015,51 @@ void OverviewRailWidget::wheelEvent(QWheelEvent *event)
 void OverviewRailWidget::resizeEvent(QResizeEvent *event)
 {
     QWidget::resizeEvent(event);
-    SyncBucketCountToHeight();
+    // Debounce: an interactive window drag fires a resize event
+    // per pixel of height change, and each `SyncBucketCountToHeight`
+    // would call `SetBucketCount(H±1)` on the model, which drops
+    // the durable per-bucket find-match counts and (with the Find
+    // bar open) forces `MainWindow` to run a full synchronous
+    // find rescan through the `bucketsChanged` lambda. Coalescing
+    // through `mBucketSyncTimer` collapses the burst to one
+    // bucket update + one rescan when the drag settles.
+    //
+    // Paints during the debounce window use the previous
+    // bucket count against the current widget height, so the
+    // rail's proportions stretch slightly for up to
+    // `BUCKET_SYNC_DEBOUNCE_MS` — visually indistinguishable
+    // from the settled state given the rail is a summary
+    // strip, not a pixel-accurate view. Click / drag / wheel
+    // still resolve against the live widget height + live
+    // model row count (see `ProxyRowForYPixel`), so hit-testing
+    // stays correct.
+    if (mBucketSyncTimer != nullptr)
+    {
+        mBucketSyncTimer->start();
+    }
+    else
+    {
+        // Defensive: constructor guarantees the timer exists,
+        // but if a future refactor moves timer construction out
+        // of the ctor keep the widget functional.
+        SyncBucketCountToHeight();
+    }
+}
+
+void OverviewRailWidget::hideEvent(QHideEvent *event)
+{
+    QWidget::hideEvent(event);
+    // Cancel any pending debounced sync. `MainWindow::
+    // SetOverviewRailVisible(false)` drops the model's bucket
+    // vector immediately after this hide fires; a queued
+    // `SyncBucketCountToHeight()` firing right after would
+    // re-populate the vector against the widget's persisted
+    // height and undo the visibility-toggle optimisation
+    // (paying rebuild cost while the rail is invisible).
+    if (mBucketSyncTimer != nullptr)
+    {
+        mBucketSyncTimer->stop();
+    }
 }
 
 void OverviewRailWidget::showEvent(QShowEvent *event)
@@ -911,8 +1075,19 @@ void OverviewRailWidget::showEvent(QShowEvent *event)
     // fire a redundant no-op transition; the follow-up
     // `resizeEvent` immediately supersedes it with the real
     // height.
+    //
+    // A show is a discrete user action (toggle, tab switch, first
+    // appearance) and must not wait on the resize debounce — the
+    // first paint after the show has to see correct bucket
+    // geometry. Cancel any pending resize-debounce so we don't
+    // double-fire `SetBucketCount` on the same H after this call
+    // returns.
     if (height() > 0)
     {
+        if (mBucketSyncTimer != nullptr)
+        {
+            mBucketSyncTimer->stop();
+        }
         SyncBucketCountToHeight();
     }
 }
@@ -1063,6 +1238,20 @@ void OverviewRailWidget::SyncBucketCountToHeight()
     // when the count matches.
     mModel->SetBucketCount(static_cast<std::size_t>(height));
 }
+
+#ifdef LOGAPP_BUILD_TESTING
+void OverviewRailWidget::FlushPendingBucketSyncForTest()
+{
+    if (mBucketSyncTimer == nullptr || !mBucketSyncTimer->isActive())
+    {
+        return;
+    }
+    // Stop first so the timer's own `timeout` can't race the
+    // sync we're about to run manually and double-fire.
+    mBucketSyncTimer->stop();
+    SyncBucketCountToHeight();
+}
+#endif
 
 void OverviewRailWidget::EmitProxyRowForY(int y, bool replaceSelection)
 {

--- a/app/src/overview_rail_widget.cpp
+++ b/app/src/overview_rail_widget.cpp
@@ -148,7 +148,7 @@ QColor ColorForAnchorSlot(const ThemeControl *theme, std::uint8_t colorIndex, co
 OverviewRailWidget::OverviewRailWidget(
     OverviewRailModel *model, ThemeControl *theme, QAbstractItemView *tableView, QWidget *parent
 )
-    : QWidget(parent), mModel(model), mTheme(theme), mTableView(tableView), mLastEmittedRow(INT_MIN)
+    : QWidget(parent), mModel(model), mTheme(theme), mTableView(tableView)
 {
     setAttribute(Qt::WA_OpaquePaintEvent, false);
     setFocusPolicy(Qt::NoFocus);
@@ -534,11 +534,12 @@ QRect OverviewRailWidget::ComputeViewportIndicatorRect() const
         return {};
     }
 
-    // The visible range is best expressed via `rowAt`/`rowAt`+
-    // viewport height on the table. Fall back to scrollbar-based
-    // math when the view can't resolve rows (empty layout).
-    const QAbstractItemModel *proxy = mTableView->model();
-    if (proxy == nullptr)
+    // The visible range is best expressed via `indexAt` on the
+    // table (top + bottom of the viewport). `indexAt` already
+    // tolerates a null model (returns an invalid index whose
+    // `.row()` is `-1`), which the row-resolution branch below
+    // treats the same as "empty layout".
+    if (mTableView->model() == nullptr)
     {
         return {};
     }

--- a/app/src/overview_rail_widget.cpp
+++ b/app/src/overview_rail_widget.cpp
@@ -327,8 +327,8 @@ int OverviewRailWidget::BucketAtYForTest(int y) const
         return -1;
     }
     const int clampedY = std::clamp(y - rail.top(), 0, rail.height() - 1);
-    const std::size_t bucket = (static_cast<std::size_t>(clampedY) * mModel->BucketCount()) /
-                               static_cast<std::size_t>(rail.height());
+    const std::size_t bucket =
+        (static_cast<std::size_t>(clampedY) * mModel->BucketCount()) / static_cast<std::size_t>(rail.height());
     return static_cast<int>(std::min(bucket, mModel->BucketCount() - 1));
 }
 
@@ -345,9 +345,7 @@ int OverviewRailWidget::YForBucketForTest(std::size_t bucket) const
     }
     const std::size_t nBuckets = mModel->BucketCount();
     const std::size_t clampedBucket = std::min(bucket, nBuckets - 1);
-    const int y = rail.top() + static_cast<int>(
-                                   (clampedBucket * static_cast<std::size_t>(rail.height())) / nBuckets
-                               );
+    const int y = rail.top() + static_cast<int>((clampedBucket * static_cast<std::size_t>(rail.height())) / nBuckets);
     return y;
 }
 
@@ -428,8 +426,7 @@ void OverviewRailWidget::paintEvent(QPaintEvent * /*event*/)
     // seams consistent across passes. Cached on
     // `(nBuckets, railTop, railHeight)` so drag-scroll bursts
     // skip the alloc.
-    if (mCachedYEdgesBuckets != nBuckets || mCachedYEdgesRailTop != railTop ||
-        mCachedYEdgesRailHeight != railHeight)
+    if (mCachedYEdgesBuckets != nBuckets || mCachedYEdgesRailTop != railTop || mCachedYEdgesRailHeight != railHeight)
     {
         mCachedYEdges.assign(nBuckets + 1, 0);
         for (std::size_t i = 0; i <= nBuckets; ++i)
@@ -485,24 +482,24 @@ void OverviewRailWidget::paintEvent(QPaintEvent * /*event*/)
             }
             const int proxyRows = mModel->ProxyRowCount();
             const int levelColIdx = mModel->LevelColumnIndexForTest();
-            qInfo().noquote() << QStringLiteral(
-                                     "[rail-trace] widget=%1x%2 rail=%3x%4 content=%5 buckets=%6 non-empty=%7 "
-                                     "maxCount=%8 base=%9 firstBucket total=%10 dom=%11 color=%12 proxyRows=%13 "
-                                     "levelColIdx=%14")
-                                     .arg(widgetRect.width())
-                                     .arg(widgetRect.height())
-                                     .arg(rail.width())
-                                     .arg(rail.height())
-                                     .arg(contentWidth)
-                                     .arg(nBuckets)
-                                     .arg(nonEmptyBuckets)
-                                     .arg(maxCount)
-                                     .arg(pal.color(QPalette::Base).name())
-                                     .arg(firstBucketTotal)
-                                     .arg(static_cast<int>(firstDominant))
-                                     .arg(firstBarColor.name())
-                                     .arg(proxyRows)
-                                     .arg(levelColIdx);
+            qInfo().noquote(
+            ) << QStringLiteral("[rail-trace] widget=%1x%2 rail=%3x%4 content=%5 buckets=%6 non-empty=%7 "
+                                "maxCount=%8 base=%9 firstBucket total=%10 dom=%11 color=%12 proxyRows=%13 "
+                                "levelColIdx=%14")
+                     .arg(widgetRect.width())
+                     .arg(widgetRect.height())
+                     .arg(rail.width())
+                     .arg(rail.height())
+                     .arg(contentWidth)
+                     .arg(nBuckets)
+                     .arg(nonEmptyBuckets)
+                     .arg(maxCount)
+                     .arg(pal.color(QPalette::Base).name())
+                     .arg(firstBucketTotal)
+                     .arg(static_cast<int>(firstDominant))
+                     .arg(firstBarColor.name())
+                     .arg(proxyRows)
+                     .arg(levelColIdx);
         }
     }
 
@@ -581,8 +578,7 @@ void OverviewRailWidget::paintEvent(QPaintEvent * /*event*/)
                     {
                         continue;
                     }
-                    const int share =
-                        static_cast<int>((segWeights[s] / totalWeight) * static_cast<double>(extra));
+                    const int share = static_cast<int>((segWeights[s] / totalWeight) * static_cast<double>(extra));
                     segWidths[s] += share;
                 }
                 // Rounding leftovers go to the heaviest level so
@@ -693,15 +689,14 @@ void OverviewRailWidget::paintEvent(QPaintEvent * /*event*/)
         pen.setCosmetic(true);
         pen.setWidth(1);
         painter.setPen(pen);
-    // Half-pixel inset so the cosmetic pen lands on whole rows
-    // and the rounded corners anti-alias cleanly.
-    const QRectF rounded(
+        // Half-pixel inset so the cosmetic pen lands on whole rows
+        // and the rounded corners anti-alias cleanly.
+        const QRectF rounded(
             indicator.left() + 0.5, indicator.top() + 0.5, indicator.width() - 1.0, indicator.height() - 1.0
         );
         painter.drawRoundedRect(rounded, INDICATOR_CORNER_RADIUS, INDICATOR_CORNER_RADIUS);
         painter.restore();
     }
-
 }
 
 void OverviewRailWidget::mousePressEvent(QMouseEvent *event)
@@ -953,8 +948,8 @@ QRect OverviewRailWidget::ComputeViewportIndicatorRect() const
     bottomRow = std::clamp(bottomRow, visibleTop, totalRows - 1);
 
     const int railHeight = rail.height();
-    const long long yTop = (static_cast<long long>(visibleTop) * static_cast<long long>(railHeight)) /
-                           static_cast<long long>(totalRows);
+    const long long yTop =
+        (static_cast<long long>(visibleTop) * static_cast<long long>(railHeight)) / static_cast<long long>(totalRows);
     const long long yBottom = (static_cast<long long>(bottomRow + 1) * static_cast<long long>(railHeight)) /
                               static_cast<long long>(totalRows);
     const int naturalHeight = static_cast<int>(yBottom - yTop);

--- a/app/src/preferences_editor.cpp
+++ b/app/src/preferences_editor.cpp
@@ -250,9 +250,9 @@ PreferencesEditor::PreferencesEditor(ThemeControl *theme, QWidget *parent)
     mOverviewRailWidthComboBox->addItem(tr("Narrow"), QStringLiteral("narrow"));
     mOverviewRailWidthComboBox->addItem(tr("Medium"), QStringLiteral("medium"));
     mOverviewRailWidthComboBox->addItem(tr("Wide"), QStringLiteral("wide"));
-    // Live preview: every selection fires the signal so
-    // `MainWindow` resizes the rail immediately. `UpdateFields`
-    // / ctor seeding block signals while loading.
+    // Live preview: every selection fires the signal so the rail
+    // resizes immediately. Ctor / `UpdateFields` block signals
+    // while seeding.
     connect(
         mOverviewRailWidthComboBox,
         QOverload<int>::of(&QComboBox::activated),

--- a/app/src/preferences_editor.cpp
+++ b/app/src/preferences_editor.cpp
@@ -253,20 +253,15 @@ PreferencesEditor::PreferencesEditor(ThemeControl *theme, QWidget *parent)
     // Live preview: every selection fires the signal so the rail
     // resizes immediately. Ctor / `UpdateFields` block signals
     // while seeding.
-    connect(
-        mOverviewRailWidthComboBox,
-        QOverload<int>::of(&QComboBox::activated),
-        this,
-        [this](int idx) {
-            if (idx < 0)
-            {
-                return;
-            }
-            const OverviewRailWidthMode mode =
-                ParseOverviewRailWidthMode(mOverviewRailWidthComboBox->itemData(idx).toString());
-            emit overviewRailWidthChanged(mode);
+    connect(mOverviewRailWidthComboBox, QOverload<int>::of(&QComboBox::activated), this, [this](int idx) {
+        if (idx < 0)
+        {
+            return;
         }
-    );
+        const OverviewRailWidthMode mode =
+            ParseOverviewRailWidthMode(mOverviewRailWidthComboBox->itemData(idx).toString());
+        emit overviewRailWidthChanged(mode);
+    });
 
     mRestoreLastSessionCheckBox = new QCheckBox("Restore last session on launch", this);
     mRestoreLastSessionCheckBox->setToolTip(
@@ -393,9 +388,8 @@ PreferencesEditor::PreferencesEditor(ThemeControl *theme, QWidget *parent)
         }
         {
             QSettings settings;
-            const OverviewRailWidthMode mode = ParseOverviewRailWidthMode(
-                mOverviewRailWidthComboBox->currentData().toString()
-            );
+            const OverviewRailWidthMode mode =
+                ParseOverviewRailWidthMode(mOverviewRailWidthComboBox->currentData().toString());
             if (mode != mInitialOverviewRailWidth)
             {
                 settings.setValue(

--- a/app/src/preferences_editor.cpp
+++ b/app/src/preferences_editor.cpp
@@ -38,6 +38,29 @@ constexpr char SETTINGS_SHOW_LEVEL_ICONS[] = "ui/showLevelIcons";
 /// (subtle row colours).
 constexpr char SETTINGS_HIGH_CONTRAST_LEVELS[] = "ui/highContrastLevels";
 
+/// `QSettings` key for overview-rail width mode. Values are
+/// `"narrow"` / `"medium"` / `"wide"`; default Medium.
+constexpr char SETTINGS_OVERVIEW_RAIL_WIDTH[] = "ui/overviewRailWidth";
+
+void SelectOverviewRailWidthCombo(QComboBox *combo, OverviewRailWidthMode mode)
+{
+    if (combo == nullptr)
+    {
+        return;
+    }
+    const QString key = OverviewRailWidthModeToSettingsString(mode);
+    for (int i = 0; i < combo->count(); ++i)
+    {
+        if (combo->itemData(i).toString() == key)
+        {
+            combo->setCurrentIndex(i);
+            return;
+        }
+    }
+    // Fallback: Medium is index 1 in the populated combo.
+    combo->setCurrentIndex(1);
+}
+
 /// Label for the synthetic "Auto" combo entry. The entry's user
 /// data carries `ThemeControl::AUTO_TOKEN` (an empty string) so a
 /// real theme literally named "Auto..." still round-trips.
@@ -216,6 +239,35 @@ PreferencesEditor::PreferencesEditor(ThemeControl *theme, QWidget *parent)
     connect(mHighContrastLevelsCheckBox, &QCheckBox::toggled, this, [this](bool on) {
         emit highContrastLevelsChanged(on);
     });
+
+    mOverviewRailWidthComboBox = new QComboBox(this);
+    mOverviewRailWidthComboBox->setObjectName(QStringLiteral("overviewRailWidthCombo"));
+    mOverviewRailWidthComboBox->setToolTip(
+        "Width of the overview rail next to the log table. All sizes scale with the system "
+        "scrollbar / DPI; Narrow is the compact strip, Medium is the default, Wide maximises "
+        "severity-band readability."
+    );
+    mOverviewRailWidthComboBox->addItem(tr("Narrow"), QStringLiteral("narrow"));
+    mOverviewRailWidthComboBox->addItem(tr("Medium"), QStringLiteral("medium"));
+    mOverviewRailWidthComboBox->addItem(tr("Wide"), QStringLiteral("wide"));
+    // Live preview: every selection fires the signal so
+    // `MainWindow` resizes the rail immediately. `UpdateFields`
+    // / ctor seeding block signals while loading.
+    connect(
+        mOverviewRailWidthComboBox,
+        QOverload<int>::of(&QComboBox::activated),
+        this,
+        [this](int idx) {
+            if (idx < 0)
+            {
+                return;
+            }
+            const OverviewRailWidthMode mode =
+                ParseOverviewRailWidthMode(mOverviewRailWidthComboBox->itemData(idx).toString());
+            emit overviewRailWidthChanged(mode);
+        }
+    );
+
     mRestoreLastSessionCheckBox = new QCheckBox("Restore last session on launch", this);
     mRestoreLastSessionCheckBox->setToolTip(
         "When enabled, the most recent auto-saved session is reopened automatically on startup. "
@@ -267,6 +319,8 @@ PreferencesEditor::PreferencesEditor(ThemeControl *theme, QWidget *parent)
     appearanceLayout->addLayout(themeButtonLayout);
     appearanceLayout->addWidget(mShowLevelIconsCheckBox);
     appearanceLayout->addWidget(mHighContrastLevelsCheckBox);
+    appearanceLayout->addWidget(new QLabel(tr("Overview rail width:")));
+    appearanceLayout->addWidget(mOverviewRailWidthComboBox);
     appearanceLayout->addWidget(mThemeStatusLabel);
 
     auto *streamingGroup = new QGroupBox("Streaming", this);
@@ -337,6 +391,18 @@ PreferencesEditor::PreferencesEditor(ThemeControl *theme, QWidget *parent)
                 settings.setValue(QString::fromLatin1(SETTINGS_HIGH_CONTRAST_LEVELS), highContrast);
             }
         }
+        {
+            QSettings settings;
+            const OverviewRailWidthMode mode = ParseOverviewRailWidthMode(
+                mOverviewRailWidthComboBox->currentData().toString()
+            );
+            if (mode != mInitialOverviewRailWidth)
+            {
+                settings.setValue(
+                    QString::fromLatin1(SETTINGS_OVERVIEW_RAIL_WIDTH), OverviewRailWidthModeToSettingsString(mode)
+                );
+            }
+        }
         emit streamingRetentionChanged(static_cast<qulonglong>(StreamingControl::RetentionLines()));
         // Only emit on a real toggle so the re-sort chain does not run
         // on every Ok click.
@@ -369,6 +435,14 @@ PreferencesEditor::PreferencesEditor(ThemeControl *theme, QWidget *parent)
         {
             emit highContrastLevelsChanged(mInitialHighContrastLevels);
         }
+        {
+            const OverviewRailWidthMode current =
+                ParseOverviewRailWidthMode(mOverviewRailWidthComboBox->currentData().toString());
+            if (current != mInitialOverviewRailWidth)
+            {
+                emit overviewRailWidthChanged(mInitialOverviewRailWidth);
+            }
+        }
         // Revert spinbox-edited values to persisted; on-disk unchanged.
         StreamingControl::LoadConfiguration();
         // Bypass `closeEvent`'s revert: Cancel already reverted.
@@ -393,6 +467,9 @@ PreferencesEditor::PreferencesEditor(ThemeControl *theme, QWidget *parent)
         const QSettings settings;
         mInitialShowLevelIcons = settings.value(QString::fromLatin1(SETTINGS_SHOW_LEVEL_ICONS), true).toBool();
         mInitialHighContrastLevels = settings.value(QString::fromLatin1(SETTINGS_HIGH_CONTRAST_LEVELS), false).toBool();
+        mInitialOverviewRailWidth = ParseOverviewRailWidthMode(
+            settings.value(QString::fromLatin1(SETTINGS_OVERVIEW_RAIL_WIDTH), QStringLiteral("medium")).toString()
+        );
         {
             const QSignalBlocker blocker(mShowLevelIconsCheckBox);
             mShowLevelIconsCheckBox->setChecked(mInitialShowLevelIcons);
@@ -400,6 +477,10 @@ PreferencesEditor::PreferencesEditor(ThemeControl *theme, QWidget *parent)
         {
             const QSignalBlocker blocker(mHighContrastLevelsCheckBox);
             mHighContrastLevelsCheckBox->setChecked(mInitialHighContrastLevels);
+        }
+        {
+            const QSignalBlocker blocker(mOverviewRailWidthComboBox);
+            SelectOverviewRailWidthCombo(mOverviewRailWidthComboBox, mInitialOverviewRailWidth);
         }
     }
 }
@@ -418,6 +499,9 @@ void PreferencesEditor::UpdateFields()
         const QSettings settings;
         mInitialShowLevelIcons = settings.value(QString::fromLatin1(SETTINGS_SHOW_LEVEL_ICONS), true).toBool();
         mInitialHighContrastLevels = settings.value(QString::fromLatin1(SETTINGS_HIGH_CONTRAST_LEVELS), false).toBool();
+        mInitialOverviewRailWidth = ParseOverviewRailWidthMode(
+            settings.value(QString::fromLatin1(SETTINGS_OVERVIEW_RAIL_WIDTH), QStringLiteral("medium")).toString()
+        );
         {
             const QSignalBlocker blocker(mShowLevelIconsCheckBox);
             mShowLevelIconsCheckBox->setChecked(mInitialShowLevelIcons);
@@ -425,6 +509,10 @@ void PreferencesEditor::UpdateFields()
         {
             const QSignalBlocker blocker(mHighContrastLevelsCheckBox);
             mHighContrastLevelsCheckBox->setChecked(mInitialHighContrastLevels);
+        }
+        {
+            const QSignalBlocker blocker(mOverviewRailWidthComboBox);
+            SelectOverviewRailWidthCombo(mOverviewRailWidthComboBox, mInitialOverviewRailWidth);
         }
     }
     RepopulateThemeCombo();
@@ -589,6 +677,14 @@ void PreferencesEditor::closeEvent(QCloseEvent *event)
     if (mHighContrastLevelsCheckBox->isChecked() != mInitialHighContrastLevels)
     {
         emit highContrastLevelsChanged(mInitialHighContrastLevels);
+    }
+    {
+        const OverviewRailWidthMode current =
+            ParseOverviewRailWidthMode(mOverviewRailWidthComboBox->currentData().toString());
+        if (current != mInitialOverviewRailWidth)
+        {
+            emit overviewRailWidthChanged(mInitialOverviewRailWidth);
+        }
     }
     StreamingControl::LoadConfiguration();
     QWidget::closeEvent(event);

--- a/doc/README.md
+++ b/doc/README.md
@@ -396,7 +396,9 @@ In [Stream Mode](#stream-mode-live-tail) and [Network Stream Mode](#network-stre
 
 The **Overview Rail** is a thin vertical strip along the right edge of the log table. It condenses the whole proxy-filtered stream into ~one row of pixels per bucket, so you can see where matches, anchors, and clusters of high-severity rows sit without scrolling.
 
-The rail is on by default; toggle it from **View → Overview Rail** (`Ctrl+Shift+O`) or the toolbar's rail icon. Visibility is persisted in `QSettings` so a re-opened window restores your preference. Width tracks `QStyle::PM_ScrollBarExtent`, so the strip scales cleanly on Hi-DPI and follows system-style changes.
+The rail is on by default; toggle it from **View → Overview Rail** (`Ctrl+Shift+O`) or the toolbar's rail icon. Visibility is persisted in `QSettings` so a re-opened window restores your preference.
+
+Width is DPI-fluent (anchored to the system scrollbar extent) and selectable in **Settings → Preferences** as **Narrow**, **Medium** (default), or **Wide**. Medium is about 1.5× the compact Narrow strip; Wide is 2× — useful when stacked severity bands need more room on Hi-DPI displays.
 
 ### What the rail shows
 

--- a/doc/README.md
+++ b/doc/README.md
@@ -413,7 +413,7 @@ The rail is computed off the current proxy chain (post filter, post sort), so it
 - **Left-drag** — scrubs the viewport indicator along the rail, live-updating the table as you drag.
 - **Mouse wheel over the rail** — routes to the table's vertical scrollbar, so you can spin through the stream from the rail.
 
-Row mapping is coalesced through `MainWindow::ScrollToProxyRow`, so rapid drags don't queue up a backlog of scroll jumps.
+The rail de-duplicates consecutive same-row emissions before calling `MainWindow::ScrollToProxyRow`, so a fast scrub across a range of pixels that all map to the same proxy row doesn't queue a backlog of identical scroll jumps.
 
 ## Searching
 

--- a/doc/README.md
+++ b/doc/README.md
@@ -392,6 +392,29 @@ Manual zoom pins the rung until you reset it, so appending new rows in a live st
 
 In [Stream Mode](#stream-mode-live-tail) and [Network Stream Mode](#network-stream-mode-tcp--udp) the strip repaints at the existing ~50 ms batch cadence — a burst of arrivals lands as a single stacked bar without dropping frames. The bucket index is rebuilt from scratch when the FIFO retention cap evicts old rows so the counts never lag the visible table.
 
+## Match overview rail
+
+The **Overview Rail** is a thin vertical strip along the right edge of the log table. It condenses the whole proxy-filtered stream into ~one row of pixels per bucket, so you can see where matches, anchors, and clusters of high-severity rows sit without scrolling.
+
+The rail is on by default; toggle it from **View → Overview Rail** (`Ctrl+Shift+O`) or the toolbar's rail icon. Visibility is persisted in `QSettings` so a re-opened window restores your preference. Width tracks `QStyle::PM_ScrollBarExtent`, so the strip scales cleanly on Hi-DPI and follows system-style changes.
+
+### What the rail shows
+
+- **Level underlay** — every bucket is tinted with the dominant [canonical `LogLevel`](#automatic-column-detection) of the rows it covers, using the active theme's row-tint palette. A wall of red immediately says "errors down there".
+- **Match ticks** — while the [Find bar](#searching) is open, current-search matches are folded into their buckets and drawn as bright ticks. Closing the Find bar clears the ticks; reopening it restores them from the cached result set.
+- **Anchor bands** — buckets with any [anchored](#anchors) row show a coloured band in the anchor's slot colour along the rail's right edge. When a bucket carries anchors from multiple slots the lowest-index slot wins (deterministic, and rare given the rail's coarse bucketing).
+- **Viewport indicator** — a translucent rectangle marks the slice of the stream that is currently visible in the table, so scrolling the table slides the indicator up or down the rail.
+
+The rail is computed off the current proxy chain (post filter, post sort), so it always agrees with what the table would show if you scrolled to that point.
+
+### Click to jump, drag to scroll
+
+- **Click a bucket** — scrolls the table so the first proxy row of that bucket is visible.
+- **Left-drag** — scrubs the viewport indicator along the rail, live-updating the table as you drag.
+- **Mouse wheel over the rail** — routes to the table's vertical scrollbar, so you can spin through the stream from the rail.
+
+Row mapping is coalesced through `MainWindow::ScrollToProxyRow`, so rapid drags don't queue up a backlog of scroll jumps.
+
 ## Searching
 
 Open the Find bar with **Edit → Find** (`Ctrl+F`). It appears at the bottom of the window with:

--- a/doc/README.md
+++ b/doc/README.md
@@ -396,7 +396,7 @@ In [Stream Mode](#stream-mode-live-tail) and [Network Stream Mode](#network-stre
 
 The **Overview Rail** is a thin vertical strip along the right edge of the log table. It condenses the whole proxy-filtered stream into ~one row of pixels per bucket, so you can see where matches, anchors, and clusters of high-severity rows sit without scrolling.
 
-The rail is on by default; toggle it from **View → Overview Rail** (`Ctrl+Shift+O`) or the toolbar's rail icon. Visibility is persisted in `QSettings` so a re-opened window restores your preference.
+The rail is on by default; toggle it from **View → Overview Rail** (`Ctrl+Shift+R`) or the toolbar's rail icon. Visibility is persisted in `QSettings` so a re-opened window restores your preference.
 
 Width is DPI-fluent (anchored to the system scrollbar extent) and selectable in **Settings → Preferences** as **Narrow**, **Medium** (default), or **Wide**. Medium is about 1.5× the compact Narrow strip; Wide is 2× — useful when stacked severity bands need more room on Hi-DPI displays.
 
@@ -528,6 +528,7 @@ Open **Settings → Preferences…** to change application-wide settings. The di
 - **Active theme** — see [Themes](#themes) above.
 - **Show level icons** — render themed glyphs in the level column instead of the raw level text.
 - **High contrast levels** — use the theme's loud row tints for Warn / Error / Fatal.
+- **Overview rail width** — pick the width preset for the [Overview Rail](#match-overview-rail): *Narrow*, *Medium* (default), or *Wide*. All three scale with the system scrollbar / DPI. Applied live and persisted on **Ok**.
 
 **Streaming** — applied transactionally on **Ok**.
 
@@ -563,6 +564,7 @@ Click **Ok** to persist (stored via `QSettings` under the organization `jan-mora
 | Toggle Record Details pane     | `Ctrl+I`            |
 | Toggle Anchors panel           | `Ctrl+K`            |
 | Toggle Histogram panel         | `Ctrl+H`            |
+| Toggle Overview Rail           | `Ctrl+Shift+R`      |
 | Anchor selection (colour 1..8) | `Ctrl+1` … `Ctrl+8` |
 | Remove anchor from selection   | `Ctrl+0`            |
 | Clear every anchor             | `Ctrl+Shift+A`      |

--- a/resources/icons/bar-chart-horizontal.svg
+++ b/resources/icons/bar-chart-horizontal.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M3 3v18h18"/><path d="M7 16h8"/><path d="M7 11h12"/><path d="M7 6h3"/></svg>

--- a/resources/resources.qrc
+++ b/resources/resources.qrc
@@ -23,6 +23,7 @@
         <file>icons/arrow-down-to-line.svg</file>
         <file>icons/arrow-down-up.svg</file>
         <file>icons/bar-chart-3.svg</file>
+        <file>icons/bar-chart-horizontal.svg</file>
         <file>icons/bookmark.svg</file>
         <file>icons/circle-x.svg</file>
         <file>icons/file-clock.svg</file>

--- a/test/app/CMakeLists.txt
+++ b/test/app/CMakeLists.txt
@@ -113,4 +113,8 @@ target_link_libraries(apptest_overview_rail PRIVATE Qt6::Test Qt6::Widgets logap
 
 target_include_directories(apptest_overview_rail PRIVATE ${CMAKE_SOURCE_DIR}/library/include)
 
-add_test(NAME apptest_overview_rail COMMAND apptest_overview_rail WORKING_DIRECTORY $<TARGET_FILE_DIR:apptest_overview_rail>)
+add_test(
+    NAME apptest_overview_rail
+    COMMAND apptest_overview_rail
+    WORKING_DIRECTORY $<TARGET_FILE_DIR:apptest_overview_rail>
+)

--- a/test/app/CMakeLists.txt
+++ b/test/app/CMakeLists.txt
@@ -96,3 +96,15 @@ target_link_libraries(apptest_histogram PRIVATE Qt6::Test Qt6::Widgets logapp)
 target_include_directories(apptest_histogram PRIVATE ${CMAKE_SOURCE_DIR}/library/include)
 
 add_test(NAME apptest_histogram COMMAND apptest_histogram WORKING_DIRECTORY $<TARGET_FILE_DIR:apptest_histogram>)
+
+# Unit tests for the match overview rail (ROADMAP item 13). Same
+# concern-per-binary pattern as `apptest_histogram`: keeps the
+# monolithic `apptest` lean and lets `ctest -R apptest_overview_rail`
+# rerun just this concern.
+qt_add_executable(apptest_overview_rail src/test_overview_rail.cpp)
+
+target_link_libraries(apptest_overview_rail PRIVATE Qt6::Test Qt6::Widgets logapp)
+
+target_include_directories(apptest_overview_rail PRIVATE ${CMAKE_SOURCE_DIR}/library/include)
+
+add_test(NAME apptest_overview_rail COMMAND apptest_overview_rail WORKING_DIRECTORY $<TARGET_FILE_DIR:apptest_overview_rail>)

--- a/test/app/CMakeLists.txt
+++ b/test/app/CMakeLists.txt
@@ -101,7 +101,13 @@ add_test(NAME apptest_histogram COMMAND apptest_histogram WORKING_DIRECTORY $<TA
 # concern-per-binary pattern as `apptest_histogram`: keeps the
 # monolithic `apptest` lean and lets `ctest -R apptest_overview_rail`
 # rerun just this concern.
-qt_add_executable(apptest_overview_rail src/test_overview_rail.cpp)
+#
+# Links the built-in theme JSONs from `resources.qrc` so the paint
+# tests can load the real Dark / Light themes via
+# `ThemeControl::SetActiveSelection` and assert contrast against a
+# realistic palette (not the offscreen QPA's blank fallback).
+qt_add_resources(RAIL_TEST_RESOURCES ${CMAKE_CURRENT_SOURCE_DIR}/../../resources/resources.qrc)
+qt_add_executable(apptest_overview_rail src/test_overview_rail.cpp ${RAIL_TEST_RESOURCES})
 
 target_link_libraries(apptest_overview_rail PRIVATE Qt6::Test Qt6::Widgets logapp)
 

--- a/test/app/src/main_window_test.cpp
+++ b/test/app/src/main_window_test.cpp
@@ -12239,9 +12239,7 @@ private slots:
         // Clear any inherited selection so the first Next starts at
         // row 0 with skipFirstN==0.
         tableView->selectionModel()->clearSelection();
-        tableView->selectionModel()->setCurrentIndex(
-            filterModel->index(0, 0), QItemSelectionModel::NoUpdate
-        );
+        tableView->selectionModel()->setCurrentIndex(filterModel->index(0, 0), QItemSelectionModel::NoUpdate);
 
         QList<int> visited;
         visited.reserve(FIXTURE_LINES);
@@ -12320,9 +12318,7 @@ private slots:
         QVERIFY2(filterModel != nullptr, "MainWindow must own a LogFilterModel proxy");
 
         tableView->selectionModel()->clearSelection();
-        tableView->selectionModel()->setCurrentIndex(
-            filterModel->index(0, 0), QItemSelectionModel::NoUpdate
-        );
+        tableView->selectionModel()->setCurrentIndex(filterModel->index(0, 0), QItemSelectionModel::NoUpdate);
 
         edit->setText(QStringLiteral("needle"));
         QSignalSpy findSpy(findRecord, &FindRecordWidget::FindRecords);
@@ -13293,17 +13289,17 @@ private slots:
         QVERIFY2(
             tooltip.contains(QStringLiteral("lower bound"), Qt::CaseInsensitive) ||
                 tooltip.contains(QStringLiteral("bails"), Qt::CaseInsensitive),
-            qPrintable(QStringLiteral(
-                           "tooltip should mention the scan's early-exit / lower-bound "
-                           "nature so the user can interpret the '+' correctly: %1"
-            )
+            qPrintable(QStringLiteral("tooltip should mention the scan's early-exit / lower-bound "
+                                      "nature so the user can interpret the '+' correctly: %1")
                            .arg(tooltip))
         );
         QVERIFY2(
             tooltip.contains(QStringLiteral("current"), Qt::CaseInsensitive) ||
                 tooltip.contains(QStringLiteral("cursor"), Qt::CaseInsensitive) ||
                 tooltip.contains(QStringLiteral("index"), Qt::CaseInsensitive),
-            qPrintable(QStringLiteral("tooltip should also mention the cursor / current-match degradation: %1").arg(tooltip))
+            qPrintable(
+                QStringLiteral("tooltip should also mention the cursor / current-match degradation: %1").arg(tooltip)
+            )
         );
 
         // Narrowing the search (overflow gone) must not leave the

--- a/test/app/src/main_window_test.cpp
+++ b/test/app/src/main_window_test.cpp
@@ -13370,6 +13370,7 @@ private slots:
             QStringLiteral("actionToggleRecordDetails"),
             QStringLiteral("actionToggleAnchors"),
             QStringLiteral("actionToggleHistogram"),
+            QStringLiteral("actionToggleOverviewRail"),
             QStringLiteral("__widget"), // expanding spacer
             QStringLiteral("actionPreferences"),
         };

--- a/test/app/src/main_window_test.cpp
+++ b/test/app/src/main_window_test.cpp
@@ -12232,7 +12232,7 @@ private slots:
 
         auto *tableView = mWindow->findChild<LogTableView *>();
         QVERIFY2(tableView != nullptr, "MainWindow must own a LogTableView");
-        LogFilterModel *filterModel = mWindow->FilterModel();
+        const LogFilterModel *filterModel = mWindow->FilterModel();
         QVERIFY2(filterModel != nullptr, "MainWindow must own a LogFilterModel proxy");
         QCOMPARE(filterModel->rowCount(), FIXTURE_LINES);
 
@@ -12314,7 +12314,7 @@ private slots:
 
         auto *tableView = mWindow->findChild<LogTableView *>();
         QVERIFY2(tableView != nullptr, "MainWindow must own a LogTableView");
-        LogFilterModel *filterModel = mWindow->FilterModel();
+        const LogFilterModel *filterModel = mWindow->FilterModel();
         QVERIFY2(filterModel != nullptr, "MainWindow must own a LogFilterModel proxy");
 
         tableView->selectionModel()->clearSelection();

--- a/test/app/src/main_window_test.cpp
+++ b/test/app/src/main_window_test.cpp
@@ -12193,6 +12193,165 @@ private slots:
         model->EndStreaming(false);
     }
 
+    // Regression: Find Next must land on every consecutive match.
+    // A double-advance (e.g. FindRecords firing twice per Enter /
+    // click, or skipFirstN skipping a row and a match) presents as
+    // "every other hit is skipped".
+    void TestFindNextVisitsEveryConsecutiveMatch()
+    {
+        // Every row contains "needle" so matches are consecutive
+        // proxy rows 0..N-1 — the strongest repro for skip-by-two.
+        constexpr int FIXTURE_LINES = 8;
+        QStringList lines;
+        lines.reserve(FIXTURE_LINES);
+        for (int i = 0; i < FIXTURE_LINES; ++i)
+        {
+            lines.append(QStringLiteral(R"({"msg": "needle row%1"})").arg(i));
+        }
+        const TempJsonFile fixture(lines);
+
+        auto *model = mWindow->findChild<LogModel *>();
+        QVERIFY2(model != nullptr, "MainWindow must own a LogModel");
+
+        QSignalSpy finishedSpy(model, &LogModel::streamingFinished);
+        QVERIFY(finishedSpy.isValid());
+
+        auto file = std::make_unique<loglib::LogFile>(fixture.Path().toStdString());
+        auto fileSource = std::make_unique<loglib::FileLineSource>(std::move(file));
+        loglib::FileLineSource *fileSourcePtr = fileSource.get();
+        const loglib::StopToken stopToken = model->BeginStreamingForSyncTest(std::move(fileSource));
+
+        loglib::ParserOptions options;
+        options.stopToken = stopToken;
+        loglib::internal::AdvancedParserOptions advanced;
+        advanced.threads = 1;
+        const loglib::JsonParser parser;
+        loglib::JsonParser::ParseStreaming(*fileSourcePtr, *model->Sink(), options, advanced);
+        QVERIFY2(finishedSpy.count() > 0 || finishedSpy.wait(5000), "streamingFinished must arrive");
+        QCOMPARE(model->rowCount(), FIXTURE_LINES);
+
+        auto *tableView = mWindow->findChild<LogTableView *>();
+        QVERIFY2(tableView != nullptr, "MainWindow must own a LogTableView");
+        LogFilterModel *filterModel = mWindow->FilterModel();
+        QVERIFY2(filterModel != nullptr, "MainWindow must own a LogFilterModel proxy");
+        QCOMPARE(filterModel->rowCount(), FIXTURE_LINES);
+
+        // Clear any inherited selection so the first Next starts at
+        // row 0 with skipFirstN==0.
+        tableView->selectionModel()->clearSelection();
+        tableView->selectionModel()->setCurrentIndex(
+            filterModel->index(0, 0), QItemSelectionModel::NoUpdate
+        );
+
+        QList<int> visited;
+        visited.reserve(FIXTURE_LINES);
+        for (int step = 0; step < FIXTURE_LINES; ++step)
+        {
+            QVERIFY2(
+                QMetaObject::invokeMethod(
+                    mWindow,
+                    "FindRecords",
+                    Qt::DirectConnection,
+                    Q_ARG(QString, QStringLiteral("needle")),
+                    Q_ARG(bool, true),
+                    Q_ARG(bool, false),
+                    Q_ARG(bool, false)
+                ),
+                "FindRecords slot must be invocable via meta-object"
+            );
+            const QModelIndex selected = tableView->selectionModel()->currentIndex();
+            QVERIFY2(selected.isValid(), "FindRecords must select a match");
+            visited.append(selected.row());
+        }
+
+        QList<int> expected;
+        expected.reserve(FIXTURE_LINES);
+        for (int i = 0; i < FIXTURE_LINES; ++i)
+        {
+            expected.append(i);
+        }
+        QCOMPARE(visited, expected);
+
+        model->EndStreaming(false);
+    }
+
+    // Same consecutive-match walk, but driven through the find bar's
+    // Enter / Next-button signals so a double-emit of `FindRecords`
+    // cannot hide behind direct slot invocation.
+    void TestFindNextViaUiDoesNotDoubleAdvance()
+    {
+        constexpr int FIXTURE_LINES = 6;
+        QStringList lines;
+        lines.reserve(FIXTURE_LINES);
+        for (int i = 0; i < FIXTURE_LINES; ++i)
+        {
+            lines.append(QStringLiteral(R"({"msg": "needle row%1"})").arg(i));
+        }
+        const TempJsonFile fixture(lines);
+
+        auto *model = mWindow->findChild<LogModel *>();
+        QVERIFY2(model != nullptr, "MainWindow must own a LogModel");
+
+        QSignalSpy finishedSpy(model, &LogModel::streamingFinished);
+        QVERIFY(finishedSpy.isValid());
+
+        auto file = std::make_unique<loglib::LogFile>(fixture.Path().toStdString());
+        auto fileSource = std::make_unique<loglib::FileLineSource>(std::move(file));
+        loglib::FileLineSource *fileSourcePtr = fileSource.get();
+        const loglib::StopToken stopToken = model->BeginStreamingForSyncTest(std::move(fileSource));
+
+        loglib::ParserOptions options;
+        options.stopToken = stopToken;
+        loglib::internal::AdvancedParserOptions advanced;
+        advanced.threads = 1;
+        const loglib::JsonParser parser;
+        loglib::JsonParser::ParseStreaming(*fileSourcePtr, *model->Sink(), options, advanced);
+        QVERIFY2(finishedSpy.count() > 0 || finishedSpy.wait(5000), "streamingFinished must arrive");
+
+        auto *findRecord = mWindow->findChild<FindRecordWidget *>();
+        QVERIFY2(findRecord != nullptr, "MainWindow must own a FindRecordWidget");
+        auto *edit = findRecord->findChild<QLineEdit *>(QStringLiteral("findEdit"));
+        auto *nextButton = findRecord->findChild<QToolButton *>(QStringLiteral("findNext"));
+        QVERIFY2(edit != nullptr && nextButton != nullptr, "find edit + next button must exist");
+
+        auto *tableView = mWindow->findChild<LogTableView *>();
+        QVERIFY2(tableView != nullptr, "MainWindow must own a LogTableView");
+        LogFilterModel *filterModel = mWindow->FilterModel();
+        QVERIFY2(filterModel != nullptr, "MainWindow must own a LogFilterModel proxy");
+
+        tableView->selectionModel()->clearSelection();
+        tableView->selectionModel()->setCurrentIndex(
+            filterModel->index(0, 0), QItemSelectionModel::NoUpdate
+        );
+
+        edit->setText(QStringLiteral("needle"));
+        QSignalSpy findSpy(findRecord, &FindRecordWidget::FindRecords);
+        QVERIFY(findSpy.isValid());
+
+        // Enter in the search field must emit FindRecords exactly once
+        // and advance by exactly one match.
+        edit->setFocus();
+        QTest::keyClick(edit, Qt::Key_Return);
+        QCOMPARE(findSpy.count(), 1);
+        QCOMPARE(tableView->selectionModel()->currentIndex().row(), 0);
+
+        // Next button: same single-step contract.
+        findSpy.clear();
+        QTest::mouseClick(nextButton, Qt::LeftButton);
+        QCOMPARE(findSpy.count(), 1);
+        QCOMPARE(tableView->selectionModel()->currentIndex().row(), 1);
+
+        // Enter again from the edit field after the button click
+        // (focus may have moved) — still one step, not a double jump.
+        findSpy.clear();
+        edit->setFocus();
+        QTest::keyClick(edit, Qt::Key_Return);
+        QCOMPARE(findSpy.count(), 1);
+        QCOMPARE(tableView->selectionModel()->currentIndex().row(), 2);
+
+        model->EndStreaming(false);
+    }
+
     // Regression: `FindRecords` used to OR `MatchContains` with the
     // regex / wildcard flags. `Matches` short-circuits on contains,
     // so the toggles were silently no-ops.

--- a/test/app/src/main_window_test.cpp
+++ b/test/app/src/main_window_test.cpp
@@ -13097,6 +13097,62 @@ private slots:
         QCOMPARE(label->text(), QStringLiteral("sentinel-do-not-touch"));
     }
 
+    // Regression: `SetMatchInfo(overflowed=true)` used to only
+    // append "+" to the visible total, which was ambiguous
+    // between "the total is a lower bound (scan bailed)" and
+    // "the total is exact but cursor-position lookup is capped".
+    // The label now installs a tooltip that spells both effects
+    // out; `overflowed=false` must clear the tooltip so a
+    // narrower search doesn't inherit a stale hover from the
+    // previous broad one. Pins both edges.
+    void TestSetMatchInfoOverflowedInstallsTooltip()
+    {
+        auto *findRecord = mWindow->findChild<FindRecordWidget *>();
+        QVERIFY2(findRecord != nullptr, "MainWindow must own a FindRecordWidget");
+        auto *label = findRecord->findChild<QLabel *>(QStringLiteral("findMatchCount"));
+        QVERIFY2(label != nullptr, "FindRecordWidget must expose its match-count label");
+
+        // Baseline: no matches, tooltip clear.
+        findRecord->SetMatchInfo(0, 0);
+        QVERIFY2(label->toolTip().isEmpty(), "empty result must clear the tooltip");
+
+        // Exact count (not overflowed): visible text has no "+"
+        // and no tooltip.
+        findRecord->SetMatchInfo(3, 42, /*overflowed=*/false);
+        QVERIFY2(!label->text().contains(QChar('+')), "non-overflowed total must not carry a '+' suffix");
+        QVERIFY2(label->toolTip().isEmpty(), "non-overflowed match info must not install a tooltip");
+
+        // Overflowed: visible text keeps "+" (lower-bound cue),
+        // AND the tooltip explains what the "+" means and calls
+        // out the cursor-position degradation. Keyword probes
+        // rather than exact-text matches so translation drift or
+        // wording tweaks don't tank the test.
+        findRecord->SetMatchInfo(0, 25000, /*overflowed=*/true);
+        QVERIFY2(label->text().contains(QChar('+')), "overflowed total must retain the '+' lower-bound cue");
+        const QString tooltip = label->toolTip();
+        QVERIFY2(!tooltip.isEmpty(), "overflowed match info must install an explanatory tooltip");
+        QVERIFY2(
+            tooltip.contains(QStringLiteral("lower bound"), Qt::CaseInsensitive) ||
+                tooltip.contains(QStringLiteral("bails"), Qt::CaseInsensitive),
+            qPrintable(QStringLiteral(
+                           "tooltip should mention the scan's early-exit / lower-bound "
+                           "nature so the user can interpret the '+' correctly: %1"
+            )
+                           .arg(tooltip))
+        );
+        QVERIFY2(
+            tooltip.contains(QStringLiteral("current"), Qt::CaseInsensitive) ||
+                tooltip.contains(QStringLiteral("cursor"), Qt::CaseInsensitive) ||
+                tooltip.contains(QStringLiteral("index"), Qt::CaseInsensitive),
+            qPrintable(QStringLiteral("tooltip should also mention the cursor / current-match degradation: %1").arg(tooltip))
+        );
+
+        // Narrowing the search (overflow gone) must not leave the
+        // previous tooltip stranded on the label.
+        findRecord->SetMatchInfo(1, 5, /*overflowed=*/false);
+        QVERIFY2(label->toolTip().isEmpty(), "narrower search must clear the stale overflow tooltip");
+    }
+
     // Regression: the status button used to total `count +
     // droppedCount`, which didn't match the dock summary ("X
     // errors; Y earlier dropped"). Now the button renders the

--- a/test/app/src/test_overview_rail.cpp
+++ b/test/app/src/test_overview_rail.cpp
@@ -21,6 +21,7 @@
 #include <loglib/file_line_source.hpp>
 #include <loglib/internal/advanced_parser_options.hpp>
 #include <loglib/log_file.hpp>
+#include <loglib/log_filter.hpp>
 #include <loglib/log_level.hpp>
 #include <loglib/log_parse_sink.hpp>
 #include <loglib/parser_options.hpp>
@@ -47,6 +48,7 @@
 #include <cstdint>
 #include <fstream>
 #include <memory>
+#include <string_view>
 #include <utility>
 #include <vector>
 
@@ -669,6 +671,180 @@ private slots:
         window.ScrollToProxyRow(25, /*replaceSelection=*/true);
         QCOMPARE(selection->selectedRows().size(), 1);
         QCOMPARE(selection->selectedRows().front().row(), 25);
+    }
+
+    /// Toggling the rail off (`SetBucketCount(0)`) drops the
+    /// bucket vector but preserves the cached match rows.
+    /// Toggling back on (`SetBucketCount(H)`) folds the cached
+    /// ticks into fresh buckets so the widget doesn't paint a
+    /// blank match band. Pins the "hide, keep find results,
+    /// reveal, ticks restored" cycle used by
+    /// `MainWindow::SetOverviewRailVisible`.
+    static void TestHideAndShowRestoresMatchTicks()
+    {
+        LogModel model;
+        QObject owner;
+        const auto chain = BuildProxyChain(&model, &owner);
+        OverviewRailModel rail(chain.filter, &model, /*anchors=*/nullptr);
+        rail.SetBucketCount(20);
+
+        constexpr int ROWS = 20;
+        const RailFixture fixture(ROWS);
+        StreamJsonPathInto(model, fixture.Path());
+        WaitForBucketsChanged(rail);
+        QCOMPARE(rail.ProxyRowCount(), ROWS);
+
+        rail.SetMatchProxyRows({4, 9, 14});
+        QVERIFY(rail.HasMatchTicks());
+
+        // Hide: bucket vector drops, `HasMatchTicks` -> false
+        // (bucketed count is zero because there are no buckets
+        // to fold into), but the raw match list is retained.
+        rail.SetBucketCount(0);
+        QCOMPARE(rail.BucketCount(), static_cast<std::size_t>(0));
+        QVERIFY2(!rail.HasMatchTicks(), "hidden rail must report no match ticks");
+
+        // Reveal: `SetBucketCount(H)` reallocates buckets,
+        // `RebuildInternal` folds the retained match list into
+        // them, and `HasMatchTicks` flips back on without the
+        // caller re-pushing the list.
+        rail.SetBucketCount(20);
+        QVERIFY2(rail.HasMatchTicks(), "revealed rail must restore the cached match ticks");
+        std::uint32_t totalMatches = 0;
+        for (const auto &bucket : rail.Buckets())
+        {
+            totalMatches += bucket.matchCount;
+        }
+        QCOMPARE(totalMatches, static_cast<std::uint32_t>(3));
+    }
+
+    /// Installing a filter on the outer proxy fires
+    /// `layoutChanged`, which the rail wires to `Rebuild`.
+    /// Assert we get a `bucketsChanged` emit within the
+    /// coalesce window (pins the wiring path that
+    /// `TestRebuildIsCoalesced` doesn't exercise).
+    static void TestLayoutChangedTriggersRebuild()
+    {
+        LogModel model;
+        QObject owner;
+        const auto chain = BuildProxyChain(&model, &owner);
+        OverviewRailModel rail(chain.filter, &model, /*anchors=*/nullptr);
+        rail.SetBucketCount(16);
+
+        constexpr int ROWS = 20;
+        const RailFixture fixture(ROWS);
+        StreamJsonPathInto(model, fixture.Path());
+        WaitForBucketsChanged(rail);
+        QCOMPARE(rail.ProxyRowCount(), ROWS);
+
+        // Install a callback filter on column 0 that drops
+        // every other source row. The rules change fires
+        // `layoutChanged` on `LogFilterModel`, which the rail
+        // wires to `Rebuild` -> coalesce timer.
+        QSignalSpy spy(&rail, &OverviewRailModel::bucketsChanged);
+        QVERIFY(spy.isValid());
+        std::vector<loglib::RowPredicate> rules;
+        rules.emplace_back(
+            std::in_place_type<loglib::CallbackStringRowPredicate>,
+            /*columnIndex=*/static_cast<std::size_t>(0),
+            /*match=*/[callCount = std::make_shared<std::size_t>(0)](std::string_view) mutable {
+                return ((*callCount)++ % 2) == 0;
+            }
+        );
+        chain.filter->SetFilterRules(std::move(rules));
+
+        QVERIFY2(spy.wait(1000), "layoutChanged must trigger a rebuild via the coalesce timer");
+        QVERIFY2(rail.ProxyRowCount() < ROWS, "filter must reduce the proxy row count");
+    }
+
+    /// Duplicate entries in the match-rows list must not
+    /// double-count into their bucket. Pins the `sort + unique`
+    /// normalisation in `SetMatchProxyRows`.
+    static void TestSetMatchProxyRowsDedupsDuplicates()
+    {
+        LogModel model;
+        QObject owner;
+        const auto chain = BuildProxyChain(&model, &owner);
+        OverviewRailModel rail(chain.filter, &model, /*anchors=*/nullptr);
+        rail.SetBucketCount(20);
+
+        constexpr int ROWS = 20;
+        const RailFixture fixture(ROWS);
+        StreamJsonPathInto(model, fixture.Path());
+        WaitForBucketsChanged(rail);
+
+        // Same three unique rows, plus assorted duplicates and
+        // out-of-order entries.
+        rail.SetMatchProxyRows({5, 10, 5, 15, 10, 5, 15, 15});
+        QVERIFY(rail.HasMatchTicks());
+        std::uint32_t total = 0;
+        for (const auto &bucket : rail.Buckets())
+        {
+            total += bucket.matchCount;
+        }
+        QCOMPARE(total, static_cast<std::uint32_t>(3));
+    }
+
+    /// `enumColumnsChanged(Grew, ...)` never moves the level
+    /// column (only `Promoted` / `Demoted` do), so it must not
+    /// schedule a rebuild. Regression against a wide-log parse
+    /// paying `O(nColumns)` scans on every dictionary grow.
+    static void TestEnumGrewDoesNotTriggerRebuild()
+    {
+        LogModel model;
+        QObject owner;
+        const auto chain = BuildProxyChain(&model, &owner);
+        OverviewRailModel rail(chain.filter, &model, /*anchors=*/nullptr);
+        rail.SetBucketCount(16);
+
+        constexpr int ROWS = 16;
+        const RailFixture fixture(ROWS);
+        StreamJsonPathInto(model, fixture.Path());
+        WaitForBucketsChanged(rail);
+
+        QSignalSpy spy(&rail, &OverviewRailModel::bucketsChanged);
+        QVERIFY(spy.isValid());
+        // Fire a synthetic `Grew` on the level column (the
+        // wide-log worst case). The rail's connect explicitly
+        // short-circuits `Grew` so the coalesce timer must not
+        // arm.
+        emit model.enumColumnsChanged(EnumColumnsChangeReason::Grew, /*columnIndex=*/0);
+
+        // Wait > coalesce interval to be sure we didn't
+        // just miss a scheduled emit. 200 ms is well past the
+        // 50 ms timer plus event-loop slack.
+        QTest::qWait(200);
+        QCOMPARE_LE(spy.count(), 0);
+    }
+
+    /// A rail widget destroyed through a non-`AttachOverviewRail`
+    /// path silently clears the view's `QPointer`. The next
+    /// geometry pass must reclaim the reserved right margin so
+    /// the viewport doesn't keep a phantom gap.
+    static void TestPhantomMarginResetsWhenRailDestroyed()
+    {
+        LogTableView view;
+        view.resize(800, 400);
+        view.show();
+
+        constexpr int RAIL_WIDTH = 16;
+        auto *rail = new QWidget(nullptr);
+        rail->setFixedWidth(RAIL_WIDTH);
+        view.AttachOverviewRail(rail);
+        QVERIFY(view.ReservedRightMargin() > 0);
+
+        // External destruction: `mOverviewRail` (QPointer) is
+        // cleared silently by Qt's QObject teardown. The view
+        // must notice on the next geometry pass and reclaim the
+        // margin without a call to `AttachOverviewRail(nullptr)`.
+        delete rail;
+        QCOMPARE(view.OverviewRail(), static_cast<QWidget *>(nullptr));
+
+        // Trigger `UpdateOverviewRailGeometry` via a resize.
+        view.resize(view.width() + 10, view.height());
+        // Give Qt a chance to deliver the resize event.
+        QCoreApplication::processEvents();
+        QCOMPARE(view.ReservedRightMargin(), 0);
     }
 };
 

--- a/test/app/src/test_overview_rail.cpp
+++ b/test/app/src/test_overview_rail.cpp
@@ -1702,7 +1702,7 @@ private slots:
         QCOMPARE(settings.value(QStringLiteral("ui/showOverviewRail")).toBool(), true);
     }
 
-    /// The Ctrl+Shift+O shortcut fires the toggle. Confirms the
+    /// The Ctrl+Shift+R shortcut fires the toggle. Confirms the
     /// shortcut is registered on the window so the discovery path
     /// (Shortcuts dialog + toolbar tooltip) matches expectations.
     static void TestMainWindowOverviewRailShortcut()
@@ -1710,7 +1710,7 @@ private slots:
         MainWindow window;
         auto *action = window.findChild<QAction *>(QStringLiteral("actionToggleOverviewRail"));
         QVERIFY(action != nullptr);
-        const QKeySequence expected(Qt::CTRL | Qt::SHIFT | Qt::Key_O);
+        const QKeySequence expected(Qt::CTRL | Qt::SHIFT | Qt::Key_R);
         QCOMPARE(action->shortcut(), expected);
     }
 

--- a/test/app/src/test_overview_rail.cpp
+++ b/test/app/src/test_overview_rail.cpp
@@ -1,0 +1,456 @@
+// GUI tests for the overview rail (ROADMAP item 13). Covers
+// `OverviewRailModel` bucketing / tick tracking,
+// `OverviewRailWidget` sizing / paint contract, the
+// `LogTableView::AttachOverviewRail` viewport-margin hook, and
+// the MainWindow toggle + find-cache push wiring.
+//
+// Kept in its own binary (mirroring `apptest_histogram` /
+// `apptest_theme`) so the concern is runnable in isolation via
+// `apptest_overview_rail`.
+
+#include "anchor_manager.hpp"
+#include "log_filter_model.hpp"
+#include "log_model.hpp"
+#include "log_table_view.hpp"
+#include "main_window.hpp"
+#include "overview_rail_model.hpp"
+#include "overview_rail_widget.hpp"
+#include "qt_streaming_log_sink.hpp"
+#include "row_order_proxy_model.hpp"
+
+#include <loglib/file_line_source.hpp>
+#include <loglib/internal/advanced_parser_options.hpp>
+#include <loglib/log_file.hpp>
+#include <loglib/log_level.hpp>
+#include <loglib/log_parse_sink.hpp>
+#include <loglib/parser_options.hpp>
+#include <loglib/parsers/json_parser.hpp>
+#include <loglib/stop_token.hpp>
+#include <loglib/theme.hpp>
+
+#include <QAbstractItemModel>
+#include <QAction>
+#include <QApplication>
+#include <QModelIndex>
+#include <QSettings>
+#include <QSignalSpy>
+#include <QString>
+#include <QStringList>
+#include <QTemporaryDir>
+#include <QToolBar>
+#include <QVariant>
+#include <QtTest/QtTest>
+
+#include <cstddef>
+#include <cstdint>
+#include <fstream>
+#include <memory>
+#include <utility>
+#include <vector>
+
+namespace
+{
+
+// N rows of `{time, level, body}` JSON. `level` cycles through
+// four canonical levels so buckets carry a mix of severities and
+// dominant-level logic has something to disambiguate.
+class RailFixture
+{
+public:
+    explicit RailFixture(int rows)
+    {
+        QVERIFY2(mDir.isValid(), "QTemporaryDir creation must succeed");
+        mPath = mDir.filePath("rail.jsonl");
+        std::ofstream stream(mPath.toStdString(), std::ios::binary);
+        QVERIFY2(stream.is_open(), "fixture must open for writing");
+        static const QStringList LEVELS = {
+            QStringLiteral("info"),
+            QStringLiteral("warn"),
+            QStringLiteral("error"),
+            QStringLiteral("debug"),
+        };
+        for (int i = 0; i < rows; ++i)
+        {
+            const int hour = i / 3600;
+            const int minute = (i / 60) % 60;
+            const int second = i % 60;
+            const QString line = QStringLiteral(R"({"time": "2026-01-01T%1:%2:%3", "level": "%4", "body": "msg %5"})")
+                                     .arg(hour, 2, 10, QChar('0'))
+                                     .arg(minute, 2, 10, QChar('0'))
+                                     .arg(second, 2, 10, QChar('0'))
+                                     .arg(LEVELS[i % LEVELS.size()])
+                                     .arg(i);
+            stream << line.toStdString() << '\n';
+        }
+    }
+
+    [[nodiscard]] QString Path() const
+    {
+        return mPath;
+    }
+
+private:
+    QTemporaryDir mDir;
+    QString mPath;
+};
+
+// Feed the JSON at @p path into @p model synchronously (mirrors
+// the `test_histogram_dock.cpp` pattern).
+void StreamJsonPathInto(LogModel &model, const QString &path)
+{
+    QSignalSpy finishedSpy(&model, &LogModel::streamingFinished);
+    QVERIFY(finishedSpy.isValid());
+
+    auto file = std::make_unique<loglib::LogFile>(path.toStdString());
+    auto fileSource = std::make_unique<loglib::FileLineSource>(std::move(file));
+    loglib::FileLineSource *parseSource = fileSource.get();
+    const loglib::StopToken stopToken = model.BeginStreamingForSyncTest(std::move(fileSource));
+
+    loglib::ParserOptions options;
+    options.stopToken = stopToken;
+    loglib::internal::AdvancedParserOptions advanced;
+    advanced.threads = 1;
+    loglib::JsonParser::ParseStreaming(*parseSource, *model.Sink(), options, advanced);
+
+    const bool finished = finishedSpy.count() > 0 || finishedSpy.wait(5000);
+    QVERIFY2(finished, "streamingFinished must arrive within the timeout");
+    model.EndStreaming(false);
+}
+
+// Spin briefly for at least one `bucketsChanged`. Coalesced
+// through a 50 ms timer (mirrors the histogram model).
+void WaitForBucketsChanged(OverviewRailModel &model)
+{
+    QSignalSpy spy(&model, &OverviewRailModel::bucketsChanged);
+    QVERIFY(spy.isValid());
+    if (spy.count() > 0)
+    {
+        return;
+    }
+    QVERIFY2(spy.wait(1000), "bucketsChanged must arrive within the timeout");
+}
+
+// Wrap the proxy chain a production MainWindow builds so tests
+// can drive the model against realistic mapToSource walks.
+struct ProxyChain
+{
+    RowOrderProxyModel *rowOrder;
+    LogFilterModel *filter;
+};
+
+ProxyChain BuildProxyChain(LogModel *model, QObject *parent)
+{
+    auto *rowOrder = new RowOrderProxyModel(parent);
+    rowOrder->setSourceModel(model);
+
+    auto *filter = new LogFilterModel(parent);
+    filter->setSourceModel(rowOrder);
+    filter->SetLogModel(model);
+    return {rowOrder, filter};
+}
+
+} // namespace
+
+// NOLINTNEXTLINE(misc-use-internal-linkage): `Q_OBJECT` QtTest fixture.
+class OverviewRailTest : public QObject
+{
+    Q_OBJECT
+
+private slots:
+    void initTestCase()
+    {
+        QVERIFY2(
+            MainWindow::InitializeTimezoneDatabase(),
+            "Failed to initialise timezone database; see qCritical above."
+        );
+    }
+
+    /// Empty model + no anchors -> zero row count, no anchor
+    /// ticks. Confirms `Rebuild()` doesn't populate spurious
+    /// buckets when there's nothing to bucket.
+    static void TestEmptyModelHasNoBuckets()
+    {
+        LogModel model;
+        QObject owner;
+        const auto chain = BuildProxyChain(&model, &owner);
+        OverviewRailModel rail(chain.filter, &model, /*anchors=*/nullptr);
+        rail.SetBucketCount(32);
+        QCOMPARE(rail.BucketCount(), static_cast<std::size_t>(32));
+        QCOMPARE(rail.ProxyRowCount(), 0);
+        QVERIFY(!rail.HasAnchorTicks());
+        QVERIFY(!rail.HasMatchTicks());
+        for (const auto &bucket : rail.Buckets())
+        {
+            QCOMPARE(bucket.levels.Total(), static_cast<std::uint32_t>(0));
+            QCOMPARE(bucket.matchCount, static_cast<std::uint32_t>(0));
+            QVERIFY(bucket.anchorSlots.none());
+        }
+    }
+
+    /// After streaming 40 rows the rail's row count matches the
+    /// proxy's, buckets sum to the total, and dominant levels
+    /// include at least one non-Unknown entry (catches a bug
+    /// where `LevelForSourceRow` always returns `Unknown`).
+    static void TestBucketsPopulateFromStream()
+    {
+        LogModel model;
+        QObject owner;
+        const auto chain = BuildProxyChain(&model, &owner);
+        OverviewRailModel rail(chain.filter, &model, /*anchors=*/nullptr);
+        constexpr std::size_t BUCKET_COUNT = 40;
+        rail.SetBucketCount(BUCKET_COUNT);
+
+        constexpr int ROWS = 40;
+        const RailFixture fixture(ROWS);
+        StreamJsonPathInto(model, fixture.Path());
+        WaitForBucketsChanged(rail);
+
+        QCOMPARE(rail.ProxyRowCount(), ROWS);
+        std::uint32_t total = 0;
+        int nonUnknownBuckets = 0;
+        for (const auto &bucket : rail.Buckets())
+        {
+            total += bucket.levels.Total();
+            if (bucket.levels.Total() > 0)
+            {
+                const loglib::LogLevel dom = rail.DominantLevel(&bucket - rail.Buckets().data());
+                if (dom != loglib::LogLevel::Unknown)
+                {
+                    ++nonUnknownBuckets;
+                }
+            }
+        }
+        QCOMPARE(total, static_cast<std::uint32_t>(ROWS));
+        QVERIFY2(nonUnknownBuckets > 0, "every bucket resolved to Unknown -- level lookup is broken");
+    }
+
+    /// `SetMatchProxyRows` folds match ticks into the bucket
+    /// vector and flips `HasMatchTicks`. Rows outside the proxy
+    /// range are silently ignored (protects the drag scrub from
+    /// stale cached rows).
+    static void TestMatchRowsFoldIntoBuckets()
+    {
+        LogModel model;
+        QObject owner;
+        const auto chain = BuildProxyChain(&model, &owner);
+        OverviewRailModel rail(chain.filter, &model, /*anchors=*/nullptr);
+        rail.SetBucketCount(20);
+
+        constexpr int ROWS = 20;
+        const RailFixture fixture(ROWS);
+        StreamJsonPathInto(model, fixture.Path());
+        WaitForBucketsChanged(rail);
+        QCOMPARE(rail.ProxyRowCount(), ROWS);
+
+        QVERIFY(!rail.HasMatchTicks());
+        // Rows 5, 10, 15, plus out-of-range 999 (must be dropped
+        // silently) and negative -1 (also dropped).
+        QSignalSpy matchSpy(&rail, &OverviewRailModel::matchesChanged);
+        rail.SetMatchProxyRows({-1, 5, 10, 15, 999});
+        QVERIFY(rail.HasMatchTicks());
+        QCOMPARE(matchSpy.count(), 1);
+
+        std::uint32_t totalMatches = 0;
+        for (const auto &bucket : rail.Buckets())
+        {
+            totalMatches += bucket.matchCount;
+        }
+        QCOMPARE(totalMatches, static_cast<std::uint32_t>(3));
+
+        // Clearing drops ticks.
+        rail.SetMatchProxyRows({});
+        QVERIFY(!rail.HasMatchTicks());
+    }
+
+    /// Adding an anchor via `AnchorManager` flows into the
+    /// rail's bit set and flips `HasAnchorTicks`. Reset drops
+    /// the ticks and lowers the flag.
+    static void TestAnchorTicksFollowAnchorManager()
+    {
+        AnchorManager anchors;
+        // Model must be wired to the anchor manager so
+        // `AnchorSlotForRow` resolves the slot the rail reads.
+        LogModel model(/*parent=*/nullptr, /*theme=*/nullptr, &anchors);
+        QObject owner;
+        const auto chain = BuildProxyChain(&model, &owner);
+        OverviewRailModel rail(chain.filter, &model, &anchors);
+        rail.SetBucketCount(16);
+
+        constexpr int ROWS = 16;
+        const RailFixture fixture(ROWS);
+        StreamJsonPathInto(model, fixture.Path());
+        WaitForBucketsChanged(rail);
+
+        QVERIFY(!rail.HasAnchorTicks());
+        // Anchor row 8; the source model's canonical locator is
+        // the temp file path. The proxy chain preserves row 8 as
+        // proxy row 8 (no sort / filter installed).
+        const auto keyOpt = model.AnchorKeyForRow(8);
+        QVERIFY2(keyOpt.has_value(), "row 8 must have an anchor key after streaming");
+        if (!keyOpt.has_value())
+        {
+            return;
+        }
+        QSignalSpy anchorSpy(&rail, &OverviewRailModel::anchorBucketsChanged);
+        anchors.SetAnchor(*keyOpt, 3);
+        // Anchor mutation triggers a full rebuild in the rail;
+        // the signal is coalesced with buckets rebuilds via a
+        // direct `emit`, so no wait is needed after the mutation.
+        // Give Qt a tick to route the queued anchor emit.
+        QCoreApplication::processEvents();
+        QVERIFY(rail.HasAnchorTicks());
+        QVERIFY(anchorSpy.count() >= 1);
+
+        anchors.ClearAll();
+        QCoreApplication::processEvents();
+        QVERIFY(!rail.HasAnchorTicks());
+    }
+
+    /// `ProxyRowForYPixel` maps rail Y linearly onto proxy rows,
+    /// clamped into `[0, rowCount)`, and `FirstProxyRowInBucket`
+    /// inverts the mapping consistently.
+    static void TestProxyRowForYPixelClampsAndInverts()
+    {
+        LogModel model;
+        QObject owner;
+        const auto chain = BuildProxyChain(&model, &owner);
+        OverviewRailModel rail(chain.filter, &model, /*anchors=*/nullptr);
+        rail.SetBucketCount(100);
+
+        constexpr int ROWS = 100;
+        const RailFixture fixture(ROWS);
+        StreamJsonPathInto(model, fixture.Path());
+        WaitForBucketsChanged(rail);
+
+        // Top of the rail resolves to row 0.
+        QCOMPARE(rail.ProxyRowForYPixel(0, 100), 0);
+        // Middle resolves to row ~50.
+        const int mid = rail.ProxyRowForYPixel(50, 100);
+        QVERIFY2(mid >= 40 && mid <= 60, "midpoint Y must land near the middle row");
+        // Overshoot clamps into the row range.
+        QCOMPARE(rail.ProxyRowForYPixel(1000, 100), ROWS - 1);
+
+        // Round trip through FirstProxyRowInBucket for bucket 0
+        // should return row 0.
+        QCOMPARE(rail.FirstProxyRowInBucket(0), 0);
+        // The last bucket must resolve to a row <= last proxy row.
+        const int lastFirst = rail.FirstProxyRowInBucket(rail.BucketCount() - 1);
+        QVERIFY(lastFirst >= 0);
+        QVERIFY(lastFirst < ROWS);
+    }
+
+    /// `sizeHint()` returns a positive DPI-fluent width and a
+    /// zero preferred height (rail grows vertically to fit the
+    /// hosting margin). `minimumSizeHint` never exceeds it.
+    static void TestWidgetSizeHintIsDpiFluent()
+    {
+        LogModel model;
+        AnchorManager anchors;
+        QObject owner;
+        const auto chain = BuildProxyChain(&model, &owner);
+        OverviewRailModel rail(chain.filter, &model, &anchors, &owner);
+        OverviewRailWidget widget(&rail, /*theme=*/nullptr, /*tableView=*/nullptr);
+        // Ensure the widget has a valid style / font (offscreen QPA
+        // still routes both). The DPI-fluent width should be > 0
+        // and >= the minimum floor.
+        widget.ensurePolished();
+        const int width = widget.sizeHint().width();
+        QVERIFY2(width > 0, "size hint width must be positive after ensurePolished");
+        const int minWidth = widget.minimumSizeHint().width();
+        QVERIFY(minWidth > 0);
+        QVERIFY(width >= minWidth);
+        // sizeHint() returns 0 height so the parent layout drives
+        // vertical extent.
+        QCOMPARE(widget.sizeHint().height(), 0);
+    }
+
+    /// Attaching a rail widget to `LogTableView` reserves a
+    /// positive right margin; detaching zeroes it. The widget is
+    /// reparented to the view while attached and returned to the
+    /// caller on detach.
+    static void TestAttachOverviewRailReservesMargin()
+    {
+        LogTableView view;
+        view.resize(800, 400);
+        view.show();
+
+        // Use a QWidget with a fixed size so `sizeHint()` returns
+        // a positive width — a bare QWidget's sizeHint is (-1,-1),
+        // which would leave `ReservedRightMargin` at zero. The
+        // `OverviewRailWidget` in production supplies its own
+        // DPI-fluent width; test just needs any positive value.
+        constexpr int RAIL_WIDTH = 16;
+        auto *rail = new QWidget(nullptr);
+        rail->setFixedWidth(RAIL_WIDTH);
+        view.AttachOverviewRail(rail);
+        QCOMPARE(view.OverviewRail(), rail);
+        QCOMPARE(view.ReservedRightMargin(), RAIL_WIDTH);
+        QCOMPARE(rail->parent(), &view);
+
+        view.AttachOverviewRail(nullptr);
+        QCOMPARE(view.OverviewRail(), static_cast<QWidget *>(nullptr));
+        QCOMPARE(view.ReservedRightMargin(), 0);
+        // Widget survives detach (caller owns it). Delete manually.
+        delete rail;
+    }
+
+    /// The MainWindow overview-rail toggle exists as a checkable
+    /// action, defaults to on (per the ROADMAP), and toggling
+    /// off attaches / detaches the widget from the table view.
+    static void TestMainWindowOverviewRailToggle()
+    {
+        // Isolate the QSettings key so a prior run doesn't seed
+        // the pref off. A scoped org / app name keeps writes in a
+        // throw-away registry hive.
+        QCoreApplication::setOrganizationName(QStringLiteral("StructuredLogViewerTest"));
+        QCoreApplication::setApplicationName(QStringLiteral("OverviewRailToggle"));
+        {
+            QSettings settings;
+            settings.remove(QStringLiteral("ui/showOverviewRail"));
+        }
+
+        MainWindow window;
+        window.show();
+
+        auto *action = window.findChild<QAction *>(QStringLiteral("actionToggleOverviewRail"));
+        QVERIFY2(action != nullptr, "MainWindow must expose actionToggleOverviewRail");
+        QVERIFY(action->isCheckable());
+        QVERIFY2(action->isChecked(), "overview rail should be on by default (ROADMAP item 13)");
+
+        auto *view = window.findChild<LogTableView *>();
+        QVERIFY(view != nullptr);
+        QVERIFY2(view->OverviewRail() != nullptr, "rail widget must attach on default-on toggle");
+        QVERIFY(view->ReservedRightMargin() > 0);
+
+        // Toggle off -- widget detaches, margin reclaimed.
+        action->trigger();
+        QVERIFY(!action->isChecked());
+        QCOMPARE(view->OverviewRail(), static_cast<QWidget *>(nullptr));
+        QCOMPARE(view->ReservedRightMargin(), 0);
+
+        // Toggle back on -- widget re-attaches.
+        action->trigger();
+        QVERIFY(action->isChecked());
+        QVERIFY(view->OverviewRail() != nullptr);
+        QVERIFY(view->ReservedRightMargin() > 0);
+
+        // Persisted preference reflects the current state.
+        const QSettings settings;
+        QCOMPARE(settings.value(QStringLiteral("ui/showOverviewRail")).toBool(), true);
+    }
+
+    /// The Ctrl+Shift+O shortcut fires the toggle. Confirms the
+    /// shortcut is registered on the window so the discovery path
+    /// (Shortcuts dialog + toolbar tooltip) matches expectations.
+    static void TestMainWindowOverviewRailShortcut()
+    {
+        MainWindow window;
+        auto *action = window.findChild<QAction *>(QStringLiteral("actionToggleOverviewRail"));
+        QVERIFY(action != nullptr);
+        const QKeySequence expected(Qt::CTRL | Qt::SHIFT | Qt::Key_O);
+        QCOMPARE(action->shortcut(), expected);
+    }
+};
+
+QTEST_MAIN(OverviewRailTest)
+#include "test_overview_rail.moc"

--- a/test/app/src/test_overview_rail.cpp
+++ b/test/app/src/test_overview_rail.cpp
@@ -17,6 +17,7 @@
 #include "overview_rail_widget.hpp"
 #include "qt_streaming_log_sink.hpp"
 #include "row_order_proxy_model.hpp"
+#include "theme_control.hpp"
 
 #include <loglib/file_line_source.hpp>
 #include <loglib/internal/advanced_parser_options.hpp>
@@ -32,8 +33,13 @@
 #include <QAbstractItemModel>
 #include <QAction>
 #include <QApplication>
+#include <QImage>
 #include <QItemSelectionModel>
 #include <QModelIndex>
+#include <QPainter>
+#include <QRect>
+#include <QScrollBar>
+#include <QSet>
 #include <QSettings>
 #include <QSignalSpy>
 #include <QStandardPaths>
@@ -481,6 +487,967 @@ private slots:
         QVERIFY(lastFirst < ROWS);
     }
 
+    /// Log-scaled bar width contract: an empty bucket paints
+    /// nothing; a 1-row bucket still lights up a visible tick at
+    /// least `MIN_BAR_WIDTH_PX` wide; a max-count bucket
+    /// saturates to the full column width; and intensity is
+    /// monotone non-decreasing in the row count. Pins the
+    /// widget's "small bins still show" guarantee without
+    /// pixel-scraping the paint output.
+    static void TestLevelBarWidthIsLogScaled()
+    {
+        constexpr int COLUMN_WIDTH = 14;
+        QCOMPARE(OverviewRailWidget::WidthForCountForTest(/*count=*/0, /*maxCount=*/100, COLUMN_WIDTH), 0);
+        QCOMPARE(OverviewRailWidget::WidthForCountForTest(/*count=*/5, /*maxCount=*/0, COLUMN_WIDTH), 0);
+        QCOMPARE(OverviewRailWidget::WidthForCountForTest(/*count=*/5, /*maxCount=*/100, /*columnWidth=*/0), 0);
+        // 1-row bucket: log scale would give a sub-1-px bar for
+        // large maxCount; the min-width clamp lifts it to 2 px.
+        const int oneRow = OverviewRailWidget::WidthForCountForTest(1, 10000, COLUMN_WIDTH);
+        QVERIFY2(oneRow >= 2, "1-row bucket must paint at least MIN_BAR_WIDTH_PX so sparse activity stays visible");
+        QVERIFY(oneRow <= COLUMN_WIDTH);
+        // Max-count bucket: intensity 1.0 -> full column width.
+        QCOMPARE(OverviewRailWidget::WidthForCountForTest(10000, 10000, COLUMN_WIDTH), COLUMN_WIDTH);
+        // A mid-range bucket sits strictly between the min-clamp
+        // and the max fill under log scaling, so we can visually
+        // distinguish "some activity" from "hot spot".
+        const int mid = OverviewRailWidget::WidthForCountForTest(100, 10000, COLUMN_WIDTH);
+        QVERIFY(mid > oneRow);
+        QVERIFY(mid < COLUMN_WIDTH);
+        // Monotone non-decreasing in count.
+        int previous = 0;
+        for (std::uint32_t count : {std::uint32_t{1}, std::uint32_t{4}, std::uint32_t{16}, std::uint32_t{64},
+                                    std::uint32_t{256}, std::uint32_t{1024}, std::uint32_t{4096}})
+        {
+            const int w = OverviewRailWidget::WidthForCountForTest(count, 4096, COLUMN_WIDTH);
+            QVERIFY2(w >= previous, "bar width must be monotone non-decreasing in the bucket count");
+            previous = w;
+        }
+    }
+
+    /// Helper: render `widget` to a QImage and count how many
+    /// pixels in the leftmost 4 px of the rail's level column
+    /// differ from the widget's background colour. Reports the
+    /// widget's Base colour so failing tests can log what "wash"
+    /// they saw the bars blending into.
+    static int CountLitLevelPixels(OverviewRailWidget *widget, QColor *outBaseColor = nullptr)
+    {
+        QImage image(widget->size(), QImage::Format_ARGB32);
+        image.fill(Qt::transparent);
+        widget->render(&image);
+        const QColor bg = widget->palette().color(QPalette::Base);
+        if (outBaseColor != nullptr)
+        {
+            *outBaseColor = bg;
+        }
+        constexpr int LEVEL_COL_LEFT = 2;
+        int lit = 0;
+        for (int y = 0; y < image.height(); ++y)
+        {
+            for (int x = LEVEL_COL_LEFT; x < LEVEL_COL_LEFT + 4; ++x)
+            {
+                if (QColor(image.pixel(x, y)).rgb() != bg.rgb())
+                {
+                    ++lit;
+                }
+            }
+        }
+        return lit;
+    }
+
+    /// End-to-end paint contract: rendering the widget onto a
+    /// `QImage` MUST produce visible level-bar pixels (i.e. any
+    /// pixel that isn't the widget's background colour) inside
+    /// the level column area, once the model has non-empty
+    /// buckets. Regression guard for "bars are drawn with a
+    /// colour that matches the widget background" bugs (e.g. the
+    /// pre-fix issue where `ColorForLevel(Info)` returned a tone
+    /// indistinguishable from `QPalette::Window`).
+    static void TestRailPaintsVisibleLevelBars()
+    {
+        LogModel model;
+        AnchorManager anchors;
+        QObject owner;
+        const auto chain = BuildProxyChain(&model, &owner);
+        OverviewRailModel railModel(chain.filter, &model, &anchors, &owner);
+        railModel.SetBucketCount(100);
+
+        constexpr int ROWS = 500;
+        const RailFixture fixture(ROWS);
+        StreamJsonPathInto(model, fixture.Path());
+        WaitForBucketsChanged(railModel);
+        QVERIFY2(railModel.BucketCount() > 0, "test fixture must yield a non-zero bucket count");
+
+        auto *widget = new OverviewRailWidget(&railModel, /*theme=*/nullptr, /*tableView=*/nullptr);
+        widget->resize(60, 200);
+        widget->show();
+        QColor bg;
+        const int lit = CountLitLevelPixels(widget, &bg);
+        QVERIFY2(
+            lit > 0,
+            qPrintable(QStringLiteral("no level-bar pixels found (bg=%1) -- bars are painting invisibly")
+                           .arg(bg.name()))
+        );
+        delete widget;
+    }
+
+    /// End-to-end integration: attach the rail through
+    /// `LogTableView::AttachOverviewRail` (production wiring) and
+    /// verify bars paint against the *live* geometry the widget
+    /// picks under the Dark theme -- narrower than the offscreen
+    /// unit tests use, so this catches regressions in the sizeHint /
+    /// three-column split that only show at production widths.
+    static void TestRailPaintsVisibleBarsAtProductionWidth()
+    {
+        ThemeControl theme;
+        theme.SetActiveSelection(QStringLiteral("Dark"));
+
+        LogTableView view;
+        view.resize(1200, 700);
+        view.show();
+        LogModel model;
+        view.setModel(&model);
+
+        AnchorManager anchors;
+        QObject owner;
+        const auto chain = BuildProxyChain(&model, &owner);
+        OverviewRailModel railModel(chain.filter, &model, &anchors, &owner);
+        auto *widget = new OverviewRailWidget(&railModel, &theme, &view);
+        view.AttachOverviewRail(widget);
+
+        QCoreApplication::processEvents();
+
+        constexpr int ROWS = 500;
+        const RailFixture fixture(ROWS);
+        StreamJsonPathInto(model, fixture.Path());
+        WaitForBucketsChanged(railModel);
+        QVERIFY(railModel.BucketCount() > 0);
+
+        // The rail's width comes from its own `sizeHint` (via
+        // `AttachOverviewRail`), not from a manual resize. That's
+        // exactly the code path the production wiring exercises.
+        QCoreApplication::processEvents();
+        const int railWidth = widget->width();
+        QVERIFY2(railWidth >= 24, qPrintable(QStringLiteral("rail is only %1 px wide -- narrower than the "
+                                                            "minimum, so the level column would collapse "
+                                                            "to a single pixel").arg(railWidth)));
+
+        QImage image(widget->size(), QImage::Format_ARGB32);
+        image.fill(Qt::transparent);
+        widget->render(&image);
+
+        // Sample the full content slot (single section from
+        // `RAIL_UNDERLAY_INSET = 1` to the widget's right edge
+        // minus that inset). The rail collapsed to a single
+        // full-width section for its bin bars; match / anchor
+        // overlays share the same slot.
+        const QColor bg = widget->palette().color(QPalette::Base);
+        constexpr int CONTENT_LEFT = 2;
+        const int contentRight = std::max(CONTENT_LEFT + 4, railWidth - 1);
+        int highContrastPixels = 0;
+        for (int y = 0; y < image.height(); ++y)
+        {
+            for (int x = CONTENT_LEFT; x < contentRight; ++x)
+            {
+                const QColor c(image.pixel(x, y));
+                const int delta =
+                    std::abs(c.red() - bg.red()) + std::abs(c.green() - bg.green()) + std::abs(c.blue() - bg.blue());
+                if (delta >= 30)
+                {
+                    ++highContrastPixels;
+                }
+            }
+        }
+        QVERIFY2(
+            highContrastPixels > image.height() / 4,
+            qPrintable(QStringLiteral("only %1 high-contrast pixels in the content slot at production width "
+                                      "%2 px -- bars are not painting visibly against Base %3")
+                           .arg(highContrastPixels)
+                           .arg(railWidth)
+                           .arg(bg.name()))
+        );
+
+        view.AttachOverviewRail(nullptr);
+        delete widget;
+    }
+
+    /// Stacked severity segments using row *background* colours.
+    /// On a mixed-level bucket the paint pass must split the bar
+    /// into per-level segments and colour each from the theme's
+    /// row background (`ThemeControl::BackgroundFor`), *not* the
+    /// foreground -- foregrounds are bright pastels tuned for
+    /// text-on-row legibility, and painting them as bars
+    /// composited to a "light band" wash across every bucket
+    /// that carried any Warn / Error / Fatal row (the "rail is
+    /// still too light" regression). Row backgrounds are the
+    /// theme designer's chosen severity *tint* on Base, so the
+    /// rail reads as a mini-map of the row-tinted table.
+    ///
+    /// Verifies (Dark theme, normal contrast):
+    /// 1. Buckets containing Error paint the row-background tone
+    ///    `#352121` -- the same tint the Error row shows on the
+    ///    main table.
+    /// 2. Buckets containing Warn but no Error paint `#272620`.
+    /// 3. The *foreground* tones (Warn `#FCD34D`, Error
+    ///    `#FCA5A5`, Fatal `#FECACA`) do *not* appear anywhere
+    ///    on the rail. Their presence would be an accidental
+    ///    revert to the "bright pastels" paint that caused the
+    ///    "too light" regression.
+    static void TestRailPaintsStackedBackgroundSegments()
+    {
+        ThemeControl theme;
+        theme.SetActiveSelection(QStringLiteral("Dark"));
+
+        LogModel model;
+        AnchorManager anchors;
+        QObject owner;
+        const auto chain = BuildProxyChain(&model, &owner);
+        OverviewRailModel railModel(chain.filter, &model, &anchors, &owner);
+        railModel.SetBucketCount(100);
+
+        // 500 rows / 4-level cycle from `RailFixture` gives every
+        // bucket a mix of Info + Warn + Error + Debug (buckets
+        // large enough to span a full cycle) or a 2--3 level
+        // slice of that cycle (buckets holding a fractional
+        // cycle).
+        constexpr int ROWS = 500;
+        const RailFixture fixture(ROWS);
+        StreamJsonPathInto(model, fixture.Path());
+        WaitForBucketsChanged(railModel);
+        QVERIFY(railModel.BucketCount() > 0);
+
+        auto *widget = new OverviewRailWidget(&railModel, &theme, /*tableView=*/nullptr);
+        widget->resize(60, 200);
+        widget->show();
+
+        QImage image(widget->size(), QImage::Format_ARGB32);
+        image.fill(Qt::transparent);
+        widget->render(&image);
+
+        // Dark theme row-background tones (levels).
+        const QRgb errorBgRgb = QColor(QStringLiteral("#352121")).rgb();
+        const QRgb warnBgRgb = QColor(QStringLiteral("#272620")).rgb();
+        const QRgb debugBgRgb = QColor(QStringLiteral("#20252E")).rgb();
+        // Bright foregrounds -- the *regression* tones that
+        // stacked-segments produced when we painted from
+        // `ForegroundFor` instead of `BackgroundFor`. They must
+        // be entirely absent.
+        const QRgb errorFgRgb = QColor(QStringLiteral("#FCA5A5")).rgb();
+        const QRgb warnFgRgb = QColor(QStringLiteral("#FCD34D")).rgb();
+        const QRgb fatalFgRgb = QColor(QStringLiteral("#FECACA")).rgb();
+
+        int errorBgPixels = 0;
+        int warnBgPixels = 0;
+        int debugBgPixels = 0;
+        int brightFgPixels = 0;
+        constexpr int CONTENT_LEFT = 2;
+        const int contentRight = std::max(CONTENT_LEFT + 4, image.width() - 1);
+        for (int y = 0; y < image.height(); ++y)
+        {
+            for (int x = CONTENT_LEFT; x < contentRight; ++x)
+            {
+                const QRgb rgb = image.pixel(x, y);
+                if (rgb == errorBgRgb)
+                {
+                    ++errorBgPixels;
+                }
+                else if (rgb == warnBgRgb)
+                {
+                    ++warnBgPixels;
+                }
+                else if (rgb == debugBgRgb)
+                {
+                    ++debugBgPixels;
+                }
+                else if (rgb == errorFgRgb || rgb == warnFgRgb || rgb == fatalFgRgb)
+                {
+                    ++brightFgPixels;
+                }
+            }
+        }
+        qInfo() << "stacked-bg paint: Error-bg" << errorBgPixels << "Warn-bg" << warnBgPixels << "Debug-bg"
+                << debugBgPixels << "bright-fg (regression)" << brightFgPixels;
+
+        QVERIFY2(errorBgPixels > 0, "stacked segments must paint the Dark theme's Error row-bg tone (#352121)");
+        QVERIFY2(warnBgPixels > 0, "stacked segments must paint the Dark theme's Warn row-bg tone (#272620)");
+        // Debug row-bg painting is a spot-check: at the widget's
+        // 200-px height Debug buckets pack tightly, but any
+        // bucket that includes a Debug row must at least paint
+        // its 1-px floor.
+        QVERIFY2(
+            debugBgPixels > 0,
+            qPrintable(QStringLiteral("stacked segments must paint the Dark theme's Debug row-bg tone (#20252E); "
+                                      "found only %1 Debug-bg pixels")
+                           .arg(debugBgPixels))
+        );
+        QVERIFY2(
+            brightFgPixels == 0,
+            qPrintable(QStringLiteral("bright foreground pastels must not appear on the rail -- their presence "
+                                      "reverts the 'rail is too light' fix; found %1 bright-fg pixels")
+                           .arg(brightFgPixels))
+        );
+
+        delete widget;
+    }
+
+    /// Rare-anomaly visibility: a bucket with 1 Fatal row and
+    /// 100 Trace rows must still paint a visible slice of the
+    /// Fatal background tone in that bucket's bar (via the
+    /// `MIN_SEGMENT_WIDTH_PX` floor in the stacked-segment
+    /// paint), so a needle-in-haystack Fatal isn't rounded away
+    /// to zero pixels. Verified by streaming a hand-rolled log
+    /// where every bucket is Trace-heavy except one bucket that
+    /// contains a single Fatal row, then asserting the Fatal
+    /// row-bg tone appears in the rendered rail.
+    static void TestRareFatalPaintsAtBucketFloor()
+    {
+        ThemeControl theme;
+        theme.SetActiveSelection(QStringLiteral("Dark"));
+
+        LogModel model;
+        AnchorManager anchors;
+        QObject owner;
+        const auto chain = BuildProxyChain(&model, &owner);
+        OverviewRailModel railModel(chain.filter, &model, &anchors, &owner);
+        railModel.SetBucketCount(50);
+
+        QTemporaryDir dir;
+        QVERIFY(dir.isValid());
+        const QString path = dir.filePath(QStringLiteral("fatal_needle.jsonl"));
+        {
+            std::ofstream stream(path.toStdString(), std::ios::binary);
+            QVERIFY(stream.is_open());
+            constexpr int ROWS = 500;
+            constexpr int FATAL_ROW = 250;
+            for (int i = 0; i < ROWS; ++i)
+            {
+                const QString level = (i == FATAL_ROW) ? QStringLiteral("fatal") : QStringLiteral("trace");
+                const QString line =
+                    QStringLiteral(R"({"time": "2026-01-01T00:00:00", "level": "%1", "body": "msg %2"})")
+                        .arg(level)
+                        .arg(i);
+                stream << line.toStdString() << '\n';
+            }
+        }
+        StreamJsonPathInto(model, path);
+        WaitForBucketsChanged(railModel);
+        QVERIFY(railModel.BucketCount() > 0);
+
+        auto *widget = new OverviewRailWidget(&railModel, &theme, /*tableView=*/nullptr);
+        widget->resize(60, 200);
+        widget->show();
+
+        QImage image(widget->size(), QImage::Format_ARGB32);
+        image.fill(Qt::transparent);
+        widget->render(&image);
+
+        // Dark theme's Fatal row background (`#4A1E1E`) must
+        // be present somewhere in the rendered rail. Its
+        // presence proves the 1-px severity floor keeps rare
+        // anomalies visible; a regression that dropped the
+        // floor for high-severity would zero the count.
+        const QRgb expectedFatalBgRgb = QColor(QStringLiteral("#4A1E1E")).rgb();
+        int fatalBgPixels = 0;
+        constexpr int CONTENT_LEFT = 2;
+        const int contentRight = std::max(CONTENT_LEFT + 4, image.width() - 1);
+        for (int y = 0; y < image.height(); ++y)
+        {
+            for (int x = CONTENT_LEFT; x < contentRight; ++x)
+            {
+                if (image.pixel(x, y) == expectedFatalBgRgb)
+                {
+                    ++fatalBgPixels;
+                }
+            }
+        }
+        QVERIFY2(
+            fatalBgPixels > 0,
+            "rare Fatal (1-in-500) must paint the Fatal row-bg tone at the 1-px severity floor"
+        );
+
+        delete widget;
+    }
+
+    /// Log-weighted segment sizing: rare severities get a
+    /// *visibly larger* slice than linear proportion would
+    /// award. On a bucket with 99 Trace + 1 Fatal (1 % Fatal),
+    /// linear shares floor the Fatal segment to 1 px (noise on
+    /// a Trace-dominated rail); the `log2(count + 1)` weighting
+    /// raises Fatal's share to
+    /// log2(2) / (log2(100) + log2(2)) ~= 13 % of the bar --
+    /// visibly readable without flipping the majority. This
+    /// test uses a fixture where *every* bucket has the same
+    /// 99 : 1 ratio (one Fatal every 100 rows), so the measured
+    /// Fatal-to-Trace pixel ratio equals the per-bucket ratio
+    /// independent of bucket count.
+    static void TestSegmentSharesUseLogWeighting()
+    {
+        ThemeControl theme;
+        theme.SetActiveSelection(QStringLiteral("Dark"));
+
+        LogModel model;
+        AnchorManager anchors;
+        QObject owner;
+        const auto chain = BuildProxyChain(&model, &owner);
+        OverviewRailModel railModel(chain.filter, &model, &anchors, &owner);
+        // Non-zero bucket count *before* streaming so the
+        // rebuild that follows fires `bucketsChanged`.
+        // `SyncBucketCountToHeight` on `widget->show()` later
+        // resizes this to the widget's rail height.
+        railModel.SetBucketCount(100);
+
+        QTemporaryDir dir;
+        QVERIFY(dir.isValid());
+        const QString path = dir.filePath(QStringLiteral("log_weight.jsonl"));
+        {
+            std::ofstream stream(path.toStdString(), std::ios::binary);
+            QVERIFY(stream.is_open());
+            constexpr int ROWS = 5000;
+            for (int i = 0; i < ROWS; ++i)
+            {
+                const QString level = (i % 100 == 0) ? QStringLiteral("fatal") : QStringLiteral("trace");
+                const QString line =
+                    QStringLiteral(R"({"time": "2026-01-01T00:00:00", "level": "%1", "body": "msg %2"})")
+                        .arg(level)
+                        .arg(i);
+                stream << line.toStdString() << '\n';
+            }
+        }
+        StreamJsonPathInto(model, path);
+        WaitForBucketsChanged(railModel);
+        QVERIFY(railModel.BucketCount() > 0);
+
+        auto *widget = new OverviewRailWidget(&railModel, &theme, /*tableView=*/nullptr);
+        widget->resize(60, 200);
+        widget->show();
+
+        QImage image(widget->size(), QImage::Format_ARGB32);
+        image.fill(Qt::transparent);
+        widget->render(&image);
+
+        const QRgb fatalBg = QColor(QStringLiteral("#4A1E1E")).rgb();
+        const QRgb traceBg = QColor(QStringLiteral("#1F2228")).rgb();
+        int fatalPixels = 0;
+        int tracePixels = 0;
+        constexpr int CONTENT_LEFT = 2;
+        const int contentRight = std::max(CONTENT_LEFT + 4, image.width() - 1);
+        for (int y = 0; y < image.height(); ++y)
+        {
+            for (int x = CONTENT_LEFT; x < contentRight; ++x)
+            {
+                const QRgb rgb = image.pixel(x, y);
+                if (rgb == fatalBg)
+                {
+                    ++fatalPixels;
+                }
+                else if (rgb == traceBg)
+                {
+                    ++tracePixels;
+                }
+            }
+        }
+        qInfo() << "log-weight paint: Fatal px" << fatalPixels << "Trace px" << tracePixels;
+
+        const int totalLevelPixels = fatalPixels + tracePixels;
+        QVERIFY2(totalLevelPixels > 0, "no severity pixels found in the rendered rail");
+        // Compare against the *linear-share* baseline. On a
+        // 1 % rare level with a 60 px content width and the
+        // 1 px severity floor, linear proportion allocates
+        // Fatal ~= floor(58 * 1 / 25) + 1 = 3 px per
+        // Fatal-carrying bucket. The rail spawns roughly one
+        // Fatal bucket per 4 buckets (5000 rows / ~196
+        // buckets ~= 25 rows / bucket, one Fatal every 100
+        // rows) -- so linear ceiling is ~= 3 px * 50 buckets
+        // = 150 Fatal pixels. Log-weighted shares raise Fatal
+        // to ~15 % per Fatal-bucket, yielding ~450 pixels in
+        // the same geometry. Assert Fatal pixels exceed 2x
+        // the linear ceiling so a regression back to linear
+        // fails loudly, without pinning the exact ratio (test
+        // stays robust to future paint-pass tuning).
+        constexpr int LINEAR_CEILING_PX = 150;
+        QVERIFY2(
+            fatalPixels > 2 * LINEAR_CEILING_PX,
+            qPrintable(QStringLiteral("log-weighted segments must give a 1-in-100 Fatal >%1 px on this "
+                                      "geometry (linear would give ~%2 px); got %3 px")
+                           .arg(2 * LINEAR_CEILING_PX)
+                           .arg(LINEAR_CEILING_PX)
+                           .arg(fatalPixels))
+        );
+        QVERIFY2(
+            tracePixels > fatalPixels,
+            "log-weighted segments must keep the majority level (Trace) larger than the rare Fatal"
+        );
+
+        delete widget;
+    }
+
+    /// High-contrast preference recolours the rail. `ThemeControl`
+    /// reads the `ui/highContrastLevels` setting into
+    /// `mHighContrast`, and `BackgroundFor(level)` -- which the
+    /// rail's paint pass reaches for -- resolves through
+    /// `StyleForLevel(theme, level, mHighContrast)`. Toggling the
+    /// preference must therefore switch every bucket's severity
+    /// segments from the theme's normal row-bg palette to the
+    /// louder `levelsHighContrast` palette without any extra
+    /// wiring in the widget. Verified by rendering the same rail
+    /// twice against the Dark theme (normal + high-contrast) and
+    /// asserting the Error segments switch from `#352121`
+    /// (normal) to `#4C1D1D` (high contrast).
+    static void TestRailRespectsHighContrastPreference()
+    {
+        ThemeControl theme;
+        theme.SetActiveSelection(QStringLiteral("Dark"));
+        QVERIFY(theme.HasLevelsHighContrast());
+        theme.SetHighContrast(false);
+
+        LogModel model;
+        AnchorManager anchors;
+        QObject owner;
+        const auto chain = BuildProxyChain(&model, &owner);
+        OverviewRailModel railModel(chain.filter, &model, &anchors, &owner);
+        railModel.SetBucketCount(100);
+
+        constexpr int ROWS = 500;
+        const RailFixture fixture(ROWS);
+        StreamJsonPathInto(model, fixture.Path());
+        WaitForBucketsChanged(railModel);
+
+        auto *widget = new OverviewRailWidget(&railModel, &theme, /*tableView=*/nullptr);
+        widget->resize(60, 200);
+        widget->show();
+
+        const QRgb normalErrorBg = QColor(QStringLiteral("#352121")).rgb();
+        const QRgb loudErrorBg = QColor(QStringLiteral("#4C1D1D")).rgb();
+
+        auto countErrorTones = [&](QRgb wanted) {
+            QImage image(widget->size(), QImage::Format_ARGB32);
+            image.fill(Qt::transparent);
+            widget->render(&image);
+            int count = 0;
+            constexpr int CONTENT_LEFT = 2;
+            const int contentRight = std::max(CONTENT_LEFT + 4, image.width() - 1);
+            for (int y = 0; y < image.height(); ++y)
+            {
+                for (int x = CONTENT_LEFT; x < contentRight; ++x)
+                {
+                    if (image.pixel(x, y) == wanted)
+                    {
+                        ++count;
+                    }
+                }
+            }
+            return count;
+        };
+
+        const int normalHitsNormal = countErrorTones(normalErrorBg);
+        const int normalHitsLoud = countErrorTones(loudErrorBg);
+        QVERIFY2(normalHitsNormal > 0, "normal-contrast paint must render the theme's normal Error row-bg");
+        QVERIFY2(normalHitsLoud == 0, "normal-contrast paint must not render the loud Error row-bg");
+
+        theme.SetHighContrast(true);
+        widget->update();
+        QApplication::processEvents();
+
+        const int loudHitsNormal = countErrorTones(normalErrorBg);
+        const int loudHitsLoud = countErrorTones(loudErrorBg);
+        QVERIFY2(loudHitsLoud > 0, "high-contrast paint must render the theme's `levelsHighContrast` Error row-bg");
+        QVERIFY2(loudHitsNormal == 0, "high-contrast paint must not render the normal Error row-bg");
+
+        delete widget;
+    }
+
+    /// Overlay contract: match ticks repaint the *entire content
+    /// width* of any bucket carrying a match row, overriding the
+    /// base-layer bin painting. Verifies the single-section
+    /// rework -- the old three-column layout dedicated only ~20 %
+    /// of the underlay to matches, which was hard to spot on a
+    /// narrow rail; the overlay approach makes every match bucket
+    /// paint as a solid full-width Highlight band. The test
+    /// pushes a single match into a known bucket and confirms
+    /// the whole content slot at that Y band is dominated by
+    /// the palette Highlight colour.
+    static void TestMatchOverlayCoversFullContentWidth()
+    {
+        ThemeControl theme;
+        theme.SetActiveSelection(QStringLiteral("Dark"));
+
+        LogModel model;
+        AnchorManager anchors;
+        QObject owner;
+        const auto chain = BuildProxyChain(&model, &owner);
+        OverviewRailModel railModel(chain.filter, &model, &anchors, &owner);
+
+        // Small bucket count so a single match row lights up a
+        // sizeable Y band we can sample confidently.
+        railModel.SetBucketCount(20);
+
+        constexpr int ROWS = 200;
+        const RailFixture fixture(ROWS);
+        StreamJsonPathInto(model, fixture.Path());
+        WaitForBucketsChanged(railModel);
+        QVERIFY(railModel.BucketCount() > 0);
+
+        // Push a match at row 50 (roughly the middle). Every
+        // bucket has activity by construction, so the base layer
+        // paints level bars first and the overlay must repaint
+        // the matched bucket in Highlight over the top.
+        railModel.SetMatchProxyRows({50});
+        QVERIFY(railModel.HasMatchTicks());
+
+        auto *widget = new OverviewRailWidget(&railModel, &theme, /*tableView=*/nullptr);
+        widget->resize(60, 200);
+        widget->show();
+
+        QImage image(widget->size(), QImage::Format_ARGB32);
+        image.fill(Qt::transparent);
+        widget->render(&image);
+
+        const QColor highlight = widget->palette().color(QPalette::Highlight);
+
+        // Locate the Y band of the bucket that received the
+        // match by scanning for the row whose content slot is
+        // dominantly Highlight-coloured. `matchProxyRow / rows *
+        // bucketCount` gives the target bucket; use the widget's
+        // helper to resolve it to a Y range.
+        const std::size_t matchBucket = std::min<std::size_t>(
+            railModel.BucketCount() - 1,
+            static_cast<std::size_t>(
+                (static_cast<std::size_t>(50) * railModel.BucketCount()) / static_cast<std::size_t>(ROWS)
+            )
+        );
+        const int yTop = widget->YForBucketForTest(matchBucket);
+        const int yBottom = matchBucket + 1 < railModel.BucketCount()
+                                ? widget->YForBucketForTest(matchBucket + 1)
+                                : image.height();
+
+        // Sample the *right* portion of the content slot (columns
+        // past where the level bar could ever reach at ~20 % row
+        // density). If the overlay repainted the full content
+        // width, we expect Highlight there; if only the old
+        // match column painted (right 20 % of the underlay), the
+        // sample also passes -- but the left portion of the
+        // content slot must also be Highlight for the overlay
+        // semantic to hold.
+        constexpr int CONTENT_LEFT = 2;
+        const int contentRight = std::max(CONTENT_LEFT + 4, image.width() - 1);
+        int highlightPixelsLeftHalf = 0;
+        int highlightPixelsRightHalf = 0;
+        const int mid = (CONTENT_LEFT + contentRight) / 2;
+        for (int y = yTop; y < yBottom; ++y)
+        {
+            for (int x = CONTENT_LEFT; x < contentRight; ++x)
+            {
+                const QColor c(image.pixel(x, y));
+                const int delta = std::abs(c.red() - highlight.red()) + std::abs(c.green() - highlight.green()) +
+                                  std::abs(c.blue() - highlight.blue());
+                if (delta < 30)
+                {
+                    if (x < mid)
+                    {
+                        ++highlightPixelsLeftHalf;
+                    }
+                    else
+                    {
+                        ++highlightPixelsRightHalf;
+                    }
+                }
+            }
+        }
+        QVERIFY2(
+            highlightPixelsLeftHalf > 0 && highlightPixelsRightHalf > 0,
+            qPrintable(
+                QStringLiteral("match overlay must span the full content width -- found %1 Highlight px on the "
+                               "left half and %2 on the right half of the matched bucket's Y band")
+                    .arg(highlightPixelsLeftHalf)
+                    .arg(highlightPixelsRightHalf)
+            )
+        );
+
+        delete widget;
+    }
+
+    /// Same as `TestRailPaintsVisibleLevelBars` but with the real
+    /// Dark theme loaded. Reproduces the user-reported "bars are
+    /// invisible" bug where the theme's subtle row-background
+    /// tint for Info-heavy buckets composited onto the rail's own
+    /// Base wash and disappeared. Row-background painting is
+    /// intentionally subtle (Warn bg delta 11, Error bg delta 21
+    /// against Base) -- the test therefore asserts (a) *any*
+    /// non-Base pixels are painted and (b) at least one distinctly
+    /// contrasting tone is present so the rail is never invisible.
+    static void TestRailPaintsVisibleBarsUnderDarkTheme()
+    {
+        ThemeControl theme;
+        theme.SetActiveSelection(QStringLiteral("Dark"));
+        QCOMPARE(QString::fromStdString(theme.Active().name), QStringLiteral("Dark"));
+
+        LogModel model;
+        AnchorManager anchors;
+        QObject owner;
+        const auto chain = BuildProxyChain(&model, &owner);
+        OverviewRailModel railModel(chain.filter, &model, &anchors, &owner);
+        railModel.SetBucketCount(100);
+
+        constexpr int ROWS = 500;
+        const RailFixture fixture(ROWS);
+        StreamJsonPathInto(model, fixture.Path());
+        WaitForBucketsChanged(railModel);
+
+        auto *widget = new OverviewRailWidget(&railModel, &theme, /*tableView=*/nullptr);
+        widget->resize(60, 200);
+        widget->show();
+
+        QImage image(widget->size(), QImage::Format_ARGB32);
+        image.fill(Qt::transparent);
+        widget->render(&image);
+
+        const QColor bg = widget->palette().color(QPalette::Base);
+        // Sample a vertical strip in the level column (left side of
+        // the rail underlay). Log every distinct non-background
+        // colour we find so a failing render tells us exactly what
+        // ghost tone was used.
+        constexpr int LEVEL_COL_LEFT = 2;
+        QSet<QRgb> distinctColors;
+        int litPixels = 0;
+        int highContrastPixels = 0;
+        for (int y = 0; y < image.height(); ++y)
+        {
+            for (int x = LEVEL_COL_LEFT; x < LEVEL_COL_LEFT + 4; ++x)
+            {
+                const QRgb pixel = image.pixel(x, y);
+                if (QColor(pixel).rgb() == bg.rgb())
+                {
+                    continue;
+                }
+                ++litPixels;
+                distinctColors.insert(pixel);
+                // Perceptual delta: sum of absolute channel diffs.
+                // Anything < 30 is essentially invisible on screen
+                // (the eye can't resolve <10% per-channel deltas on
+                // small strips at typical desktop viewing distance).
+                const QColor c(pixel);
+                const int delta =
+                    std::abs(c.red() - bg.red()) + std::abs(c.green() - bg.green()) + std::abs(c.blue() - bg.blue());
+                if (delta >= 30)
+                {
+                    ++highContrastPixels;
+                }
+            }
+        }
+
+        // Emit the colour set as a debug info so a failing test
+        // shows *what* tones the rail is using.
+        QStringList colorNames;
+        for (const QRgb c : distinctColors)
+        {
+            colorNames << QColor(c).name();
+        }
+        qInfo() << "Dark rail bar colours found:" << colorNames << "against bg" << bg.name();
+        qInfo() << "Lit pixels:" << litPixels << "  high-contrast pixels:" << highContrastPixels;
+
+        QVERIFY2(litPixels > 0, "no level-bar pixels found under Dark theme (bars painted invisibly)");
+        // At least one bucket must paint a *distinctly*
+        // contrasting tone (delta >= 30). Under the row-
+        // background palette this is guaranteed by any Error /
+        // Fatal bucket (Error bg delta 21 is borderline; Fatal
+        // bg delta 48 clears the bar); the `RailFixture` cycle
+        // ensures every bucket lands an Error row. Guards
+        // against a regression that mis-routes paint back to
+        // Base (invisible) or to a single near-Base tint (also
+        // invisible).
+        QVERIFY2(
+            highContrastPixels > 0,
+            qPrintable(QStringLiteral("Dark theme: no bar pixels contrast strongly against bg %1. Bars painted "
+                                      "with `ColorForLevel` are near-invisible on the widget background.")
+                           .arg(bg.name()))
+        );
+
+        delete widget;
+    }
+
+    /// Whole-file overview contract: the rail projects the file's
+    /// row range across its *entire* widget height (klogg / glogg /
+    /// VS Code minimap style), not just the viewport-Y slice below
+    /// the header. Pinned via `YForBucketForTest(0)` -- the first
+    /// bucket's Y must land near the top of the widget (well above
+    /// the viewport's top edge) so bars fill the whole rail
+    /// instead of being confined to a header-height-shifted strip.
+    static void TestRailProjectsAcrossFullWidgetHeight()
+    {
+        LogTableView view;
+        view.resize(800, 400);
+        view.show();
+        LogModel model;
+        view.setModel(&model);
+
+        AnchorManager anchors;
+        QObject owner;
+        const auto chain = BuildProxyChain(&model, &owner);
+        OverviewRailModel railModel(chain.filter, &model, &anchors, &owner);
+        auto *widget = new OverviewRailWidget(&railModel, /*theme=*/nullptr, &view);
+        view.AttachOverviewRail(widget);
+
+        // Give Qt a chance to lay out header + viewport under the
+        // reserved margin so `viewport()->geometry().top()` reflects
+        // the actual header height (offscreen QPA still routes the
+        // layout pass).
+        QCoreApplication::processEvents();
+
+        constexpr int ROWS = 40;
+        const RailFixture fixture(ROWS);
+        StreamJsonPathInto(model, fixture.Path());
+        WaitForBucketsChanged(railModel);
+        QVERIFY(railModel.BucketCount() > 0);
+
+        const int viewportTop = view.viewport()->geometry().top();
+        QVERIFY2(viewportTop > 0, "test needs a non-degenerate header height to be meaningful");
+
+        // Bar for bucket 0 must sit *above* the viewport's top
+        // edge in the widget's own coordinate system -- i.e., the
+        // rail's row-to-Y projection spans the full widget, not
+        // just the viewport-Y slice. Otherwise the rail wastes the
+        // header-Y strip as empty chrome, which reads as "the rail
+        // is broken -- half of it is empty".
+        const int firstBucketY = widget->YForBucketForTest(0);
+        QVERIFY2(firstBucketY < viewportTop, "first bucket must sit above the viewport top (whole-file overview)");
+
+        // Last bucket must sit near the widget bottom so the file's
+        // final rows are reachable via a click at the rail's foot.
+        const int lastBucketY = widget->YForBucketForTest(static_cast<int>(railModel.BucketCount()) - 1);
+        QVERIFY2(lastBucketY >= viewportTop, "last bucket must be at or below the viewport top");
+        QVERIFY(lastBucketY < widget->height());
+
+        view.AttachOverviewRail(nullptr);
+        delete widget;
+    }
+
+    /// Viewport indicator centring: on tall logs the visible-row
+    /// Y-range naturally maps to fewer than `INDICATOR_MIN_HEIGHT_PX`
+    /// rail pixels, so the widget inflates the indicator up to the
+    /// minimum. That inflation must happen *around the centre* of
+    /// the visible range, not by pinning the indicator's top to
+    /// the visible-top's Y -- otherwise a row selected in the
+    /// middle of the viewport is drawn near the top of the
+    /// indicator on the rail, which reads as "current-view
+    /// preview is misaligned relative to what I see in the
+    /// table" (regression report). Verified by scrolling to the
+    /// middle of a tall model and asserting the indicator's
+    /// vertical mid-point lands on (or very close to) the Y of
+    /// the middle visible row.
+    static void TestViewportIndicatorCentersOnVisibleRange()
+    {
+        LogTableView view;
+        view.resize(800, 400);
+        view.show();
+        LogModel model;
+        view.setModel(&model);
+
+        AnchorManager anchors;
+        QObject owner;
+        const auto chain = BuildProxyChain(&model, &owner);
+        OverviewRailModel railModel(chain.filter, &model, &anchors, &owner);
+        auto *widget = new OverviewRailWidget(&railModel, /*theme=*/nullptr, &view);
+        view.AttachOverviewRail(widget);
+
+        QCoreApplication::processEvents();
+
+        // Enough rows that ~20 visible rows fall below the
+        // indicator's min-height floor when projected onto the
+        // rail -- i.e. the min-height inflation path *must* run.
+        constexpr int ROWS = 10000;
+        const RailFixture fixture(ROWS);
+        StreamJsonPathInto(model, fixture.Path());
+        WaitForBucketsChanged(railModel);
+        QVERIFY(railModel.BucketCount() > 0);
+
+        // Scroll the table to somewhere in the middle so the
+        // visible range is a small window well away from either
+        // edge. `PositionAtCenter` centres `middleRow` in the
+        // viewport (subject to Qt's scrollbar snap) -- exactly
+        // the layout that used to trigger the "anchor at the
+        // top of the indicator" bug.
+        constexpr int MIDDLE_ROW = ROWS / 2;
+        const QModelIndex midIdx = view.model()->index(MIDDLE_ROW, 0);
+        QVERIFY(midIdx.isValid());
+        view.scrollTo(midIdx, QAbstractItemView::PositionAtCenter);
+        QCoreApplication::processEvents();
+
+        const QRect indicator = widget->ViewportIndicatorRectForTest();
+        QVERIFY2(!indicator.isEmpty(), "viewport indicator must be non-empty when the table has rows");
+
+        // Y coordinate on the rail where the *middle* visible row
+        // projects to. If the indicator top was pinned to the
+        // visible-top's Y (pre-fix behaviour), the middle-row Y
+        // would land near the *top edge* of the indicator on a
+        // very tall log. With centring, the middle-row Y must
+        // land close to the indicator's vertical mid-point.
+        const int middleBucket = widget->BucketAtYForTest(
+            widget->height() / 2 // seed near the widget centre
+        );
+        // Bucket index for the middle row via the projection the
+        // widget itself uses (row -> bucket = row * nBuckets /
+        // rowCount). Guarded against a torn bucket count.
+        const std::size_t nBuckets = railModel.BucketCount();
+        QVERIFY(nBuckets > 0);
+        const std::size_t midRowBucket = std::min<std::size_t>(
+            nBuckets - 1,
+            (static_cast<std::size_t>(MIDDLE_ROW) * nBuckets) / static_cast<std::size_t>(ROWS)
+        );
+        const int midRowY = widget->YForBucketForTest(midRowBucket);
+
+        const int indicatorMidY = indicator.top() + (indicator.height() / 2);
+        const int misalignment = std::abs(indicatorMidY - midRowY);
+
+        // Tolerance: half the indicator height plus one pixel of
+        // rounding slack from Qt's row-to-scrollbar snapping. If
+        // the fix is in place, `misalignment` is typically zero
+        // or one; pre-fix the middle row landed at the indicator
+        // top so `misalignment ≈ indicator.height() / 2`, far
+        // above the tolerance.
+        const int tolerance = 3;
+        QVERIFY2(
+            misalignment <= tolerance,
+            qPrintable(QStringLiteral("indicator midpoint (%1) must be within %2 px of the middle visible row's "
+                                      "rail-Y (%3); off by %4 px. indicator=%5x%6 at (%7,%8)")
+                           .arg(indicatorMidY)
+                           .arg(tolerance)
+                           .arg(midRowY)
+                           .arg(misalignment)
+                           .arg(indicator.width())
+                           .arg(indicator.height())
+                           .arg(indicator.left())
+                           .arg(indicator.top()))
+        );
+        // Silence unused-var warning when the seed bucket isn't
+        // referenced by any assertion above; the call itself
+        // exercises the widget's Y-to-bucket path.
+        Q_UNUSED(middleBucket);
+
+        view.AttachOverviewRail(nullptr);
+        delete widget;
+    }
+
+    /// Single-section content contract: the level bins, match
+    /// ticks, and anchor ticks all share one full-width content
+    /// slot inside the usable underlay. Match / anchor ticks are
+    /// *overlays* on top of the bins (see the paint pass) rather
+    /// than dedicated columns, so a search hit or user anchor
+    /// paints the whole rail width in that bucket and reads as
+    /// an unambiguous "here!" marker even on a narrow rail.
+    static void TestContentRectSpansFullUnderlay()
+    {
+        constexpr int UNDERLAY_LEFT = 2;
+        constexpr int UNDERLAY_WIDTH = 25; // 28 px rail - 1 sep - 2 inset
+        const QRect content = OverviewRailWidget::ContentRectForTest(UNDERLAY_LEFT, UNDERLAY_WIDTH);
+
+        QCOMPARE(content.left(), UNDERLAY_LEFT);
+        QCOMPARE(content.width(), UNDERLAY_WIDTH);
+
+        // Degenerate zero-width underlay: helper returns an
+        // empty rect without crashing.
+        const QRect empty = OverviewRailWidget::ContentRectForTest(UNDERLAY_LEFT, 0);
+        QCOMPARE(empty.width(), 0);
+    }
+
     /// `sizeHint()` returns a positive DPI-fluent width and a
     /// zero preferred height (rail grows vertically to fit the
     /// hosting margin). `minimumSizeHint` never exceeds it.
@@ -518,21 +1485,107 @@ private slots:
 
         // Use a QWidget with a fixed size so `sizeHint()` returns
         // a positive width — a bare QWidget's sizeHint is (-1,-1),
-        // which would leave `ReservedRightMargin` at zero. The
+        // which would leave the reservation at zero. The
         // `OverviewRailWidget` in production supplies its own
-        // DPI-fluent width; test just needs any positive value.
+        // DPI-fluent width; the test just needs any positive value.
         constexpr int RAIL_WIDTH = 16;
         auto *rail = new QWidget(nullptr);
         rail->setFixedWidth(RAIL_WIDTH);
         view.AttachOverviewRail(rail);
         QCOMPARE(view.OverviewRail(), rail);
+        // Reserved right margin is JUST the rail width.
+        // `QAbstractScrollArea::layoutChildren_helper` already
+        // reserves `PM_ScrollBarExtent` for the vertical
+        // scrollbar independently of viewport margins, so the
+        // scrollbar auto-places past the rail without needing an
+        // extra reservation here.
         QCOMPARE(view.ReservedRightMargin(), RAIL_WIDTH);
         QCOMPARE(rail->parent(), &view);
+
+        // Force an `updateGeometries` pass so `QTableView`'s
+        // implicit `setViewportMargins(headerW, headerH, 0, 0)`
+        // gets a chance to wipe our right margin. Our override
+        // must re-apply it, otherwise the rail's slot silently
+        // disappears on the first row insert / column change /
+        // header resize in production.
+        view.UpdateGeometriesForTest();
+        QCOMPARE(view.ViewportMarginsForTest().right(), RAIL_WIDTH);
+
+        // Geometry: the rail must sit immediately right of the
+        // viewport and MUST NOT overlap the scrollbar's rect --
+        // that was the "invisible rail" bug where the scrollbar
+        // painted on top of the rail's rightmost pixels. The Y
+        // span covers the frame from Y=0 (aligned with the top
+        // of the horizontal header) down to the viewport bottom
+        // so the strip reads as one continuous piece of chrome
+        // from the header down to the scrollbar corner. The
+        // level bars / viewport indicator themselves paint only
+        // in the viewport-Y slice (`InteractiveRailRect` skips
+        // the header-Y strip) so a bar for a visible row still
+        // aligns horizontally with that row's table entry --
+        // the header-Y strip above stays as wash chrome.
+        const QRect railGeom = rail->geometry();
+        const QRect vpGeom = view.viewport()->geometry();
+        QCOMPARE(railGeom.left(), vpGeom.right() + 1);
+        QCOMPARE(railGeom.width(), RAIL_WIDTH);
+        QCOMPARE(railGeom.top(), 0);
+        QCOMPARE(railGeom.bottom(), vpGeom.bottom());
+        if (const QScrollBar *vsb = view.verticalScrollBar(); vsb != nullptr && vsb->isVisible())
+        {
+            QVERIFY2(
+                railGeom.right() < vsb->geometry().left(),
+                "rail must not overlap the vertical scrollbar's paint rect"
+            );
+        }
 
         view.AttachOverviewRail(nullptr);
         QCOMPARE(view.OverviewRail(), static_cast<QWidget *>(nullptr));
         QCOMPARE(view.ReservedRightMargin(), 0);
         // Widget survives detach (caller owns it). Delete manually.
+        delete rail;
+    }
+
+    /// Regression against the bug where `QTableView::updateGeometries()`
+    /// unconditionally calls `setViewportMargins(vHeaderW, hHeaderH,
+    /// 0, 0)` and would silently wipe the rail's reserved slot on
+    /// the next row insert / column change / header resize. Force
+    /// several implicit re-layouts and assert the margin sticks
+    /// each time.
+    static void TestRailMarginSurvivesUpdateGeometries()
+    {
+        LogTableView view;
+        view.resize(800, 400);
+        view.show();
+
+        constexpr int RAIL_WIDTH = 18;
+        auto *rail = new QWidget(nullptr);
+        rail->setFixedWidth(RAIL_WIDTH);
+        view.AttachOverviewRail(rail);
+
+        // Attach a small model so `updateGeometries` runs through
+        // the same code paths a live table hits (columns, rows,
+        // scrollbar range checks).
+        LogModel model;
+        view.setModel(&model);
+
+        for (int i = 0; i < 5; ++i)
+        {
+            view.UpdateGeometriesForTest();
+            QCOMPARE(view.ViewportMarginsForTest().right(), RAIL_WIDTH);
+            const QRect railGeom = rail->geometry();
+            const QRect vpGeom = view.viewport()->geometry();
+            QCOMPARE(railGeom.left(), vpGeom.right() + 1);
+            QCOMPARE(railGeom.width(), RAIL_WIDTH);
+            // Rail Y span must stay from the frame top down to
+            // the viewport bottom across every implicit re-layout
+            // so the strip reads as one continuous piece of
+            // chrome (`InteractiveRailRect` handles the header-Y
+            // skip for the bars themselves).
+            QCOMPARE(railGeom.top(), 0);
+            QCOMPARE(railGeom.bottom(), vpGeom.bottom());
+        }
+
+        view.AttachOverviewRail(nullptr);
         delete rail;
     }
 

--- a/test/app/src/test_overview_rail.cpp
+++ b/test/app/src/test_overview_rail.cpp
@@ -9,6 +9,7 @@
 // `apptest_overview_rail`.
 
 #include "anchor_manager.hpp"
+#include "find_dock.hpp"
 #include "log_filter_model.hpp"
 #include "log_model.hpp"
 #include "log_table_view.hpp"
@@ -33,8 +34,10 @@
 #include <QAbstractItemModel>
 #include <QAction>
 #include <QApplication>
+#include <QCoreApplication>
 #include <QImage>
 #include <QItemSelectionModel>
+#include <QMetaObject>
 #include <QModelIndex>
 #include <QPainter>
 #include <QRect>
@@ -1677,6 +1680,161 @@ private slots:
         );
     }
 
+    /// Closing and reopening the find dock must restore unbiased
+    /// rail ticks from cached per-bucket counts — not the capped
+    /// `sortedRows` list. Pins the regression where a cache-hit
+    /// debounce after `revealed` left the rail painting only the
+    /// first 10 000 hits of a common needle.
+    static void TestFindDockRevealRestoresUnbiasedMatchTicks()
+    {
+        {
+            QSettings settings;
+            settings.remove(QStringLiteral("ui/showOverviewRail"));
+        }
+        MainWindow window;
+        window.show();
+        QCoreApplication::processEvents();
+
+        constexpr int ROWS = 40;
+        const RailFixture fixture(ROWS);
+        auto *model = window.Model();
+        QVERIFY(model != nullptr);
+        StreamJsonPathInto(*model, fixture.Path());
+        QCOMPARE(window.FilterModel()->rowCount(), ROWS);
+
+        auto *railModel = window.findChild<OverviewRailModel *>();
+        QVERIFY(railModel != nullptr);
+        QVERIFY(railModel->BucketCount() > 0);
+
+        auto *findDock = window.findChild<FindDock *>();
+        QVERIFY(findDock != nullptr);
+        findDock->show();
+        QCoreApplication::processEvents();
+        QVERIFY(findDock->isVisible());
+
+        // "msg" matches every fixture row — spreads ticks across
+        // the whole rail when bucketed correctly.
+        QVERIFY(QMetaObject::invokeMethod(
+            &window,
+            "UpdateFindMatchCount",
+            Qt::DirectConnection,
+            Q_ARG(QString, QStringLiteral("msg")),
+            Q_ARG(bool, false),
+            Q_ARG(bool, false)
+        ));
+        QVERIFY(railModel->HasMatchTicks());
+
+        std::vector<uint32_t> baseline;
+        baseline.reserve(railModel->BucketCount());
+        uint32_t baselineTotal = 0;
+        std::size_t bucketsWithTicks = 0;
+        for (const auto &bucket : railModel->Buckets())
+        {
+            baseline.push_back(bucket.matchCount);
+            baselineTotal += bucket.matchCount;
+            if (bucket.matchCount > 0)
+            {
+                ++bucketsWithTicks;
+            }
+        }
+        QCOMPARE(baselineTotal, static_cast<uint32_t>(ROWS));
+        QVERIFY2(bucketsWithTicks > 1, "matches must span more than one bucket before close");
+
+        // Close clears live rail ticks; cache survives.
+        emit findDock->closed();
+        QVERIFY2(!railModel->HasMatchTicks(), "closing find must clear rail match ticks");
+
+        // Reveal must restore the same unbiased distribution —
+        // not a top-biased strip from capped sortedRows.
+        emit findDock->revealed();
+        QVERIFY2(railModel->HasMatchTicks(), "revealed find must restore rail match ticks");
+        QCOMPARE(railModel->BucketCount(), baseline.size());
+        for (std::size_t i = 0; i < baseline.size(); ++i)
+        {
+            QCOMPARE(railModel->Buckets()[i].matchCount, baseline[i]);
+        }
+    }
+
+    /// Resizing the rail widget past a bucket-count boundary
+    /// (e.g. user drags the window taller, `SyncBucketCountToHeight`
+    /// calls `SetBucketCount(newH)`) invalidates the durable
+    /// `mMatchBucketCounts` — sizes disagree, so `ApplyStoredMatch-
+    /// BucketCounts` no-ops and the freshly-rebuilt buckets have
+    /// zero ticks. Without the `bucketsChanged` -> `PushFindMatches-
+    /// ToOverviewRail` wiring in `MainWindow`, the rail would then
+    /// paint an empty match strip until the next find-bar debounce
+    /// (or forever, if the user isn't typing). Pins that the wire
+    /// triggers a synchronous recount and re-installs ticks at the
+    /// new H.
+    static void TestRailResizeReinstallsFindTicksAtNewBucketCount()
+    {
+        {
+            QSettings settings;
+            settings.remove(QStringLiteral("ui/showOverviewRail"));
+        }
+        MainWindow window;
+        window.show();
+        QCoreApplication::processEvents();
+
+        constexpr int ROWS = 40;
+        const RailFixture fixture(ROWS);
+        auto *model = window.Model();
+        QVERIFY(model != nullptr);
+        StreamJsonPathInto(*model, fixture.Path());
+        QCOMPARE(window.FilterModel()->rowCount(), ROWS);
+
+        auto *railModel = window.findChild<OverviewRailModel *>();
+        QVERIFY(railModel != nullptr);
+        const std::size_t initialBuckets = railModel->BucketCount();
+        QVERIFY(initialBuckets > 0);
+
+        auto *findDock = window.findChild<FindDock *>();
+        QVERIFY(findDock != nullptr);
+        findDock->show();
+        QCoreApplication::processEvents();
+
+        // Broad needle: every row is a hit, so every bucket must
+        // light up when ticks are correctly installed.
+        QVERIFY(QMetaObject::invokeMethod(
+            &window,
+            "UpdateFindMatchCount",
+            Qt::DirectConnection,
+            Q_ARG(QString, QStringLiteral("msg")),
+            Q_ARG(bool, false),
+            Q_ARG(bool, false)
+        ));
+        QVERIFY2(railModel->HasMatchTicks(), "broad find must light up rail ticks before resize");
+
+        // Simulate a rail-widget height change by pushing a new
+        // bucket count into the model — same call path the widget
+        // takes through `SyncBucketCountToHeight`. Pick a value
+        // that is provably different from `initialBuckets` so the
+        // durable-counts fast path can't accidentally rescue us.
+        const std::size_t newBuckets = (initialBuckets == 24) ? 48 : 24;
+        railModel->SetBucketCount(newBuckets);
+
+        // Post-condition: the `bucketsChanged` slot fires
+        // synchronously (DirectConnection, same thread), the slot
+        // sees size-mismatched cached counts, drops into the
+        // rescan branch of `PushFindMatchesToOverviewRail`, and
+        // installs fresh ticks against `newBuckets` before this
+        // call returns. No event-loop pump needed.
+        QCOMPARE(railModel->BucketCount(), newBuckets);
+        QVERIFY2(
+            railModel->HasMatchTicks(),
+            "rail-resize past a bucket-count boundary must not leave ticks empty; "
+            "bucketsChanged is wired to PushFindMatchesToOverviewRail's rescan branch"
+        );
+        // Every fixture row is a hit and there are more rows than
+        // buckets, so *every* bucket should carry a tick after the
+        // rescan. Pins the "unbiased distribution" property in
+        // addition to plain `HasMatchTicks`.
+        for (std::size_t i = 0; i < newBuckets; ++i)
+        {
+            QVERIFY2(railModel->Buckets()[i].matchCount > 0, "every bucket must carry a tick after resize rescan");
+        }
+    }
+
     /// A drag scrub across the rail must preserve the user's
     /// existing selection. Simulates the emit the widget sends
     /// on `mouseMoveEvent` (replaceSelection == false) and pins
@@ -1898,6 +2056,606 @@ private slots:
         // Give Qt a chance to deliver the resize event.
         QCoreApplication::processEvents();
         QCOMPARE(view.ReservedRightMargin(), 0);
+    }
+
+    /// `SetMatchBucketCounts` installs pre-bucketed match counts
+    /// directly, without going through the raw-row fold path.
+    /// This is the API `MainWindow::UpdateFindMatchCount` uses to
+    /// feed the rail unbiased ticks when a broad needle would
+    /// otherwise fill an O(matches) row vector on the GUI thread.
+    static void TestSetMatchBucketCountsBasic()
+    {
+        LogModel model;
+        QObject owner;
+        const auto chain = BuildProxyChain(&model, &owner);
+        OverviewRailModel rail(chain.filter, &model, /*anchors=*/nullptr);
+        rail.SetBucketCount(20);
+
+        constexpr int ROWS = 20;
+        const RailFixture fixture(ROWS);
+        StreamJsonPathInto(model, fixture.Path());
+        WaitForBucketsChanged(rail);
+        QCOMPARE(rail.ProxyRowCount(), ROWS);
+        QVERIFY(!rail.HasMatchTicks());
+
+        std::vector<uint32_t> counts(20, uint32_t{0});
+        counts[3] = 7;
+        counts[19] = 42;
+
+        QSignalSpy matchSpy(&rail, &OverviewRailModel::matchesChanged);
+        rail.SetMatchBucketCounts(counts, /*totalMatches=*/49);
+        QCOMPARE(matchSpy.count(), 1);
+        QVERIFY(rail.HasMatchTicks());
+
+        std::size_t i = 0;
+        for (const auto &bucket : rail.Buckets())
+        {
+            QCOMPARE(bucket.matchCount, counts[i]);
+            ++i;
+        }
+
+        // Zeroing every bucket flips `HasMatchTicks` back off,
+        // matching the row-list path.
+        rail.SetMatchBucketCounts(std::vector<uint32_t>(20, uint32_t{0}), /*totalMatches=*/0);
+        QVERIFY(!rail.HasMatchTicks());
+    }
+
+    /// `SetMatchBucketCounts` must leave the level counts and
+    /// anchor bits untouched; only the tick counters move.
+    /// Mirrors `TestSetMatchProxyRowsLeavesLevelCountsUntouched`
+    /// for the bucketed API so future refactors can't silently
+    /// tie a match-set push to a full rebuild.
+    static void TestSetMatchBucketCountsLeavesLevelCountsUntouched()
+    {
+        LogModel model;
+        QObject owner;
+        const auto chain = BuildProxyChain(&model, &owner);
+        OverviewRailModel rail(chain.filter, &model, /*anchors=*/nullptr);
+        rail.SetBucketCount(20);
+
+        constexpr int ROWS = 20;
+        const RailFixture fixture(ROWS);
+        StreamJsonPathInto(model, fixture.Path());
+        WaitForBucketsChanged(rail);
+        QCOMPARE(rail.ProxyRowCount(), ROWS);
+
+        std::vector<loglib::LevelBucket> baseline;
+        baseline.reserve(rail.BucketCount());
+        for (const auto &bucket : rail.Buckets())
+        {
+            baseline.push_back(bucket.levels);
+        }
+
+        std::vector<uint32_t> counts(20, uint32_t{0});
+        counts[5] = 3;
+        counts[10] = 5;
+        rail.SetMatchBucketCounts(counts, /*totalMatches=*/8);
+
+        std::size_t i = 0;
+        for (const auto &bucket : rail.Buckets())
+        {
+            QCOMPARE(bucket.levels.counts, baseline[i].counts);
+            ++i;
+        }
+    }
+
+    /// Size mismatch (mid-resize race, or a caller with stale
+    /// bucket-count info) must be dropped silently so a half-
+    /// applied vector cannot leak into the rail. Pins the
+    /// defensive size check on `SetMatchBucketCounts`.
+    static void TestSetMatchBucketCountsSizeMismatchDropsSilently()
+    {
+        LogModel model;
+        QObject owner;
+        const auto chain = BuildProxyChain(&model, &owner);
+        OverviewRailModel rail(chain.filter, &model, /*anchors=*/nullptr);
+        rail.SetBucketCount(20);
+
+        constexpr int ROWS = 20;
+        const RailFixture fixture(ROWS);
+        StreamJsonPathInto(model, fixture.Path());
+        WaitForBucketsChanged(rail);
+        QCOMPARE(rail.ProxyRowCount(), ROWS);
+
+        // Prime the rail with a known set of ticks so we can
+        // prove the mismatched call didn't overwrite them.
+        rail.SetMatchProxyRows({5, 10, 15});
+        QVERIFY(rail.HasMatchTicks());
+        const uint32_t baselineTotal = [&]() {
+            uint32_t sum = 0;
+            for (const auto &bucket : rail.Buckets())
+            {
+                sum += bucket.matchCount;
+            }
+            return sum;
+        }();
+        QCOMPARE(baselineTotal, static_cast<uint32_t>(3));
+
+        QSignalSpy matchSpy(&rail, &OverviewRailModel::matchesChanged);
+        // Off-by-one on the vector size: rail has 20 buckets.
+        rail.SetMatchBucketCounts(std::vector<uint32_t>(19, uint32_t{7}), /*totalMatches=*/133);
+        QCOMPARE(matchSpy.count(), 0);
+
+        // Original tick totals must survive the rejected push.
+        uint32_t survivedTotal = 0;
+        for (const auto &bucket : rail.Buckets())
+        {
+            survivedTotal += bucket.matchCount;
+        }
+        QCOMPARE(survivedTotal, baselineTotal);
+    }
+
+    /// After `SetMatchBucketCounts` the raw-rows vector must be
+    /// cleared *and* the durable bucket counts retained, so a
+    /// follow-up full rebuild (anchor edit, coalesced proxy
+    /// change, hide→show at the same H) re-applies the same
+    /// ticks without double-folding a stale row list on top.
+    static void TestSetMatchBucketCountsClearsRawRowsSoRebuildDoesNotDoubleFold()
+    {
+        LogModel model;
+        QObject owner;
+        const auto chain = BuildProxyChain(&model, &owner);
+        OverviewRailModel rail(chain.filter, &model, /*anchors=*/nullptr);
+        rail.SetBucketCount(20);
+
+        constexpr int ROWS = 20;
+        const RailFixture fixture(ROWS);
+        StreamJsonPathInto(model, fixture.Path());
+        WaitForBucketsChanged(rail);
+
+        // Seed the raw-rows path so `mMatchProxyRows` is
+        // non-empty going in.
+        rail.SetMatchProxyRows({2, 4, 6, 8});
+        QCOMPARE(rail.HasMatchTicks(), true);
+
+        // Now overwrite via the bucketed API. The buckets should
+        // reflect the new counts exactly, not "new counts + old
+        // row-list fold".
+        std::vector<uint32_t> counts(20, uint32_t{0});
+        counts[10] = 1;
+        rail.SetMatchBucketCounts(counts, /*totalMatches=*/1);
+
+        // Force a synchronous full rebuild. Durable bucket counts
+        // must survive (same H); the cleared raw-rows list must
+        // not resurrect the earlier {2,4,6,8} fold on top.
+        rail.RebuildNow();
+        uint32_t afterRebuild = 0;
+        for (const auto &bucket : rail.Buckets())
+        {
+            afterRebuild += bucket.matchCount;
+        }
+        QCOMPARE(afterRebuild, static_cast<uint32_t>(1));
+        QCOMPARE(rail.Buckets()[10].matchCount, static_cast<uint32_t>(1));
+        QVERIFY(rail.HasMatchTicks());
+    }
+
+    /// Bucket-counts path mirrors `TestHideAndShowRestoresMatchTicks`:
+    /// `SetBucketCount(0)` drops the live vector but keeps durable
+    /// counts, and `SetBucketCount(H)` re-applies them without the
+    /// caller re-pushing.
+    static void TestSetMatchBucketCountsSurviveHideAndShow()
+    {
+        LogModel model;
+        QObject owner;
+        const auto chain = BuildProxyChain(&model, &owner);
+        OverviewRailModel rail(chain.filter, &model, /*anchors=*/nullptr);
+        rail.SetBucketCount(20);
+
+        constexpr int ROWS = 20;
+        const RailFixture fixture(ROWS);
+        StreamJsonPathInto(model, fixture.Path());
+        WaitForBucketsChanged(rail);
+
+        std::vector<uint32_t> counts(20, uint32_t{0});
+        counts[3] = 5;
+        counts[17] = 2;
+        rail.SetMatchBucketCounts(counts, /*totalMatches=*/7);
+        QVERIFY(rail.HasMatchTicks());
+
+        rail.SetBucketCount(0);
+        QVERIFY2(!rail.HasMatchTicks(), "hidden rail must report no match ticks");
+
+        rail.SetBucketCount(20);
+        QVERIFY2(rail.HasMatchTicks(), "revealed rail must restore durable bucket counts");
+        QCOMPARE(rail.Buckets()[3].matchCount, static_cast<uint32_t>(5));
+        QCOMPARE(rail.Buckets()[17].matchCount, static_cast<uint32_t>(2));
+        uint32_t total = 0;
+        for (const auto &bucket : rail.Buckets())
+        {
+            total += bucket.matchCount;
+        }
+        QCOMPARE(total, static_cast<uint32_t>(7));
+    }
+
+    /// Changing H invalidates durable bucket counts (size mismatch).
+    /// Rebuild must not invent ticks; the caller (MainWindow) is
+    /// responsible for rescanning against the new bucket count.
+    static void TestSetMatchBucketCountsDroppedOnBucketCountChange()
+    {
+        LogModel model;
+        QObject owner;
+        const auto chain = BuildProxyChain(&model, &owner);
+        OverviewRailModel rail(chain.filter, &model, /*anchors=*/nullptr);
+        rail.SetBucketCount(20);
+
+        constexpr int ROWS = 20;
+        const RailFixture fixture(ROWS);
+        StreamJsonPathInto(model, fixture.Path());
+        WaitForBucketsChanged(rail);
+
+        std::vector<uint32_t> counts(20, uint32_t{0});
+        counts[5] = 4;
+        rail.SetMatchBucketCounts(counts, /*totalMatches=*/4);
+        QVERIFY(rail.HasMatchTicks());
+
+        rail.SetBucketCount(30);
+        QVERIFY2(!rail.HasMatchTicks(), "H change must drop size-mismatched durable counts");
+    }
+
+    /// Regression for the "stale proxy row count misplaces ticks"
+    /// bug. `RefreshMatchTicks` / `FoldMatchTicksIntoBuckets` use
+    /// `mProxyRowCount`, which was only written inside the
+    /// coalesced `RebuildInternal`. A `SetMatchProxyRows` call
+    /// scheduled between a filter/insert layout change and the
+    /// next rebuild would fold rows referenced to the live row
+    /// count against a stale denominator, dropping hits (when
+    /// the proxy grew) or misplacing them into the last bucket
+    /// (either direction).
+    ///
+    /// The fix: `SetMatchProxyRows` refreshes `mProxyRowCount`
+    /// from the live proxy at entry, so the fold uses the same
+    /// denominator the caller scanned against.
+    ///
+    /// We drive the divergence with a filter install: it fires
+    /// `layoutChanged` on `LogFilterModel`, which the rail wires
+    /// to `Rebuild` -> `ScheduleRebuild` (50 ms coalesce timer).
+    /// Between `SetFilterRules` returning and the timer firing,
+    /// no event-loop iteration happens in this test, so the
+    /// cached `mProxyRowCount` is guaranteed to be stale when
+    /// we call `SetMatchProxyRows` on the next line.
+    static void TestSetMatchProxyRowsRefreshesRowCountAfterProxyChurn()
+    {
+        LogModel model;
+        QObject owner;
+        const auto chain = BuildProxyChain(&model, &owner);
+        OverviewRailModel rail(chain.filter, &model, /*anchors=*/nullptr);
+        rail.SetBucketCount(20);
+
+        constexpr int ROWS = 40;
+        const RailFixture fixture(ROWS);
+        StreamJsonPathInto(model, fixture.Path());
+        WaitForBucketsChanged(rail);
+        QCOMPARE(rail.ProxyRowCount(), ROWS);
+
+        // Install a filter that drops every other row. The
+        // proxy's row count halves (~20 rows) but the rail's
+        // cached `mProxyRowCount` stays at 40 until the coalesce
+        // timer fires ~50 ms later.
+        std::vector<loglib::RowPredicate> rules;
+        rules.emplace_back(
+            std::in_place_type<loglib::CallbackStringRowPredicate>,
+            static_cast<std::size_t>(0),
+            [callCount = std::make_shared<std::size_t>(0)](std::string_view) mutable {
+                return ((*callCount)++ % 2) == 0;
+            }
+        );
+        chain.filter->SetFilterRules(std::move(rules));
+        const int liveRowCount = chain.filter->rowCount();
+        QVERIFY2(liveRowCount > 0 && liveRowCount < ROWS, "filter must reduce the proxy row count");
+
+        // Under the pre-fix code path, `mProxyRowCount` stays 40
+        // and folding row `liveRowCount - 1` (in range under the
+        // filter, but potentially misbucketed against the old
+        // denominator) misplaces the tick. Under the fix,
+        // `mProxyRowCount` refreshes and the tick lands correctly.
+        rail.SetMatchProxyRows({liveRowCount - 1});
+        QCOMPARE(rail.ProxyRowCount(), liveRowCount);
+        QVERIFY(rail.HasMatchTicks());
+
+        // Sanity: the tick sits in one of the tail buckets --
+        // `(liveRowCount - 1) * 20 / liveRowCount` rounds to
+        // ~19 for any positive `liveRowCount`.
+        uint32_t totalTicks = 0;
+        std::size_t highestBucketWithTick = 0;
+        for (std::size_t i = 0; i < rail.BucketCount(); ++i)
+        {
+            const uint32_t c = rail.Buckets()[i].matchCount;
+            totalTicks += c;
+            if (c > 0)
+            {
+                highestBucketWithTick = i;
+            }
+        }
+        QCOMPARE(totalTicks, static_cast<uint32_t>(1));
+        QCOMPARE(highestBucketWithTick, rail.BucketCount() - 1);
+    }
+
+    /// Companion regression for the bucketed API: same stale-
+    /// denominator failure mode, checked through
+    /// `SetMatchBucketCounts` (which is what `MainWindow`
+    /// actually calls under the fix).
+    static void TestSetMatchBucketCountsRefreshesRowCountAfterProxyChurn()
+    {
+        LogModel model;
+        QObject owner;
+        const auto chain = BuildProxyChain(&model, &owner);
+        OverviewRailModel rail(chain.filter, &model, /*anchors=*/nullptr);
+        rail.SetBucketCount(20);
+
+        constexpr int ROWS = 40;
+        const RailFixture fixture(ROWS);
+        StreamJsonPathInto(model, fixture.Path());
+        WaitForBucketsChanged(rail);
+        QCOMPARE(rail.ProxyRowCount(), ROWS);
+
+        std::vector<loglib::RowPredicate> rules;
+        rules.emplace_back(
+            std::in_place_type<loglib::CallbackStringRowPredicate>,
+            static_cast<std::size_t>(0),
+            [callCount = std::make_shared<std::size_t>(0)](std::string_view) mutable {
+                return ((*callCount)++ % 2) == 0;
+            }
+        );
+        chain.filter->SetFilterRules(std::move(rules));
+        const int liveRowCount = chain.filter->rowCount();
+        QVERIFY2(liveRowCount > 0 && liveRowCount < ROWS, "filter must reduce the proxy row count");
+
+        std::vector<uint32_t> counts(rail.BucketCount(), uint32_t{0});
+        counts[rail.BucketCount() - 1] = 3;
+        rail.SetMatchBucketCounts(counts, /*totalMatches=*/3);
+
+        // The row count must refresh independently of the raw-
+        // rows path: `SetMatchBucketCounts` has its own
+        // `mProxyRowCount = mProxyModel->rowCount()` assignment
+        // so downstream `HasMatchTicks` / `BucketForProxyRow`
+        // math sees the current denominator.
+        QCOMPARE(rail.ProxyRowCount(), liveRowCount);
+        QVERIFY(rail.HasMatchTicks());
+    }
+
+    /// `LogFilterModel::ForEachMatchingRow` walks every matching
+    /// row without allocating a `QList<QModelIndex>`, which is
+    /// how `MainWindow::UpdateFindMatchCount` avoids the memory
+    /// spike on a broad needle. Pin the contract: the callback
+    /// fires once per matching row, in ascending order, and
+    /// returning `false` stops the walk mid-stream. Removing the
+    /// hard 10 000-hit cap on the sorted-rows cache is only safe
+    /// if callers can accumulate counters cheaply without the
+    /// intermediate list.
+    static void TestForEachMatchingRowStreamsWithoutMaterialising()
+    {
+        LogModel model;
+        QObject owner;
+        const auto chain = BuildProxyChain(&model, &owner);
+
+        constexpr int ROWS = 30;
+        const RailFixture fixture(ROWS);
+        StreamJsonPathInto(model, fixture.Path());
+        QCOMPARE(chain.filter->rowCount(), ROWS);
+
+        // Every fixture row carries a `"msg N"` body, so "msg"
+        // matches every row.
+        const QModelIndex start = chain.filter->index(0, 0);
+        QVERIFY(start.isValid());
+
+        std::vector<int> seenRows;
+        seenRows.reserve(ROWS);
+        chain.filter->ForEachMatchingRow(
+            start,
+            Qt::DisplayRole,
+            QVariant::fromValue(QStringLiteral("msg")),
+            Qt::MatchContains | Qt::MatchWrap,
+            /*forward=*/true,
+            /*skipFirstN=*/0,
+            [&](const QModelIndex &proxyIndex) -> bool {
+                seenRows.push_back(proxyIndex.row());
+                return true;
+            }
+        );
+
+        QCOMPARE(static_cast<int>(seenRows.size()), ROWS);
+        QVERIFY2(std::ranges::is_sorted(seenRows), "ForEachMatchingRow must yield rows in ascending order");
+        QVERIFY2(
+            std::ranges::adjacent_find(seenRows) == seenRows.end(),
+            "ForEachMatchingRow must not repeat a row"
+        );
+
+        // Returning `false` stops the walk on the first hit. The
+        // caller has full control over the accumulator shape.
+        int visitedCount = 0;
+        chain.filter->ForEachMatchingRow(
+            start,
+            Qt::DisplayRole,
+            QVariant::fromValue(QStringLiteral("msg")),
+            Qt::MatchContains | Qt::MatchWrap,
+            /*forward=*/true,
+            /*skipFirstN=*/0,
+            [&](const QModelIndex &) -> bool {
+                ++visitedCount;
+                return false;
+            }
+        );
+        QCOMPARE(visitedCount, 1);
+    }
+
+    /// Regression for the "uncapped find scan" bug. Pin the two
+    /// consumer patterns `MainWindow::UpdateFindMatchCount` uses
+    /// to avoid the O(matches) allocation while keeping the rail
+    /// unbiased:
+    ///   1. A capped row vector for the "*i* of *N*" binary
+    ///      search (never grows past `SCAN_CAP` regardless of
+    ///      total hits).
+    ///   2. An `nBuckets`-sized counter vector for the rail (sees
+    ///      every hit, including tail rows past the row-vector
+    ///      cap).
+    ///
+    /// This test drives `ForEachMatchingRow` with a broad needle
+    /// that matches every row and asserts both invariants
+    /// simultaneously.
+    static void TestForEachMatchingRowFeedsCappedListPlusUnbiasedBuckets()
+    {
+        LogModel model;
+        QObject owner;
+        const auto chain = BuildProxyChain(&model, &owner);
+
+        constexpr int ROWS = 60;
+        constexpr int SCAN_CAP = 10;
+        constexpr std::size_t BUCKETS = 6;
+        const RailFixture fixture(ROWS);
+        StreamJsonPathInto(model, fixture.Path());
+        QCOMPARE(chain.filter->rowCount(), ROWS);
+
+        const QModelIndex start = chain.filter->index(0, 0);
+        QVERIFY(start.isValid());
+
+        std::vector<int> cappedRows;
+        cappedRows.reserve(SCAN_CAP);
+        std::vector<uint32_t> bucketCounts(BUCKETS, uint32_t{0});
+        uint32_t totalMatches = 0;
+        chain.filter->ForEachMatchingRow(
+            start,
+            Qt::DisplayRole,
+            QVariant::fromValue(QStringLiteral("msg")),
+            Qt::MatchContains | Qt::MatchWrap,
+            /*forward=*/true,
+            /*skipFirstN=*/0,
+            [&](const QModelIndex &proxyIndex) -> bool {
+                ++totalMatches;
+                const std::size_t bucket = (static_cast<std::size_t>(proxyIndex.row()) * BUCKETS) /
+                                           static_cast<std::size_t>(ROWS);
+                ++bucketCounts[std::min(bucket, BUCKETS - 1)];
+                if (static_cast<int>(cappedRows.size()) < SCAN_CAP)
+                {
+                    cappedRows.push_back(proxyIndex.row());
+                }
+                return true;
+            }
+        );
+
+        QCOMPARE(totalMatches, static_cast<uint32_t>(ROWS));
+        QCOMPARE(static_cast<int>(cappedRows.size()), SCAN_CAP);
+        // The capped list holds only the first N rows, biased to
+        // the top of the log (this is the trade-off the row cap
+        // makes -- the "*i* of *N*" navigator degrades past the
+        // cap, but the total count and the rail stay accurate).
+        QCOMPARE(cappedRows.front(), 0);
+        QCOMPARE(cappedRows.back(), SCAN_CAP - 1);
+
+        // Bucket sum must equal total (no matches dropped). Every
+        // bucket must carry at least one hit since matches are
+        // spread across all rows -- this is the "unbiased rail"
+        // property that the cap on `cappedRows` alone would have
+        // broken.
+        uint32_t summedFromBuckets = 0;
+        for (std::size_t i = 0; i < BUCKETS; ++i)
+        {
+            summedFromBuckets += bucketCounts[i];
+            QVERIFY2(
+                bucketCounts[i] > 0,
+                qPrintable(QStringLiteral("bucket %1 must carry at least one match tick").arg(i))
+            );
+        }
+        QCOMPARE(summedFromBuckets, totalMatches);
+    }
+
+    /// Pins the early-exit policy `UpdateFindMatchCount` uses so a
+    /// common needle cannot force a full proxy walk on the GUI
+    /// thread: once the navigator list is past its cap *and* every
+    /// rail bucket already has a presence tick, the walk stops.
+    /// Paint is presence-only, so further density is irrelevant;
+    /// sparse needles (not every bucket lit) still scan to the end.
+    static void TestFindMatchScanEarlyExitsWhenRailPresenceSettled()
+    {
+        LogModel model;
+        QObject owner;
+        const auto chain = BuildProxyChain(&model, &owner);
+
+        constexpr int ROWS = 60;
+        constexpr int SCAN_CAP = 10;
+        constexpr std::size_t BUCKETS = 6;
+        const RailFixture fixture(ROWS);
+        StreamJsonPathInto(model, fixture.Path());
+        QCOMPARE(chain.filter->rowCount(), ROWS);
+
+        const QModelIndex start = chain.filter->index(0, 0);
+        QVERIFY(start.isValid());
+
+        std::vector<int> cappedRows;
+        cappedRows.reserve(SCAN_CAP);
+        std::vector<uint32_t> bucketCounts(BUCKETS, uint32_t{0});
+        uint32_t totalMatches = 0;
+        std::size_t bucketsHit = 0;
+        bool scanExhausted = true;
+        int callbackInvocations = 0;
+        chain.filter->ForEachMatchingRow(
+            start,
+            Qt::DisplayRole,
+            QVariant::fromValue(QStringLiteral("msg")),
+            Qt::MatchContains | Qt::MatchWrap,
+            /*forward=*/true,
+            /*skipFirstN=*/0,
+            [&](const QModelIndex &proxyIndex) -> bool {
+                ++callbackInvocations;
+                ++totalMatches;
+                const std::size_t bucket = (static_cast<std::size_t>(proxyIndex.row()) * BUCKETS) /
+                                           static_cast<std::size_t>(ROWS);
+                uint32_t &slot = bucketCounts[std::min(bucket, BUCKETS - 1)];
+                if (slot == 0)
+                {
+                    ++bucketsHit;
+                }
+                ++slot;
+                if (static_cast<int>(cappedRows.size()) < SCAN_CAP)
+                {
+                    cappedRows.push_back(proxyIndex.row());
+                }
+                if (totalMatches > static_cast<uint32_t>(SCAN_CAP) && bucketsHit >= BUCKETS)
+                {
+                    scanExhausted = false;
+                    return false;
+                }
+                return true;
+            }
+        );
+
+        QVERIFY2(!scanExhausted, "dense needle must early-exit once every bucket has a tick");
+        QVERIFY2(
+            callbackInvocations < ROWS,
+            "early-exit must stop before visiting every matching row"
+        );
+        QCOMPARE(static_cast<int>(cappedRows.size()), SCAN_CAP);
+        QCOMPARE(bucketsHit, BUCKETS);
+        for (std::size_t i = 0; i < BUCKETS; ++i)
+        {
+            QVERIFY2(bucketCounts[i] > 0, "every bucket must carry a presence tick after early-exit");
+        }
+
+        // Sparse needle: only the first few rows match a unique
+        // body token, so not every bucket lights up and the walk
+        // must exhaust the proxy (no early-exit).
+        int sparseInvocations = 0;
+        bool sparseExhausted = true;
+        chain.filter->ForEachMatchingRow(
+            start,
+            Qt::DisplayRole,
+            QVariant::fromValue(QStringLiteral("msg 0")),
+            Qt::MatchContains | Qt::MatchWrap,
+            /*forward=*/true,
+            /*skipFirstN=*/0,
+            [&](const QModelIndex &) -> bool {
+                ++sparseInvocations;
+                // Cap proven + "all buckets hit" can never both be
+                // true for a single-row hit set spanning one bucket.
+                if (sparseInvocations > SCAN_CAP)
+                {
+                    sparseExhausted = false;
+                    return false;
+                }
+                return true;
+            }
+        );
+        QVERIFY2(sparseExhausted, "sparse needle must not take the dense early-exit path");
+        QCOMPARE(sparseInvocations, 1);
     }
 };
 

--- a/test/app/src/test_overview_rail.cpp
+++ b/test/app/src/test_overview_rail.cpp
@@ -1454,6 +1454,8 @@ private slots:
     /// `sizeHint()` returns a positive DPI-fluent width and a
     /// zero preferred height (rail grows vertically to fit the
     /// hosting margin). `minimumSizeHint` never exceeds it.
+    /// Default width mode is Medium (the shipped Preferences /
+    /// `QSettings` default).
     static void TestWidgetSizeHintIsDpiFluent()
     {
         LogModel model;
@@ -1466,6 +1468,7 @@ private slots:
         // still routes both). The DPI-fluent width should be > 0
         // and >= the minimum floor.
         widget.ensurePolished();
+        QCOMPARE(widget.WidthMode(), OverviewRailWidthMode::Medium);
         const int width = widget.sizeHint().width();
         QVERIFY2(width > 0, "size hint width must be positive after ensurePolished");
         const int minWidth = widget.minimumSizeHint().width();
@@ -1474,6 +1477,70 @@ private slots:
         // sizeHint() returns 0 height so the parent layout drives
         // vertical extent.
         QCOMPARE(widget.sizeHint().height(), 0);
+    }
+
+    /// Width modes scale the same DPI base: Medium > Narrow and
+    /// Wide > Medium. Unknown settings strings parse to Medium.
+    static void TestWidthModesScaleSizeHint()
+    {
+        LogModel model;
+        AnchorManager anchors;
+        QObject owner;
+        const auto chain = BuildProxyChain(&model, &owner);
+        OverviewRailModel rail(chain.filter, &model, &anchors, &owner);
+        OverviewRailWidget widget(&rail, /*theme=*/nullptr, /*tableView=*/nullptr);
+        widget.ensurePolished();
+
+        QCOMPARE(ParseOverviewRailWidthMode(QStringLiteral("narrow")), OverviewRailWidthMode::Narrow);
+        QCOMPARE(ParseOverviewRailWidthMode(QStringLiteral("medium")), OverviewRailWidthMode::Medium);
+        QCOMPARE(ParseOverviewRailWidthMode(QStringLiteral("wide")), OverviewRailWidthMode::Wide);
+        QCOMPARE(ParseOverviewRailWidthMode(QStringLiteral("garbage")), OverviewRailWidthMode::Medium);
+        QCOMPARE(OverviewRailWidthModeToSettingsString(OverviewRailWidthMode::Wide), QStringLiteral("wide"));
+
+        widget.SetWidthMode(OverviewRailWidthMode::Narrow);
+        const int narrow = widget.sizeHint().width();
+        widget.SetWidthMode(OverviewRailWidthMode::Medium);
+        const int medium = widget.sizeHint().width();
+        widget.SetWidthMode(OverviewRailWidthMode::Wide);
+        const int wide = widget.sizeHint().width();
+
+        QVERIFY2(medium > narrow, "Medium must be wider than Narrow");
+        QVERIFY2(wide > medium, "Wide must be wider than Medium");
+        QVERIFY(narrow >= 24);
+        QVERIFY(wide <= 128);
+    }
+
+    /// Changing the width mode on an attached rail refreshes the
+    /// reserved right margin so the viewport tracks sizeHint.
+    static void TestWidthModeChangeRefreshesReservedMargin()
+    {
+        LogTableView view;
+        view.resize(800, 400);
+        view.show();
+
+        LogModel model;
+        AnchorManager anchors;
+        QObject owner;
+        const auto chain = BuildProxyChain(&model, &owner);
+        OverviewRailModel railModel(chain.filter, &model, &anchors, &owner);
+        auto *widget = new OverviewRailWidget(&railModel, /*theme=*/nullptr, &view);
+        widget->SetWidthMode(OverviewRailWidthMode::Narrow);
+        view.AttachOverviewRail(widget);
+        QCoreApplication::processEvents();
+
+        const int narrowMargin = view.ReservedRightMargin();
+        QCOMPARE(narrowMargin, widget->sizeHint().width());
+
+        widget->SetWidthMode(OverviewRailWidthMode::Wide);
+        view.RefreshOverviewRailMargin();
+        QCoreApplication::processEvents();
+
+        const int wideMargin = view.ReservedRightMargin();
+        QCOMPARE(wideMargin, widget->sizeHint().width());
+        QVERIFY2(wideMargin > narrowMargin, "Wide mode must enlarge the reserved table margin");
+
+        view.AttachOverviewRail(nullptr);
+        delete widget;
     }
 
     /// Attaching a rail widget to `LogTableView` reserves a
@@ -2656,6 +2723,528 @@ private slots:
         );
         QVERIFY2(sparseExhausted, "sparse needle must not take the dense early-exit path");
         QCOMPARE(sparseInvocations, 1);
+    }
+
+    /// Regression against the "resize-storm rescan" bug. A live
+    /// drag-resize of the window fires a resize event per pixel
+    /// of rail-height change, and each `SetBucketCount(H±1)` on
+    /// the model would invalidate the durable per-bucket
+    /// find-match counts and force `MainWindow`'s
+    /// `bucketsChanged` -> `PushFindMatchesToOverviewRail`
+    /// wiring to run a synchronous full-table find rescan --
+    /// seconds of freeze on a large log with the Find bar open.
+    ///
+    /// The widget debounces `SyncBucketCountToHeight()` through
+    /// `mBucketSyncTimer`; a burst of resize events must collapse
+    /// to a single `SetBucketCount(finalH)` when the drag settles.
+    static void TestResizeStormCoalescesToSingleBucketCountUpdate()
+    {
+        LogModel model;
+        QObject owner;
+        const auto chain = BuildProxyChain(&model, &owner);
+        OverviewRailModel railModel(chain.filter, &model, /*anchors=*/nullptr, &owner);
+
+        constexpr int ROWS = 40;
+        const RailFixture fixture(ROWS);
+        StreamJsonPathInto(model, fixture.Path());
+
+        auto *widget = new OverviewRailWidget(&railModel, /*theme=*/nullptr, /*tableView=*/nullptr);
+        // Initial size + show fires the synchronous first-sync
+        // path in `showEvent`. Subsequent resize events are what
+        // this test asserts on -- they must go through the
+        // debounce, not straight to `SetBucketCount`.
+        widget->resize(60, 100);
+        widget->show();
+        QCoreApplication::processEvents();
+
+        // Spy starts after the initial show so the baseline is
+        // clean; anything the spy sees now is the response to
+        // the resize burst below.
+        QSignalSpy spy(&railModel, &OverviewRailModel::bucketsChanged);
+        QVERIFY(spy.isValid());
+
+        // Simulate a drag-resize storm: many resize events with
+        // different heights in rapid succession. Without the
+        // debounce, each one would land on the model as a
+        // separate `SetBucketCount(H)` and emit `bucketsChanged`.
+        constexpr int STORM_START_H = 101;
+        constexpr int STORM_END_H = 130;
+        for (int h = STORM_START_H; h <= STORM_END_H; ++h)
+        {
+            widget->resize(60, h);
+        }
+
+        // Immediately after the storm the debounce is still
+        // armed; no bucket-count update has landed on the model
+        // yet. `processEvents` here would let queued Qt events
+        // run but must NOT let the timer fire.
+        QCoreApplication::processEvents();
+        QCOMPARE(spy.count(), 0);
+
+        // Wait for the debounce interval to elapse and the
+        // trailing sync to fire. Generous slack over the
+        // 100 ms debounce so CI jitter doesn't flake.
+        QVERIFY2(
+            spy.wait(1000),
+            "debounced sync must land within a comfortable slack over BUCKET_SYNC_DEBOUNCE_MS"
+        );
+
+        // One more event-loop spin to prove no stragglers land
+        // after the trailing edge (defends against a future bug
+        // where the timer re-arms itself under some condition).
+        QCoreApplication::processEvents();
+        QCOMPARE(spy.count(), 1);
+
+        // Bucket count reflects the *final* widget height, not
+        // any of the intermediate storm values -- pins that the
+        // coalesce takes the last resize's height, not an
+        // arbitrary one from the middle.
+        const QRect finalRail = widget->rect().adjusted(0, 2, 0, -2);
+        QCOMPARE(static_cast<int>(railModel.BucketCount()), std::max(0, finalRail.height()));
+
+        delete widget;
+    }
+
+    /// `showEvent` bypasses the resize-debounce timer so the
+    /// first paint after a show sees correct bucket geometry.
+    /// A toggle / tab-switch / initial appearance is a discrete
+    /// user action and must feel instant; deferring it to the
+    /// debounce would paint a stale (or empty) rail for up to
+    /// `BUCKET_SYNC_DEBOUNCE_MS` on every show.
+    static void TestShowFlushesPendingBucketSyncSynchronously()
+    {
+        LogModel model;
+        QObject owner;
+        const auto chain = BuildProxyChain(&model, &owner);
+        OverviewRailModel railModel(chain.filter, &model, /*anchors=*/nullptr, &owner);
+
+        constexpr int ROWS = 20;
+        const RailFixture fixture(ROWS);
+        StreamJsonPathInto(model, fixture.Path());
+
+        auto *widget = new OverviewRailWidget(&railModel, /*theme=*/nullptr, /*tableView=*/nullptr);
+        // Pre-show resize: `SetBucketCount` has NOT run yet
+        // because `resizeEvent` before show is queued but the
+        // widget's own machinery only exercises it inside the
+        // show flow. Either way, this must be a hard 0 before
+        // the show fires.
+        widget->resize(60, 150);
+        QCOMPARE(static_cast<int>(railModel.BucketCount()), 0);
+
+        QSignalSpy spy(&railModel, &OverviewRailModel::bucketsChanged);
+        QVERIFY(spy.isValid());
+
+        widget->show();
+
+        // Contract: bucket count reflects the widget height
+        // *before* `show()` returns. No `processEvents`, no
+        // timer wait. Paint tests rely on this -- rendering
+        // straight after `show()` must not see a zero-bucket
+        // model.
+        QVERIFY2(
+            railModel.BucketCount() > 0,
+            "showEvent must apply the current widget height synchronously; the "
+            "resize-debounce timer is only for interactive drag-resize storms"
+        );
+        QCOMPARE(spy.count(), 1);
+
+        delete widget;
+    }
+
+    /// `showEvent` cancels any pending resize-debounce so a
+    /// resize-then-show sequence doesn't double-fire the sync
+    /// (once synchronously in show, once when the debounced
+    /// timer expires against the same H). Both would emit
+    /// `bucketsChanged`, and the second is a wasted paint
+    /// invalidation.
+    static void TestShowCancelsPendingResizeDebounce()
+    {
+        LogModel model;
+        QObject owner;
+        const auto chain = BuildProxyChain(&model, &owner);
+        OverviewRailModel railModel(chain.filter, &model, /*anchors=*/nullptr, &owner);
+
+        constexpr int ROWS = 20;
+        const RailFixture fixture(ROWS);
+        StreamJsonPathInto(model, fixture.Path());
+
+        auto *widget = new OverviewRailWidget(&railModel, /*theme=*/nullptr, /*tableView=*/nullptr);
+        widget->resize(60, 100);
+        widget->show();
+        QCoreApplication::processEvents();
+
+        // Hide + resize (arms the debounce) + show. If show
+        // doesn't cancel the pending debounce, the timer fires
+        // ~100 ms later on the same H, wasting a
+        // `bucketsChanged` + repaint pass.
+        widget->hide();
+        widget->resize(60, 140);
+        // Confirm the debounce is armed post-resize: no
+        // `bucketsChanged` yet.
+        QSignalSpy spy(&railModel, &OverviewRailModel::bucketsChanged);
+        QVERIFY(spy.isValid());
+        widget->show();
+        // Show fires exactly one emit synchronously.
+        QCOMPARE(spy.count(), 1);
+        // Wait long enough for a stray debounce to sneak in
+        // (200 ms > 100 ms debounce) and pin that none does.
+        QTest::qWait(200);
+        QCOMPARE(spy.count(), 1);
+
+        delete widget;
+    }
+
+    /// `wheelEvent` on the rail forwards to the table view's
+    /// vertical scrollbar so scrolling over the rail feels like
+    /// scrolling past the scrollbar. Regression: the forwarded
+    /// event's *local* position must sit inside the scrollbar's
+    /// rect, not the rail widget's -- `QAbstractSlider::wheelEvent`
+    /// currently reads only `angleDelta`, but a style /
+    /// accessibility layer that inspects position must not see
+    /// rail-widget coordinates that don't correspond to anything
+    /// on the scrollbar. `angleDelta` must be preserved verbatim
+    /// so the scrollbar acts on the same scroll the user gave.
+    static void TestWheelForwardTranslatesPositionIntoScrollbarCoords()
+    {
+        LogTableView view;
+        view.resize(600, 400);
+
+        LogModel model;
+        AnchorManager anchors;
+        QObject owner;
+        const auto chain = BuildProxyChain(&model, &owner);
+        view.setModel(chain.filter);
+        view.show();
+        QCoreApplication::processEvents();
+
+        // Enough rows to force a scrollable range so the vbar
+        // is realised with a positive rect.
+        constexpr int ROWS = 400;
+        const RailFixture fixture(ROWS);
+        StreamJsonPathInto(model, fixture.Path());
+        QCoreApplication::processEvents();
+
+        QScrollBar *vbar = view.verticalScrollBar();
+        QVERIFY(vbar != nullptr);
+        // The scrollbar has to be realised (visible) so its
+        // rect is populated; without rows the vbar range is
+        // 0 and Qt hides it.
+        QVERIFY2(vbar->isVisible(), "vertical scrollbar must be visible for the wheel forward test");
+        const QRect vbarRect = vbar->rect();
+        QVERIFY(vbarRect.width() > 0 && vbarRect.height() > 0);
+
+        OverviewRailModel railModel(chain.filter, &model, &anchors, &owner);
+        auto *widget = new OverviewRailWidget(&railModel, /*theme=*/nullptr, &view);
+        widget->resize(30, 300);
+        widget->show();
+        QCoreApplication::processEvents();
+
+        // Event filter captures wheel events landing on the
+        // vbar so the test inspects the forwarded coordinates
+        // without pumping the real style through.
+        class WheelSpy : public QObject
+        {
+        public:
+            QList<QPointF> localPositions;
+            QList<QPoint> angleDeltas;
+            bool eventFilter(QObject *watched, QEvent *event) override
+            {
+                if (event->type() == QEvent::Wheel)
+                {
+                    // `QEvent::Wheel` guarantees the dynamic
+                    // type; Qt doesn't enable RTTI on `QEvent`.
+                    auto *w = // NOLINT(cppcoreguidelines-pro-type-static-cast-downcast)
+                        static_cast<QWheelEvent *>(event);
+                    localPositions.append(w->position());
+                    angleDeltas.append(w->angleDelta());
+                }
+                return QObject::eventFilter(watched, event);
+            }
+        };
+        WheelSpy spy;
+        vbar->installEventFilter(&spy);
+
+        // Synthesise a wheel event at a point inside the rail
+        // widget. In rail-widget coords the point is nowhere
+        // near `vbar->rect()`; the wheelEvent path must
+        // translate it via `vbar->mapFromGlobal` before
+        // forwarding.
+        const QPointF railLocal(10.0, 40.0);
+        const QPoint globalPos = widget->mapToGlobal(railLocal.toPoint());
+        const QPoint angleDelta(0, -120);
+        QWheelEvent wheel(
+            railLocal,
+            QPointF(globalPos),
+            QPoint(),
+            angleDelta,
+            Qt::NoButton,
+            Qt::NoModifier,
+            Qt::NoScrollPhase,
+            /*inverted=*/false
+        );
+        QApplication::sendEvent(widget, &wheel);
+
+        // Delta preserved verbatim -- the scrollbar sees the
+        // same scroll the user gave.
+        QCOMPARE(spy.angleDeltas.size(), 1);
+        QCOMPARE(spy.angleDeltas.first(), angleDelta);
+
+        // Position now sits inside the scrollbar's coordinate
+        // space. The vbar's local rect is anchored at (0, 0),
+        // so a translated point should fall inside the rect
+        // (or at worst touch its bounds). If the widget were
+        // still forwarding rail-widget coords, the point's X
+        // would be far past `vbarRect.right()`.
+        QCOMPARE(spy.localPositions.size(), 1);
+        const QPointF forwarded = spy.localPositions.first();
+        QVERIFY2(
+            forwarded.x() <= static_cast<qreal>(vbarRect.width()),
+            qPrintable(QStringLiteral(
+                "forwarded local X %1 must land within vbar width %2; larger value means "
+                "rail-widget coords leaked through")
+                           .arg(forwarded.x())
+                           .arg(vbarRect.width()))
+        );
+
+        vbar->removeEventFilter(&spy);
+        delete widget;
+    }
+
+    /// Rail click / scrub must disengage Follow newest. `scrollTo`
+    /// is programmatic and would not fire `userScrolledAwayFromTail`
+    /// on its own — without an explicit Follow off in
+    /// `ScrollToProxyRow`, a live-tail batch would yank the
+    /// viewport back to the tail after the user navigated away
+    /// via the minimap.
+    static void TestScrollToProxyRowDisengagesFollow()
+    {
+        {
+            QSettings settings;
+            settings.remove(QStringLiteral("ui/showOverviewRail"));
+        }
+        MainWindow window;
+        window.show();
+        QCoreApplication::processEvents();
+
+        constexpr int ROWS = 40;
+        const RailFixture fixture(ROWS);
+        auto *model = window.Model();
+        QVERIFY(model != nullptr);
+        StreamJsonPathInto(*model, fixture.Path());
+
+        QAction *followAction = window.findChild<QAction *>(QStringLiteral("actionFollowTail"));
+        QVERIFY(followAction != nullptr);
+        followAction->setEnabled(true);
+        followAction->setChecked(true);
+        QVERIFY(followAction->isChecked());
+
+        // Scrub path (replaceSelection == false) must also
+        // disengage — exploring via drag is still browsing.
+        window.ScrollToProxyRow(5, /*replaceSelection=*/false);
+        QVERIFY2(
+            !followAction->isChecked(),
+            "rail scrub must disengage Follow newest so live-tail cannot yank the viewport back"
+        );
+
+        followAction->setChecked(true);
+        window.ScrollToProxyRow(10, /*replaceSelection=*/true);
+        QVERIFY2(
+            !followAction->isChecked(),
+            "rail click must disengage Follow newest so live-tail cannot yank the viewport back"
+        );
+    }
+
+    /// Closing find clears rail ticks but keeps `mFindMatchCache`
+    /// so a later reveal can restore without re-scanning.
+    /// Toggling the overview rail off→on must NOT re-apply that
+    /// cache while find is still closed — otherwise stale search
+    /// ticks reappear with no active find bar.
+    static void TestRailToggleDoesNotRestoreTicksWhenFindClosed()
+    {
+        {
+            QSettings settings;
+            settings.remove(QStringLiteral("ui/showOverviewRail"));
+        }
+        MainWindow window;
+        window.show();
+        QCoreApplication::processEvents();
+
+        constexpr int ROWS = 40;
+        const RailFixture fixture(ROWS);
+        auto *model = window.Model();
+        QVERIFY(model != nullptr);
+        StreamJsonPathInto(*model, fixture.Path());
+
+        auto *railModel = window.findChild<OverviewRailModel *>();
+        QVERIFY(railModel != nullptr);
+        QVERIFY(railModel->BucketCount() > 0);
+
+        auto *findDock = window.findChild<FindDock *>();
+        QVERIFY(findDock != nullptr);
+        findDock->show();
+        QCoreApplication::processEvents();
+        QVERIFY(findDock->isVisible());
+
+        QVERIFY(QMetaObject::invokeMethod(
+            &window,
+            "UpdateFindMatchCount",
+            Qt::DirectConnection,
+            Q_ARG(QString, QStringLiteral("msg")),
+            Q_ARG(bool, false),
+            Q_ARG(bool, false)
+        ));
+        QVERIFY(railModel->HasMatchTicks());
+
+        // Genuine dismissal: ticks clear, cache survives.
+        emit findDock->closed();
+        findDock->hide();
+        QCoreApplication::processEvents();
+        QVERIFY2(!railModel->HasMatchTicks(), "closing find must clear rail match ticks");
+
+        // Rail off→on with find still closed must leave ticks empty.
+        window.SetOverviewRailVisible(false);
+        QCoreApplication::processEvents();
+        window.SetOverviewRailVisible(true);
+        QCoreApplication::processEvents();
+        // showEvent may re-arm buckets asynchronously relative to
+        // attach; flush any pending bucket sync from the widget.
+        auto *railWidget = window.findChild<OverviewRailWidget *>();
+        QVERIFY(railWidget != nullptr);
+        railWidget->FlushPendingBucketSyncForTest();
+        QCoreApplication::processEvents();
+
+        QVERIFY2(
+            !railModel->HasMatchTicks(),
+            "toggling overview rail on after find was closed must not resurrect cached match ticks"
+        );
+        QVERIFY2(railModel->BucketCount() > 0, "rail toggle-on must re-arm a non-zero bucket vector");
+    }
+
+    /// Tabbing the find dock away (visibilityChanged(false)
+    /// without `closed`) must clear rail match ticks, matching
+    /// the "*i* of *N*" indicator which is only shown while the
+    /// bar is visible. `closed` alone is not enough: tabified
+    /// bottom docks fire visibilityChanged on tab switch but
+    /// leave the dock "open" from the menu-checkmark's point
+    /// of view.
+    static void TestFindTabHideClearsMatchTicks()
+    {
+        {
+            QSettings settings;
+            settings.remove(QStringLiteral("ui/showOverviewRail"));
+        }
+        MainWindow window;
+        window.show();
+        QCoreApplication::processEvents();
+
+        constexpr int ROWS = 40;
+        const RailFixture fixture(ROWS);
+        auto *model = window.Model();
+        QVERIFY(model != nullptr);
+        StreamJsonPathInto(*model, fixture.Path());
+
+        auto *railModel = window.findChild<OverviewRailModel *>();
+        QVERIFY(railModel != nullptr);
+
+        auto *findDock = window.findChild<FindDock *>();
+        QVERIFY(findDock != nullptr);
+        findDock->show();
+        QCoreApplication::processEvents();
+        QVERIFY(findDock->isVisible());
+
+        QVERIFY(QMetaObject::invokeMethod(
+            &window,
+            "UpdateFindMatchCount",
+            Qt::DirectConnection,
+            Q_ARG(QString, QStringLiteral("msg")),
+            Q_ARG(bool, false),
+            Q_ARG(bool, false)
+        ));
+        QVERIFY(railModel->HasMatchTicks());
+
+        // Tab-hide path: `hide()` fires visibilityChanged(false)
+        // but does NOT emit FindDock::closed (that is reserved
+        // for genuine dismissal). Match ticks must still clear.
+        findDock->hide();
+        QCoreApplication::processEvents();
+        QVERIFY2(
+            !railModel->HasMatchTicks(),
+            "tab-hiding the find dock must clear rail match ticks even without FindDock::closed"
+        );
+
+        // Production `FindDock::showEvent` emits `revealed` only
+        // after the dock is visible again; push is gated on
+        // `IsFindBarVisible()`, so restore requires a real show.
+        findDock->show();
+        QCoreApplication::processEvents();
+        emit findDock->revealed();
+        QVERIFY2(railModel->HasMatchTicks(), "revealed find must restore rail match ticks after a tab hide");
+    }
+
+    /// Wheel over the rail must attribute the scrollbar change
+    /// as user-initiated so Follow newest disengages. The rail
+    /// forwards via `sendEvent` to the scrollbar and bypasses
+    /// `LogTableView::wheelEvent`; without
+    /// `AttributeNextScrollToUser` (or a reliable
+    /// `actionTriggered` path) Follow would stay engaged.
+    static void TestRailWheelDisengagesFollow()
+    {
+        {
+            QSettings settings;
+            settings.remove(QStringLiteral("ui/showOverviewRail"));
+        }
+        MainWindow window;
+        window.show();
+        QCoreApplication::processEvents();
+
+        constexpr int ROWS = 200;
+        const RailFixture fixture(ROWS);
+        auto *model = window.Model();
+        QVERIFY(model != nullptr);
+        StreamJsonPathInto(*model, fixture.Path());
+        QCoreApplication::processEvents();
+
+        auto *view = window.findChild<LogTableView *>();
+        QVERIFY(view != nullptr);
+        auto *railWidget = window.findChild<OverviewRailWidget *>();
+        QVERIFY(railWidget != nullptr);
+        QVERIFY(railWidget->isVisible());
+
+        QAction *followAction = window.findChild<QAction *>(QStringLiteral("actionFollowTail"));
+        QVERIFY(followAction != nullptr);
+        followAction->setEnabled(true);
+        followAction->setChecked(true);
+
+        QScrollBar *vbar = view->verticalScrollBar();
+        QVERIFY(vbar != nullptr);
+        QVERIFY(vbar->maximum() > 0);
+        vbar->setValue(vbar->maximum());
+        view->SetTailEdge(LogTableView::TailEdge::Bottom);
+        QVERIFY(followAction->isChecked());
+
+        const QSignalSpy awaySpy(view, &LogTableView::userScrolledAwayFromTail);
+        QVERIFY(awaySpy.isValid());
+
+        // Wheel up on the rail (negative angleDelta = scroll
+        // content up / scrollbar value down from the bottom
+        // tail). Must leave the tail edge and disengage Follow.
+        const QPointF railLocal(10.0, 40.0);
+        const QPoint globalPos = railWidget->mapToGlobal(railLocal.toPoint());
+        QWheelEvent wheel(
+            railLocal,
+            QPointF(globalPos),
+            QPoint(),
+            QPoint(0, 120), // angleDelta: scroll toward older rows
+            Qt::NoButton,
+            Qt::NoModifier,
+            Qt::NoScrollPhase,
+            /*inverted=*/false
+        );
+        QApplication::sendEvent(railWidget, &wheel);
+        QCoreApplication::processEvents();
+
+        QVERIFY2(awaySpy.count() >= 1, "rail wheel away from tail must emit userScrolledAwayFromTail");
+        QVERIFY2(!followAction->isChecked(), "rail wheel away from tail must disengage Follow newest");
     }
 };
 

--- a/test/app/src/test_overview_rail.cpp
+++ b/test/app/src/test_overview_rail.cpp
@@ -159,7 +159,7 @@ ProxyChain BuildProxyChain(LogModel *model, QObject *parent)
     auto *filter = new LogFilterModel(parent);
     filter->setSourceModel(rowOrder);
     filter->SetLogModel(model);
-    return {rowOrder, filter};
+    return {.rowOrder = rowOrder, .filter = filter};
 }
 
 } // namespace
@@ -274,7 +274,7 @@ private slots:
         QVERIFY(!rail.HasMatchTicks());
         // Rows 5, 10, 15, plus out-of-range 999 (must be dropped
         // silently) and negative -1 (also dropped).
-        QSignalSpy matchSpy(&rail, &OverviewRailModel::matchesChanged);
+        const QSignalSpy matchSpy(&rail, &OverviewRailModel::matchesChanged);
         rail.SetMatchProxyRows({-1, 5, 10, 15, 999});
         QVERIFY(rail.HasMatchTicks());
         QCOMPARE(matchSpy.count(), 1);
@@ -822,7 +822,7 @@ private slots:
         OverviewRailModel railModel(chain.filter, &model, &anchors, &owner);
         railModel.SetBucketCount(50);
 
-        QTemporaryDir dir;
+        const QTemporaryDir dir;
         QVERIFY(dir.isValid());
         const QString path = dir.filePath(QStringLiteral("fatal_needle.jsonl"));
         {
@@ -906,7 +906,7 @@ private slots:
         // resizes this to the widget's rail height.
         railModel.SetBucketCount(100);
 
-        QTemporaryDir dir;
+        const QTemporaryDir dir;
         QVERIFY(dir.isValid());
         const QString path = dir.filePath(QStringLiteral("log_weight.jsonl"));
         {
@@ -1121,9 +1121,7 @@ private slots:
         // helper to resolve it to a Y range.
         const std::size_t matchBucket = std::min<std::size_t>(
             railModel.BucketCount() - 1,
-            static_cast<std::size_t>(
-                (static_cast<std::size_t>(50) * railModel.BucketCount()) / static_cast<std::size_t>(ROWS)
-            )
+            ((static_cast<std::size_t>(50) * railModel.BucketCount()) / static_cast<std::size_t>(ROWS))
         );
         const int yTop = widget->YForBucketForTest(matchBucket);
         const int yBottom =
@@ -1467,7 +1465,7 @@ private slots:
         QObject owner;
         const auto chain = BuildProxyChain(&model, &owner);
         OverviewRailModel rail(chain.filter, &model, &anchors, &owner);
-        OverviewRailWidget widget(&rail, /*theme=*/nullptr, /*tableView=*/nullptr);
+        const OverviewRailWidget widget(&rail, /*theme=*/nullptr, /*tableView=*/nullptr);
         // Ensure the widget has a valid style / font (offscreen QPA
         // still routes both). The DPI-fluent width should be > 0
         // and >= the minimum floor.
@@ -1710,7 +1708,7 @@ private slots:
     /// (Shortcuts dialog + toolbar tooltip) matches expectations.
     static void TestMainWindowOverviewRailShortcut()
     {
-        MainWindow window;
+        const MainWindow window;
         auto *action = window.findChild<QAction *>(QStringLiteral("actionToggleOverviewRail"));
         QVERIFY(action != nullptr);
         const QKeySequence expected(Qt::CTRL | Qt::SHIFT | Qt::Key_R);
@@ -2083,7 +2081,7 @@ private slots:
         StreamJsonPathInto(model, fixture.Path());
         WaitForBucketsChanged(rail);
 
-        QSignalSpy spy(&rail, &OverviewRailModel::bucketsChanged);
+        const QSignalSpy spy(&rail, &OverviewRailModel::bucketsChanged);
         QVERIFY(spy.isValid());
         // Fire a synthetic `Grew` on the level column (the
         // wide-log worst case). The rail's connect explicitly
@@ -2152,7 +2150,7 @@ private slots:
         counts[3] = 7;
         counts[19] = 42;
 
-        QSignalSpy matchSpy(&rail, &OverviewRailModel::matchesChanged);
+        const QSignalSpy matchSpy(&rail, &OverviewRailModel::matchesChanged);
         rail.SetMatchBucketCounts(counts, /*totalMatches=*/49);
         QCOMPARE(matchSpy.count(), 1);
         QVERIFY(rail.HasMatchTicks());
@@ -2241,7 +2239,7 @@ private slots:
         }();
         QCOMPARE(baselineTotal, static_cast<uint32_t>(3));
 
-        QSignalSpy matchSpy(&rail, &OverviewRailModel::matchesChanged);
+        const QSignalSpy matchSpy(&rail, &OverviewRailModel::matchesChanged);
         // Off-by-one on the vector size: rail has 20 buckets.
         rail.SetMatchBucketCounts(std::vector<uint32_t>(19, uint32_t{7}), /*totalMatches=*/133);
         QCOMPARE(matchSpy.count(), 0);
@@ -2824,7 +2822,7 @@ private slots:
         widget->resize(60, 150);
         QCOMPARE(static_cast<int>(railModel.BucketCount()), 0);
 
-        QSignalSpy spy(&railModel, &OverviewRailModel::bucketsChanged);
+        const QSignalSpy spy(&railModel, &OverviewRailModel::bucketsChanged);
         QVERIFY(spy.isValid());
 
         widget->show();
@@ -2874,7 +2872,7 @@ private slots:
         widget->resize(60, 140);
         // Confirm the debounce is armed post-resize: no
         // `bucketsChanged` yet.
-        QSignalSpy spy(&railModel, &OverviewRailModel::bucketsChanged);
+        const QSignalSpy spy(&railModel, &OverviewRailModel::bucketsChanged);
         QVERIFY(spy.isValid());
         widget->show();
         // Show fires exactly one emit synchronously.
@@ -2946,8 +2944,8 @@ private slots:
                 {
                     // `QEvent::Wheel` guarantees the dynamic
                     // type; Qt doesn't enable RTTI on `QEvent`.
-                    auto *w = // NOLINT(cppcoreguidelines-pro-type-static-cast-downcast)
-                        static_cast<QWheelEvent *>(event);
+                    // NOLINTNEXTLINE(cppcoreguidelines-pro-type-static-cast-downcast)
+                    auto *w = static_cast<QWheelEvent *>(event);
                     localPositions.append(w->position());
                     angleDeltas.append(w->angleDelta());
                 }
@@ -3024,7 +3022,7 @@ private slots:
         QVERIFY(model != nullptr);
         StreamJsonPathInto(*model, fixture.Path());
 
-        QAction *followAction = window.findChild<QAction *>(QStringLiteral("actionFollowTail"));
+        auto *followAction = window.findChild<QAction *>(QStringLiteral("actionFollowTail"));
         QVERIFY(followAction != nullptr);
         followAction->setEnabled(true);
         followAction->setChecked(true);
@@ -3202,7 +3200,7 @@ private slots:
         QVERIFY(railWidget != nullptr);
         QVERIFY(railWidget->isVisible());
 
-        QAction *followAction = window.findChild<QAction *>(QStringLiteral("actionFollowTail"));
+        auto *followAction = window.findChild<QAction *>(QStringLiteral("actionFollowTail"));
         QVERIFY(followAction != nullptr);
         followAction->setEnabled(true);
         followAction->setChecked(true);

--- a/test/app/src/test_overview_rail.cpp
+++ b/test/app/src/test_overview_rail.cpp
@@ -173,8 +173,7 @@ private slots:
     void initTestCase()
     {
         QVERIFY2(
-            MainWindow::InitializeTimezoneDatabase(),
-            "Failed to initialise timezone database; see qCritical above."
+            MainWindow::InitializeTimezoneDatabase(), "Failed to initialise timezone database; see qCritical above."
         );
         // Route every QSettings / QStandardPaths lookup this
         // suite makes to a throw-away location. Prevents the
@@ -518,8 +517,14 @@ private slots:
         QVERIFY(mid < COLUMN_WIDTH);
         // Monotone non-decreasing in count.
         int previous = 0;
-        for (std::uint32_t count : {std::uint32_t{1}, std::uint32_t{4}, std::uint32_t{16}, std::uint32_t{64},
-                                    std::uint32_t{256}, std::uint32_t{1024}, std::uint32_t{4096}})
+        for (std::uint32_t count :
+             {std::uint32_t{1},
+              std::uint32_t{4},
+              std::uint32_t{16},
+              std::uint32_t{64},
+              std::uint32_t{256},
+              std::uint32_t{1024},
+              std::uint32_t{4096}})
         {
             const int w = OverviewRailWidget::WidthForCountForTest(count, 4096, COLUMN_WIDTH);
             QVERIFY2(w >= previous, "bar width must be monotone non-decreasing in the bucket count");
@@ -587,8 +592,8 @@ private slots:
         const int lit = CountLitLevelPixels(widget, &bg);
         QVERIFY2(
             lit > 0,
-            qPrintable(QStringLiteral("no level-bar pixels found (bg=%1) -- bars are painting invisibly")
-                           .arg(bg.name()))
+            qPrintable(QStringLiteral("no level-bar pixels found (bg=%1) -- bars are painting invisibly").arg(bg.name())
+            )
         );
         delete widget;
     }
@@ -630,9 +635,13 @@ private slots:
         // exactly the code path the production wiring exercises.
         QCoreApplication::processEvents();
         const int railWidth = widget->width();
-        QVERIFY2(railWidth >= 24, qPrintable(QStringLiteral("rail is only %1 px wide -- narrower than the "
-                                                            "minimum, so the level column would collapse "
-                                                            "to a single pixel").arg(railWidth)));
+        QVERIFY2(
+            railWidth >= 24,
+            qPrintable(QStringLiteral("rail is only %1 px wide -- narrower than the "
+                                      "minimum, so the level column would collapse "
+                                      "to a single pixel")
+                           .arg(railWidth))
+        );
 
         QImage image(widget->size(), QImage::Format_ARGB32);
         image.fill(Qt::transparent);
@@ -863,8 +872,7 @@ private slots:
             }
         }
         QVERIFY2(
-            fatalBgPixels > 0,
-            "rare Fatal (1-in-500) must paint the Fatal row-bg tone at the 1-px severity floor"
+            fatalBgPixels > 0, "rare Fatal (1-in-500) must paint the Fatal row-bg tone at the 1-px severity floor"
         );
 
         delete widget;
@@ -1118,9 +1126,8 @@ private slots:
             )
         );
         const int yTop = widget->YForBucketForTest(matchBucket);
-        const int yBottom = matchBucket + 1 < railModel.BucketCount()
-                                ? widget->YForBucketForTest(matchBucket + 1)
-                                : image.height();
+        const int yBottom =
+            matchBucket + 1 < railModel.BucketCount() ? widget->YForBucketForTest(matchBucket + 1) : image.height();
 
         // Sample the *right* portion of the content slot (columns
         // past where the level bar could ever reach at ~20 % row
@@ -1157,12 +1164,10 @@ private slots:
         }
         QVERIFY2(
             highlightPixelsLeftHalf > 0 && highlightPixelsRightHalf > 0,
-            qPrintable(
-                QStringLiteral("match overlay must span the full content width -- found %1 Highlight px on the "
-                               "left half and %2 on the right half of the matched bucket's Y band")
-                    .arg(highlightPixelsLeftHalf)
-                    .arg(highlightPixelsRightHalf)
-            )
+            qPrintable(QStringLiteral("match overlay must span the full content width -- found %1 Highlight px on the "
+                                      "left half and %2 on the right half of the matched bucket's Y band")
+                           .arg(highlightPixelsLeftHalf)
+                           .arg(highlightPixelsRightHalf))
         );
 
         delete widget;
@@ -1392,8 +1397,7 @@ private slots:
         const std::size_t nBuckets = railModel.BucketCount();
         QVERIFY(nBuckets > 0);
         const std::size_t midRowBucket = std::min<std::size_t>(
-            nBuckets - 1,
-            (static_cast<std::size_t>(MIDDLE_ROW) * nBuckets) / static_cast<std::size_t>(ROWS)
+            nBuckets - 1, (static_cast<std::size_t>(MIDDLE_ROW) * nBuckets) / static_cast<std::size_t>(ROWS)
         );
         const int midRowY = widget->YForBucketForTest(midRowBucket);
 
@@ -1603,8 +1607,7 @@ private slots:
         if (const QScrollBar *vsb = view.verticalScrollBar(); vsb != nullptr && vsb->isVisible())
         {
             QVERIFY2(
-                railGeom.right() < vsb->geometry().left(),
-                "rail must not overlap the vertical scrollbar's paint rect"
+                railGeom.right() < vsb->geometry().left(), "rail must not overlap the vertical scrollbar's paint rect"
             );
         }
 
@@ -1742,8 +1745,7 @@ private slots:
         action->trigger();
         QVERIFY(action->isChecked());
         QVERIFY2(
-            railModel->BucketCount() > 0,
-            "re-showing the rail must re-sync the bucket count from the widget height"
+            railModel->BucketCount() > 0, "re-showing the rail must re-sync the bucket count from the widget height"
         );
     }
 
@@ -2025,7 +2027,8 @@ private slots:
         rules.emplace_back(
             std::in_place_type<loglib::CallbackStringRowPredicate>,
             /*columnIndex=*/static_cast<std::size_t>(0),
-            /*match=*/[callCount = std::make_shared<std::size_t>(0)](std::string_view) mutable {
+            /*match=*/
+            [callCount = std::make_shared<std::size_t>(0)](std::string_view) mutable {
                 return ((*callCount)++ % 2) == 0;
             }
         );
@@ -2522,10 +2525,7 @@ private slots:
 
         QCOMPARE(static_cast<int>(seenRows.size()), ROWS);
         QVERIFY2(std::ranges::is_sorted(seenRows), "ForEachMatchingRow must yield rows in ascending order");
-        QVERIFY2(
-            std::ranges::adjacent_find(seenRows) == seenRows.end(),
-            "ForEachMatchingRow must not repeat a row"
-        );
+        QVERIFY2(std::ranges::adjacent_find(seenRows) == seenRows.end(), "ForEachMatchingRow must not repeat a row");
 
         // Returning `false` stops the walk on the first hit. The
         // caller has full control over the accumulator shape.
@@ -2588,8 +2588,8 @@ private slots:
             /*skipFirstN=*/0,
             [&](const QModelIndex &proxyIndex) -> bool {
                 ++totalMatches;
-                const std::size_t bucket = (static_cast<std::size_t>(proxyIndex.row()) * BUCKETS) /
-                                           static_cast<std::size_t>(ROWS);
+                const std::size_t bucket =
+                    (static_cast<std::size_t>(proxyIndex.row()) * BUCKETS) / static_cast<std::size_t>(ROWS);
                 ++bucketCounts[std::min(bucket, BUCKETS - 1)];
                 if (static_cast<int>(cappedRows.size()) < SCAN_CAP)
                 {
@@ -2618,8 +2618,7 @@ private slots:
         {
             summedFromBuckets += bucketCounts[i];
             QVERIFY2(
-                bucketCounts[i] > 0,
-                qPrintable(QStringLiteral("bucket %1 must carry at least one match tick").arg(i))
+                bucketCounts[i] > 0, qPrintable(QStringLiteral("bucket %1 must carry at least one match tick").arg(i))
             );
         }
         QCOMPARE(summedFromBuckets, totalMatches);
@@ -2664,8 +2663,8 @@ private slots:
             [&](const QModelIndex &proxyIndex) -> bool {
                 ++callbackInvocations;
                 ++totalMatches;
-                const std::size_t bucket = (static_cast<std::size_t>(proxyIndex.row()) * BUCKETS) /
-                                           static_cast<std::size_t>(ROWS);
+                const std::size_t bucket =
+                    (static_cast<std::size_t>(proxyIndex.row()) * BUCKETS) / static_cast<std::size_t>(ROWS);
                 uint32_t &slot = bucketCounts[std::min(bucket, BUCKETS - 1)];
                 if (slot == 0)
                 {
@@ -2686,10 +2685,7 @@ private slots:
         );
 
         QVERIFY2(!scanExhausted, "dense needle must early-exit once every bucket has a tick");
-        QVERIFY2(
-            callbackInvocations < ROWS,
-            "early-exit must stop before visiting every matching row"
-        );
+        QVERIFY2(callbackInvocations < ROWS, "early-exit must stop before visiting every matching row");
         QCOMPARE(static_cast<int>(cappedRows.size()), SCAN_CAP);
         QCOMPARE(bucketsHit, BUCKETS);
         for (std::size_t i = 0; i < BUCKETS; ++i)
@@ -2784,10 +2780,7 @@ private slots:
         // Wait for the debounce interval to elapse and the
         // trailing sync to fire. Generous slack over the
         // 100 ms debounce so CI jitter doesn't flake.
-        QVERIFY2(
-            spy.wait(1000),
-            "debounced sync must land within a comfortable slack over BUCKET_SYNC_DEBOUNCE_MS"
-        );
+        QVERIFY2(spy.wait(1000), "debounced sync must land within a comfortable slack over BUCKET_SYNC_DEBOUNCE_MS");
 
         // One more event-loop spin to prove no stragglers land
         // after the trailing edge (defends against a future bug
@@ -2999,9 +2992,8 @@ private slots:
         const QPointF forwarded = spy.localPositions.first();
         QVERIFY2(
             forwarded.x() <= static_cast<qreal>(vbarRect.width()),
-            qPrintable(QStringLiteral(
-                "forwarded local X %1 must land within vbar width %2; larger value means "
-                "rail-widget coords leaked through")
+            qPrintable(QStringLiteral("forwarded local X %1 must land within vbar width %2; larger value means "
+                                      "rail-widget coords leaked through")
                            .arg(forwarded.x())
                            .arg(vbarRect.width()))
         );

--- a/test/app/src/test_overview_rail.cpp
+++ b/test/app/src/test_overview_rail.cpp
@@ -31,9 +31,11 @@
 #include <QAbstractItemModel>
 #include <QAction>
 #include <QApplication>
+#include <QItemSelectionModel>
 #include <QModelIndex>
 #include <QSettings>
 #include <QSignalSpy>
+#include <QStandardPaths>
 #include <QString>
 #include <QStringList>
 #include <QTemporaryDir>
@@ -163,6 +165,23 @@ private slots:
             MainWindow::InitializeTimezoneDatabase(),
             "Failed to initialise timezone database; see qCritical above."
         );
+        // Route every QSettings / QStandardPaths lookup this
+        // suite makes to a throw-away location. Prevents the
+        // MainWindow toggle test from writing real registry keys
+        // on Windows, and pins the test's org / app name so slot
+        // ordering can't leak state between tests.
+        QStandardPaths::setTestModeEnabled(true);
+        QCoreApplication::setOrganizationName(QStringLiteral("StructuredLogViewerTest"));
+        QCoreApplication::setApplicationName(QStringLiteral("OverviewRailTest"));
+    }
+
+    void cleanupTestCase()
+    {
+        // Belt-and-braces cleanup: even under `setTestModeEnabled`
+        // the file/registry hive lingers on disk. Clearing keeps
+        // successive local runs deterministic.
+        QSettings settings;
+        settings.clear();
     }
 
     /// Empty model + no anchors -> zero row count, no anchor
@@ -260,6 +279,128 @@ private slots:
         // Clearing drops ticks.
         rail.SetMatchProxyRows({});
         QVERIFY(!rail.HasMatchTicks());
+
+        // `HasMatchTicks` reflects the *bucketed* count, not the
+        // raw list. A caller pushing only out-of-range rows (all
+        // silently dropped by the folder) must NOT see ticks.
+        rail.SetMatchProxyRows({-1, 999, -5, 42});
+        QVERIFY2(!rail.HasMatchTicks(), "all-out-of-range match rows must fold to zero ticks");
+    }
+
+    /// `SetMatchProxyRows` is the find-bar hot path — every
+    /// keystroke calls it, so it must NOT walk the whole proxy
+    /// to re-fill level counts / anchor bits. Pin the invariant
+    /// by capturing per-bucket level counts, calling
+    /// `SetMatchProxyRows`, and asserting the level counts are
+    /// bit-for-bit unchanged (only `matchCount` moved).
+    static void TestSetMatchProxyRowsLeavesLevelCountsUntouched()
+    {
+        LogModel model;
+        QObject owner;
+        const auto chain = BuildProxyChain(&model, &owner);
+        OverviewRailModel rail(chain.filter, &model, /*anchors=*/nullptr);
+        rail.SetBucketCount(20);
+
+        constexpr int ROWS = 20;
+        const RailFixture fixture(ROWS);
+        StreamJsonPathInto(model, fixture.Path());
+        WaitForBucketsChanged(rail);
+        QCOMPARE(rail.ProxyRowCount(), ROWS);
+
+        std::vector<loglib::LevelBucket> baseline;
+        baseline.reserve(rail.BucketCount());
+        for (const auto &bucket : rail.Buckets())
+        {
+            baseline.push_back(bucket.levels);
+        }
+
+        rail.SetMatchProxyRows({2, 7, 11});
+
+        std::size_t i = 0;
+        for (const auto &bucket : rail.Buckets())
+        {
+            QCOMPARE(bucket.levels.counts, baseline[i].counts);
+            ++i;
+        }
+    }
+
+    /// `Rebuild()` is coalesced through a 50 ms timer, so a
+    /// burst of proxy signals must collapse to a single
+    /// `bucketsChanged` emission (and a single walk of the
+    /// row set). Without the coalesce, `LogFilterModel`'s
+    /// per-row `rowsInserted` volley under an active sort would
+    /// pay `O(rowCount)` per row.
+    static void TestRebuildIsCoalesced()
+    {
+        LogModel model;
+        QObject owner;
+        const auto chain = BuildProxyChain(&model, &owner);
+        OverviewRailModel rail(chain.filter, &model, /*anchors=*/nullptr);
+        rail.SetBucketCount(16);
+
+        constexpr int ROWS = 16;
+        const RailFixture fixture(ROWS);
+        StreamJsonPathInto(model, fixture.Path());
+        WaitForBucketsChanged(rail);
+
+        // Fire many rebuild requests inside one quiet window.
+        // A single timeout should suffice for all of them.
+        QSignalSpy spy(&rail, &OverviewRailModel::bucketsChanged);
+        for (int i = 0; i < 10; ++i)
+        {
+            rail.Rebuild();
+        }
+        QVERIFY(spy.wait(1000));
+        QCOMPARE_LE(spy.count(), 1);
+    }
+
+    /// `SetBucketCount(0)` -- the mechanism
+    /// `MainWindow::SetOverviewRailVisible(false)` uses to stop
+    /// paying rebuild cost while the rail is hidden -- must make
+    /// subsequent proxy signals cheap. Assert `BucketCount()` is
+    /// zero after the drop; the `RebuildInternal` short-circuit
+    /// on `mBuckets.empty()` is what makes the hidden state free.
+    static void TestSetBucketCountZeroDropsBuckets()
+    {
+        LogModel model;
+        QObject owner;
+        const auto chain = BuildProxyChain(&model, &owner);
+        OverviewRailModel rail(chain.filter, &model, /*anchors=*/nullptr);
+        rail.SetBucketCount(32);
+        QCOMPARE(rail.BucketCount(), static_cast<std::size_t>(32));
+
+        rail.SetBucketCount(0);
+        QCOMPARE(rail.BucketCount(), static_cast<std::size_t>(0));
+        QVERIFY(rail.Buckets().empty());
+    }
+
+    /// `ProxyRowForYPixel` maps rail Y linearly onto proxy rows,
+    /// bypassing the bucket step. A click near the top of a
+    /// bucket-spanning range must resolve to a lower row than a
+    /// click near the bottom of the same range (klogg-style
+    /// sub-bucket precision so scrubbing feels smooth).
+    static void TestProxyRowForYPixelSubBucketPrecision()
+    {
+        LogModel model;
+        QObject owner;
+        const auto chain = BuildProxyChain(&model, &owner);
+        OverviewRailModel rail(chain.filter, &model, /*anchors=*/nullptr);
+        // Deliberately fewer buckets than rows so each bucket
+        // spans several rows -- the sub-bucket mapping is only
+        // observable under that ratio.
+        rail.SetBucketCount(10);
+
+        constexpr int ROWS = 100;
+        const RailFixture fixture(ROWS);
+        StreamJsonPathInto(model, fixture.Path());
+        WaitForBucketsChanged(rail);
+
+        // Bucket 0 spans rows [0, 10). Y=0 should land row 0,
+        // Y=9 should land row >= 4 (a bucket-first mapping would
+        // return 0 for both).
+        QCOMPARE(rail.ProxyRowForYPixel(0, 100), 0);
+        const int nearBucketBottom = rail.ProxyRowForYPixel(9, 100);
+        QVERIFY2(nearBucketBottom >= 4, "sub-bucket precision must move within a single bucket");
     }
 
     /// Adding an anchor via `AnchorManager` flows into the
@@ -291,18 +432,17 @@ private slots:
         {
             return;
         }
+        // Anchor mutations flow through `Rebuild()`, which is
+        // coalesced through the 50 ms rebuild timer. Waiting on
+        // the signal spy synchronises the test against the timer
+        // without hard-coding a sleep.
         QSignalSpy anchorSpy(&rail, &OverviewRailModel::anchorBucketsChanged);
         anchors.SetAnchor(*keyOpt, 3);
-        // Anchor mutation triggers a full rebuild in the rail;
-        // the signal is coalesced with buckets rebuilds via a
-        // direct `emit`, so no wait is needed after the mutation.
-        // Give Qt a tick to route the queued anchor emit.
-        QCoreApplication::processEvents();
+        QVERIFY2(anchorSpy.wait(1000), "anchor rebuild must emit anchorBucketsChanged within the timeout");
         QVERIFY(rail.HasAnchorTicks());
-        QVERIFY(anchorSpy.count() >= 1);
 
         anchors.ClearAll();
-        QCoreApplication::processEvents();
+        QVERIFY2(anchorSpy.wait(1000), "anchor clear must emit anchorBucketsChanged within the timeout");
         QVERIFY(!rail.HasAnchorTicks());
     }
 
@@ -399,11 +539,9 @@ private slots:
     /// off attaches / detaches the widget from the table view.
     static void TestMainWindowOverviewRailToggle()
     {
-        // Isolate the QSettings key so a prior run doesn't seed
-        // the pref off. A scoped org / app name keeps writes in a
-        // throw-away registry hive.
-        QCoreApplication::setOrganizationName(QStringLiteral("StructuredLogViewerTest"));
-        QCoreApplication::setApplicationName(QStringLiteral("OverviewRailToggle"));
+        // `initTestCase` set the org / app name and enabled
+        // test-mode QSettings; clear the specific key we probe
+        // so a prior run doesn't seed the pref off.
         {
             QSettings settings;
             settings.remove(QStringLiteral("ui/showOverviewRail"));
@@ -449,6 +587,88 @@ private slots:
         QVERIFY(action != nullptr);
         const QKeySequence expected(Qt::CTRL | Qt::SHIFT | Qt::Key_O);
         QCOMPARE(action->shortcut(), expected);
+    }
+
+    /// Toggling the rail off drops the underlying
+    /// `OverviewRailModel`'s bucket vector so subsequent proxy
+    /// signals short-circuit inside `RebuildInternal`. Toggling
+    /// back on re-arms the bucket count from the widget's height
+    /// (via `showEvent` -> `SyncBucketCountToHeight`).
+    static void TestMainWindowOverviewRailHideDropsBuckets()
+    {
+        {
+            QSettings settings;
+            settings.remove(QStringLiteral("ui/showOverviewRail"));
+        }
+        MainWindow window;
+        window.show();
+
+        auto *action = window.findChild<QAction *>(QStringLiteral("actionToggleOverviewRail"));
+        QVERIFY(action != nullptr);
+        auto *railModel = window.findChild<OverviewRailModel *>();
+        QVERIFY2(railModel != nullptr, "OverviewRailModel must be a QObject child of MainWindow");
+        QVERIFY2(action->isChecked(), "rail should be on by default");
+        QVERIFY2(railModel->BucketCount() > 0, "model must be armed while the rail is visible");
+
+        action->trigger();
+        QVERIFY(!action->isChecked());
+        QCOMPARE(railModel->BucketCount(), static_cast<std::size_t>(0));
+
+        action->trigger();
+        QVERIFY(action->isChecked());
+        QVERIFY2(
+            railModel->BucketCount() > 0,
+            "re-showing the rail must re-sync the bucket count from the widget height"
+        );
+    }
+
+    /// A drag scrub across the rail must preserve the user's
+    /// existing selection. Simulates the emit the widget sends
+    /// on `mouseMoveEvent` (replaceSelection == false) and pins
+    /// that `ScrollToProxyRow` doesn't clobber the caller's
+    /// selection model.
+    static void TestScrollToProxyRowPreservesSelectionOnDrag()
+    {
+        {
+            QSettings settings;
+            settings.remove(QStringLiteral("ui/showOverviewRail"));
+        }
+        MainWindow window;
+        window.show();
+
+        auto *view = window.findChild<LogTableView *>();
+        QVERIFY(view != nullptr);
+
+        // Populate the model so there are rows to select.
+        constexpr int ROWS = 30;
+        const RailFixture fixture(ROWS);
+        auto *model = window.Model();
+        QVERIFY(model != nullptr);
+        StreamJsonPathInto(*model, fixture.Path());
+
+        auto *proxy = window.FilterModel();
+        QVERIFY(proxy != nullptr);
+        QCOMPARE(proxy->rowCount(), ROWS);
+
+        // Seed a multi-row selection [3, 4, 5].
+        auto *selection = view->selectionModel();
+        QVERIFY(selection != nullptr);
+        selection->clearSelection();
+        for (int r = 3; r <= 5; ++r)
+        {
+            selection->select(proxy->index(r, 0), QItemSelectionModel::Select | QItemSelectionModel::Rows);
+        }
+        QCOMPARE(selection->selectedRows().size(), 3);
+
+        // Drag scrub to row 20 -- selection should survive.
+        window.ScrollToProxyRow(20, /*replaceSelection=*/false);
+        QCOMPARE(selection->selectedRows().size(), 3);
+
+        // Fresh click at row 25 -- selection is replaced with
+        // just that row (matches `SelectSourceRow` semantics).
+        window.ScrollToProxyRow(25, /*replaceSelection=*/true);
+        QCOMPARE(selection->selectedRows().size(), 1);
+        QCOMPARE(selection->selectedRows().front().row(), 25);
     }
 };
 


### PR DESCRIPTION
Add a **Match overview rail / minimap** along the right edge of the log table, painted in a reserved viewport margin of `LogTableView`. One rail pixel row folds a slice of the outermost proxy stream into a `LevelBucket` (per-canonical-`LogLevel` counts, reused from the histogram), a find-match tick counter, and an `ANCHOR_PALETTE_SIZE`-wide anchor slot bitset; the widget paints a stacked-severity bin bar (log-scaled by density, split into per-level segments in severity-descending order with a `MIN_BAR_WIDTH_PX` floor), match-tick and anchor-band overlays on top, and a translucent viewport indicator glued to the table's vertical scrollbar. Click a bucket to jump the table there; drag scrubs the viewport indicator live; the wheel forwards to the vertical scrollbar with proper user attribution so Follow newest disengages exactly the way a manual scroll does. On by default; toggle from **View → Overview Rail** (`Ctrl+Shift+R`) or the toolbar's bar-chart-horizontal icon, and pick **Narrow** / **Medium** (default) / **Wide** from **Settings → Preferences → Overview rail width** — all three scale off the platform's scrollbar extent so the rail stays DPI-fluent across monitor moves.

Ships item **13** of [`ROADMAP.md`](ROADMAP.md#13-match-overview-rail--minimap) (crossed off in this PR).

## Why

Klogg's overview rail and Logan's minimap sit near the top of every reviewer's ranked list of "log viewer power features": once you're staring at a filtered 500 k-row triage view, the difference between "scroll to find the red bit" and "click the red column at 40 % down the rail" is enormous. The [comparative feature matrix](ROADMAP.md#comparative-feature-matrix) flags the absence as a Tier 1 v1 blocker alongside compressed inputs and the histogram. Item 13 explicitly frames the rail as "the histogram's bucket data structure tilted 90°" — the moment [item 2](ROADMAP.md#2-histogram--activity-rate-strip) shipped a densely-bucketed `LevelBucket` + anchor-slot bitset in `loglib::HistogramBucketIndex`, adding a rail on top of it was cheap and idiomatic.

The right shape is a *Qt-side model + Qt-side widget* pair that lives in `app/`. Unlike the histogram, which needs its bucket index reusable from a future headless CLI (`ROADMAP` item 10) so it sits under `loglib/`, the rail is inherently coupled to a `QTableView`'s scrollbar and viewport-margin plumbing — there is nothing to reuse across the layer boundary. `OverviewRailModel` reads the *outermost* proxy (`LogFilterModel` in production, so filter + sort are honoured), buckets rows into a `pixel-row-per-bucket` vector, and pushes coalesced `bucketsChanged` at 50 ms cadence to match the histogram's live-tail rebuild timer. `OverviewRailWidget` is a plain `QWidget` with a custom `paintEvent`; no `QtCharts`, no `QGraphicsView` — one paint routine covers the level underlay, match overlay, anchor band, and viewport indicator with shared bucket-edge geometry (`mCachedYEdges`) so a drag-scroll burst pays one alloc, not one per paint.

Keying the bucket vector on the *outermost* proxy row space is the load-bearing invariant. Newest-first orientation flips row order via `RowOrderProxyModel` (a middle proxy above `LogModel` below `LogFilterModel`); bucketing at the top means proxy row 0 is always the visually-topmost row in the table, so both orientations paint the same way and the viewport indicator's Y math is trivially correct. The chain walk cache (`mProxyChain` — `QPointer<QAbstractProxyModel>` per hop) hoists a `qobject_cast` per row out of the rebuild hot path and short-circuits to `-1` if any middle proxy dies before its `modelReset` catches us; a release-mode `qWarning` breadcrumb (armed once per cache lifetime, reset on `RebuildProxyChainCache`) surfaces chain drift without spamming the log on every row.

Rebuild coalescing is the second correctness point. `LogFilterModel::OnSourceRowsInserted` under an active sort emits *per-row* `rowsInserted` (each new row lands via `lower_bound` under the sort comparator, since coalescing that into a single bracketed insert would need real merge machinery for a niche case). With the rail listening directly to the outermost proxy, a 50 k-row live-tail batch under a sort would fan into 50 k O(rowCount) walks; the 50 ms coalesce timer collapses it to one. `SetBucketCount` and `RebuildNow` (widget resize, initial attach) still emit synchronously because the caller *needs* fresh data on return. `SetMatchProxyRows` bypasses the coalesce because find updates are already debounced upstream (`FindRecordWidget::mMatchCountTimer` + max-age), and touching only `matchCount` (via `RefreshMatchTicks`) avoids a bucketed-level rebuild on every keystroke.

The match-tick pipeline has two APIs that trade different asymptotic wins. `SetMatchProxyRows(rows)` is the classic path — the caller pushes the deduplicated row list and the model folds it into `matchCount`. For a common needle on a 1 M-row log, that materialises a `vector<int>` of a million entries just to derive per-bucket totals; `SetMatchBucketCounts(perBucketCounts, totalMatches)` is the new fast path that lets `MainWindow`'s find scan (via a new `LogFilterModel::ForEachMatchingRow` streaming callback) accumulate directly into a per-bucket presence tally and skip the intermediate row list entirely. The two are mutually exclusive: whichever API the caller uses clears the other so a coalesced rebuild never double-folds. The bucket-counts path also lets `MainWindow::UpdateFindMatchCount` early-exit its scan once every rail bucket has at least one hit and the `MAX_FIND_MATCH_COUNT` (10 000) cursor cache is full — for a needle that hits every log line the scan bails out an order of magnitude earlier than the pre-rail behaviour without lying to the rail about which buckets are hot.

Durable per-bucket counts are also what makes the hide → show toggle correct without a rescan. `SetOverviewRailVisible(false)` drops the model's bucket vector so subsequent proxy signals short-circuit inside `RebuildInternal` (zero cost while hidden). A same-height re-show reinstalls the counts from `mMatchBucketCounts`; a different-height re-show (or a scan that ran while hidden) triggers a `PushFindMatchesToOverviewRail` re-scan on the `bucketsChanged` seam. Toggle-and-scroll on a huge log is now free; drag-resize the rail's height and the ticks reappear in one debounce window instead of vanishing until the next find keystroke.

Viewport-margin reservation is the third integration seam that had to be right. `QTableView::updateGeometries` unconditionally resets the right viewport margin to zero on every layout pass (row insert, column change, viewport show), so a naive `setViewportMargins` call in the constructor gets wiped the first time a batch arrives. `LogTableView::AttachOverviewRail` caches the rail's `sizeHint().width()` into `mReservedRightMargin` and the overridden `updateGeometries()` re-applies it after the base call; the horizontal header is re-positioned against the shrunken viewport in the same pass so the header doesn't leak into the rail's slot. `setViewportMargins` fires a viewport `Resize` that would re-enter `updateGeometries` and wipe the margin, so `viewportEvent` swallows that resize under an `mApplyingRailMargin` flag — the layout settles in one pass, not a bounce. The `QPointer` on `mOverviewRail` self-heals: a rail destroyed by its original owner (Qt-parented tests, teardown races) zeroes the pointer and the next geometry pass reclaims the margin instead of stranding a phantom gap.

Wheel-forward is the last interaction quirk worth calling out. The rail widget forwards `wheelEvent` directly to the table's vertical scrollbar so the rail behaves like a scrollbar extension (a Klogg-style feel). That bypasses `LogTableView::wheelEvent`'s user-attribution flag, so `AttributeNextScrollToUser()` marks the next `valueChanged` as user-initiated — otherwise a live-tail wheel-forward would look programmatic and Follow newest would never disengage. When the scrollbar is already pinned at `minimum()` / `maximum()` (top / bottom of the stream) the wheel forward doesn't move the value and no `valueChanged` fires, so `ClearNextScrollUserAttribution()` immediately clears the flag; without this it would linger to the next — possibly programmatic — scroll and spuriously fire `userScrolled{To,AwayFrom}Tail`.

## What changed

**`OverviewRailModel` (`app/include/overview_rail_model.hpp` + `app/src/overview_rail_model.cpp`, ~920 lines).** Qt-side densely-bucketed view of the outermost proxy row space:

- **Bucket vector.** `Bucket { LevelBucket levels; uint32_t matchCount; std::bitset<ANCHOR_PALETTE_SIZE> anchorSlots; }` — one per rail pixel row. `LevelBucket` is `loglib::LevelBucket` reused from `HistogramBucketIndex`, so the rail and the histogram share the per-level counts layout exactly as ROADMAP item 13 spec'd ("tilted 90°").
- **Signal wiring.** `rowsInserted` / `rowsRemoved` / `modelReset` / `layoutChanged` on the outermost proxy trigger a coalesced `Rebuild()` (50 ms timer); `columnsInserted` / `columnsRemoved` route into `OnColumnsChanged` to recompute the cached first-`Type::Level` column index (`ComputeLevelColumnIndex`); `enumColumnsChanged(Grew)` is filtered out (dictionary grows don't move columns and would trigger an O(nColumns) scan for nothing); `AnchorManager::changed` / `reset` hit dedicated slots so anchor edits don't force a level-count rebuild.
- **Proxy chain cache.** `RebuildProxyChainCache` walks `outermost proxy -> ... -> LogModel` once per `modelReset`, storing `QPointer<QAbstractProxyModel>` for each hop; `ProxyToSourceRow` reads the cache instead of `qobject_cast`-ing every row, and short-circuits to `-1` on a null slot (dead mid-chain proxy) or a chain that no longer terminates at the cached `LogModel`. A once-per-cache-lifetime `qWarning` surfaces drift in release; debug builds `Q_ASSERT_X` on the same seam.
- **Match APIs.** `SetMatchProxyRows(rows)` folds a deduplicated row list into `matchCount` (`RefreshMatchTicks` is the fast path — level counts / anchor bits untouched); `SetMatchBucketCounts(perBucketCounts, totalMatches)` stores the totals durably so `RebuildInternal` can re-apply them without the caller re-pushing. `mMatchProxyRows` and `mMatchBucketCounts` are mutually exclusive; whichever API is active clears the other. `HasMatchTicks` tracks the *bucketed* count, not the raw list size, so an all-out-of-range match list correctly reports "no ticks".
- **Anchor bits.** `ANCHOR_PALETTE_SIZE`-wide bitset per bucket; `mAnchorBucketBitsSet` (running popcount over `mBuckets`) drives `HasAnchorTicks` in O(1) so the widget's paint path can skip the anchor overlay entirely on a session with no anchors. Anchor changes hit `OnAnchorChanged` / `OnAnchorsReset`; the widget re-emits `anchorBucketsChanged` when the aggregate bit-count actually changes.
- **Geometry helpers.** `FirstProxyRowInBucket(bucket)` via `ceil(bucket * M / N)` (O(1)); `ProxyRowForYPixel(y, railHeight)` maps a widget-Y directly to a proxy row, clamped into `[0, proxyRowCount)`, so drag scrubs feel smooth at sub-bucket precision (a fast drag across a 500 px rail on a 1 M-row log resolves ~2 000 rows per pixel of movement without the perceptible "snap to bucket" behaviour a bucket-only mapping would produce).

**`OverviewRailWidget` (`app/include/overview_rail_widget.hpp` + `app/src/overview_rail_widget.cpp`, ~1 245 lines).** Plain `QWidget` with a custom paint routine:

- **Paint layers (bottom-up).** `QPalette::Base` wash so the rail reads as an extension of the table's data area; per-bucket stacked-severity bin bar (bar width = log-scaled density with a `MIN_BAR_WIDTH_PX` floor so rare severities never round away; segments sized by each level's `log2(count + 1)` share, ordered `Fatal > Error > Warn > Info > Debug > Trace > Unknown`); match-tick and anchor-band overlays that repaint the full content width for hit buckets so a click hit-tests to what the eye sees; anti-aliased translucent viewport indicator with a cosmetic outline. Level colours come from `ThemeControl::BackgroundFor` (so the rail honours the high-contrast toggle for free) with `QPalette::PlaceholderText` for unstyled levels; anchor bands read the anchor palette slot colour; unresolved-level rows contribute to the `Unknown` slot rather than a phantom gap.
- **Interaction.** `mousePressEvent` seeds the drag, `mouseMoveEvent` scrubs, `mouseReleaseEvent` commits — de-duplicated by `mLastEmittedRow` so a fast scrub across a range of pixels that all map to the same proxy row doesn't queue a backlog of identical `proxyRowClicked` emissions. `proxyRowClicked` carries a `replaceSelection` flag: `true` on a fresh click (select the row, clear existing selection), `false` on drag scrubs (leave selection alone so a multi-row selection survives a rail scroll). `Esc` handling isn't needed — a rail drag never installs a filter; it only moves the viewport.
- **Wheel-forward.** `wheelEvent` calls `AttributeNextScrollToUser()` on the table view before forwarding to the vertical scrollbar. When the scrollbar is pinned at its `minimum()` / `maximum()` (bottom / top of the stream) the forward is a no-op and no `valueChanged` fires, so we call `ClearNextScrollUserAttribution()` to drop the flag rather than let it linger to a subsequent — possibly programmatic — value change.
- **DPI-fluent sizing.** `sizeHint()` returns `2 × max(PM_ScrollBarExtent, font 'M')` scaled by the active `OverviewRailWidthMode` (Narrow 1.0 / Medium 1.5 / Wide 2.0), clamped at 22 px on the low end so it stays clickable on styles with an unusually narrow `PM_ScrollBarExtent`. `SetWidthMode` calls `updateGeometry()` so `LogTableView::RefreshOverviewRailMargin` re-reserves the viewport margin at the new width. `mCachedRailWidth` caches the last `sizeHint()` result so `RailWidthForTest` reads the same value the layout used.
- **Show / hide / resize hooks.** `showEvent` re-syncs the model's bucket count to the current height synchronously (needed because `MainWindow::SetOverviewRailVisible(false)` drops the vector, and a same-height re-show wouldn't fire `resizeEvent`). `hideEvent` cancels any pending `mBucketSyncTimer` so a queued sync can't re-populate buckets after the toggle-optimisation dropped them. `resizeEvent` coalesces per-pixel drag-height changes through the 50 ms `mBucketSyncTimer` — each `SetBucketCount(H)` drops the durable match counts and (with find open) forces a full rescan, so a per-pixel drag burst would melt the GUI without coalescing. `mCachedYEdges` is invalidated on `(nBuckets, railTop, railHeight)` change so the three paint passes (level bars / match ticks / anchor bands) share one ~2 KB allocation per repaint window.

**`LogTableView::AttachOverviewRail` (`app/include/log_table_view.hpp` + `app/src/log_table_view.cpp`).** Viewport-margin hook:

- **Attach / detach.** `AttachOverviewRail(rail)` reparents the widget to the view, caches its `sizeHint().width()` into `mReservedRightMargin`, and calls `updateGeometries()`; `AttachOverviewRail(nullptr)` reclaims the margin. `ResolvedRailWidth` falls back through `sizeHint -> minimumSizeHint -> width` so simpler fixtures (a bare `QWidget` with `setFixedWidth`) still get a positive reservation; production `OverviewRailWidget` always supplies a valid sizeHint so the fallback is inert.
- **Margin preservation.** `updateGeometries()` overrides `QTableView::updateGeometries` and re-applies `mReservedRightMargin` after the base call zeroes it. `setViewportMargins` fires a viewport `Resize` that would re-enter `updateGeometries` and wipe the margin; `viewportEvent()` swallows that resize under an `mApplyingRailMargin` flag so the layout settles in one pass. The horizontal header is re-positioned against the shrunken viewport in the same pass so it doesn't leak into the rail's slot.
- **DPI-fluent refresh.** `changeEvent` on `StyleChange` / `PaletteChange` / `FontChange` / `ApplicationFontChange` / `ScreenChangeInternal` (Qt's private DPR-change proxy — public `DevicePixelRatioChange` needs Qt 6.6+) re-reads the rail's sizeHint and rewrites the margin so a monitor move between different scale factors keeps the rail's proportions.
- **User-scroll attribution seam.** `AttributeNextScrollToUser()` / `ClearNextScrollUserAttribution()` let the rail's wheel-forward path pretend to be a user-initiated scroll for `userScrolled{To,AwayFrom}Tail`'s edge-triggered filter without opening a general "treat everything as user" escape hatch. Same shape as the existing `mNextValueChangeIsUser` flag; the wheel-forward path just gets its own public entry.
- **Phantom-margin guard.** `mOverviewRail` is a `QPointer`; if a rail is destroyed outside `AttachOverviewRail(nullptr)` the pointer zeroes silently, so `UpdateOverviewRailGeometry` observes the null and reclaims `mReservedRightMargin` on the next geometry pass. Without this a session whose rail widget was deleted by a test / teardown race would keep a phantom gap on the right edge until the next layout re-run.

**`LogFilterModel::ForEachMatchingRow` (`app/include/log_filter_model.hpp` + `app/src/log_filter_model.cpp`).** Streaming variant of `MatchRow`: same probe semantics, but invokes a `MatchRowCallback` per hit instead of building a `QList<QModelIndex>`. `MainWindow::UpdateFindMatchCount` uses it to walk matches without materialising an O(matches) list — the scan accumulates both the capped `sortedRows` (for the "*i* of *N*" indicator) and a per-bucket presence tally (for the rail) in one pass, and early-exits once the cursor cache is full *and* every rail bucket has at least one hit. `MatchRow` becomes a thin wrapper around `ForEachMatchingRow` so all existing callers keep working; the `hits == 0` sentinel is now an explicit `Q_ASSERT` (the old "silently stops after one match" behaviour was a footgun).

**`FindRecordWidget` (`app/include/find_record_widget.hpp` + `app/src/find_record_widget.cpp`).** Two small correctness fixes wired up while the rail was landing:

- **Return / Shift+Return handling.** Previously the widget wired both `QLineEdit::returnPressed` (→ FindNext) *and* an `eventFilter` case for Shift+Return (→ FindPrevious). `QLineEdit` emits `returnPressed` then ignores the key, so the parent `keyPressEvent` fires FindNext a *second* time, double-advancing and skipping every other match on the plain Return path. The fix moves both cases into `eventFilter` (consuming the key before it bubbles) and drops the `returnPressed` wiring; `keyPressEvent` continues to handle Enter when focus is on a toggle / arrow button.
- **Empty-needle broadcast.** `RequestMatchCountSoon` on an empty needle now emits `MatchCountRequested("", ...)` after clearing the label so `MainWindow::UpdateFindMatchCount` drops both the cache *and* the rail's tick vector in one round-trip. Without the emit, a cleared find bar would leave the last needle's ticks stranded on the rail until the next non-empty keystroke.
- **Overflow tooltip.** The "+" suffix on the match count (`totalMatches` > `MAX_FIND_MATCH_COUNT`) grows a tooltip explaining that (a) the count is a lower bound, (b) the current-match index may read as 0 for a match past the cursor cache, and (c) the overview rail still shows every bucket that carries a hit. The tooltip clears when the search narrows back under the cap so it doesn't linger stale.

**`MainWindow` wiring (`app/include/main_window.hpp` + `app/src/main_window.cpp`, ~415 lines).** Owns the rail lifecycle and every integration seam:

- **Construction.** `mOverviewRailModel` is built right after the proxy chain and `mOverviewRailWidget` right after that (widget stays hidden; the toolbar seed decides visibility). The model stays live even when the rail is hidden so the toggle is instant on both edges.
- **`SetOverviewRailVisible(bool)`.** Single entry point for the load-time seed (`QSettings ui/showOverviewRail`, default `true`), the user toggle, and programmatic tests. Attaches / detaches via `LogTableView::AttachOverviewRail`, mirrors state onto `mActionToggleOverviewRail`, and writes `QSettings` with a diff so the load-time seed doesn't churn the registry on every window construction. On hide it also calls `SetBucketCount(0)` so proxy signals arriving while hidden short-circuit.
- **`ScrollToProxyRow(int proxyRow, bool replaceSelection)`.** Rail click / drag handler; centres the row via `scrollTo(PositionAtCenter)`, disengages Follow newest (rail navigation is intentional browsing, and `scrollTo` alone doesn't fire `userScrolledAwayFromTail`), and either commits selection (fresh click) or leaves it alone (drag scrub). Silent on transient out-of-range proxy rows so a drag scrub during an insert / filter race stays smooth. Null-checks `ui->actionFollowTail` in addition to `ui` so a partial-`setupUi` teardown path can't crash the handler.
- **Find integration.** `UpdateFindMatchCount` now scans via `ForEachMatchingRow`, accumulating `sortedRows` (capped at `MAX_FIND_MATCH_COUNT = 10 000`) and a per-bucket presence tally in parallel; the tally is stored on `mFindMatchCache.bucketCounts` and re-pushed to the rail on every `FindDock::revealed`. `PushFindMatchesToOverviewRail` prefers cached per-bucket counts (unbiased even when `sortedRows` is capped) and only falls back to `SetMatchProxyRows` when the counts are missing or size-mismatched (fresh cache after a resize). `InvalidateFindMatchCache` drops both the cache and the rail's ticks in lockstep.
- **Rail-resize catch-up.** A `bucketsChanged` connection re-pushes match state when the size changes and durable counts get dropped, so a rail height change under find keeps its ticks without waiting for the next keystroke.
- **Preferences.** `PreferencesEditor` grows an **Overview rail width** combo (Narrow / Medium / Wide) with live preview: every change fires `overviewRailWidthChanged`, `MainWindow` forwards to `mOverviewRailWidget->SetWidthMode()` + `mTableView->RefreshOverviewRailMargin()`, and Ok / Cancel persist / revert through `QSettings ui/overviewRailWidth`. `mInitialOverviewRailWidth` snapshots the value on dialog open so Cancel rolls a live preview back to the pre-dialog state.
- **Toolbar / menu placement.** A new Lucide **bar-chart-horizontal** icon (visually paired with the histogram's `bar-chart-3`; registered in `resources.qrc`) sits between the Histogram toggle and the expanding spacer on the primary toolbar and directly below the Histogram entry in the View menu. `Ctrl+Shift+R` ("R" for Rail) is the discoverable shortcut. `Ctrl+Shift+O` would have been the obvious first pick but it belongs to `actionOpenLogStream` — binding both against the same window produced an ambiguous-shortcut warning at runtime.

**Documentation.**

- `doc/README.md`: new "Match overview rail" section describing the paint layers (level underlay, match ticks, anchor bands, viewport indicator), the click / drag / wheel-through interactions, the default-on `Ctrl+Shift+R` toggle with `QSettings` persistence, and the width preset preference. The Preferences section grows an **Overview rail width** entry. The shortcut table grows a **Toggle Overview Rail** row.
- `ROADMAP.md`: item 13 ("Match overview rail / minimap") strike-through + "Shipped." callout matching the shape items 1 and 2 use, pointing at the new README section.

**Tests (`test/app/CMakeLists.txt` + new `apptest_overview_rail` binary; `test/app/src/test_overview_rail.cpp`, ~3 250 lines).** Concern-per-binary pattern mirroring `apptest_histogram` / `apptest_theme` so the rail is runnable in isolation via `ctest -R apptest_overview_rail`. Links the built-in theme JSONs from `resources.qrc` so paint tests can load real Dark / Light themes rather than the offscreen QPA's blank fallback. Coverage:

- **Model.** Empty-log emptiness, bucket population from a streamed source, match-row fold semantics, `SetMatchProxyRows` leaves level counts untouched, coalesced `Rebuild()` collapses N proxy signals into one bucketed rebuild, `SetBucketCount(0)` drops buckets, sub-bucket-precision `ProxyRowForYPixel`, anchor ticks follow `AnchorManager`, level-column cache tracks moves, log-scaled level bar widths, `SetMatchBucketCounts` size-mismatch drops silently, `SetMatchBucketCounts` clears raw rows so a coalesced rebuild doesn't double-fold, bucket-counts survive hide/show but are dropped on a size change, both APIs refresh the cached `mProxyRowCount` from the live proxy before folding so tail hits arriving after a rebuild are still attributed to the right bucket, phantom-margin reclaim when the rail is destroyed out from under the view, `enumColumnsChanged(Grew)` is a no-op, `SetMatchProxyRows` dedups duplicates, `LayoutChanged` triggers a coalesced rebuild.
- **Widget.** `sizeHint()` is DPI-fluent and width-mode-scaled; `WidthModeChangeRefreshesReservedMargin`; content rect spans the full underlay; level bars paint at production width; stacked severity segments respect log-weighted shares (both a common `Info` majority and a rare `Fatal` outlier); high-contrast preference flips the palette; the match overlay covers the full content width; dark theme paints legible bars; the rail projects across the full widget height (no top/bottom cropping past the 2 px tick-outline inset); the viewport indicator centres on the visible range; hide→show restores match ticks from the durable counts.
- **Interactions.** Click emits `proxyRowClicked` with `replaceSelection=true`; drag scrubs preserve selection; wheel-forward hits the scrollbar with proper user attribution and disengages Follow newest; wheel-forward on a pinned edge doesn't leak the attribution flag; a `ScrollToProxyRow` from the rail always disengages Follow newest; the rail toggle doesn't restore ticks when the find dock is closed; the tabified find dock hiding via tab-switch clears match ticks.
- **`LogTableView` viewport-margin hook.** `AttachOverviewRail` reserves the right margin; `updateGeometries` re-applies it after the base wipes it; a resize storm coalesces to a single bucket-count update; `showEvent` flushes pending sync synchronously; `showEvent` cancels a pending resize debounce; a rail destroyed outside `AttachOverviewRail(null)` still reclaims the margin.
- **`MainWindow` end-to-end.** Default-on visibility; `Ctrl+Shift+R` toggle; hide drops model buckets; find-dock reveal restores unbiased match ticks from `bucketCounts` even when `sortedRows` was capped; rail resize under find reinstalls ticks at the new bucket count; find-match scan early-exits once the rail's presence fold is settled and the cursor cache is full.
- **`ForEachMatchingRow`.** Streams without materialising a full row list; feeds a capped `sortedRows` in parallel with unbiased bucket counts; the early-exit fires when both stop conditions are met.

## Trailing-commit cleanup

The `feature/overview-rail` review loop landed the base commit plus **12** follow-up polish / correctness passes; every one has a self-contained commit message with its rationale. Highlights (see `git log` on the branch for the full list):

- `e207a43` — Base commit: `OverviewRailModel` + `OverviewRailWidget` + `LogTableView::AttachOverviewRail`.
- `2670341` — Wire the rail into `MainWindow`: `SetOverviewRailVisible`, `ScrollToProxyRow`, find integration through `mFindMatchCache`, toolbar / View menu / `QSettings` seed.
- `db2f7e3` — First tests-only pass (`apptest_overview_rail` binary): base model / widget / view-hook / MainWindow toggle coverage, plus the `AttachOverviewRail` sizeHint-fallback hardening for fixtures that ship a bare `setFixedWidth` rail.
- `756ebb9` — Document the rail in `doc/README.md`; mark ROADMAP item 13 shipped in the item-1 / item-2 style.
- `47b9c73` — Review pass 1: `Rebuild()` coalescing through the 50 ms timer (fixes the per-row `rowsInserted` fan-out under an active sort), `SetMatchProxyRows` fast path via `RefreshMatchTicks`, hide-time bucket-vector drop, `HasMatchTicks` tracks the bucketed count, sub-bucket click precision via `ProxyRowForYPixel`, drag scrubs preserve selection, rail-width clamp at 22 px.
- `549f1e7` — Review pass 2: `ScheduleRebuild` short-circuits on empty buckets, `SetMatchProxyRows` drops the redundant `bucketsChanged` emit, `mLastEmittedRow` in-class init, dead local in `ComputeViewportIndicatorRect`, `SetOverviewRailVisible` diffs before writing to `QSettings`, `README` drag-coalescing paragraph rewritten to match reality.
- `aa55892` — Review pass 3: cache the proxy chain so `ProxyToSourceRow` skips `qobject_cast` per row, filter out `enumColumnsChanged(Grew)`, drop the phantom-Unknown fallback in `RebuildInternal`, dedup `SetMatchProxyRows`, hoist per-bucket Y math into a shared `mCachedYEdges` vector, phantom-margin reclaim when the rail is destroyed externally.
- `de74aab` — `LogTableView::updateGeometries()` override + `viewportEvent()` swallow so the reserved right margin survives every implicit re-layout (row insert, column change, viewport show) in one pass instead of bouncing through a second layout.
- `3b81002` — Scale the find-match scan: `ForEachMatchingRow` streaming callback + per-bucket presence counts on the rail path, early-exit when both stop conditions are met; drops the O(matches) allocation on broad needles and eliminates the top-biased rail-tick strip.
- `4224467` — `FindRecordWidget` Return / Shift+Return handling reworked to consume the key in `eventFilter` (fixes the double-advance regression that skipped every other match on Return), plus tests pinning the fix.
- `0e63d06` — `PreferencesEditor` grows the Overview rail width combo (Narrow / Medium / Wide); `OverviewRailWidget::SetWidthMode` + `LogTableView::RefreshOverviewRailMargin`; live preview + `QSettings` persistence; assorted small fixes.
- `826fdb4` — Proxy-lifetime hardening (`QPointer<QAbstractProxyModel>` in `mProxyChain` + one-shot drift warning), wheel-forward attribution flag cleared on a pinned edge, `ScrollToProxyRow` null-checks `ui->actionFollowTail`, `RequestMatchCountSoon` on empty needle now emits `MatchCountRequested("")` so the rail ticks drop in one round-trip.
- `886427e` — Docs / shortcut polish: condense the verbose commentary added during review down to essential intent, rebind the shortcut to `Ctrl+Shift+R` (avoiding the ambiguous overload with `actionOpenLogStream`'s existing `Ctrl+Shift+O`), add the shortcut to the docs and the shortcut-table test.

## Test plan

- [x] `ctest --preset debug` green locally on Windows + MSVC + Debug + offscreen Qt, including the ~60 new `apptest_overview_rail` cases and the ~4 new `apptest` `MainWindow` cases covering the rail toolbar + toggle wiring.
- [x] `ctest --preset release` green.
- [x] `run-clang-tidy` over the new / heavily-modified TUs (`overview_rail_model.hpp`, `overview_rail_model.cpp`, `overview_rail_widget.hpp`, `overview_rail_widget.cpp`, `log_table_view.hpp`, `log_table_view.cpp`, `log_filter_model.hpp`, `log_filter_model.cpp`, `find_record_widget.hpp`, `find_record_widget.cpp`, `main_window.hpp`, `main_window.cpp`, `preferences_editor.hpp`, `preferences_editor.cpp`, `test_overview_rail.cpp`) reports zero warnings on the new code.
- [x] `pre-commit run --all-files` clean locally.
- [x] Manual smoke: open a 500 k-row JSONL — the rail appears on the right edge, level bars paint immediately, clicking on a red-tinted stretch jumps to the first error row in that bucket, dragging scrubs the viewport indicator with the table following live.
- [x] Manual smoke: open the same file under Stream Mode with a `log_generator` appending rows — the rail repaints on the 50 ms coalesce cadence, buckets grow proportionally, wheeling over the rail scrolls the table and (once past the pinned tail) disengages Follow newest.
- [x] Manual smoke: open the Find bar with a common needle — match ticks paint across every bucket that carries a hit, the "*N*+ matches" indicator surfaces the overflow tooltip, and the current-match index resolves to 0 past the cursor cache as documented.
- [x] Manual smoke: anchor rows with `Ctrl+1` .. `Ctrl+8` — coloured bands appear on the rail's right edge in the anchor's slot colour; removing every anchor collapses the bands back to nothing.
- [x] Manual smoke: **View → Overview Rail** (`Ctrl+Shift+R`) toggle — the rail hides / re-appears, the table viewport reclaims / re-reserves the right margin without a bounce, and the toggle state persists across a restart via `QSettings ui/showOverviewRail`.
- [x] Manual smoke: **Settings → Preferences → Overview rail width** — Narrow / Medium / Wide preview live; Cancel reverts; Ok persists and future restarts open at the new preset.
- [x] Manual smoke: drag the horizontal splitter that shrinks / grows the main window — the rail resizes with the viewport, buckets re-fold on the coalesce cadence, and durable find-match counts survive the resize as long as the height doesn't change (a per-pixel drag doesn't lose ticks between debounce windows).
- [x] Manual smoke: theme swap (Light → Dark → High-Contrast) while the rail is populated — the level underlay, match overlay, anchor bands, and viewport indicator all repaint through the new palette without stale colours.
- [x] Manual smoke: window close (`X`) while a live-tail session is populating the rail — no crash, no double-free on `OverviewRailModel` (owned by the window), auto-save session doesn't record any rail-specific state (visibility + width live under `QSettings`).
- [x] CI: `pre-commit`, `clang-ci (asan-ubsan / tsan / coverage)`, `build-linux`, `build-macos`, `build-windows` all expected green on this PR.
