### PR TITLE
Add Go to Line / Go to Timestamp menu entries

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -17,7 +17,7 @@ For the architecture each item plugs into, see [CONTRIBUTING.md → Architecture
   - [5. Boolean filter expressions (AND / OR / NOT)](#5-boolean-filter-expressions-and--or--not)
   - [6. Multi-line records (stack traces and continuation lines)](#6-multi-line-records-stack-traces-and-continuation-lines)
   - [7. Export filtered rows](#7-export-filtered-rows)
-  - [8. Goto line / Goto timestamp](#8-goto-line--goto-timestamp)
+  - [8. ~~Goto line / Goto timestamp~~ (shipped)](#8-goto-line--goto-timestamp)
   - [9. Stdin / pipe input](#9-stdin--pipe-input)
   - [10. Headless / scriptable CLI mode](#10-headless--scriptable-cli-mode)
 - [Tier 2 — `v1.x` strong differentiators](#tier-2--v1x-strong-differentiators)
@@ -185,19 +185,9 @@ Exports respect the current filter set and sort order; an explicit "Export selec
 
 **Touches.** `app`: new `app/include/export_dialog.hpp` + `.cpp`, `MainWindow::SaveConfiguration` neighbourhood for menu wiring.
 
-### 8. Goto line / Goto timestamp
+### 8. ~~Goto line / Goto timestamp~~
 
-**Why.** Trivial UX gap; every alternative has it. `Ctrl+G` jumps to a source-model row number; an adjacent **Goto Timestamp…** dialog accepts `"2024-04-28 12:34:56"` or a relative `"-1h"` and lands the table on the first row at or after that time.
-
-**Scope.** Two menu entries under **Edit** (`Ctrl+G` and `Ctrl+Shift+G`), each opens a small modal with a single input.
-
-**Non-goals (v1).** Bookmarks in the goto history (item 24 covers history), per-second slider widget, time-zone selector on the goto box (it uses the same display TZ as the table).
-
-**Approach.** `SelectSourceRow` already exists. Goto Timestamp binary-searches the first `Type::Time` column (already sorted in file order) and falls back to a linear scan when a user sort is active on a different column.
-
-**Acceptance bar.** Both jumps land in `< 100 ms` on a 10 M-row file. Goto Timestamp accepts every format the table's timestamp column already parses, plus the relative `-Nh` / `-Nm` shortcuts.
-
-**Touches.** `app`: `MainWindow` (two new slots, two new actions), `app/src/main_window.ui` (menu entries).
+> **Shipped.** **Edit → Go to Line…** (`Ctrl+G`) jumps to a 1-based source-model row (line 1 is the earliest retained row; streaming FIFO eviction may have dropped older rows so numbers need not match the source file). **Edit → Go to Timestamp…** (`Ctrl+Shift+G`) accepts every format the timestamp column already parses, two ISO 8601 fallbacks (`%FT%T` and `%F %T`), and the relative shortcuts `-Nh` / `-Nm` (case-insensitive; `+N` and bare `N` also mean "N ago", matching lnav / less). Naive inputs (no `%z` / `%Z`) are interpreted in the display TZ (`loglib::CurrentZone()`) and shifted to UTC via `loglib::LocalMicrosecondsSinceEpochToUtc`. Search takes one of three branches: an O(log N) source-row binary search when the timestamps are monotonic and no user sort is active (guarded by `LogModel::TimestampsAreMonotonic()`, which flips false on multi-file `Append` / rotation / clock skew); an O(N_visible) outer-proxy walk when monotonicity has broken; an O(N_visible) display-order scan under a user sort. See [`doc/README.md § Jumping to a Line or Timestamp`](doc/README.md#jumping-to-a-line-or-timestamp).
 
 ### 9. Stdin / pipe input
 
@@ -370,7 +360,7 @@ Reference snapshot from the survey that informed the roadmap (June 2026). `✓` 
 | Match overview rail / minimap               |                  |           |   ✓   |           |             |         |              |           |   ✓   |
 | Pretty-print JSON / XML inline              | ~ Record Details |     ✓     |       |           |      ✓      |    ✓    |      ✓       |           |   ✓   |
 | Multi-line records (stack traces)           |                  |     ✓     |   ✓   |     ✓     |      ✓      |    ✓    |      ✓       |     ✓     |   ✓   |
-| Goto line / Goto timestamp                  |                  |     ✓     |   ✓   |     ✓     |      ✓      |    ✓    |      ✓       |     ✓     |   ✓   |
+| Goto line / Goto timestamp                  |        ✓         |     ✓     |   ✓   |     ✓     |      ✓      |    ✓    |      ✓       |     ✓     |   ✓   |
 | Time-range zoom / jump-by-N-min             |  ~ time filter   |     ✓     |       |     ✓     |      ✓      |    ✓    |      ✓       |     ✓     |   ✓   |
 | Timeshift (per-file clock offset)           |                  |           |       |     ✓     |             |         |              |           |       |
 | Encoding auto-detect (UTF-16, cp125x)       |                  |           |   ✓   |     ✓     |      ✓      |    ✓    |              |           |       |

--- a/app/include/log_model.hpp
+++ b/app/include/log_model.hpp
@@ -225,6 +225,33 @@ public:
     /// Current retention cap (`0` means unbounded). GUI thread only.
     [[nodiscard]] size_t RetentionCap() const noexcept;
 
+    /// True while every batch we've appended so far has landed with
+    /// its first valid timestamp `>=` the last valid timestamp of
+    /// the previous batch (i.e. source-row order matches wall-clock
+    /// order across batch boundaries). Reset to `true` on
+    /// `Reset()` / `BeginStreaming*` and flipped irreversibly to
+    /// `false` the first time we detect an out-of-order boundary in
+    /// `AppendBatch`. Used by `MainWindow::FindFirstRowAtOrAfter` to
+    /// gate its `lower_bound`-on-source-rows fast path: the search
+    /// requires monotonicity to be correct, and multi-file `Append`
+    /// / rotation / clock skew can violate it. Intra-batch
+    /// inversions are not observed by this cheap check -- the
+    /// caller degrades to an O(N_visible) proxy walk when this
+    /// returns `false`, so a false-positive "monotonic" answer is
+    /// what we optimise away, not correctness. Rows without a
+    /// resolvable timestamp are skipped rather than treated as
+    /// `-inf` (same rationale as the fast-path binary search).
+    [[nodiscard]] bool TimestampsAreMonotonic() const noexcept;
+
+    /// Test seam: force `TimestampsAreMonotonic()` to return false
+    /// so `MainWindow::FindFirstRowAtOrAfter` takes its non-
+    /// monotonic branch even in single-batch fixtures where the
+    /// streaming-path detector has nothing to trip on. Idempotent
+    /// (there's no cheap way back, mirroring production semantics).
+    /// Not gated behind `LOGAPP_BUILD_TESTING` because the header
+    /// has no such guard; the name makes intent clear at call sites.
+    void SetTimestampsMonotonicForTest(bool monotonic) noexcept;
+
     /// UTF-8 bytes -> single-line, simplified `QString` (the
     /// `Qt::DisplayRole` representation). Public so `MatchRow` and
     /// `MainWindow::MakeStringMatcher` apply the same normalisation
@@ -382,6 +409,17 @@ private:
     /// Shared implementation of `Reset()` / `StopAndKeepRows()`.
     void TeardownStreamingSessionInternal(bool resetTable);
 
+    /// Scan the source rows `[firstNewRow, endNewRow)` we've just
+    /// appended for the first & last valid timestamp value, and
+    /// update `mTimestampsMonotonic` / `mLastAppendedTimestampMicros`
+    /// accordingly. Bails out early if the flag is already false
+    /// (irreversible) or the configuration has no `Type::Time`
+    /// column. Missing-timestamp rows are ignored rather than
+    /// treated as `-inf`; a batch consisting entirely of
+    /// missing-ts rows leaves the tracker unchanged. Called from
+    /// `AppendBatch` while row insertion is already O(N_batch).
+    void UpdateTimestampMonotonicity(int firstNewRow, int endNewRow);
+
     /// Canonical level for @p row via the first `Type::Level`
     /// column. Returns nullopt when there's no level column or the
     /// row has no resolvable level. Drives the Background /
@@ -423,6 +461,25 @@ private:
 
     /// Retention cap; `0` means unbounded.
     size_t mRetentionCap = 0;
+
+    /// See `TimestampsAreMonotonic()`. Starts true on every fresh
+    /// streaming / static session and only ever flips to false --
+    /// there's no cheap way to prove a previously-broken sequence
+    /// has healed. The Goto Timestamp fast path reads this to
+    /// decide between a source-row `lower_bound` (O(log N)) and a
+    /// visible-proxy walk (O(N_visible)).
+    bool mTimestampsMonotonic = true;
+
+    /// Last valid timestamp value (epoch micros) observed in an
+    /// appended batch, or nullopt when no batch with a valid
+    /// timestamp has landed yet in the current session. Compared
+    /// against the FIRST valid timestamp of every subsequent batch
+    /// to detect boundary inversions (multi-file `Append`,
+    /// rotation, clock skew). Prefix eviction leaves this untouched
+    /// -- the invariant we care about is "later batch's first ts
+    /// >= earlier batch's last ts", which is preserved when older
+    /// rows drop out.
+    std::optional<int64_t> mLastAppendedTimestampMicros;
 
     /// Per-batch capture: column -> (canonical level -> raw dictionary
     /// bytes), recorded when a `Type::Level` column demotes during the

--- a/app/include/log_model.hpp
+++ b/app/include/log_model.hpp
@@ -225,31 +225,21 @@ public:
     /// Current retention cap (`0` means unbounded). GUI thread only.
     [[nodiscard]] size_t RetentionCap() const noexcept;
 
-    /// True while every batch we've appended so far has landed with
-    /// its first valid timestamp `>=` the last valid timestamp of
-    /// the previous batch (i.e. source-row order matches wall-clock
-    /// order across batch boundaries). Reset to `true` on
-    /// `Reset()` / `BeginStreaming*` and flipped irreversibly to
-    /// `false` the first time we detect an out-of-order boundary in
-    /// `AppendBatch`. Used by `MainWindow::FindFirstRowAtOrAfter` to
-    /// gate its `lower_bound`-on-source-rows fast path: the search
-    /// requires monotonicity to be correct, and multi-file `Append`
-    /// / rotation / clock skew can violate it. Intra-batch
-    /// inversions are not observed by this cheap check -- the
-    /// caller degrades to an O(N_visible) proxy walk when this
-    /// returns `false`, so a false-positive "monotonic" answer is
-    /// what we optimise away, not correctness. Rows without a
-    /// resolvable timestamp are skipped rather than treated as
-    /// `-inf` (same rationale as the fast-path binary search).
+    /// True while source-row order matches wall-clock order across
+    /// every appended batch boundary. Reset on session start; flips
+    /// irreversibly to false on the first inversion seen by
+    /// `AppendBatch` (multi-file `Append`, rotation, clock skew).
+    /// Gates the `MainWindow::FindFirstRowAtOrAfter` binary-search
+    /// fast path; a false answer degrades that caller to an
+    /// O(N_visible) proxy walk (still correct, just slower).
+    /// Intra-batch inversions and rows without a timestamp are not
+    /// checked here -- only the batch boundary.
     [[nodiscard]] bool TimestampsAreMonotonic() const noexcept;
 
     /// Test seam: force `TimestampsAreMonotonic()` to return false
-    /// so `MainWindow::FindFirstRowAtOrAfter` takes its non-
-    /// monotonic branch even in single-batch fixtures where the
-    /// streaming-path detector has nothing to trip on. Idempotent
-    /// (there's no cheap way back, mirroring production semantics).
-    /// Not gated behind `LOGAPP_BUILD_TESTING` because the header
-    /// has no such guard; the name makes intent clear at call sites.
+    /// so `MainWindow::FindFirstRowAtOrAfter` exercises its non-
+    /// monotonic branch without a real inversion. Irreversible,
+    /// matching production semantics.
     void SetTimestampsMonotonicForTest(bool monotonic) noexcept;
 
     /// UTF-8 bytes -> single-line, simplified `QString` (the
@@ -409,15 +399,13 @@ private:
     /// Shared implementation of `Reset()` / `StopAndKeepRows()`.
     void TeardownStreamingSessionInternal(bool resetTable);
 
-    /// Scan the source rows `[firstNewRow, endNewRow)` we've just
-    /// appended for the first & last valid timestamp value, and
-    /// update `mTimestampsMonotonic` / `mLastAppendedTimestampMicros`
-    /// accordingly. Bails out early if the flag is already false
-    /// (irreversible) or the configuration has no `Type::Time`
-    /// column. Missing-timestamp rows are ignored rather than
-    /// treated as `-inf`; a batch consisting entirely of
-    /// missing-ts rows leaves the tracker unchanged. Called from
-    /// `AppendBatch` while row insertion is already O(N_batch).
+    /// Scan the freshly appended rows `[firstNewRow, endNewRow)`
+    /// and update `mTimestampsMonotonic` /
+    /// `mLastAppendedTimestampMicros`. No-op once the flag has
+    /// flipped false or when the configuration has no `Type::Time`
+    /// column. Missing-timestamp rows are skipped, not treated as
+    /// `-inf`. Piggybacks on the O(N_batch) work `AppendBatch`
+    /// already does.
     void UpdateTimestampMonotonicity(int firstNewRow, int endNewRow);
 
     /// Canonical level for @p row via the first `Type::Level`
@@ -462,23 +450,16 @@ private:
     /// Retention cap; `0` means unbounded.
     size_t mRetentionCap = 0;
 
-    /// See `TimestampsAreMonotonic()`. Starts true on every fresh
-    /// streaming / static session and only ever flips to false --
-    /// there's no cheap way to prove a previously-broken sequence
-    /// has healed. The Goto Timestamp fast path reads this to
-    /// decide between a source-row `lower_bound` (O(log N)) and a
-    /// visible-proxy walk (O(N_visible)).
+    /// Backing store for `TimestampsAreMonotonic()`. True at
+    /// session start, only ever flips false (no cheap heal path).
     bool mTimestampsMonotonic = true;
 
-    /// Last valid timestamp value (epoch micros) observed in an
-    /// appended batch, or nullopt when no batch with a valid
-    /// timestamp has landed yet in the current session. Compared
-    /// against the FIRST valid timestamp of every subsequent batch
-    /// to detect boundary inversions (multi-file `Append`,
-    /// rotation, clock skew). Prefix eviction leaves this untouched
-    /// -- the invariant we care about is "later batch's first ts
-    /// >= earlier batch's last ts", which is preserved when older
-    /// rows drop out.
+    /// Last valid timestamp (epoch micros) seen in an appended
+    /// batch, or nullopt before the first valid timestamp lands.
+    /// Compared against the FIRST valid timestamp of each new
+    /// batch to detect boundary inversions. Prefix eviction leaves
+    /// this untouched -- the "next batch's first ts >= previous
+    /// batch's last ts" invariant survives dropping older rows.
     std::optional<int64_t> mLastAppendedTimestampMicros;
 
     /// Per-batch capture: column -> (canonical level -> raw dictionary

--- a/app/include/main_window.hpp
+++ b/app/include/main_window.hpp
@@ -21,6 +21,16 @@
 #include <loglib/stop_token.hpp>
 #include <loglib/theme.hpp>
 
+// `ParseGotoTimestampInput` takes an optional display time zone so
+// callers can convert naive absolute inputs (`YYYY-MM-DD HH:MM:SS`)
+// from the user's wall-clock frame into UTC micros comparable with
+// the table's stored timestamps. Forward declared to avoid pulling
+// `<date/tz.h>` into every translation unit that includes this header.
+namespace date
+{
+class time_zone;
+} // namespace date
+
 // `loglib::EnumDictionary` is referenced via `ResolveEnumDictionary` below;
 // the full type comes in transitively through `log_filter_model.hpp`.
 
@@ -376,47 +386,82 @@ public:
     void SelectSourceRow(int sourceRow);
 
     /// Pop the "Go to Line..." modal (`actionGotoLine`, `Ctrl+G`).
-    /// Line numbers are 1-based over the source model (line 1 is the
-    /// first line in the file, unaffected by newest-first display
-    /// reversal). Invalid input / no active model surfaces a
-    /// status-bar hint; a valid row hands off to `SelectSourceRow`.
+    /// Line numbers are 1-based over the source model as it exists
+    /// now: line 1 is the earliest row currently retained (streaming
+    /// FIFO eviction may have dropped older rows, so line numbers
+    /// are **not** guaranteed to match the source file's line
+    /// numbering). Newest-first display reversal only affects
+    /// rendering, not the number the user types. Invalid input /
+    /// no active model surfaces a status-bar hint; a valid row hands
+    /// off to `SelectSourceRow`.
     void GotoLine();
 
     /// Pop the "Go to Timestamp..." modal (`actionGotoTimestamp`,
     /// `Ctrl+Shift+G`). Accepts the current time column's own
     /// `parseFormats` plus two ISO fallbacks and the relative
-    /// shortcuts `-Nh` / `-Nm`. Binary-searches the source model
-    /// when no user sort is active; falls back to a linear proxy
-    /// scan otherwise. Lands on the first row at or after the
-    /// requested time via `SelectSourceRow`, or surfaces a
-    /// status-bar hint when no such row exists.
+    /// shortcuts `-Nh` / `-Nm`. Naive absolute inputs (no `%z` /
+    /// `%Z` in the winning format) are interpreted in the table's
+    /// display time zone (`loglib::CurrentZone()`) and shifted to
+    /// UTC before the search. Binary-searches the source model in
+    /// file order when no user sort is active (also respects the
+    /// active row filter), and falls back to a linear scan over
+    /// visible proxy rows otherwise so the "first" row honours the
+    /// user's chosen display order. Lands via `SelectSourceRow`, or
+    /// surfaces a status-bar hint when no such row exists.
     void GotoTimestamp();
 
-    /// Pure helper for `GotoTimestamp`; returns epoch microseconds
-    /// on success. Tries the relative shortcut `^-\s*(\d+)\s*([hm])\s*$`
-    /// first (case-insensitive, evaluated against @p now), then each
-    /// entry of @p columnParseFormats via `loglib::TryParseTimestamp`,
-    /// then the two ISO fallbacks `"%FT%T"` and `"%F %T"`. Returns
-    /// `std::nullopt` on failure. Kept out of any class member state
-    /// so unit tests can drive it without a `MainWindow` instance.
-    [[nodiscard]] static std::optional<int64_t> ParseGotoTimestampInput(
+    /// Result of `ParseGotoTimestampInput`.
+    ///
+    /// `micros` is epoch microseconds. `isNaive` is `true` when the
+    /// winning format lacked a `%z` / `%Ez` / `%Z` specifier so the
+    /// value should be interpreted in the caller's display time zone
+    /// before comparing against stored (UTC-normalised) timestamps.
+    /// The relative shortcut path returns `isNaive == false` because
+    /// it derives `micros` from a `std::chrono::system_clock::time_point`
+    /// which is already UTC.
+    struct GotoTimestampParse
+    {
+        int64_t micros = 0;
+        bool isNaive = false;
+    };
+
+    /// Pure helper for `GotoTimestamp`. Tries the relative shortcut
+    /// `^[+-]?\s*(\d+)\s*([hm])\s*$` first (case-insensitive; the
+    /// `+` / no-sign variants also mean "N units ago" for parity
+    /// with lnav / less), then each entry of @p columnParseFormats
+    /// via `loglib::TryParseTimestamp`, then the two ISO fallbacks
+    /// `"%FT%T"` and `"%F %T"`. When @p displayZone is non-null and
+    /// the winning format is naive, the returned `micros` is *not*
+    /// pre-shifted -- callers apply the shift via
+    /// `loglib::LocalMicrosecondsSinceEpochToUtc` after inspecting
+    /// `isNaive`. Overflow in the relative shortcut (`-Nh` /
+    /// `-Nm` with an `N` that would overrun `int64_t` microseconds)
+    /// returns `std::nullopt` rather than wrapping. Kept out of any
+    /// class member state so unit tests can drive it without a
+    /// `MainWindow` instance.
+    [[nodiscard]] static std::optional<GotoTimestampParse> ParseGotoTimestampInput(
         const QString &input,
         const std::vector<std::string> &columnParseFormats,
         std::chrono::system_clock::time_point now
     );
 
     /// Locate the first row whose timestamp on @p timeCol is at or
-    /// after @p targetMicros. Uses an in-place binary search over
-    /// the source model when no user sort is active
-    /// (`LogFilterModel::SortColumn() < 0`); falls back to a linear
-    /// scan over the visible proxy rows otherwise so the "first"
-    /// row honours the user's chosen display order (see ROADMAP
-    /// item 8). Returns the source-model row index, or `-1` when
-    /// no live row qualifies. Rows with an unpromoted / missing
-    /// timestamp sort as `-inf` (keeps the binary search partition
-    /// monotonic and prevents the linear scan from ever picking
-    /// them as "first at or after"). Public so tests can exercise
-    /// both search branches without popping the modal.
+    /// after @p targetMicros **and** is currently visible through
+    /// the outer proxy (respects the active row filter).
+    ///
+    /// Fast path (no user sort): binary-searches source rows in file
+    /// order, tolerating interleaved missing / unpromoted timestamps
+    /// by skipping forward past them during each probe, then walks
+    /// forward from the binary-search result to skip any filtered-
+    /// out rows.
+    ///
+    /// Slow path (user sort active): linear scan over visible proxy
+    /// rows in display order so the "first" row honours the user's
+    /// chosen sort direction (see ROADMAP item 8).
+    ///
+    /// Returns the source-model row index, or `-1` when no live
+    /// row qualifies. Public so tests can exercise both branches
+    /// without popping the modal.
     [[nodiscard]] int FindFirstRowAtOrAfter(int timeCol, int64_t targetMicros) const;
 
     /// Jump the table to the first row in histogram bucket

--- a/app/include/main_window.hpp
+++ b/app/include/main_window.hpp
@@ -394,6 +394,10 @@ public:
     /// rendering, not the number the user types. Invalid input /
     /// no active model surfaces a status-bar hint; a valid row hands
     /// off to `SelectSourceRow`.
+    ///
+    /// Post-dialog work is factored into `ExecuteGotoLine` so tests
+    /// (and any future non-modal entry) can drive it without a
+    /// blocking `QInputDialog::exec`.
     void GotoLine();
 
     /// Pop the "Go to Timestamp..." modal (`actionGotoTimestamp`,
@@ -455,9 +459,24 @@ public:
     /// forward from the binary-search result to skip any filtered-
     /// out rows.
     ///
+    /// **Precondition (fast path):** source rows are assumed to be
+    /// monotonic in @p timeCol (times increase with row index).
+    /// This is the common case for single-source logs, but can be
+    /// violated by multi-file `Append` opens spanning overlapping
+    /// wall-clock ranges, multi-producer network streams, and clock
+    /// skew around rotation. When the invariant is broken, the fast
+    /// path may return `-1` even when a qualifying row exists earlier
+    /// in the file, or land past an earlier candidate. There is no
+    /// runtime guard: enforcing monotonicity would require an O(N)
+    /// pre-scan on every call which defeats the point of the fast
+    /// path. If this becomes a real complaint, gate the branch on a
+    /// `mModel->TimestampsAreMonotonic()` flag maintained on the
+    /// streaming path.
+    ///
     /// Slow path (user sort active): linear scan over visible proxy
     /// rows in display order so the "first" row honours the user's
-    /// chosen sort direction (see ROADMAP item 8).
+    /// chosen sort direction (see ROADMAP item 8). Not sensitive to
+    /// the monotonicity caveat above.
     ///
     /// Returns the source-model row index, or `-1` when no live
     /// row qualifies. Public so tests can exercise both branches
@@ -608,6 +627,14 @@ public:
     /// anchored (identical-note no-ops still return true). Returns
     /// false on an unanchored row -- no ghost anchor is spawned.
     bool SubmitAnchorNoteForRowForTest(int sourceRow, const QString &note);
+
+    /// Test seam replaying the post-`exec` body of `GotoLine`
+    /// without a modal `QInputDialog`. @p input is the raw text
+    /// value the dialog would have returned. Lets tests drive both
+    /// the current-row-count range check (shrink-while-modal-open
+    /// simulation: pass a line > `mModel->rowCount()`) and the
+    /// filter-visibility hint without popping a dialog.
+    void ExecuteGotoLineForTest(const QString &input);
 #endif
 
 protected:
@@ -843,6 +870,17 @@ private:
     /// on the current selection (same as the `Ctrl+1..8` hotkeys).
     /// No-op if model, theme, or anchor manager is missing.
     void AppendAnchorActionsToRowMenu(QMenu *menu, int sourceRow);
+
+    /// Shared post-`exec` body of `GotoLine`. Given the raw text @p
+    /// input the dialog collected, validates against the *current*
+    /// `mModel->rowCount()` (so a shrink between open and accept --
+    /// FIFO eviction, session swap -- is caught rather than trusted
+    /// to the stale `QIntValidator` range), then probes filter
+    /// visibility, then hands off to `SelectSourceRow`. Emits the
+    /// user-facing status hint for every rejection branch. Kept
+    /// separate from the modal-owning slot so tests can drive both
+    /// branches through `ExecuteGotoLineForTest`.
+    void ExecuteGotoLine(const QString &input);
 
     /// Logical index of the column whose `keys` match @p keys, or
     /// `-1` if none. `keys` is the only identifier that survives a
@@ -1776,6 +1814,14 @@ private:
     /// signal against half-updated state. The outer call finishes
     /// its rebuild and the queued re-entry becomes a no-op.
     bool mApplyingEnumRebuild = false;
+
+    /// Last text the user typed into the Goto Timestamp dialog,
+    /// pre-populated on the next open. Users often want to jump
+    /// several times around the same instant; making the dialog
+    /// remember the last input saves the retype. Cleared on
+    /// session switch to avoid leaking a stale reference from a
+    /// closed file into a fresh one.
+    QString mLastGotoTimestampInput;
 
     /// Latch: a loaded session's sort is pending, to be applied
     /// once streaming finishes. Avoids the O(N^2) per-row insert

--- a/app/include/main_window.hpp
+++ b/app/include/main_window.hpp
@@ -453,34 +453,44 @@ public:
     /// after @p targetMicros **and** is currently visible through
     /// the outer proxy (respects the active row filter).
     ///
-    /// Fast path (no user sort): binary-searches source rows in file
-    /// order, tolerating interleaved missing / unpromoted timestamps
-    /// by skipping forward past them during each probe, then walks
-    /// forward from the binary-search result to skip any filtered-
-    /// out rows.
+    /// Three internal branches, one for each interesting combination
+    /// of (user-sort, monotonicity):
     ///
-    /// **Precondition (fast path):** source rows are assumed to be
-    /// monotonic in @p timeCol (times increase with row index).
-    /// This is the common case for single-source logs, but can be
-    /// violated by multi-file `Append` opens spanning overlapping
-    /// wall-clock ranges, multi-producer network streams, and clock
-    /// skew around rotation. When the invariant is broken, the fast
-    /// path may return `-1` even when a qualifying row exists earlier
-    /// in the file, or land past an earlier candidate. There is no
-    /// runtime guard: enforcing monotonicity would require an O(N)
-    /// pre-scan on every call which defeats the point of the fast
-    /// path. If this becomes a real complaint, gate the branch on a
-    /// `mModel->TimestampsAreMonotonic()` flag maintained on the
-    /// streaming path.
+    /// * **Fast path** -- no user sort AND
+    ///   `LogModel::TimestampsAreMonotonic()`. Binary-searches
+    ///   source rows in file order (O(log N)), tolerating
+    ///   interleaved missing / unpromoted timestamps by skipping
+    ///   forward during each probe. After the search returns a
+    ///   candidate row `lo`, the visibility check runs against `lo`
+    ///   directly (happy path: O(1)); on a miss it walks the
+    ///   *outer proxy* -- not the source -- to find the smallest
+    ///   visible source row `>= lo` with a valid ts, yielding
+    ///   O(N_visible) worst case rather than O(N_source). This
+    ///   matters when a heavy filter hides most of the tail: the
+    ///   old source-walk was O(10M) on a 10M-row file with a
+    ///   1-in-a-million filter, well past the ROADMAP `< 100 ms`
+    ///   budget.
     ///
-    /// Slow path (user sort active): linear scan over visible proxy
-    /// rows in display order so the "first" row honours the user's
-    /// chosen sort direction (see ROADMAP item 8). Not sensitive to
-    /// the monotonicity caveat above.
+    /// * **Non-monotonic path** -- no user sort AND
+    ///   `TimestampsAreMonotonic()` is false (multi-file `Append`,
+    ///   rotation, clock skew). The binary search would silently
+    ///   return a wrong row, so we fall back to an O(N_visible)
+    ///   walk over the outer proxy and pick the visible row with
+    ///   the SMALLEST ts that still satisfies `ts >= target` --
+    ///   the chronologically earliest match. Monotonicity is
+    ///   tracked cheaply on the streaming path
+    ///   (`LogModel::UpdateTimestampMonotonicity`); no per-call
+    ///   scan is required to decide which branch to take.
+    ///
+    /// * **User-sort path** -- user has clicked a header. Linear
+    ///   scan over visible proxy rows in display order and return
+    ///   the first row whose source ts qualifies, so "first"
+    ///   honours the user's chosen sort direction (see ROADMAP
+    ///   item 8).
     ///
     /// Returns the source-model row index, or `-1` when no live
-    /// row qualifies. Public so tests can exercise both branches
-    /// without popping the modal.
+    /// row qualifies. Public so tests can exercise all three
+    /// branches without popping the modal.
     [[nodiscard]] int FindFirstRowAtOrAfter(int timeCol, int64_t targetMicros) const;
 
     /// Jump the table to the first row in histogram bucket
@@ -635,6 +645,29 @@ public:
     /// simulation: pass a line > `mModel->rowCount()`) and the
     /// filter-visibility hint without popping a dialog.
     void ExecuteGotoLineForTest(const QString &input);
+
+    /// Test seam replaying the post-`exec` body of `GotoTimestamp`
+    /// without a modal `QInputDialog`. @p input is the raw text
+    /// value the dialog would have returned; @p now pins the clock
+    /// so relative shortcuts (`-1h`) are deterministic. Exercises
+    /// the naive-vs-zoned dispatch, the `mLastGotoTimestampInput`
+    /// sticky-input update, the "no time column" / "could not
+    /// parse" hints, and the `FindFirstRowAtOrAfter` handoff --
+    /// none of which are reachable through `ParseGotoTimestampInput`
+    /// alone.
+    void ExecuteGotoTimestampForTest(const QString &input, std::chrono::system_clock::time_point now);
+
+    /// Test-only accessor for the sticky Goto Timestamp input so
+    /// the session-boundary clear (`NewSession()` -> `.clear()`)
+    /// can be pinned end-to-end.
+    [[nodiscard]] QString LastGotoTimestampInputForTest() const;
+
+    /// Test seam: force `LogModel::TimestampsAreMonotonic()` to
+    /// return false so `FindFirstRowAtOrAfter` takes the non-
+    /// monotonic branch even in fixtures where the streaming
+    /// path's guard has not observed an inversion. Idempotent;
+    /// no way back once tripped (mirrors production semantics).
+    void ForceTimestampsNonMonotonicForTest();
 #endif
 
 protected:
@@ -881,6 +914,19 @@ private:
     /// separate from the modal-owning slot so tests can drive both
     /// branches through `ExecuteGotoLineForTest`.
     void ExecuteGotoLine(const QString &input);
+
+    /// Shared post-`exec` body of `GotoTimestamp`. Given the raw
+    /// text @p input the dialog collected and @p now (pinned by
+    /// tests, `system_clock::now()` in production), updates the
+    /// sticky-input mirror, invokes `ParseGotoTimestampInput`,
+    /// shifts naive results through `LocalMicrosecondsSinceEpochToUtc`,
+    /// then hands off to `FindFirstRowAtOrAfter` + `SelectSourceRow`.
+    /// Emits the user-facing status hint for every rejection
+    /// branch. Kept separate from the modal-owning slot so tests
+    /// can drive naive-vs-zoned dispatch and the various error
+    /// branches through `ExecuteGotoTimestampForTest` without
+    /// popping a dialog.
+    void ExecuteGotoTimestamp(const QString &input, std::chrono::system_clock::time_point now);
 
     /// Logical index of the column whose `keys` match @p keys, or
     /// `-1` if none. `keys` is the only identifier that survives a
@@ -1822,6 +1868,15 @@ private:
     /// session switch to avoid leaking a stale reference from a
     /// closed file into a fresh one.
     QString mLastGotoTimestampInput;
+
+    /// Last text the user typed into the Goto Line dialog. Same
+    /// UX rationale as `mLastGotoTimestampInput`: users walking a
+    /// stack trace or diffing two runs re-open the dialog with an
+    /// adjacent line number, and retyping is friction. Cleared on
+    /// session switch alongside the timestamp mirror; validated
+    /// against the *current* row count on re-open so an out-of-
+    /// range carry-over from a smaller session no longer applies.
+    QString mLastGotoLineInput;
 
     /// Latch: a loaded session's sort is pending, to be applied
     /// once streaming finishes. Avoids the O(N^2) per-row insert

--- a/app/include/main_window.hpp
+++ b/app/include/main_window.hpp
@@ -375,6 +375,50 @@ public:
     /// note). Used by the Anchors dock for jump targets.
     void SelectSourceRow(int sourceRow);
 
+    /// Pop the "Go to Line..." modal (`actionGotoLine`, `Ctrl+G`).
+    /// Line numbers are 1-based over the source model (line 1 is the
+    /// first line in the file, unaffected by newest-first display
+    /// reversal). Invalid input / no active model surfaces a
+    /// status-bar hint; a valid row hands off to `SelectSourceRow`.
+    void GotoLine();
+
+    /// Pop the "Go to Timestamp..." modal (`actionGotoTimestamp`,
+    /// `Ctrl+Shift+G`). Accepts the current time column's own
+    /// `parseFormats` plus two ISO fallbacks and the relative
+    /// shortcuts `-Nh` / `-Nm`. Binary-searches the source model
+    /// when no user sort is active; falls back to a linear proxy
+    /// scan otherwise. Lands on the first row at or after the
+    /// requested time via `SelectSourceRow`, or surfaces a
+    /// status-bar hint when no such row exists.
+    void GotoTimestamp();
+
+    /// Pure helper for `GotoTimestamp`; returns epoch microseconds
+    /// on success. Tries the relative shortcut `^-\s*(\d+)\s*([hm])\s*$`
+    /// first (case-insensitive, evaluated against @p now), then each
+    /// entry of @p columnParseFormats via `loglib::TryParseTimestamp`,
+    /// then the two ISO fallbacks `"%FT%T"` and `"%F %T"`. Returns
+    /// `std::nullopt` on failure. Kept out of any class member state
+    /// so unit tests can drive it without a `MainWindow` instance.
+    [[nodiscard]] static std::optional<int64_t> ParseGotoTimestampInput(
+        const QString &input,
+        const std::vector<std::string> &columnParseFormats,
+        std::chrono::system_clock::time_point now
+    );
+
+    /// Locate the first row whose timestamp on @p timeCol is at or
+    /// after @p targetMicros. Uses an in-place binary search over
+    /// the source model when no user sort is active
+    /// (`LogFilterModel::SortColumn() < 0`); falls back to a linear
+    /// scan over the visible proxy rows otherwise so the "first"
+    /// row honours the user's chosen display order (see ROADMAP
+    /// item 8). Returns the source-model row index, or `-1` when
+    /// no live row qualifies. Rows with an unpromoted / missing
+    /// timestamp sort as `-inf` (keeps the binary search partition
+    /// monotonic and prevents the linear scan from ever picking
+    /// them as "first at or after"). Public so tests can exercise
+    /// both search branches without popping the modal.
+    [[nodiscard]] int FindFirstRowAtOrAfter(int timeCol, int64_t targetMicros) const;
+
     /// Jump the table to the first row in histogram bucket
     /// @p bucketIndex. Wired to `HistogramDock::bucketClicked`.
     void JumpToFirstRowInBucket(std::size_t bucketIndex);

--- a/app/include/main_window.hpp
+++ b/app/include/main_window.hpp
@@ -21,11 +21,8 @@
 #include <loglib/stop_token.hpp>
 #include <loglib/theme.hpp>
 
-// `ParseGotoTimestampInput` takes an optional display time zone so
-// callers can convert naive absolute inputs (`YYYY-MM-DD HH:MM:SS`)
-// from the user's wall-clock frame into UTC micros comparable with
-// the table's stored timestamps. Forward declared to avoid pulling
-// `<date/tz.h>` into every translation unit that includes this header.
+// Forward-declared so this header does not pull in `<date/tz.h>`
+// just for the Goto Timestamp helpers' zone argument.
 namespace date
 {
 class time_zone;
@@ -385,112 +382,78 @@ public:
     /// note). Used by the Anchors dock for jump targets.
     void SelectSourceRow(int sourceRow);
 
-    /// Pop the "Go to Line..." modal (`actionGotoLine`, `Ctrl+G`).
-    /// Line numbers are 1-based over the source model as it exists
-    /// now: line 1 is the earliest row currently retained (streaming
-    /// FIFO eviction may have dropped older rows, so line numbers
-    /// are **not** guaranteed to match the source file's line
-    /// numbering). Newest-first display reversal only affects
-    /// rendering, not the number the user types. Invalid input /
-    /// no active model surfaces a status-bar hint; a valid row hands
-    /// off to `SelectSourceRow`.
-    ///
-    /// Post-dialog work is factored into `ExecuteGotoLine` so tests
-    /// (and any future non-modal entry) can drive it without a
-    /// blocking `QInputDialog::exec`.
+    /// Pop the "Go to Line..." modal (`Ctrl+G`). Line numbers are
+    /// 1-based over the source model as it currently is; line 1 is
+    /// always the earliest retained row (streaming FIFO eviction
+    /// may have dropped older rows, so numbers need not match the
+    /// source file's numbering). Newest-first display reversal only
+    /// affects rendering, not the number the user types. Rejects
+    /// and status-bar-hints on any error; a valid row hands off to
+    /// `SelectSourceRow`. Post-dialog work lives in
+    /// `ExecuteGotoLine` so tests can drive it without a modal.
     void GotoLine();
 
-    /// Pop the "Go to Timestamp..." modal (`actionGotoTimestamp`,
-    /// `Ctrl+Shift+G`). Accepts the current time column's own
-    /// `parseFormats` plus two ISO fallbacks and the relative
-    /// shortcuts `-Nh` / `-Nm`. Naive absolute inputs (no `%z` /
-    /// `%Z` in the winning format) are interpreted in the table's
-    /// display time zone (`loglib::CurrentZone()`) and shifted to
-    /// UTC before the search. Binary-searches the source model in
-    /// file order when no user sort is active (also respects the
-    /// active row filter), and falls back to a linear scan over
-    /// visible proxy rows otherwise so the "first" row honours the
-    /// user's chosen display order. Lands via `SelectSourceRow`, or
-    /// surfaces a status-bar hint when no such row exists.
+    /// Pop the "Go to Timestamp..." modal (`Ctrl+Shift+G`). Accepts
+    /// the current time column's `parseFormats`, two ISO fallbacks
+    /// (`%FT%T`, `%F %T`), and the relative shortcuts `-Nh` /
+    /// `-Nm`. Naive inputs (no `%z` / `%Z` in the winning format)
+    /// are shifted from the table's display time zone
+    /// (`loglib::CurrentZone()`) to UTC before the search. Lands
+    /// on the first matching row via `FindFirstRowAtOrAfter` +
+    /// `SelectSourceRow`, or status-bar-hints if none qualifies.
     void GotoTimestamp();
 
-    /// Result of `ParseGotoTimestampInput`.
-    ///
-    /// `micros` is epoch microseconds. `isNaive` is `true` when the
-    /// winning format lacked a `%z` / `%Ez` / `%Z` specifier so the
-    /// value should be interpreted in the caller's display time zone
-    /// before comparing against stored (UTC-normalised) timestamps.
-    /// The relative shortcut path returns `isNaive == false` because
-    /// it derives `micros` from a `std::chrono::system_clock::time_point`
-    /// which is already UTC.
+    /// Result of `ParseGotoTimestampInput`. `micros` is epoch
+    /// microseconds; `isNaive` is true when the winning format had
+    /// no zone specifier (`%z` / `%Ez` / `%Z`) and the caller must
+    /// therefore shift `micros` through the display TZ before
+    /// comparing against stored (UTC-normalised) timestamps. The
+    /// relative-shortcut path always returns `isNaive == false`
+    /// since it derives from `system_clock::now()` (already UTC).
     struct GotoTimestampParse
     {
         int64_t micros = 0;
         bool isNaive = false;
     };
 
-    /// Pure helper for `GotoTimestamp`. Tries the relative shortcut
-    /// `^[+-]?\s*(\d+)\s*([hm])\s*$` first (case-insensitive; the
-    /// `+` / no-sign variants also mean "N units ago" for parity
-    /// with lnav / less), then each entry of @p columnParseFormats
-    /// via `loglib::TryParseTimestamp`, then the two ISO fallbacks
-    /// `"%FT%T"` and `"%F %T"`. When @p displayZone is non-null and
-    /// the winning format is naive, the returned `micros` is *not*
-    /// pre-shifted -- callers apply the shift via
-    /// `loglib::LocalMicrosecondsSinceEpochToUtc` after inspecting
-    /// `isNaive`. Overflow in the relative shortcut (`-Nh` /
-    /// `-Nm` with an `N` that would overrun `int64_t` microseconds)
-    /// returns `std::nullopt` rather than wrapping. Kept out of any
-    /// class member state so unit tests can drive it without a
-    /// `MainWindow` instance.
+    /// Pure parser for `GotoTimestamp`. Tries, in order: the
+    /// relative shortcut `^[+-]?\s*(\d+)\s*([hm])\s*$` (case-
+    /// insensitive; `+` / no-sign also mean "N units ago", matching
+    /// lnav / less); each entry of @p columnParseFormats via
+    /// `loglib::TryParseTimestamp`; the ISO fallbacks `%FT%T` and
+    /// `%F %T`. Returns `std::nullopt` on no match or on relative-
+    /// shortcut overflow (silent wrap would jump the user forward,
+    /// which is worse than a hint). Static so unit tests can drive
+    /// it without a `MainWindow` instance.
     [[nodiscard]] static std::optional<GotoTimestampParse> ParseGotoTimestampInput(
         const QString &input,
         const std::vector<std::string> &columnParseFormats,
         std::chrono::system_clock::time_point now
     );
 
-    /// Locate the first row whose timestamp on @p timeCol is at or
-    /// after @p targetMicros **and** is currently visible through
-    /// the outer proxy (respects the active row filter).
+    /// First row whose timestamp on @p timeCol is `>= targetMicros`
+    /// AND is currently visible through the outer proxy (respects
+    /// the active row filter). Returns the source-model row index
+    /// or `-1` when nothing qualifies.
     ///
-    /// Three internal branches, one for each interesting combination
-    /// of (user-sort, monotonicity):
+    /// Three branches, picked from (user-sort, monotonicity):
     ///
-    /// * **Fast path** -- no user sort AND
-    ///   `LogModel::TimestampsAreMonotonic()`. Binary-searches
-    ///   source rows in file order (O(log N)), tolerating
-    ///   interleaved missing / unpromoted timestamps by skipping
-    ///   forward during each probe. After the search returns a
-    ///   candidate row `lo`, the visibility check runs against `lo`
-    ///   directly (happy path: O(1)); on a miss it walks the
-    ///   *outer proxy* -- not the source -- to find the smallest
-    ///   visible source row `>= lo` with a valid ts, yielding
-    ///   O(N_visible) worst case rather than O(N_source). This
-    ///   matters when a heavy filter hides most of the tail: the
-    ///   old source-walk was O(10M) on a 10M-row file with a
-    ///   1-in-a-million filter, well past the ROADMAP `< 100 ms`
-    ///   budget.
+    /// * **Fast path** -- no user sort, `TimestampsAreMonotonic()`
+    ///   true. Binary-search source rows (O(log N)); on a filter
+    ///   miss, walk the outer proxy for the smallest visible row
+    ///   with a valid ts `>= lo` (O(N_visible) worst case, not
+    ///   O(N_source)). Missing timestamps are skipped, not
+    ///   `-inf`-treated.
+    /// * **Non-monotonic path** -- no user sort, monotonicity
+    ///   false (multi-file `Append`, rotation, clock skew). Walk
+    ///   the outer proxy and pick the visible row with the
+    ///   smallest ts satisfying `>= target` (chronologically
+    ///   earliest match).
+    /// * **User-sort path** -- header sort active. Linear scan in
+    ///   display order and return the first proxy row whose source
+    ///   ts qualifies, so "first" honours the user's sort.
     ///
-    /// * **Non-monotonic path** -- no user sort AND
-    ///   `TimestampsAreMonotonic()` is false (multi-file `Append`,
-    ///   rotation, clock skew). The binary search would silently
-    ///   return a wrong row, so we fall back to an O(N_visible)
-    ///   walk over the outer proxy and pick the visible row with
-    ///   the SMALLEST ts that still satisfies `ts >= target` --
-    ///   the chronologically earliest match. Monotonicity is
-    ///   tracked cheaply on the streaming path
-    ///   (`LogModel::UpdateTimestampMonotonicity`); no per-call
-    ///   scan is required to decide which branch to take.
-    ///
-    /// * **User-sort path** -- user has clicked a header. Linear
-    ///   scan over visible proxy rows in display order and return
-    ///   the first row whose source ts qualifies, so "first"
-    ///   honours the user's chosen sort direction (see ROADMAP
-    ///   item 8).
-    ///
-    /// Returns the source-model row index, or `-1` when no live
-    /// row qualifies. Public so tests can exercise all three
-    /// branches without popping the modal.
+    /// Public so tests can drive all three branches directly.
     [[nodiscard]] int FindFirstRowAtOrAfter(int timeCol, int64_t targetMicros) const;
 
     /// Jump the table to the first row in histogram bucket
@@ -639,34 +602,25 @@ public:
     bool SubmitAnchorNoteForRowForTest(int sourceRow, const QString &note);
 
     /// Test seam replaying the post-`exec` body of `GotoLine`
-    /// without a modal `QInputDialog`. @p input is the raw text
-    /// value the dialog would have returned. Lets tests drive both
-    /// the current-row-count range check (shrink-while-modal-open
-    /// simulation: pass a line > `mModel->rowCount()`) and the
-    /// filter-visibility hint without popping a dialog.
+    /// without a modal dialog. Lets tests drive the range check
+    /// (shrink-while-modal-open simulation: pass a line larger
+    /// than the current row count) and the filter-visibility hint.
     void ExecuteGotoLineForTest(const QString &input);
 
     /// Test seam replaying the post-`exec` body of `GotoTimestamp`
-    /// without a modal `QInputDialog`. @p input is the raw text
-    /// value the dialog would have returned; @p now pins the clock
-    /// so relative shortcuts (`-1h`) are deterministic. Exercises
-    /// the naive-vs-zoned dispatch, the `mLastGotoTimestampInput`
-    /// sticky-input update, the "no time column" / "could not
-    /// parse" hints, and the `FindFirstRowAtOrAfter` handoff --
-    /// none of which are reachable through `ParseGotoTimestampInput`
-    /// alone.
+    /// without a modal dialog. @p now pins the clock so relative
+    /// shortcuts (`-1h`) are deterministic. Covers the sticky-
+    /// input update, error hints, and `FindFirstRowAtOrAfter`
+    /// handoff -- none reachable through `ParseGotoTimestampInput`.
     void ExecuteGotoTimestampForTest(const QString &input, std::chrono::system_clock::time_point now);
 
     /// Test-only accessor for the sticky Goto Timestamp input so
-    /// the session-boundary clear (`NewSession()` -> `.clear()`)
-    /// can be pinned end-to-end.
+    /// tests can pin the session-boundary clear.
     [[nodiscard]] QString LastGotoTimestampInputForTest() const;
 
-    /// Test seam: force `LogModel::TimestampsAreMonotonic()` to
-    /// return false so `FindFirstRowAtOrAfter` takes the non-
-    /// monotonic branch even in fixtures where the streaming
-    /// path's guard has not observed an inversion. Idempotent;
-    /// no way back once tripped (mirrors production semantics).
+    /// Test seam: force `LogModel::TimestampsAreMonotonic()` false
+    /// so `FindFirstRowAtOrAfter` takes its non-monotonic branch
+    /// without a real inversion. Irreversible.
     void ForceTimestampsNonMonotonicForTest();
 #endif
 
@@ -904,28 +858,18 @@ private:
     /// No-op if model, theme, or anchor manager is missing.
     void AppendAnchorActionsToRowMenu(QMenu *menu, int sourceRow);
 
-    /// Shared post-`exec` body of `GotoLine`. Given the raw text @p
-    /// input the dialog collected, validates against the *current*
-    /// `mModel->rowCount()` (so a shrink between open and accept --
-    /// FIFO eviction, session swap -- is caught rather than trusted
-    /// to the stale `QIntValidator` range), then probes filter
-    /// visibility, then hands off to `SelectSourceRow`. Emits the
-    /// user-facing status hint for every rejection branch. Kept
-    /// separate from the modal-owning slot so tests can drive both
-    /// branches through `ExecuteGotoLineForTest`.
+    /// Shared post-`exec` body of `GotoLine`. Re-checks the live
+    /// row count (catches a shrink while the modal was open),
+    /// probes filter visibility, then hands off to
+    /// `SelectSourceRow`. Emits a status hint on every rejection.
     void ExecuteGotoLine(const QString &input);
 
-    /// Shared post-`exec` body of `GotoTimestamp`. Given the raw
-    /// text @p input the dialog collected and @p now (pinned by
-    /// tests, `system_clock::now()` in production), updates the
-    /// sticky-input mirror, invokes `ParseGotoTimestampInput`,
-    /// shifts naive results through `LocalMicrosecondsSinceEpochToUtc`,
-    /// then hands off to `FindFirstRowAtOrAfter` + `SelectSourceRow`.
-    /// Emits the user-facing status hint for every rejection
-    /// branch. Kept separate from the modal-owning slot so tests
-    /// can drive naive-vs-zoned dispatch and the various error
-    /// branches through `ExecuteGotoTimestampForTest` without
-    /// popping a dialog.
+    /// Shared post-`exec` body of `GotoTimestamp`. Updates the
+    /// sticky-input mirror, parses via `ParseGotoTimestampInput`,
+    /// shifts naive results through
+    /// `LocalMicrosecondsSinceEpochToUtc`, then hands off to
+    /// `FindFirstRowAtOrAfter` + `SelectSourceRow`. @p now is
+    /// pinned in tests, `system_clock::now()` in production.
     void ExecuteGotoTimestamp(const QString &input, std::chrono::system_clock::time_point now);
 
     /// Logical index of the column whose `keys` match @p keys, or
@@ -1861,21 +1805,16 @@ private:
     /// its rebuild and the queued re-entry becomes a no-op.
     bool mApplyingEnumRebuild = false;
 
-    /// Last text the user typed into the Goto Timestamp dialog,
-    /// pre-populated on the next open. Users often want to jump
-    /// several times around the same instant; making the dialog
-    /// remember the last input saves the retype. Cleared on
-    /// session switch to avoid leaking a stale reference from a
-    /// closed file into a fresh one.
+    /// Last text typed into the Goto Timestamp dialog, pre-
+    /// populated on the next open so successive jumps around the
+    /// same instant do not need retyping. Cleared on session
+    /// switch to avoid leaking a stale reference into a new file.
     QString mLastGotoTimestampInput;
 
-    /// Last text the user typed into the Goto Line dialog. Same
-    /// UX rationale as `mLastGotoTimestampInput`: users walking a
-    /// stack trace or diffing two runs re-open the dialog with an
-    /// adjacent line number, and retyping is friction. Cleared on
-    /// session switch alongside the timestamp mirror; validated
-    /// against the *current* row count on re-open so an out-of-
-    /// range carry-over from a smaller session no longer applies.
+    /// Last text typed into the Goto Line dialog. Same UX
+    /// rationale as `mLastGotoTimestampInput`. Cleared on session
+    /// switch; re-validated against the current row count on open
+    /// so a carry-over from a larger session no longer applies.
     QString mLastGotoLineInput;
 
     /// Latch: a loaded session's sort is pending, to be applied

--- a/app/src/log_model.cpp
+++ b/app/src/log_model.cpp
@@ -13,6 +13,8 @@
 #include <loglib/line_source.hpp>
 #include <loglib/log_configuration.hpp>
 #include <loglib/log_parse_sink.hpp>
+#include <loglib/log_processing.hpp>
+#include <loglib/log_value.hpp>
 #include <loglib/parser_options.hpp>
 #include <loglib/parsers/json_parser.hpp>
 #include <loglib/stream_line_source.hpp>
@@ -37,6 +39,8 @@
 
 #include <algorithm>
 #include <cstddef>
+#include <cstdint>
+#include <limits>
 #include <memory>
 #include <optional>
 #include <string>
@@ -176,6 +180,11 @@ void LogModel::TeardownStreamingSessionInternal(bool resetTable)
         mErrorCount = 0;
         mStreamingErrors.clear();
         mLastReportedShutdownDropCount = 0;
+        // Wipe the Goto Timestamp fast-path guards so a fresh
+        // session doesn't inherit a previous session's "non-
+        // monotonic" verdict or its last-seen timestamp reference.
+        mTimestampsMonotonic = true;
+        mLastAppendedTimestampMicros.reset();
         // Drop the per-batch capture alongside the table's rank cache
         // so the next session doesn't see stale demote mappings.
         mLastBatchLevelDemoteMapping.clear();
@@ -238,6 +247,11 @@ void LogModel::BeginStreamingShared(std::unique_ptr<loglib::LineSource> source)
     mErrorCount = 0;
     mStreamingErrors.clear();
     mLastReportedShutdownDropCount = 0;
+    // Fresh session: reset the Goto Timestamp fast-path guards so
+    // a prior session's "non-monotonic" verdict doesn't leak into
+    // a fresh (potentially well-ordered) log.
+    mTimestampsMonotonic = true;
+    mLastAppendedTimestampMicros.reset();
 
     // Every new session starts unbounded. Live-tail re-applies its
     // retention cap after returning; static paths leave it at 0.
@@ -614,6 +628,16 @@ void LogModel::AppendBatch(loglib::StreamedBatch batch)
     }
 
     mLogTable.AppendBatch(std::move(batch));
+
+    // Cheap monotonicity guard for the Goto Timestamp fast path:
+    // scan the just-inserted rows' timestamp column for a
+    // batch-boundary or intra-batch inversion. Piggybacks on the
+    // O(N_batch) work the append already did. Skipped once the flag
+    // has already flipped false -- it's irreversible for the session.
+    if (rowsGrew)
+    {
+        UpdateTimestampMonotonicity(currentRowCount, static_cast<int>(mLogTable.RowCount()));
+    }
 
     // Defensive: today batches only add rows, but a future source-
     // bearing batch path must still see a warm cache.
@@ -2145,6 +2169,85 @@ void LogModel::SetRetentionCap(size_t cap)
 size_t LogModel::RetentionCap() const noexcept
 {
     return mRetentionCap;
+}
+
+bool LogModel::TimestampsAreMonotonic() const noexcept
+{
+    return mTimestampsMonotonic;
+}
+
+void LogModel::SetTimestampsMonotonicForTest(bool monotonic) noexcept
+{
+    mTimestampsMonotonic = monotonic;
+}
+
+void LogModel::UpdateTimestampMonotonicity(int firstNewRow, int endNewRow)
+{
+    // Early-exit branches ordered cheapest-first so the common
+    // "already flipped" / "no time column" cases pay nothing per
+    // batch. `mTimestampsMonotonic` is intentionally irreversible
+    // -- there is no cheap heal path, and the fast-path caller
+    // degrades to O(N_visible) proxy iteration for the remainder
+    // of the session (see `TimestampsAreMonotonic` doc).
+    if (!mTimestampsMonotonic)
+    {
+        return;
+    }
+    if (firstNewRow >= endNewRow)
+    {
+        return;
+    }
+    const int timeCol = loglib::FirstTimeColumnIndex(Configuration());
+    if (timeCol < 0)
+    {
+        return;
+    }
+
+    // Single pass: track a running max of valid ts values in the
+    // batch (catches intra-batch inversions) AND compare the first
+    // valid ts to `mLastAppendedTimestampMicros` (catches
+    // batch-boundary inversions -- multi-file `Append`, rotation,
+    // clock skew). Missing-ts rows are ignored rather than treated
+    // as `-inf`; a batch of all-missing rows leaves the tracker
+    // unchanged so the next batch compares against the same
+    // reference point. Bails out early on the first violation
+    // because a single inversion is terminal.
+    const auto colIdx = static_cast<std::size_t>(timeCol);
+    std::optional<int64_t> lastValidInBatch;
+    int64_t runningMax = std::numeric_limits<int64_t>::min();
+    for (int row = firstNewRow; row < endNewRow; ++row)
+    {
+        const auto ts = loglib::AsEpochMicroseconds(mLogTable.GetValue(static_cast<std::size_t>(row), colIdx));
+        if (!ts.has_value())
+        {
+            continue;
+        }
+        if (!lastValidInBatch.has_value())
+        {
+            // First valid ts -- do the batch-boundary check now,
+            // before the running max absorbs it.
+            if (mLastAppendedTimestampMicros.has_value() && *ts < *mLastAppendedTimestampMicros)
+            {
+                mTimestampsMonotonic = false;
+                mLastAppendedTimestampMicros = *ts;
+                return;
+            }
+        }
+        else if (*ts < runningMax)
+        {
+            // Intra-batch inversion.
+            mTimestampsMonotonic = false;
+            mLastAppendedTimestampMicros = *ts;
+            return;
+        }
+        runningMax = *ts;
+        lastValidInBatch = *ts;
+    }
+
+    if (lastValidInBatch.has_value())
+    {
+        mLastAppendedTimestampMicros = *lastValidInBatch;
+    }
 }
 
 QString LogModel::ConvertToSingleLineCompactQString(std::string_view bytes)

--- a/app/src/log_model.cpp
+++ b/app/src/log_model.cpp
@@ -180,9 +180,8 @@ void LogModel::TeardownStreamingSessionInternal(bool resetTable)
         mErrorCount = 0;
         mStreamingErrors.clear();
         mLastReportedShutdownDropCount = 0;
-        // Wipe the Goto Timestamp fast-path guards so a fresh
-        // session doesn't inherit a previous session's "non-
-        // monotonic" verdict or its last-seen timestamp reference.
+        // Reset the Goto Timestamp fast-path guards so a fresh
+        // session does not inherit a prior "non-monotonic" verdict.
         mTimestampsMonotonic = true;
         mLastAppendedTimestampMicros.reset();
         // Drop the per-batch capture alongside the table's rank cache
@@ -247,9 +246,8 @@ void LogModel::BeginStreamingShared(std::unique_ptr<loglib::LineSource> source)
     mErrorCount = 0;
     mStreamingErrors.clear();
     mLastReportedShutdownDropCount = 0;
-    // Fresh session: reset the Goto Timestamp fast-path guards so
-    // a prior session's "non-monotonic" verdict doesn't leak into
-    // a fresh (potentially well-ordered) log.
+    // Reset the Goto Timestamp fast-path guards -- see the
+    // matching block in `TeardownStreamingSessionInternal`.
     mTimestampsMonotonic = true;
     mLastAppendedTimestampMicros.reset();
 
@@ -629,11 +627,9 @@ void LogModel::AppendBatch(loglib::StreamedBatch batch)
 
     mLogTable.AppendBatch(std::move(batch));
 
-    // Cheap monotonicity guard for the Goto Timestamp fast path:
-    // scan the just-inserted rows' timestamp column for a
-    // batch-boundary or intra-batch inversion. Piggybacks on the
-    // O(N_batch) work the append already did. Skipped once the flag
-    // has already flipped false -- it's irreversible for the session.
+    // Monotonicity guard for the Goto Timestamp fast path. Cheap
+    // (piggybacks on the O(N_batch) append) and no-op once the
+    // flag has already flipped false.
     if (rowsGrew)
     {
         UpdateTimestampMonotonicity(currentRowCount, static_cast<int>(mLogTable.RowCount()));
@@ -2183,12 +2179,8 @@ void LogModel::SetTimestampsMonotonicForTest(bool monotonic) noexcept
 
 void LogModel::UpdateTimestampMonotonicity(int firstNewRow, int endNewRow)
 {
-    // Early-exit branches ordered cheapest-first so the common
-    // "already flipped" / "no time column" cases pay nothing per
-    // batch. `mTimestampsMonotonic` is intentionally irreversible
-    // -- there is no cheap heal path, and the fast-path caller
-    // degrades to O(N_visible) proxy iteration for the remainder
-    // of the session (see `TimestampsAreMonotonic` doc).
+    // Cheapest guards first so the common "already flipped" / "no
+    // time column" paths add nothing per batch.
     if (!mTimestampsMonotonic)
     {
         return;
@@ -2203,15 +2195,12 @@ void LogModel::UpdateTimestampMonotonicity(int firstNewRow, int endNewRow)
         return;
     }
 
-    // Single pass: track a running max of valid ts values in the
-    // batch (catches intra-batch inversions) AND compare the first
-    // valid ts to `mLastAppendedTimestampMicros` (catches
-    // batch-boundary inversions -- multi-file `Append`, rotation,
-    // clock skew). Missing-ts rows are ignored rather than treated
-    // as `-inf`; a batch of all-missing rows leaves the tracker
-    // unchanged so the next batch compares against the same
-    // reference point. Bails out early on the first violation
-    // because a single inversion is terminal.
+    // Single pass over the new rows: `runningMax` catches intra-
+    // batch inversions; the first valid ts is compared against
+    // `mLastAppendedTimestampMicros` for the boundary case.
+    // Missing-ts rows are skipped (a batch of all-missing rows
+    // leaves the tracker untouched). One inversion is terminal, so
+    // we bail out immediately.
     const auto colIdx = static_cast<std::size_t>(timeCol);
     std::optional<int64_t> lastValidInBatch;
     int64_t runningMax = std::numeric_limits<int64_t>::min();
@@ -2224,8 +2213,8 @@ void LogModel::UpdateTimestampMonotonicity(int firstNewRow, int endNewRow)
         }
         if (!lastValidInBatch.has_value())
         {
-            // First valid ts -- do the batch-boundary check now,
-            // before the running max absorbs it.
+            // Boundary check on the first valid ts, before
+            // `runningMax` absorbs it.
             if (mLastAppendedTimestampMicros.has_value() && *ts < *mLastAppendedTimestampMicros)
             {
                 mTimestampsMonotonic = false;
@@ -2235,7 +2224,6 @@ void LogModel::UpdateTimestampMonotonicity(int firstNewRow, int endNewRow)
         }
         else if (*ts < runningMax)
         {
-            // Intra-batch inversion.
             mTimestampsMonotonic = false;
             mLastAppendedTimestampMicros = *ts;
             return;

--- a/app/src/log_model.cpp
+++ b/app/src/log_model.cpp
@@ -2218,23 +2218,23 @@ void LogModel::UpdateTimestampMonotonicity(int firstNewRow, int endNewRow)
             if (mLastAppendedTimestampMicros.has_value() && *ts < *mLastAppendedTimestampMicros)
             {
                 mTimestampsMonotonic = false;
-                mLastAppendedTimestampMicros = *ts;
+                mLastAppendedTimestampMicros = ts;
                 return;
             }
         }
         else if (*ts < runningMax)
         {
             mTimestampsMonotonic = false;
-            mLastAppendedTimestampMicros = *ts;
+            mLastAppendedTimestampMicros = ts;
             return;
         }
         runningMax = *ts;
-        lastValidInBatch = *ts;
+        lastValidInBatch = ts;
     }
 
     if (lastValidInBatch.has_value())
     {
-        mLastAppendedTimestampMicros = *lastValidInBatch;
+        mLastAppendedTimestampMicros = lastValidInBatch;
     }
 }
 

--- a/app/src/main_window.cpp
+++ b/app/src/main_window.cpp
@@ -6574,7 +6574,7 @@ std::optional<MainWindow::GotoTimestampParse> MainWindow::ParseGotoTimestampInpu
             std::chrono::duration_cast<std::chrono::microseconds>(now.time_since_epoch()).count();
         // `nowMicros` is >= 0 for post-1970 clocks; subtraction of a
         // non-negative bounded `offsetMicros` cannot overflow.
-        return GotoTimestampParse{nowMicros - offsetMicros, /*isNaive=*/false};
+        return GotoTimestampParse{.micros = nowMicros - offsetMicros, .isNaive = false};
     }
 
     // Absolute path: try every parse format the column itself
@@ -6602,7 +6602,9 @@ std::optional<MainWindow::GotoTimestampParse> MainWindow::ParseGotoTimestampInpu
         loglib::TimeStamp parsed{};
         if (loglib::TryParseTimestamp(stdInput, fmt, loglib::ClassifyTimestampFormat(fmt), scratch, parsed))
         {
-            return GotoTimestampParse{parsed.time_since_epoch().count(), /*isNaive=*/!FormatHasZoneSpecifier(fmt)};
+            return GotoTimestampParse{
+                .micros = parsed.time_since_epoch().count(),
+                .isNaive = !FormatHasZoneSpecifier(fmt)};
         }
     }
     return std::nullopt;

--- a/app/src/main_window.cpp
+++ b/app/src/main_window.cpp
@@ -932,8 +932,8 @@ MainWindow::MainWindow(
     ui->actionFind->setToolTip(tr("Find in logs. Press again to close."));
     connect(ui->actionFind, &QAction::triggered, this, &MainWindow::Find);
 
-    // Goto Line / Goto Timestamp. Both actions live in the Edit
-    // menu (`Ctrl+G` and `Ctrl+Shift+G`); see item 8 in `ROADMAP.md`.
+    // Goto Line / Goto Timestamp actions (Edit menu; `Ctrl+G`
+    // and `Ctrl+Shift+G`).
     connect(ui->actionGotoLine, &QAction::triggered, this, &MainWindow::GotoLine);
     connect(ui->actionGotoTimestamp, &QAction::triggered, this, &MainWindow::GotoTimestamp);
 
@@ -2416,12 +2416,10 @@ void MainWindow::NewSession()
     mPendingDecompressionErrors.clear();
     // The configuration that requested the deferred sort is gone.
     mPendingApplySortFromConfig = false;
-    // Drop the "last Goto Timestamp input" carry-over: a
-    // string that made sense in the outgoing session's zone /
-    // format can be nonsense in the new one, and pre-populating
-    // a fresh dialog with it would just annoy the user.
-    // Same rationale for the Goto Line mirror: a valid line
-    // number in a 10M-row log is out-of-range in an empty one.
+    // Drop the Goto Timestamp / Goto Line sticky inputs: a value
+    // that made sense in the outgoing session (zone, format, row
+    // count) can be nonsense in a new one, and pre-populating the
+    // dialog with it just annoys the user.
     mLastGotoTimestampInput.clear();
     mLastGotoLineInput.clear();
     // Drop the pinned uuid + open-windows membership so the next
@@ -6361,30 +6359,19 @@ void MainWindow::GotoLine()
 
     const int rowCount = mModel->rowCount();
 
-    // Instantiated `QInputDialog` (not the static `getInt` helper)
-    // so we can attach a `QIntValidator` to the line edit and lean
-    // on Qt's built-in accept-blocking rather than re-validating
-    // after `exec`. Range is 1..rowCount; lines are 1-based for
-    // parity with every editor's "Go to Line" dialog. `QIntValidator`
-    // parses without a group separator by default, so the label
-    // uses `QString::number` (also separator-free) rather than
-    // `QLocale::system().toString(...)` -- the two would otherwise
-    // disagree in locales like `en_US` that group with commas,
-    // presenting the user with a range they cannot actually type.
+    // A `QInputDialog` (rather than the static `getInt` helper) so
+    // we can attach a `QIntValidator` and lean on Qt's accept-
+    // blocking instead of re-validating after `exec`. The label
+    // uses `QString::number` (not `QLocale`) to match the
+    // validator, which has no group separator -- otherwise `en_US`
+    // shows commas in a range the user cannot actually type.
     QInputDialog dialog(this);
     dialog.setWindowTitle(tr("Go to Line"));
-    // Semantics reminder alongside the range: with newest-first
-    // display active, "line 1" is still the earliest row (the one
-    // at the bottom of the visible list), not the top. See
-    // `GotoLine` docstring; also spelled out in the `.ui` tooltip.
+    // Reminder: with newest-first display active, "line 1" is
+    // still the earliest row (bottom of the list), not the top.
     dialog.setLabelText(tr("Line number (1 = earliest row; 1 - %1):").arg(QString::number(rowCount)));
     dialog.setInputMode(QInputDialog::TextInput);
     dialog.setTextEchoMode(QLineEdit::Normal);
-    // Pre-populate with the previous input so a user walking a
-    // stack trace doesn't retype every line number. Clamped to
-    // the current row range because a value that was in-range in
-    // a prior session can be out-of-range now. Cleared on session
-    // switch (see `mLastGotoLineInput`).
     if (!mLastGotoLineInput.isEmpty())
     {
         dialog.setTextValue(mLastGotoLineInput);
@@ -6393,8 +6380,6 @@ void MainWindow::GotoLine()
     {
         editor->setValidator(new QIntValidator(1, rowCount, &dialog));
         editor->setPlaceholderText(tr("e.g. 12345"));
-        // `selectAll` on the pre-populated text lets the user
-        // overwrite by typing, matching the `GotoTimestamp` UX.
         editor->selectAll();
     }
     if (dialog.exec() != QDialog::Accepted)
@@ -6409,13 +6394,9 @@ void MainWindow::GotoLine()
 
 void MainWindow::ExecuteGotoLine(const QString &input)
 {
-    // Re-read `rowCount` here (not before the modal) so a shrink
-    // while the dialog was open -- streaming FIFO eviction, session
-    // swap -- is reflected in both the range check and the error
-    // hint. Using a stale captured value would (a) let an evicted
-    // line pass the check and land on the misleading generic
-    // `SelectSourceRow` hint, and (b) show the user a range that
-    // no longer exists.
+    // Read `rowCount` live (not captured before the modal) so a
+    // shrink while the dialog was open -- FIFO eviction or session
+    // swap -- is reflected in both the range check and the hint.
     if (mModel == nullptr || mSortFilterProxyModel == nullptr || mRowOrderProxyModel == nullptr)
     {
         statusBar()->showMessage(tr("No log loaded."), STATUS_BAR_MESSAGE_TIMEOUT_MS);
@@ -6439,14 +6420,9 @@ void MainWindow::ExecuteGotoLine(const QString &input)
         return;
     }
 
-    // `SelectSourceRow` prints a generic "Row is not currently
-    // visible" hint when the target is filtered out; the caller
-    // knows more context (this is a Goto Line jump, not an anchor
-    // seek), so front-run a filter-visibility probe and print the
-    // more specific message before deferring. Safe now that the
-    // range check above guarantees `sourceRow` is in-model, so an
-    // invalid `mapFromSource` result really does mean "filter",
-    // not "evicted".
+    // Print the caller-specific "filtered out" hint before
+    // deferring to `SelectSourceRow`, which would otherwise show
+    // the generic "Row is not currently visible" fallback.
     const int sourceRow = oneBased - 1;
     const QModelIndex sourceIdx = mModel->index(sourceRow, 0);
     const QModelIndex midIdx = mRowOrderProxyModel->mapFromSource(sourceIdx);
@@ -6466,21 +6442,13 @@ void MainWindow::ExecuteGotoLine(const QString &input)
 namespace
 {
 
-/// True if @p fmt contains a `date::parse` zone specifier -- `%z`,
-/// `%Z`, `%Ez`, or `%Oz` -- so a successful parse produces a
-/// UTC-normalised value that must NOT be TZ-shifted again.
-/// `%%` is treated as a literal percent (not the start of a
-/// specifier), so `"%%z"` in a format string does NOT register.
-/// Kept adjacent to `ParseGotoTimestampInput` because that is its
-/// only caller.
-///
-/// The scan advances one byte at a time on non-match branches
-/// (rather than skipping past the tentative specifier) so a
+/// True if @p fmt contains a `date::parse` zone specifier (`%z`,
+/// `%Z`, `%Ez`, `%Oz`); such a parse yields UTC and must NOT be
+/// TZ-shifted again. `%%` is a literal percent and does not
+/// register. On a non-match the scan only advances one byte so a
 /// malformed prefix like `"%E%z"` still detects the inner `%z`
-/// on a re-scan starting at the `%`. `date::parse` would reject
-/// such a format anyway, but a false negative here would flag
-/// the parsed value as naive and double-shift it downstream --
-/// worse than false-positive-recognising a bad format.
+/// (false negatives here would double-shift downstream, worse
+/// than false-positive-recognising a bad format).
 [[nodiscard]] bool FormatHasZoneSpecifier(std::string_view fmt) noexcept
 {
     for (std::size_t i = 0; i < fmt.size(); ++i)
@@ -6496,10 +6464,7 @@ namespace
         }
         if (fmt[next] == '%')
         {
-            // `%%` is a literal percent -- consume both and keep
-            // scanning. The outer `++i` moves past the first `%`;
-            // this `++i` moves past the second, so we resume at
-            // the byte after `%%`.
+            // `%%` is a literal percent; skip both bytes.
             ++i;
             continue;
         }
@@ -6512,11 +6477,8 @@ namespace
         {
             return true;
         }
-        // Fall through with only the outer `++i` moving forward
-        // one byte. Deliberately do NOT jump past `specifier`:
-        // that would swallow a subsequent `%z` in malformed
-        // formats like `"%E%z"`, producing the double-shift
-        // regression noted in the comment above.
+        // Only the outer `++i` advances; jumping past `specifier`
+        // would miss a `%z` following a malformed `%E`.
     }
     return false;
 }
@@ -6535,14 +6497,10 @@ std::optional<MainWindow::GotoTimestampParse> MainWindow::ParseGotoTimestampInpu
         return std::nullopt;
     }
 
-    // Relative shortcut: `[+-]?N[hm]` (case-insensitive, whitespace-
-    // tolerant). All three sign variants (`-1h`, `+1h`, `1h`) mean
-    // "one hour before @p now" -- users almost never mean "an hour
-    // in the future" in a log viewer, and lnav / less resolve the
-    // ambiguity the same way. Evaluated against @p now so tests can
-    // pin the clock; production wires `system_clock::now()`.
-    // ROADMAP item 8 spells out `-Nh` / `-Nm` as the required units;
-    // seconds / days are left for future contributions.
+    // Relative shortcut `[+-]?N[hm]` (case-insensitive,
+    // whitespace-tolerant). All sign variants mean "N units before
+    // @p now" -- "the future" is meaningless in a log viewer, and
+    // lnav / less resolve the same way.
     static const QRegularExpression RELATIVE_SHORTCUT_RE(
         QStringLiteral(R"(^[+-]?\s*(\d+)\s*([hm])\s*$)"), QRegularExpression::CaseInsensitiveOption
     );
@@ -6556,11 +6514,8 @@ std::optional<MainWindow::GotoTimestampParse> MainWindow::ParseGotoTimestampInpu
             return std::nullopt;
         }
         const QChar unit = relMatch.captured(2).at(0).toLower();
-        // Overflow guard: cap `N` at whatever fits in `int64_t`
-        // microseconds for the chosen unit. Anything larger is
-        // rejected rather than wrapped -- silently subtracting a
-        // negative duration would jump the user forward in time
-        // rather than backward, which is worse than an error hint.
+        // Reject values that would overflow `int64_t` micros --
+        // wrapping silently would jump the user forward, not back.
         constexpr int64_t MICROS_PER_HOUR = 3'600LL * 1'000'000LL;
         constexpr int64_t MICROS_PER_MINUTE = 60LL * 1'000'000LL;
         const int64_t microsPerUnit = (unit == QLatin1Char('h')) ? MICROS_PER_HOUR : MICROS_PER_MINUTE;
@@ -6572,15 +6527,12 @@ std::optional<MainWindow::GotoTimestampParse> MainWindow::ParseGotoTimestampInpu
         const int64_t offsetMicros = static_cast<int64_t>(n) * microsPerUnit;
         const auto nowMicros =
             std::chrono::duration_cast<std::chrono::microseconds>(now.time_since_epoch()).count();
-        // `nowMicros` is >= 0 for post-1970 clocks; subtraction of a
-        // non-negative bounded `offsetMicros` cannot overflow.
         return GotoTimestampParse{.micros = nowMicros - offsetMicros, .isNaive = false};
     }
 
-    // Absolute path: try every parse format the column itself
-    // accepts, then two ISO fallbacks so a column with an empty
-    // `parseFormats` list (auto-detected `Type::Time`) still
-    // resolves the two forms users routinely paste.
+    // Absolute path: try the column's own `parseFormats` first,
+    // then two ISO fallbacks so columns with an empty format list
+    // (auto-detected `Type::Time`) still accept typical inputs.
     const std::string stdInput = trimmed.toStdString();
     std::vector<std::string> candidates;
     candidates.reserve(columnParseFormats.size() + 2);
@@ -6627,20 +6579,13 @@ void MainWindow::GotoTimestamp()
 
     QInputDialog dialog(this);
     dialog.setWindowTitle(tr("Go to Timestamp"));
-    // Label mentions "local time" so users understand that a bare
-    // `YYYY-MM-DD HH:MM:SS` (no offset) is interpreted in the
-    // display time zone, not UTC. The `parseFormats`-fed table
-    // already displays in local time; the dialog matches. Users
-    // who paste a raw `Z`-suffixed value from the file get the
-    // zoned parser branch (`%Ez` / `%Z` in `parseFormats`), which
-    // does NOT shift.
+    // "local time" makes clear that a bare `YYYY-MM-DD HH:MM:SS`
+    // is interpreted in the display TZ, matching the table.
+    // Raw `Z`-suffixed values from the file hit the zoned parser
+    // and are not shifted.
     dialog.setLabelText(tr("Timestamp (local time; ISO 8601 or -Nh / -Nm):"));
     dialog.setInputMode(QInputDialog::TextInput);
     dialog.setTextEchoMode(QLineEdit::Normal);
-    // Pre-populate with the previous input so successive jumps
-    // around the same instant don't require a retype. Cleared on
-    // session boundaries (see `mLastGotoTimestampInput` field
-    // comment) to avoid leaking a stale reference into a fresh log.
     dialog.setTextValue(mLastGotoTimestampInput);
     if (auto *editor = dialog.findChild<QLineEdit *>())
     {
@@ -6657,10 +6602,7 @@ void MainWindow::GotoTimestamp()
 
 void MainWindow::ExecuteGotoTimestamp(const QString &input, std::chrono::system_clock::time_point now)
 {
-    // Re-read model + config here (not before the modal) so a
-    // session swap or column edit while the dialog was open is
-    // reflected in the error paths. Mirrors `ExecuteGotoLine`'s
-    // "read live state, never a captured snapshot" pattern.
+    // Read model + config live -- mirrors `ExecuteGotoLine`.
     if (mModel == nullptr || mModel->rowCount() == 0)
     {
         statusBar()->showMessage(tr("No log loaded."), STATUS_BAR_MESSAGE_TIMEOUT_MS);
@@ -6674,9 +6616,8 @@ void MainWindow::ExecuteGotoTimestamp(const QString &input, std::chrono::system_
         return;
     }
 
-    // Sticky-input update happens before the parse so a garbage
-    // input the user wants to correct is retained on the next open.
-    // A parse failure below doesn't roll this back.
+    // Update the sticky input before the parse so a garbage value
+    // the user wants to correct is retained on the next open.
     mLastGotoTimestampInput = input;
 
     const std::optional<GotoTimestampParse> parsed =
@@ -6686,20 +6627,12 @@ void MainWindow::ExecuteGotoTimestamp(const QString &input, std::chrono::system_
         statusBar()->showMessage(tr("Could not parse timestamp."), STATUS_BAR_MESSAGE_TIMEOUT_MS);
         return;
     }
-    // Stored cell timestamps live in the same numeric space the
-    // table's TZ-shifted display uses: columns with a `%z` / `%Ez`
-    // / `%Z` specifier land as true UTC micros; naive columns
-    // (including the ISO fast path and any `parseFormats` without
-    // a zone specifier) store the wall-clock digits *as-if UTC*,
-    // which then get TZ-shifted again for display. Either way, a
-    // naive user input represents a display-zone wall-clock
-    // instant and needs the same local -> UTC shift to line up
-    // with what the table shows on-screen. Users who paste a raw
-    // (naive) log value from the file rather than the displayed
-    // value will land off by the display-zone offset; the dialog
-    // label ("local time") flags this. `LocalMicrosecondsSinceEpoch
-    // ToUtc` handles the DST edge cases so we don't have to catch
-    // here.
+    // Stored cell timestamps line up with the TZ-shifted display:
+    // zoned columns hold true UTC micros, naive columns hold the
+    // wall-clock digits which are then TZ-shifted for rendering.
+    // Naive user input represents a display-zone wall-clock
+    // instant, so it needs the same local -> UTC shift to match.
+    // `LocalMicrosecondsSinceEpochToUtc` handles DST edge cases.
     const int64_t targetMicros =
         parsed->isNaive ? loglib::LocalMicrosecondsSinceEpochToUtc(parsed->micros) : parsed->micros;
 
@@ -6724,12 +6657,10 @@ int MainWindow::FindFirstRowAtOrAfter(int timeCol, int64_t targetMicros) const
         return -1;
     }
 
-    // Cell -> epoch µs. Returns `nullopt` for rows whose timestamp
-    // slot is missing / unpromoted -- the two searches below both
-    // need to handle that gap explicitly rather than pretend such
-    // rows sort at `-inf` (that assumption breaks binary-search
-    // monotonicity as soon as one interleaved gap appears; see the
-    // fast-path comment for details).
+    // Cell -> epoch micros. `nullopt` for rows whose timestamp
+    // slot is missing / unpromoted; both searches below skip such
+    // rows explicitly (treating them as `-inf` would break the
+    // fast-path binary search's monotonicity invariant).
     const auto tsFor = [this, timeCol](int sourceRow) -> std::optional<int64_t>
     {
         return loglib::AsEpochMicroseconds(
@@ -6737,10 +6668,8 @@ int MainWindow::FindFirstRowAtOrAfter(int timeCol, int64_t targetMicros) const
         );
     };
 
-    // Source row -> outermost proxy row (respects the mid-proxy's
-    // newest-first reversal *and* the outer proxy's active filter).
-    // Returns `nullopt` when the row is currently hidden. Cached in
-    // a lambda so both branches use the same visibility rule.
+    // Source row -> visible through the outer proxy? Respects the
+    // mid-proxy's newest-first reversal and the active row filter.
     const auto isVisible = [this](int sourceRow) -> bool
     {
         const QModelIndex sourceIdx = mModel->index(sourceRow, 0);
@@ -6752,9 +6681,8 @@ int MainWindow::FindFirstRowAtOrAfter(int timeCol, int64_t targetMicros) const
         return mSortFilterProxyModel->mapFromSource(midIdx).isValid();
     };
 
-    // Outer proxy row -> source row, or `-1` when the mapping breaks
-    // (transient state during a proxy layout change). Factored out
-    // so the three branches below share one traversal skeleton.
+    // Outer proxy row -> source row, or `-1` when the mapping is
+    // transiently broken (proxy layout change in flight).
     const auto proxyRowToSource = [this](int proxyRow) -> int
     {
         const QModelIndex proxyIdx = mSortFilterProxyModel->index(proxyRow, 0);
@@ -6772,36 +6700,23 @@ int MainWindow::FindFirstRowAtOrAfter(int timeCol, int64_t targetMicros) const
 
     if (userSortColumn < 0 && timestampsMonotonic)
     {
-        // Fast path: no user sort + source rows are monotonic in
-        // the time column. Binary-search source rows in place --
-        // allocating an `iota`d indices vector for a 10M-row file
-        // would burn 40 MiB and blow the ROADMAP `< 100 ms` budget.
+        // Fast path: binary-search source rows in place. Building
+        // an `iota` index array would cost ~40 MiB on a 10 M-row
+        // file, blowing the ROADMAP `< 100 ms` budget.
         //
-        // Monotonicity is guarded by
-        // `LogModel::TimestampsAreMonotonic()`, which the streaming
-        // path flips to false on the first batch-boundary or intra-
-        // batch inversion (multi-file `Append`, rotation, clock
-        // skew). Once false we drop into the O(N_visible) branch
-        // below, which is correct for arbitrary orders.
-        //
-        // Missing timestamps must be handled explicitly rather than
-        // treated as `-inf`: they can appear anywhere in the middle
-        // of a file (JSON rows that omit the timestamp key) and any
-        // "assign to -inf" or "assign to +inf" rule breaks the
-        // monotonicity that `lower_bound` requires. Each probe
-        // walks forward from `mid` to the first row with a valid
-        // timestamp before making a decision. Worst case (all rows
-        // missing) degrades to O(N); common case (rare gaps) stays
-        // O(log N).
+        // Missing timestamps require an explicit skip -- there is
+        // no `-inf` / `+inf` rule that preserves the monotonicity
+        // `lower_bound` needs when gaps interleave valid rows. Each
+        // probe walks forward from `mid` to the first valid ts.
+        // Worst case (all rows missing) is O(N); typical case
+        // (rare gaps) stays O(log N).
         //
         // Invariants:
         //   * `[0, lo)`  -- every row has "missing OR ts < target".
-        //   * `[hi, sourceRowCount)` -- either empty, or extendable
-        //     to satisfy "missing OR ts >= target" (see the
-        //     `hi = mid` branch, which uses the fact that the range
-        //     probed was all-missing).
-        // Terminal `lo == hi`; the answer, if any, is the first row
-        // in `[lo, sourceRowCount)` whose ts is valid and >= target.
+        //   * `[hi, sourceRowCount)` -- either empty or all-missing
+        //     as observed by the `hi = mid` branch.
+        // At `lo == hi`, the answer (if any) is the first valid
+        // ts >= target in `[lo, sourceRowCount)`.
         int lo = 0;
         int hi = sourceRowCount;
         while (lo < hi)
@@ -6815,8 +6730,7 @@ int MainWindow::FindFirstRowAtOrAfter(int timeCol, int64_t targetMicros) const
             }
             if (probe >= hi)
             {
-                // `[mid, hi)` all missing -- no candidate on this
-                // half. Shrink the search window to the left half.
+                // `[mid, hi)` is all missing -- shrink to the left.
                 hi = mid;
             }
             else if (*probeTs < targetMicros)
@@ -6834,10 +6748,9 @@ int MainWindow::FindFirstRowAtOrAfter(int timeCol, int64_t targetMicros) const
             return -1;
         }
 
-        // Happy path: row `lo` itself is visible and carries a
-        // valid ts. Skips both the proxy walk below and its
-        // `mapFromSource` overhead in the common "no filter" case,
-        // where the fast path is O(log N) end-to-end.
+        // Happy path: `lo` itself is a valid, visible answer.
+        // Skips the proxy walk below in the common no-filter case,
+        // keeping the fast path O(log N) end-to-end.
         {
             const auto ts = tsFor(lo);
             if (ts.has_value() && *ts >= targetMicros && isVisible(lo))
@@ -6846,19 +6759,17 @@ int MainWindow::FindFirstRowAtOrAfter(int timeCol, int64_t targetMicros) const
             }
         }
 
-        // Fallback: walk the OUTER PROXY (not the source) to find
-        // the smallest visible source row `>= lo` that carries a
-        // valid ts. This is O(N_visible) rather than O(N_source);
-        // the old source-walk degraded to O(N_source) when a heavy
-        // filter hid most of `[lo, sourceRowCount)`, blowing the
+        // Otherwise walk the outer proxy (not the source) for the
+        // smallest visible source row `>= lo` with a valid ts.
+        // O(N_visible), not O(N_source) -- a heavy filter that
+        // hides most of `[lo, sourceRowCount)` used to blow the
         // ROADMAP budget on huge files.
         //
-        // Correctness: by the binary-search invariant, every source
-        // row in `[lo, sourceRowCount)` either has a valid ts >=
-        // target or is missing. So any visible source row `>= lo`
-        // with a valid ts is a qualifying answer, and the SMALLEST
-        // such row is the one we want (earliest chronologically,
-        // by monotonicity).
+        // Correctness: the binary-search invariant guarantees
+        // every source row `>= lo` is either missing or has
+        // ts >= target, so any visible one with a valid ts
+        // qualifies; the smallest such row is earliest
+        // chronologically (by monotonicity).
         int best = -1;
         const int proxyRowCount = mSortFilterProxyModel->rowCount();
         for (int proxyRow = 0; proxyRow < proxyRowCount; ++proxyRow)
@@ -6883,16 +6794,10 @@ int MainWindow::FindFirstRowAtOrAfter(int timeCol, int64_t targetMicros) const
 
     if (userSortColumn < 0)
     {
-        // No user sort, but the source is not monotonic in time
-        // (multi-file `Append`, rotation, clock skew observed via
-        // `LogModel::TimestampsAreMonotonic()`). The fast path
-        // above is unsafe: `lower_bound` would silently return a
-        // wrong row. Fall back to an O(N_visible) walk over the
-        // outer proxy and pick the visible row with the SMALLEST
-        // ts that still satisfies `ts >= target`. That is the
-        // chronologically earliest match, matching the natural
-        // "at or after" semantic even when source order is not
-        // wall-clock order.
+        // Non-monotonic source: the binary search above would
+        // silently return a wrong row. Walk the outer proxy and
+        // pick the visible row with the smallest ts satisfying
+        // `>= target` -- the chronologically earliest match.
         int best = -1;
         int64_t bestTs = std::numeric_limits<int64_t>::max();
         const int proxyRowCount = mSortFilterProxyModel->rowCount();
@@ -6917,10 +6822,9 @@ int MainWindow::FindFirstRowAtOrAfter(int timeCol, int64_t targetMicros) const
         return best;
     }
 
-    // Slow path: user sort active. Linear scan in display order and
-    // return the first proxy row whose source timestamp qualifies
-    // -- respects the user's chosen "first" (top of the sorted
-    // view, which may not be the earliest chronologically).
+    // User sort active: linear scan in display order so "first"
+    // matches the user's chosen sort (may not be earliest in
+    // wall-clock time).
     const int proxyRowCount = mSortFilterProxyModel->rowCount();
     for (int proxyRow = 0; proxyRow < proxyRowCount; ++proxyRow)
     {
@@ -8971,15 +8875,13 @@ bool MainWindow::SubmitAnchorNoteForRowForTest(int sourceRow, const QString &not
 
 void MainWindow::ExecuteGotoLineForTest(const QString &input)
 {
-    // Thin forwarder to the production body. Kept trivial so a
-    // regression in the modal-owning `GotoLine` slot cannot mask a
-    // regression in the validation branches (and vice versa).
+    // Thin forwarder so a regression in the modal-owning slot
+    // cannot mask a regression in the validation branches.
     ExecuteGotoLine(input);
 }
 
 void MainWindow::ExecuteGotoTimestampForTest(const QString &input, std::chrono::system_clock::time_point now)
 {
-    // Thin forwarder; same rationale as `ExecuteGotoLineForTest`.
     ExecuteGotoTimestamp(input, now);
 }
 

--- a/app/src/main_window.cpp
+++ b/app/src/main_window.cpp
@@ -2416,6 +2416,11 @@ void MainWindow::NewSession()
     mPendingDecompressionErrors.clear();
     // The configuration that requested the deferred sort is gone.
     mPendingApplySortFromConfig = false;
+    // Drop the "last Goto Timestamp input" carry-over: a
+    // string that made sense in the outgoing session's zone /
+    // format can be nonsense in the new one, and pre-populating
+    // a fresh dialog with it would just annoy the user.
+    mLastGotoTimestampInput.clear();
     // Drop the pinned uuid + open-windows membership so the next
     // AutoSave creates a fresh entry and a crash before then
     // doesn't re-restore the discarded session.
@@ -6378,16 +6383,36 @@ void MainWindow::GotoLine()
         return;
     }
 
-    bool ok = false;
-    const int oneBased = dialog.textValue().toInt(&ok);
-    if (!ok || oneBased < 1 || oneBased > rowCount)
+    ExecuteGotoLine(dialog.textValue());
+}
+
+void MainWindow::ExecuteGotoLine(const QString &input)
+{
+    // Re-read `rowCount` here (not before the modal) so a shrink
+    // while the dialog was open -- streaming FIFO eviction, session
+    // swap -- is reflected in both the range check and the error
+    // hint. Using a stale captured value would (a) let an evicted
+    // line pass the check and land on the misleading generic
+    // `SelectSourceRow` hint, and (b) show the user a range that
+    // no longer exists.
+    if (mModel == nullptr)
     {
-        // The validator normally blocks Accept on out-of-range
-        // input, but paranoia: if the model shrank while the modal
-        // was open (streaming eviction, session swap), surface it
-        // instead of silently no-oping.
+        statusBar()->showMessage(tr("No log loaded."), STATUS_BAR_MESSAGE_TIMEOUT_MS);
+        return;
+    }
+    const int currentRowCount = mModel->rowCount();
+    if (currentRowCount == 0)
+    {
+        statusBar()->showMessage(tr("No log loaded."), STATUS_BAR_MESSAGE_TIMEOUT_MS);
+        return;
+    }
+
+    bool ok = false;
+    const int oneBased = input.toInt(&ok);
+    if (!ok || oneBased < 1 || oneBased > currentRowCount)
+    {
         statusBar()->showMessage(
-            tr("Line %1 is out of range (1 - %2).").arg(dialog.textValue(), QString::number(rowCount)),
+            tr("Line %1 is out of range (1 - %2).").arg(input, QString::number(currentRowCount)),
             STATUS_BAR_MESSAGE_TIMEOUT_MS
         );
         return;
@@ -6397,7 +6422,10 @@ void MainWindow::GotoLine()
     // visible" hint when the target is filtered out; the caller
     // knows more context (this is a Goto Line jump, not an anchor
     // seek), so front-run a filter-visibility probe and print the
-    // more specific message before deferring.
+    // more specific message before deferring. Safe now that the
+    // range check above guarantees `sourceRow` is in-model, so an
+    // invalid `mapFromSource` result really does mean "filter",
+    // not "evicted".
     const int sourceRow = oneBased - 1;
     if (mSortFilterProxyModel != nullptr && mRowOrderProxyModel != nullptr)
     {
@@ -6423,37 +6451,54 @@ namespace
 /// True if @p fmt contains a `date::parse` zone specifier -- `%z`,
 /// `%Z`, `%Ez`, or `%Oz` -- so a successful parse produces a
 /// UTC-normalised value that must NOT be TZ-shifted again.
-/// `%%` is skipped so literal `"%%z"` in a format string doesn't
-/// register as a zone specifier. Kept adjacent to
-/// `ParseGotoTimestampInput` because that is its only caller.
+/// `%%` is treated as a literal percent (not the start of a
+/// specifier), so `"%%z"` in a format string does NOT register.
+/// Kept adjacent to `ParseGotoTimestampInput` because that is its
+/// only caller.
+///
+/// The scan advances one byte at a time on non-match branches
+/// (rather than skipping past the tentative specifier) so a
+/// malformed prefix like `"%E%z"` still detects the inner `%z`
+/// on a re-scan starting at the `%`. `date::parse` would reject
+/// such a format anyway, but a false negative here would flag
+/// the parsed value as naive and double-shift it downstream --
+/// worse than false-positive-recognising a bad format.
 [[nodiscard]] bool FormatHasZoneSpecifier(std::string_view fmt) noexcept
 {
-    for (std::size_t i = 0; i < fmt.size();)
+    for (std::size_t i = 0; i < fmt.size(); ++i)
     {
         if (fmt[i] != '%')
         {
-            ++i;
             continue;
         }
-        if (i + 1 >= fmt.size())
+        const std::size_t next = i + 1;
+        if (next >= fmt.size())
         {
             break;
         }
-        if (fmt[i + 1] == '%')
+        if (fmt[next] == '%')
         {
-            i += 2;
+            // `%%` is a literal percent -- consume both and keep
+            // scanning. The outer `++i` moves past the first `%`;
+            // this `++i` moves past the second, so we resume at
+            // the byte after `%%`.
+            ++i;
             continue;
         }
-        std::size_t j = i + 1;
-        if (fmt[j] == 'E' || fmt[j] == 'O')
+        std::size_t specifier = next;
+        if ((fmt[specifier] == 'E' || fmt[specifier] == 'O') && specifier + 1 < fmt.size())
         {
-            ++j;
+            ++specifier;
         }
-        if (j < fmt.size() && (fmt[j] == 'z' || fmt[j] == 'Z'))
+        if (fmt[specifier] == 'z' || fmt[specifier] == 'Z')
         {
             return true;
         }
-        i = j + 1;
+        // Fall through with only the outer `++i` moving forward
+        // one byte. Deliberately do NOT jump past `specifier`:
+        // that would swallow a subsequent `%z` in malformed
+        // formats like `"%E%z"`, producing the double-shift
+        // regression noted in the comment above.
     }
     return false;
 }
@@ -6566,31 +6611,46 @@ void MainWindow::GotoTimestamp()
     dialog.setLabelText(tr("Timestamp:"));
     dialog.setInputMode(QInputDialog::TextInput);
     dialog.setTextEchoMode(QLineEdit::Normal);
+    // Pre-populate with the previous input so successive jumps
+    // around the same instant don't require a retype. Cleared on
+    // session boundaries (see `mLastGotoTimestampInput` field
+    // comment) to avoid leaking a stale reference into a fresh log.
+    dialog.setTextValue(mLastGotoTimestampInput);
     if (auto *editor = dialog.findChild<QLineEdit *>())
     {
         editor->setPlaceholderText(tr("YYYY-MM-DD HH:MM:SS or -1h / -30m"));
+        editor->selectAll();
     }
     if (dialog.exec() != QDialog::Accepted)
     {
         return;
     }
 
+    const QString rawInput = dialog.textValue();
+    mLastGotoTimestampInput = rawInput;
     const std::optional<GotoTimestampParse> parsed = ParseGotoTimestampInput(
-        dialog.textValue(),
-        config.columns[static_cast<std::size_t>(timeCol)].parseFormats,
-        std::chrono::system_clock::now()
+        rawInput, config.columns[static_cast<std::size_t>(timeCol)].parseFormats, std::chrono::system_clock::now()
     );
     if (!parsed.has_value())
     {
         statusBar()->showMessage(tr("Could not parse timestamp."), STATUS_BAR_MESSAGE_TIMEOUT_MS);
         return;
     }
-    // Stored cell timestamps are always UTC micros (columns with
-    // `%z` / `%Ez` format specifiers, and the ISO fast path, both
-    // normalise to UTC). A naive user input needs the same shift
-    // through the *display* zone -- otherwise a user in UTC+2 who
-    // types "12:00" jumps to the row two hours off. The library
-    // helper handles DST edge cases so we don't have to catch here.
+    // Stored cell timestamps live in the same numeric space the
+    // table's TZ-shifted display uses: columns with a `%z` / `%Ez`
+    // / `%Z` specifier land as true UTC micros; naive columns
+    // (including the ISO fast path and any `parseFormats` without
+    // a zone specifier) store the wall-clock digits *as-if UTC*,
+    // which then get TZ-shifted again for display. Either way, a
+    // naive user input represents a display-zone wall-clock
+    // instant and needs the same local -> UTC shift to line up
+    // with what the table shows on-screen. Users who paste a raw
+    // (naive) log value from the file rather than the displayed
+    // value will land off by the display-zone offset; that's a
+    // documented caveat, not a bug -- the dialog's canonical
+    // meaning is "the wall-clock time the user reads in the row".
+    // `LocalMicrosecondsSinceEpochToUtc` handles the DST edge
+    // cases so we don't have to catch here.
     const int64_t targetMicros =
         parsed->isNaive ? loglib::LocalMicrosecondsSinceEpochToUtc(parsed->micros) : parsed->micros;
 
@@ -8779,6 +8839,14 @@ bool MainWindow::SubmitAnchorNoteForRowForTest(int sourceRow, const QString &not
     // internally so multi-line input collapses to one line.
     mAnchors->SetAnchorNote(*key, note.toStdString());
     return true;
+}
+
+void MainWindow::ExecuteGotoLineForTest(const QString &input)
+{
+    // Thin forwarder to the production body. Kept trivial so a
+    // regression in the modal-owning `GotoLine` slot cannot mask a
+    // regression in the validation branches (and vice versa).
+    ExecuteGotoLine(input);
 }
 #endif
 

--- a/app/src/main_window.cpp
+++ b/app/src/main_window.cpp
@@ -6357,12 +6357,15 @@ void MainWindow::GotoLine()
     // so we can attach a `QIntValidator` to the line edit and lean
     // on Qt's built-in accept-blocking rather than re-validating
     // after `exec`. Range is 1..rowCount; lines are 1-based for
-    // parity with every editor's "Go to Line" dialog.
+    // parity with every editor's "Go to Line" dialog. `QIntValidator`
+    // parses without a group separator by default, so the label
+    // uses `QString::number` (also separator-free) rather than
+    // `QLocale::system().toString(...)` -- the two would otherwise
+    // disagree in locales like `en_US` that group with commas,
+    // presenting the user with a range they cannot actually type.
     QInputDialog dialog(this);
     dialog.setWindowTitle(tr("Go to Line"));
-    dialog.setLabelText(
-        tr("Line number (1 - %1):").arg(QLocale::system().toString(rowCount))
-    );
+    dialog.setLabelText(tr("Line number (1 - %1):").arg(QString::number(rowCount)));
     dialog.setInputMode(QInputDialog::TextInput);
     dialog.setTextEchoMode(QLineEdit::Normal);
     if (auto *editor = dialog.findChild<QLineEdit *>())
@@ -6384,17 +6387,80 @@ void MainWindow::GotoLine()
         // was open (streaming eviction, session swap), surface it
         // instead of silently no-oping.
         statusBar()->showMessage(
-            tr("Line %1 is out of range (1 - %2).")
-                .arg(dialog.textValue(), QLocale::system().toString(rowCount)),
+            tr("Line %1 is out of range (1 - %2).").arg(dialog.textValue(), QString::number(rowCount)),
             STATUS_BAR_MESSAGE_TIMEOUT_MS
         );
         return;
     }
 
-    SelectSourceRow(oneBased - 1);
+    // `SelectSourceRow` prints a generic "Row is not currently
+    // visible" hint when the target is filtered out; the caller
+    // knows more context (this is a Goto Line jump, not an anchor
+    // seek), so front-run a filter-visibility probe and print the
+    // more specific message before deferring.
+    const int sourceRow = oneBased - 1;
+    if (mSortFilterProxyModel != nullptr && mRowOrderProxyModel != nullptr)
+    {
+        const QModelIndex sourceIdx = mModel->index(sourceRow, 0);
+        const QModelIndex midIdx = mRowOrderProxyModel->mapFromSource(sourceIdx);
+        const bool visible = midIdx.isValid() && mSortFilterProxyModel->mapFromSource(midIdx).isValid();
+        if (!visible)
+        {
+            statusBar()->showMessage(
+                tr("Line %1 is currently filtered out.").arg(QString::number(oneBased)),
+                STATUS_BAR_MESSAGE_TIMEOUT_MS
+            );
+            return;
+        }
+    }
+
+    SelectSourceRow(sourceRow);
 }
 
-std::optional<int64_t> MainWindow::ParseGotoTimestampInput(
+namespace
+{
+
+/// True if @p fmt contains a `date::parse` zone specifier -- `%z`,
+/// `%Z`, `%Ez`, or `%Oz` -- so a successful parse produces a
+/// UTC-normalised value that must NOT be TZ-shifted again.
+/// `%%` is skipped so literal `"%%z"` in a format string doesn't
+/// register as a zone specifier. Kept adjacent to
+/// `ParseGotoTimestampInput` because that is its only caller.
+[[nodiscard]] bool FormatHasZoneSpecifier(std::string_view fmt) noexcept
+{
+    for (std::size_t i = 0; i < fmt.size();)
+    {
+        if (fmt[i] != '%')
+        {
+            ++i;
+            continue;
+        }
+        if (i + 1 >= fmt.size())
+        {
+            break;
+        }
+        if (fmt[i + 1] == '%')
+        {
+            i += 2;
+            continue;
+        }
+        std::size_t j = i + 1;
+        if (fmt[j] == 'E' || fmt[j] == 'O')
+        {
+            ++j;
+        }
+        if (j < fmt.size() && (fmt[j] == 'z' || fmt[j] == 'Z'))
+        {
+            return true;
+        }
+        i = j + 1;
+    }
+    return false;
+}
+
+} // namespace
+
+std::optional<MainWindow::GotoTimestampParse> MainWindow::ParseGotoTimestampInput(
     const QString &input,
     const std::vector<std::string> &columnParseFormats,
     std::chrono::system_clock::time_point now
@@ -6406,13 +6472,16 @@ std::optional<int64_t> MainWindow::ParseGotoTimestampInput(
         return std::nullopt;
     }
 
-    // Relative shortcut first: `-Nh` / `-Nm` (case-insensitive,
-    // whitespace-tolerant). Evaluated against @p now so tests can
+    // Relative shortcut: `[+-]?N[hm]` (case-insensitive, whitespace-
+    // tolerant). All three sign variants (`-1h`, `+1h`, `1h`) mean
+    // "one hour before @p now" -- users almost never mean "an hour
+    // in the future" in a log viewer, and lnav / less resolve the
+    // ambiguity the same way. Evaluated against @p now so tests can
     // pin the clock; production wires `system_clock::now()`.
-    // ROADMAP item 8 spells out these two units explicitly; adding
-    // more (like `-Ns`, `-Nd`) is left for future contributions.
+    // ROADMAP item 8 spells out `-Nh` / `-Nm` as the required units;
+    // seconds / days are left for future contributions.
     static const QRegularExpression RELATIVE_SHORTCUT_RE(
-        QStringLiteral(R"(^-\s*(\d+)\s*([hm])\s*$)"), QRegularExpression::CaseInsensitiveOption
+        QStringLiteral(R"(^[+-]?\s*(\d+)\s*([hm])\s*$)"), QRegularExpression::CaseInsensitiveOption
     );
     const auto relMatch = RELATIVE_SHORTCUT_RE.match(trimmed);
     if (relMatch.hasMatch())
@@ -6424,15 +6493,25 @@ std::optional<int64_t> MainWindow::ParseGotoTimestampInput(
             return std::nullopt;
         }
         const QChar unit = relMatch.captured(2).at(0).toLower();
-        const int64_t nSigned = static_cast<int64_t>(n);
-        // Common type for the ternary: convert both branches to
-        // microseconds so `std::chrono::hours` and `minutes` share
-        // a representation.
-        const auto offset = unit == QLatin1Char('h')
-                                ? std::chrono::duration_cast<std::chrono::microseconds>(std::chrono::hours(nSigned))
-                                : std::chrono::duration_cast<std::chrono::microseconds>(std::chrono::minutes(nSigned));
-        const auto target = now - offset;
-        return std::chrono::duration_cast<std::chrono::microseconds>(target.time_since_epoch()).count();
+        // Overflow guard: cap `N` at whatever fits in `int64_t`
+        // microseconds for the chosen unit. Anything larger is
+        // rejected rather than wrapped -- silently subtracting a
+        // negative duration would jump the user forward in time
+        // rather than backward, which is worse than an error hint.
+        constexpr int64_t MICROS_PER_HOUR = 3'600LL * 1'000'000LL;
+        constexpr int64_t MICROS_PER_MINUTE = 60LL * 1'000'000LL;
+        const int64_t microsPerUnit = (unit == QLatin1Char('h')) ? MICROS_PER_HOUR : MICROS_PER_MINUTE;
+        const auto maxN = static_cast<qulonglong>(std::numeric_limits<int64_t>::max() / microsPerUnit);
+        if (n > maxN)
+        {
+            return std::nullopt;
+        }
+        const int64_t offsetMicros = static_cast<int64_t>(n) * microsPerUnit;
+        const auto nowMicros =
+            std::chrono::duration_cast<std::chrono::microseconds>(now.time_since_epoch()).count();
+        // `nowMicros` is >= 0 for post-1970 clocks; subtraction of a
+        // non-negative bounded `offsetMicros` cannot overflow.
+        return GotoTimestampParse{nowMicros - offsetMicros, /*isNaive=*/false};
     }
 
     // Absolute path: try every parse format the column itself
@@ -6460,7 +6539,7 @@ std::optional<int64_t> MainWindow::ParseGotoTimestampInput(
         loglib::TimeStamp parsed{};
         if (loglib::TryParseTimestamp(stdInput, fmt, loglib::ClassifyTimestampFormat(fmt), scratch, parsed))
         {
-            return parsed.time_since_epoch().count();
+            return GotoTimestampParse{parsed.time_since_epoch().count(), /*isNaive=*/!FormatHasZoneSpecifier(fmt)};
         }
     }
     return std::nullopt;
@@ -6496,21 +6575,29 @@ void MainWindow::GotoTimestamp()
         return;
     }
 
-    const std::optional<int64_t> targetMicros = ParseGotoTimestampInput(
+    const std::optional<GotoTimestampParse> parsed = ParseGotoTimestampInput(
         dialog.textValue(),
         config.columns[static_cast<std::size_t>(timeCol)].parseFormats,
         std::chrono::system_clock::now()
     );
-    if (!targetMicros.has_value())
+    if (!parsed.has_value())
     {
         statusBar()->showMessage(tr("Could not parse timestamp."), STATUS_BAR_MESSAGE_TIMEOUT_MS);
         return;
     }
+    // Stored cell timestamps are always UTC micros (columns with
+    // `%z` / `%Ez` format specifiers, and the ISO fast path, both
+    // normalise to UTC). A naive user input needs the same shift
+    // through the *display* zone -- otherwise a user in UTC+2 who
+    // types "12:00" jumps to the row two hours off. The library
+    // helper handles DST edge cases so we don't have to catch here.
+    const int64_t targetMicros =
+        parsed->isNaive ? loglib::LocalMicrosecondsSinceEpochToUtc(parsed->micros) : parsed->micros;
 
-    const int sourceRow = FindFirstRowAtOrAfter(timeCol, *targetMicros);
+    const int sourceRow = FindFirstRowAtOrAfter(timeCol, targetMicros);
     if (sourceRow < 0)
     {
-        statusBar()->showMessage(tr("No row at or after that time."), STATUS_BAR_MESSAGE_TIMEOUT_MS);
+        statusBar()->showMessage(tr("No visible row at or after that time."), STATUS_BAR_MESSAGE_TIMEOUT_MS);
         return;
     }
     SelectSourceRow(sourceRow);
@@ -6528,9 +6615,12 @@ int MainWindow::FindFirstRowAtOrAfter(int timeCol, int64_t targetMicros) const
         return -1;
     }
 
-    // Cell -> epoch µs. Missing / unpromoted timestamps sort as
-    // `-inf` so `lower_bound` stays monotonic and a linear scan
-    // never picks them as "first at or after".
+    // Cell -> epoch µs. Returns `nullopt` for rows whose timestamp
+    // slot is missing / unpromoted -- the two searches below both
+    // need to handle that gap explicitly rather than pretend such
+    // rows sort at `-inf` (that assumption breaks binary-search
+    // monotonicity as soon as one interleaved gap appears; see the
+    // fast-path comment for details).
     const auto tsFor = [this, timeCol](int sourceRow) -> std::optional<int64_t>
     {
         return loglib::AsEpochMicroseconds(
@@ -6538,45 +6628,104 @@ int MainWindow::FindFirstRowAtOrAfter(int timeCol, int64_t targetMicros) const
         );
     };
 
+    // Source row -> outermost proxy row (respects the mid-proxy's
+    // newest-first reversal *and* the outer proxy's active filter).
+    // Returns `nullopt` when the row is currently hidden. Cached in
+    // a lambda so both branches use the same visibility rule.
+    const auto isVisible = [this](int sourceRow) -> bool
+    {
+        const QModelIndex sourceIdx = mModel->index(sourceRow, 0);
+        const QModelIndex midIdx = mRowOrderProxyModel->mapFromSource(sourceIdx);
+        if (!midIdx.isValid())
+        {
+            return false;
+        }
+        return mSortFilterProxyModel->mapFromSource(midIdx).isValid();
+    };
+
     if (mSortFilterProxyModel->SortColumn() < 0)
     {
-        // Binary-search source rows in place -- allocating an
-        // `iota`d indices vector for a 10M-row file would burn
-        // 40 MiB and blow the ROADMAP `< 100 ms` budget. File
-        // order is (practically always) timestamp-ordered; ROADMAP
-        // item 8 declares this the fast path.
+        // Fast path: no user sort. File order is (practically always)
+        // timestamp-ordered, so we binary-search source rows in place
+        // -- allocating an `iota`d indices vector for a 10M-row file
+        // would burn 40 MiB and blow the ROADMAP `< 100 ms` budget.
         //
-        // Invariant: `hi` is the first row known to satisfy
-        // `ts >= target`, or `sourceRowCount` if none does yet.
-        // Rows with missing timestamps are treated as `-inf`
-        // (they stay left of every real timestamp, preserving
-        // monotonicity).
+        // Missing timestamps must be handled explicitly rather than
+        // treated as `-inf`: they can appear anywhere in the middle
+        // of a file (JSON rows that omit the timestamp key) and any
+        // "assign to -inf" or "assign to +inf" rule breaks the
+        // monotonicity that `lower_bound` requires. Instead, each
+        // probe walks forward from `mid` to the first row with a
+        // valid timestamp before making a decision. Worst case (all
+        // rows missing) degrades to O(N); common case (rare gaps)
+        // stays O(log N).
+        //
+        // Invariants:
+        //   * `[0, lo)`  -- every row has "missing OR ts < target".
+        //   * `[hi, sourceRowCount)` -- either empty, or extendable
+        //     to satisfy "missing OR ts >= target" (see the
+        //     `hi = mid` branch, which uses the fact that the range
+        //     probed was all-missing).
+        // Terminal `lo == hi`; the answer, if any, is the first row
+        // in `[lo, sourceRowCount)` whose ts is valid and >= target.
         int lo = 0;
         int hi = sourceRowCount;
         while (lo < hi)
         {
             const int mid = lo + ((hi - lo) / 2);
-            const auto ts = tsFor(mid);
-            if (!ts.has_value() || *ts < targetMicros)
+            int probe = mid;
+            std::optional<int64_t> probeTs;
+            while (probe < hi && !(probeTs = tsFor(probe)).has_value())
             {
-                lo = mid + 1;
+                ++probe;
+            }
+            if (probe >= hi)
+            {
+                // `[mid, hi)` all missing -- no candidate on this
+                // half. Shrink the search window to the left half.
+                hi = mid;
+            }
+            else if (*probeTs < targetMicros)
+            {
+                lo = probe + 1;
             }
             else
             {
-                hi = mid;
+                hi = probe;
             }
         }
-        if (lo >= sourceRowCount)
+
+        // Walk forward from `lo` to the first row that both carries
+        // a valid timestamp >= `target` AND is currently visible via
+        // the outer proxy. The visibility step matters when a filter
+        // is active: without it, the fast path can return a source
+        // row that's filtered out and `SelectSourceRow` then prints
+        // "Row is not currently visible" -- which looks like a bug
+        // to the user when there IS a visible qualifying row further
+        // down.
+        for (int row = lo; row < sourceRowCount; ++row)
         {
-            return -1;
+            const auto ts = tsFor(row);
+            if (!ts.has_value() || *ts < targetMicros)
+            {
+                // The binary-search invariant guarantees no `ts <
+                // target` past `lo`, but a missing-ts row can appear
+                // here (the invariant only pins the answer, not the
+                // gaps between it and the tail).
+                continue;
+            }
+            if (isVisible(row))
+            {
+                return row;
+            }
         }
-        return lo;
+        return -1;
     }
 
-    // User sort active on a different (or the same) column. Do a
-    // linear scan in display order and return the first proxy
-    // row whose source timestamp qualifies -- respects the user's
-    // chosen "first".
+    // Slow path: user sort active. Linear scan in display order and
+    // return the first proxy row whose source timestamp qualifies
+    // -- respects the user's chosen "first" (top of the sorted
+    // view, which may not be the earliest chronologically).
     const int proxyRowCount = mSortFilterProxyModel->rowCount();
     for (int proxyRow = 0; proxyRow < proxyRowCount; ++proxyRow)
     {

--- a/app/src/main_window.cpp
+++ b/app/src/main_window.cpp
@@ -2420,7 +2420,10 @@ void MainWindow::NewSession()
     // string that made sense in the outgoing session's zone /
     // format can be nonsense in the new one, and pre-populating
     // a fresh dialog with it would just annoy the user.
+    // Same rationale for the Goto Line mirror: a valid line
+    // number in a 10M-row log is out-of-range in an empty one.
     mLastGotoTimestampInput.clear();
+    mLastGotoLineInput.clear();
     // Drop the pinned uuid + open-windows membership so the next
     // AutoSave creates a fresh entry and a crash before then
     // doesn't re-restore the discarded session.
@@ -6370,20 +6373,38 @@ void MainWindow::GotoLine()
     // presenting the user with a range they cannot actually type.
     QInputDialog dialog(this);
     dialog.setWindowTitle(tr("Go to Line"));
-    dialog.setLabelText(tr("Line number (1 - %1):").arg(QString::number(rowCount)));
+    // Semantics reminder alongside the range: with newest-first
+    // display active, "line 1" is still the earliest row (the one
+    // at the bottom of the visible list), not the top. See
+    // `GotoLine` docstring; also spelled out in the `.ui` tooltip.
+    dialog.setLabelText(tr("Line number (1 = earliest row; 1 - %1):").arg(QString::number(rowCount)));
     dialog.setInputMode(QInputDialog::TextInput);
     dialog.setTextEchoMode(QLineEdit::Normal);
+    // Pre-populate with the previous input so a user walking a
+    // stack trace doesn't retype every line number. Clamped to
+    // the current row range because a value that was in-range in
+    // a prior session can be out-of-range now. Cleared on session
+    // switch (see `mLastGotoLineInput`).
+    if (!mLastGotoLineInput.isEmpty())
+    {
+        dialog.setTextValue(mLastGotoLineInput);
+    }
     if (auto *editor = dialog.findChild<QLineEdit *>())
     {
         editor->setValidator(new QIntValidator(1, rowCount, &dialog));
         editor->setPlaceholderText(tr("e.g. 12345"));
+        // `selectAll` on the pre-populated text lets the user
+        // overwrite by typing, matching the `GotoTimestamp` UX.
+        editor->selectAll();
     }
     if (dialog.exec() != QDialog::Accepted)
     {
         return;
     }
 
-    ExecuteGotoLine(dialog.textValue());
+    const QString rawInput = dialog.textValue();
+    mLastGotoLineInput = rawInput;
+    ExecuteGotoLine(rawInput);
 }
 
 void MainWindow::ExecuteGotoLine(const QString &input)
@@ -6395,7 +6416,7 @@ void MainWindow::ExecuteGotoLine(const QString &input)
     // line pass the check and land on the misleading generic
     // `SelectSourceRow` hint, and (b) show the user a range that
     // no longer exists.
-    if (mModel == nullptr)
+    if (mModel == nullptr || mSortFilterProxyModel == nullptr || mRowOrderProxyModel == nullptr)
     {
         statusBar()->showMessage(tr("No log loaded."), STATUS_BAR_MESSAGE_TIMEOUT_MS);
         return;
@@ -6427,19 +6448,16 @@ void MainWindow::ExecuteGotoLine(const QString &input)
     // invalid `mapFromSource` result really does mean "filter",
     // not "evicted".
     const int sourceRow = oneBased - 1;
-    if (mSortFilterProxyModel != nullptr && mRowOrderProxyModel != nullptr)
+    const QModelIndex sourceIdx = mModel->index(sourceRow, 0);
+    const QModelIndex midIdx = mRowOrderProxyModel->mapFromSource(sourceIdx);
+    const bool visible = midIdx.isValid() && mSortFilterProxyModel->mapFromSource(midIdx).isValid();
+    if (!visible)
     {
-        const QModelIndex sourceIdx = mModel->index(sourceRow, 0);
-        const QModelIndex midIdx = mRowOrderProxyModel->mapFromSource(sourceIdx);
-        const bool visible = midIdx.isValid() && mSortFilterProxyModel->mapFromSource(midIdx).isValid();
-        if (!visible)
-        {
-            statusBar()->showMessage(
-                tr("Line %1 is currently filtered out.").arg(QString::number(oneBased)),
-                STATUS_BAR_MESSAGE_TIMEOUT_MS
-            );
-            return;
-        }
+        statusBar()->showMessage(
+            tr("Line %1 is currently filtered out.").arg(QString::number(oneBased)),
+            STATUS_BAR_MESSAGE_TIMEOUT_MS
+        );
+        return;
     }
 
     SelectSourceRow(sourceRow);
@@ -6598,8 +6616,7 @@ void MainWindow::GotoTimestamp()
         return;
     }
 
-    const auto &config = mModel->Configuration();
-    const int timeCol = loglib::FirstTimeColumnIndex(config);
+    const int timeCol = loglib::FirstTimeColumnIndex(mModel->Configuration());
     if (timeCol < 0)
     {
         statusBar()->showMessage(tr("This log has no timestamp column."), STATUS_BAR_MESSAGE_TIMEOUT_MS);
@@ -6608,7 +6625,14 @@ void MainWindow::GotoTimestamp()
 
     QInputDialog dialog(this);
     dialog.setWindowTitle(tr("Go to Timestamp"));
-    dialog.setLabelText(tr("Timestamp:"));
+    // Label mentions "local time" so users understand that a bare
+    // `YYYY-MM-DD HH:MM:SS` (no offset) is interpreted in the
+    // display time zone, not UTC. The `parseFormats`-fed table
+    // already displays in local time; the dialog matches. Users
+    // who paste a raw `Z`-suffixed value from the file get the
+    // zoned parser branch (`%Ez` / `%Z` in `parseFormats`), which
+    // does NOT shift.
+    dialog.setLabelText(tr("Timestamp (local time; ISO 8601 or -Nh / -Nm):"));
     dialog.setInputMode(QInputDialog::TextInput);
     dialog.setTextEchoMode(QLineEdit::Normal);
     // Pre-populate with the previous input so successive jumps
@@ -6618,7 +6642,7 @@ void MainWindow::GotoTimestamp()
     dialog.setTextValue(mLastGotoTimestampInput);
     if (auto *editor = dialog.findChild<QLineEdit *>())
     {
-        editor->setPlaceholderText(tr("YYYY-MM-DD HH:MM:SS or -1h / -30m"));
+        editor->setPlaceholderText(tr("e.g. 2024-04-28 12:34:56 (local) or -1h / -30m"));
         editor->selectAll();
     }
     if (dialog.exec() != QDialog::Accepted)
@@ -6626,11 +6650,35 @@ void MainWindow::GotoTimestamp()
         return;
     }
 
-    const QString rawInput = dialog.textValue();
-    mLastGotoTimestampInput = rawInput;
-    const std::optional<GotoTimestampParse> parsed = ParseGotoTimestampInput(
-        rawInput, config.columns[static_cast<std::size_t>(timeCol)].parseFormats, std::chrono::system_clock::now()
-    );
+    ExecuteGotoTimestamp(dialog.textValue(), std::chrono::system_clock::now());
+}
+
+void MainWindow::ExecuteGotoTimestamp(const QString &input, std::chrono::system_clock::time_point now)
+{
+    // Re-read model + config here (not before the modal) so a
+    // session swap or column edit while the dialog was open is
+    // reflected in the error paths. Mirrors `ExecuteGotoLine`'s
+    // "read live state, never a captured snapshot" pattern.
+    if (mModel == nullptr || mModel->rowCount() == 0)
+    {
+        statusBar()->showMessage(tr("No log loaded."), STATUS_BAR_MESSAGE_TIMEOUT_MS);
+        return;
+    }
+    const auto &config = mModel->Configuration();
+    const int timeCol = loglib::FirstTimeColumnIndex(config);
+    if (timeCol < 0)
+    {
+        statusBar()->showMessage(tr("This log has no timestamp column."), STATUS_BAR_MESSAGE_TIMEOUT_MS);
+        return;
+    }
+
+    // Sticky-input update happens before the parse so a garbage
+    // input the user wants to correct is retained on the next open.
+    // A parse failure below doesn't roll this back.
+    mLastGotoTimestampInput = input;
+
+    const std::optional<GotoTimestampParse> parsed =
+        ParseGotoTimestampInput(input, config.columns[static_cast<std::size_t>(timeCol)].parseFormats, now);
     if (!parsed.has_value())
     {
         statusBar()->showMessage(tr("Could not parse timestamp."), STATUS_BAR_MESSAGE_TIMEOUT_MS);
@@ -6646,11 +6694,10 @@ void MainWindow::GotoTimestamp()
     // instant and needs the same local -> UTC shift to line up
     // with what the table shows on-screen. Users who paste a raw
     // (naive) log value from the file rather than the displayed
-    // value will land off by the display-zone offset; that's a
-    // documented caveat, not a bug -- the dialog's canonical
-    // meaning is "the wall-clock time the user reads in the row".
-    // `LocalMicrosecondsSinceEpochToUtc` handles the DST edge
-    // cases so we don't have to catch here.
+    // value will land off by the display-zone offset; the dialog
+    // label ("local time") flags this. `LocalMicrosecondsSinceEpoch
+    // ToUtc` handles the DST edge cases so we don't have to catch
+    // here.
     const int64_t targetMicros =
         parsed->isNaive ? loglib::LocalMicrosecondsSinceEpochToUtc(parsed->micros) : parsed->micros;
 
@@ -6703,22 +6750,47 @@ int MainWindow::FindFirstRowAtOrAfter(int timeCol, int64_t targetMicros) const
         return mSortFilterProxyModel->mapFromSource(midIdx).isValid();
     };
 
-    if (mSortFilterProxyModel->SortColumn() < 0)
+    // Outer proxy row -> source row, or `-1` when the mapping breaks
+    // (transient state during a proxy layout change). Factored out
+    // so the three branches below share one traversal skeleton.
+    const auto proxyRowToSource = [this](int proxyRow) -> int
     {
-        // Fast path: no user sort. File order is (practically always)
-        // timestamp-ordered, so we binary-search source rows in place
-        // -- allocating an `iota`d indices vector for a 10M-row file
+        const QModelIndex proxyIdx = mSortFilterProxyModel->index(proxyRow, 0);
+        const QModelIndex midIdx = mSortFilterProxyModel->mapToSource(proxyIdx);
+        if (!midIdx.isValid())
+        {
+            return -1;
+        }
+        const QModelIndex sourceIdx = mRowOrderProxyModel->mapToSource(midIdx);
+        return sourceIdx.isValid() ? sourceIdx.row() : -1;
+    };
+
+    const int userSortColumn = mSortFilterProxyModel->SortColumn();
+    const bool timestampsMonotonic = mModel->TimestampsAreMonotonic();
+
+    if (userSortColumn < 0 && timestampsMonotonic)
+    {
+        // Fast path: no user sort + source rows are monotonic in
+        // the time column. Binary-search source rows in place --
+        // allocating an `iota`d indices vector for a 10M-row file
         // would burn 40 MiB and blow the ROADMAP `< 100 ms` budget.
+        //
+        // Monotonicity is guarded by
+        // `LogModel::TimestampsAreMonotonic()`, which the streaming
+        // path flips to false on the first batch-boundary or intra-
+        // batch inversion (multi-file `Append`, rotation, clock
+        // skew). Once false we drop into the O(N_visible) branch
+        // below, which is correct for arbitrary orders.
         //
         // Missing timestamps must be handled explicitly rather than
         // treated as `-inf`: they can appear anywhere in the middle
         // of a file (JSON rows that omit the timestamp key) and any
         // "assign to -inf" or "assign to +inf" rule breaks the
-        // monotonicity that `lower_bound` requires. Instead, each
-        // probe walks forward from `mid` to the first row with a
-        // valid timestamp before making a decision. Worst case (all
-        // rows missing) degrades to O(N); common case (rare gaps)
-        // stays O(log N).
+        // monotonicity that `lower_bound` requires. Each probe
+        // walks forward from `mid` to the first row with a valid
+        // timestamp before making a decision. Worst case (all rows
+        // missing) degrades to O(N); common case (rare gaps) stays
+        // O(log N).
         //
         // Invariants:
         //   * `[0, lo)`  -- every row has "missing OR ts < target".
@@ -6755,31 +6827,92 @@ int MainWindow::FindFirstRowAtOrAfter(int timeCol, int64_t targetMicros) const
             }
         }
 
-        // Walk forward from `lo` to the first row that both carries
-        // a valid timestamp >= `target` AND is currently visible via
-        // the outer proxy. The visibility step matters when a filter
-        // is active: without it, the fast path can return a source
-        // row that's filtered out and `SelectSourceRow` then prints
-        // "Row is not currently visible" -- which looks like a bug
-        // to the user when there IS a visible qualifying row further
-        // down.
-        for (int row = lo; row < sourceRowCount; ++row)
+        if (lo >= sourceRowCount)
         {
-            const auto ts = tsFor(row);
-            if (!ts.has_value() || *ts < targetMicros)
+            return -1;
+        }
+
+        // Happy path: row `lo` itself is visible and carries a
+        // valid ts. Skips both the proxy walk below and its
+        // `mapFromSource` overhead in the common "no filter" case,
+        // where the fast path is O(log N) end-to-end.
+        {
+            const auto ts = tsFor(lo);
+            if (ts.has_value() && *ts >= targetMicros && isVisible(lo))
             {
-                // The binary-search invariant guarantees no `ts <
-                // target` past `lo`, but a missing-ts row can appear
-                // here (the invariant only pins the answer, not the
-                // gaps between it and the tail).
-                continue;
-            }
-            if (isVisible(row))
-            {
-                return row;
+                return lo;
             }
         }
-        return -1;
+
+        // Fallback: walk the OUTER PROXY (not the source) to find
+        // the smallest visible source row `>= lo` that carries a
+        // valid ts. This is O(N_visible) rather than O(N_source);
+        // the old source-walk degraded to O(N_source) when a heavy
+        // filter hid most of `[lo, sourceRowCount)`, blowing the
+        // ROADMAP budget on huge files.
+        //
+        // Correctness: by the binary-search invariant, every source
+        // row in `[lo, sourceRowCount)` either has a valid ts >=
+        // target or is missing. So any visible source row `>= lo`
+        // with a valid ts is a qualifying answer, and the SMALLEST
+        // such row is the one we want (earliest chronologically,
+        // by monotonicity).
+        int best = -1;
+        const int proxyRowCount = mSortFilterProxyModel->rowCount();
+        for (int proxyRow = 0; proxyRow < proxyRowCount; ++proxyRow)
+        {
+            const int sourceRow = proxyRowToSource(proxyRow);
+            if (sourceRow < lo)
+            {
+                continue;
+            }
+            const auto ts = tsFor(sourceRow);
+            if (!ts.has_value() || *ts < targetMicros)
+            {
+                continue;
+            }
+            if (best < 0 || sourceRow < best)
+            {
+                best = sourceRow;
+            }
+        }
+        return best;
+    }
+
+    if (userSortColumn < 0)
+    {
+        // No user sort, but the source is not monotonic in time
+        // (multi-file `Append`, rotation, clock skew observed via
+        // `LogModel::TimestampsAreMonotonic()`). The fast path
+        // above is unsafe: `lower_bound` would silently return a
+        // wrong row. Fall back to an O(N_visible) walk over the
+        // outer proxy and pick the visible row with the SMALLEST
+        // ts that still satisfies `ts >= target`. That is the
+        // chronologically earliest match, matching the natural
+        // "at or after" semantic even when source order is not
+        // wall-clock order.
+        int best = -1;
+        int64_t bestTs = std::numeric_limits<int64_t>::max();
+        const int proxyRowCount = mSortFilterProxyModel->rowCount();
+        for (int proxyRow = 0; proxyRow < proxyRowCount; ++proxyRow)
+        {
+            const int sourceRow = proxyRowToSource(proxyRow);
+            if (sourceRow < 0)
+            {
+                continue;
+            }
+            const auto ts = tsFor(sourceRow);
+            if (!ts.has_value() || *ts < targetMicros)
+            {
+                continue;
+            }
+            if (*ts < bestTs)
+            {
+                bestTs = *ts;
+                best = sourceRow;
+            }
+        }
+        return best;
     }
 
     // Slow path: user sort active. Linear scan in display order and
@@ -6789,18 +6922,11 @@ int MainWindow::FindFirstRowAtOrAfter(int timeCol, int64_t targetMicros) const
     const int proxyRowCount = mSortFilterProxyModel->rowCount();
     for (int proxyRow = 0; proxyRow < proxyRowCount; ++proxyRow)
     {
-        const QModelIndex proxyIdx = mSortFilterProxyModel->index(proxyRow, 0);
-        const QModelIndex midIdx = mSortFilterProxyModel->mapToSource(proxyIdx);
-        if (!midIdx.isValid())
+        const int sourceRow = proxyRowToSource(proxyRow);
+        if (sourceRow < 0)
         {
             continue;
         }
-        const QModelIndex sourceIdx = mRowOrderProxyModel->mapToSource(midIdx);
-        if (!sourceIdx.isValid())
-        {
-            continue;
-        }
-        const int sourceRow = sourceIdx.row();
         const auto ts = tsFor(sourceRow);
         if (ts.has_value() && *ts >= targetMicros)
         {
@@ -8847,6 +8973,25 @@ void MainWindow::ExecuteGotoLineForTest(const QString &input)
     // regression in the modal-owning `GotoLine` slot cannot mask a
     // regression in the validation branches (and vice versa).
     ExecuteGotoLine(input);
+}
+
+void MainWindow::ExecuteGotoTimestampForTest(const QString &input, std::chrono::system_clock::time_point now)
+{
+    // Thin forwarder; same rationale as `ExecuteGotoLineForTest`.
+    ExecuteGotoTimestamp(input, now);
+}
+
+QString MainWindow::LastGotoTimestampInputForTest() const
+{
+    return mLastGotoTimestampInput;
+}
+
+void MainWindow::ForceTimestampsNonMonotonicForTest()
+{
+    if (mModel != nullptr)
+    {
+        mModel->SetTimestampsMonotonicForTest(false);
+    }
 }
 #endif
 

--- a/app/src/main_window.cpp
+++ b/app/src/main_window.cpp
@@ -6430,8 +6430,7 @@ void MainWindow::ExecuteGotoLine(const QString &input)
     if (!visible)
     {
         statusBar()->showMessage(
-            tr("Line %1 is currently filtered out.").arg(QString::number(oneBased)),
-            STATUS_BAR_MESSAGE_TIMEOUT_MS
+            tr("Line %1 is currently filtered out.").arg(QString::number(oneBased)), STATUS_BAR_MESSAGE_TIMEOUT_MS
         );
         return;
     }
@@ -6486,9 +6485,7 @@ namespace
 } // namespace
 
 std::optional<MainWindow::GotoTimestampParse> MainWindow::ParseGotoTimestampInput(
-    const QString &input,
-    const std::vector<std::string> &columnParseFormats,
-    std::chrono::system_clock::time_point now
+    const QString &input, const std::vector<std::string> &columnParseFormats, std::chrono::system_clock::time_point now
 )
 {
     const QString trimmed = input.trimmed();
@@ -6525,8 +6522,7 @@ std::optional<MainWindow::GotoTimestampParse> MainWindow::ParseGotoTimestampInpu
             return std::nullopt;
         }
         const int64_t offsetMicros = static_cast<int64_t>(n) * microsPerUnit;
-        const auto nowMicros =
-            std::chrono::duration_cast<std::chrono::microseconds>(now.time_since_epoch()).count();
+        const auto nowMicros = std::chrono::duration_cast<std::chrono::microseconds>(now.time_since_epoch()).count();
         return GotoTimestampParse{.micros = nowMicros - offsetMicros, .isNaive = false};
     }
 
@@ -6555,8 +6551,8 @@ std::optional<MainWindow::GotoTimestampParse> MainWindow::ParseGotoTimestampInpu
         if (loglib::TryParseTimestamp(stdInput, fmt, loglib::ClassifyTimestampFormat(fmt), scratch, parsed))
         {
             return GotoTimestampParse{
-                .micros = parsed.time_since_epoch().count(),
-                .isNaive = !FormatHasZoneSpecifier(fmt)};
+                .micros = parsed.time_since_epoch().count(), .isNaive = !FormatHasZoneSpecifier(fmt)
+            };
         }
     }
     return std::nullopt;
@@ -6661,8 +6657,7 @@ int MainWindow::FindFirstRowAtOrAfter(int timeCol, int64_t targetMicros) const
     // slot is missing / unpromoted; both searches below skip such
     // rows explicitly (treating them as `-inf` would break the
     // fast-path binary search's monotonicity invariant).
-    const auto tsFor = [this, timeCol](int sourceRow) -> std::optional<int64_t>
-    {
+    const auto tsFor = [this, timeCol](int sourceRow) -> std::optional<int64_t> {
         return loglib::AsEpochMicroseconds(
             mModel->Table().GetValue(static_cast<std::size_t>(sourceRow), static_cast<std::size_t>(timeCol))
         );
@@ -6670,8 +6665,7 @@ int MainWindow::FindFirstRowAtOrAfter(int timeCol, int64_t targetMicros) const
 
     // Source row -> visible through the outer proxy? Respects the
     // mid-proxy's newest-first reversal and the active row filter.
-    const auto isVisible = [this](int sourceRow) -> bool
-    {
+    const auto isVisible = [this](int sourceRow) -> bool {
         const QModelIndex sourceIdx = mModel->index(sourceRow, 0);
         const QModelIndex midIdx = mRowOrderProxyModel->mapFromSource(sourceIdx);
         if (!midIdx.isValid())
@@ -6683,8 +6677,7 @@ int MainWindow::FindFirstRowAtOrAfter(int timeCol, int64_t targetMicros) const
 
     // Outer proxy row -> source row, or `-1` when the mapping is
     // transiently broken (proxy layout change in flight).
-    const auto proxyRowToSource = [this](int proxyRow) -> int
-    {
+    const auto proxyRowToSource = [this](int proxyRow) -> int {
         const QModelIndex proxyIdx = mSortFilterProxyModel->index(proxyRow, 0);
         const QModelIndex midIdx = mSortFilterProxyModel->mapToSource(proxyIdx);
         if (!midIdx.isValid())

--- a/app/src/main_window.cpp
+++ b/app/src/main_window.cpp
@@ -6716,17 +6716,23 @@ int MainWindow::FindFirstRowAtOrAfter(int timeCol, int64_t targetMicros) const
         {
             const int mid = lo + ((hi - lo) / 2);
             int probe = mid;
-            std::optional<int64_t> probeTs;
-            while (probe < hi && !(probeTs = tsFor(probe)).has_value())
+            int64_t probeTsValue = 0;
+            bool probeHasTs = false;
+            for (; probe < hi; ++probe)
             {
-                ++probe;
+                if (const auto probeTs = tsFor(probe); probeTs.has_value())
+                {
+                    probeTsValue = *probeTs;
+                    probeHasTs = true;
+                    break;
+                }
             }
-            if (probe >= hi)
+            if (!probeHasTs)
             {
                 // `[mid, hi)` is all missing -- shrink to the left.
                 hi = mid;
             }
-            else if (*probeTs < targetMicros)
+            else if (probeTsValue < targetMicros)
             {
                 lo = probe + 1;
             }

--- a/app/src/main_window.cpp
+++ b/app/src/main_window.cpp
@@ -62,6 +62,7 @@
 #include <QGuiApplication>
 #include <QHeaderView>
 #include <QInputDialog>
+#include <QIntValidator>
 #include <QKeyEvent>
 #include <QKeySequence>
 #include <QLabel>
@@ -74,6 +75,7 @@
 #include <QPixmap>
 #include <QPlainTextEdit>
 #include <QProgressDialog>
+#include <QRegularExpression>
 #include <QScopeGuard>
 #include <QSettings>
 #include <QSignalBlocker>
@@ -929,6 +931,11 @@ MainWindow::MainWindow(
     // Tooltip reflects `Find`'s smart toggle behaviour.
     ui->actionFind->setToolTip(tr("Find in logs. Press again to close."));
     connect(ui->actionFind, &QAction::triggered, this, &MainWindow::Find);
+
+    // Goto Line / Goto Timestamp. Both actions live in the Edit
+    // menu (`Ctrl+G` and `Ctrl+Shift+G`); see item 8 in `ROADMAP.md`.
+    connect(ui->actionGotoLine, &QAction::triggered, this, &MainWindow::GotoLine);
+    connect(ui->actionGotoTimestamp, &QAction::triggered, this, &MainWindow::GotoTimestamp);
 
     connect(ui->actionAddFilter, &QAction::triggered, this, [this]() { AddFilter(QUuid::createUuid().toString()); });
     connect(ui->actionClearAllFilters, &QAction::triggered, this, &MainWindow::ClearAllFilters);
@@ -6334,6 +6341,264 @@ void MainWindow::SelectSourceRow(int sourceRow)
     mTableView->scrollTo(proxyIdx, QAbstractItemView::PositionAtCenter);
     mTableView->selectionModel()->select(proxyIdx, QItemSelectionModel::Select | QItemSelectionModel::Rows);
     mTableView->selectionModel()->setCurrentIndex(proxyIdx, QItemSelectionModel::NoUpdate);
+}
+
+void MainWindow::GotoLine()
+{
+    if (mModel == nullptr || mModel->rowCount() == 0)
+    {
+        statusBar()->showMessage(tr("No log loaded."), STATUS_BAR_MESSAGE_TIMEOUT_MS);
+        return;
+    }
+
+    const int rowCount = mModel->rowCount();
+
+    // Instantiated `QInputDialog` (not the static `getInt` helper)
+    // so we can attach a `QIntValidator` to the line edit and lean
+    // on Qt's built-in accept-blocking rather than re-validating
+    // after `exec`. Range is 1..rowCount; lines are 1-based for
+    // parity with every editor's "Go to Line" dialog.
+    QInputDialog dialog(this);
+    dialog.setWindowTitle(tr("Go to Line"));
+    dialog.setLabelText(
+        tr("Line number (1 - %1):").arg(QLocale::system().toString(rowCount))
+    );
+    dialog.setInputMode(QInputDialog::TextInput);
+    dialog.setTextEchoMode(QLineEdit::Normal);
+    if (auto *editor = dialog.findChild<QLineEdit *>())
+    {
+        editor->setValidator(new QIntValidator(1, rowCount, &dialog));
+        editor->setPlaceholderText(tr("e.g. 12345"));
+    }
+    if (dialog.exec() != QDialog::Accepted)
+    {
+        return;
+    }
+
+    bool ok = false;
+    const int oneBased = dialog.textValue().toInt(&ok);
+    if (!ok || oneBased < 1 || oneBased > rowCount)
+    {
+        // The validator normally blocks Accept on out-of-range
+        // input, but paranoia: if the model shrank while the modal
+        // was open (streaming eviction, session swap), surface it
+        // instead of silently no-oping.
+        statusBar()->showMessage(
+            tr("Line %1 is out of range (1 - %2).")
+                .arg(dialog.textValue(), QLocale::system().toString(rowCount)),
+            STATUS_BAR_MESSAGE_TIMEOUT_MS
+        );
+        return;
+    }
+
+    SelectSourceRow(oneBased - 1);
+}
+
+std::optional<int64_t> MainWindow::ParseGotoTimestampInput(
+    const QString &input,
+    const std::vector<std::string> &columnParseFormats,
+    std::chrono::system_clock::time_point now
+)
+{
+    const QString trimmed = input.trimmed();
+    if (trimmed.isEmpty())
+    {
+        return std::nullopt;
+    }
+
+    // Relative shortcut first: `-Nh` / `-Nm` (case-insensitive,
+    // whitespace-tolerant). Evaluated against @p now so tests can
+    // pin the clock; production wires `system_clock::now()`.
+    // ROADMAP item 8 spells out these two units explicitly; adding
+    // more (like `-Ns`, `-Nd`) is left for future contributions.
+    static const QRegularExpression RELATIVE_SHORTCUT_RE(
+        QStringLiteral(R"(^-\s*(\d+)\s*([hm])\s*$)"), QRegularExpression::CaseInsensitiveOption
+    );
+    const auto relMatch = RELATIVE_SHORTCUT_RE.match(trimmed);
+    if (relMatch.hasMatch())
+    {
+        bool ok = false;
+        const qulonglong n = relMatch.captured(1).toULongLong(&ok);
+        if (!ok)
+        {
+            return std::nullopt;
+        }
+        const QChar unit = relMatch.captured(2).at(0).toLower();
+        const int64_t nSigned = static_cast<int64_t>(n);
+        // Common type for the ternary: convert both branches to
+        // microseconds so `std::chrono::hours` and `minutes` share
+        // a representation.
+        const auto offset = unit == QLatin1Char('h')
+                                ? std::chrono::duration_cast<std::chrono::microseconds>(std::chrono::hours(nSigned))
+                                : std::chrono::duration_cast<std::chrono::microseconds>(std::chrono::minutes(nSigned));
+        const auto target = now - offset;
+        return std::chrono::duration_cast<std::chrono::microseconds>(target.time_since_epoch()).count();
+    }
+
+    // Absolute path: try every parse format the column itself
+    // accepts, then two ISO fallbacks so a column with an empty
+    // `parseFormats` list (auto-detected `Type::Time`) still
+    // resolves the two forms users routinely paste.
+    const std::string stdInput = trimmed.toStdString();
+    std::vector<std::string> candidates;
+    candidates.reserve(columnParseFormats.size() + 2);
+    for (const auto &fmt : columnParseFormats)
+    {
+        candidates.push_back(fmt);
+    }
+    for (const auto *fallback : {"%FT%T", "%F %T"})
+    {
+        if (std::find(candidates.begin(), candidates.end(), std::string{fallback}) == candidates.end())
+        {
+            candidates.emplace_back(fallback);
+        }
+    }
+
+    loglib::TimestampParseScratch scratch;
+    for (const auto &fmt : candidates)
+    {
+        loglib::TimeStamp parsed{};
+        if (loglib::TryParseTimestamp(stdInput, fmt, loglib::ClassifyTimestampFormat(fmt), scratch, parsed))
+        {
+            return parsed.time_since_epoch().count();
+        }
+    }
+    return std::nullopt;
+}
+
+void MainWindow::GotoTimestamp()
+{
+    if (mModel == nullptr || mModel->rowCount() == 0)
+    {
+        statusBar()->showMessage(tr("No log loaded."), STATUS_BAR_MESSAGE_TIMEOUT_MS);
+        return;
+    }
+
+    const auto &config = mModel->Configuration();
+    const int timeCol = loglib::FirstTimeColumnIndex(config);
+    if (timeCol < 0)
+    {
+        statusBar()->showMessage(tr("This log has no timestamp column."), STATUS_BAR_MESSAGE_TIMEOUT_MS);
+        return;
+    }
+
+    QInputDialog dialog(this);
+    dialog.setWindowTitle(tr("Go to Timestamp"));
+    dialog.setLabelText(tr("Timestamp:"));
+    dialog.setInputMode(QInputDialog::TextInput);
+    dialog.setTextEchoMode(QLineEdit::Normal);
+    if (auto *editor = dialog.findChild<QLineEdit *>())
+    {
+        editor->setPlaceholderText(tr("YYYY-MM-DD HH:MM:SS or -1h / -30m"));
+    }
+    if (dialog.exec() != QDialog::Accepted)
+    {
+        return;
+    }
+
+    const std::optional<int64_t> targetMicros = ParseGotoTimestampInput(
+        dialog.textValue(),
+        config.columns[static_cast<std::size_t>(timeCol)].parseFormats,
+        std::chrono::system_clock::now()
+    );
+    if (!targetMicros.has_value())
+    {
+        statusBar()->showMessage(tr("Could not parse timestamp."), STATUS_BAR_MESSAGE_TIMEOUT_MS);
+        return;
+    }
+
+    const int sourceRow = FindFirstRowAtOrAfter(timeCol, *targetMicros);
+    if (sourceRow < 0)
+    {
+        statusBar()->showMessage(tr("No row at or after that time."), STATUS_BAR_MESSAGE_TIMEOUT_MS);
+        return;
+    }
+    SelectSourceRow(sourceRow);
+}
+
+int MainWindow::FindFirstRowAtOrAfter(int timeCol, int64_t targetMicros) const
+{
+    if (mModel == nullptr || mSortFilterProxyModel == nullptr || mRowOrderProxyModel == nullptr)
+    {
+        return -1;
+    }
+    const int sourceRowCount = mModel->rowCount();
+    if (timeCol < 0 || sourceRowCount == 0)
+    {
+        return -1;
+    }
+
+    // Cell -> epoch µs. Missing / unpromoted timestamps sort as
+    // `-inf` so `lower_bound` stays monotonic and a linear scan
+    // never picks them as "first at or after".
+    const auto tsFor = [this, timeCol](int sourceRow) -> std::optional<int64_t>
+    {
+        return loglib::AsEpochMicroseconds(
+            mModel->Table().GetValue(static_cast<std::size_t>(sourceRow), static_cast<std::size_t>(timeCol))
+        );
+    };
+
+    if (mSortFilterProxyModel->SortColumn() < 0)
+    {
+        // Binary-search source rows in place -- allocating an
+        // `iota`d indices vector for a 10M-row file would burn
+        // 40 MiB and blow the ROADMAP `< 100 ms` budget. File
+        // order is (practically always) timestamp-ordered; ROADMAP
+        // item 8 declares this the fast path.
+        //
+        // Invariant: `hi` is the first row known to satisfy
+        // `ts >= target`, or `sourceRowCount` if none does yet.
+        // Rows with missing timestamps are treated as `-inf`
+        // (they stay left of every real timestamp, preserving
+        // monotonicity).
+        int lo = 0;
+        int hi = sourceRowCount;
+        while (lo < hi)
+        {
+            const int mid = lo + ((hi - lo) / 2);
+            const auto ts = tsFor(mid);
+            if (!ts.has_value() || *ts < targetMicros)
+            {
+                lo = mid + 1;
+            }
+            else
+            {
+                hi = mid;
+            }
+        }
+        if (lo >= sourceRowCount)
+        {
+            return -1;
+        }
+        return lo;
+    }
+
+    // User sort active on a different (or the same) column. Do a
+    // linear scan in display order and return the first proxy
+    // row whose source timestamp qualifies -- respects the user's
+    // chosen "first".
+    const int proxyRowCount = mSortFilterProxyModel->rowCount();
+    for (int proxyRow = 0; proxyRow < proxyRowCount; ++proxyRow)
+    {
+        const QModelIndex proxyIdx = mSortFilterProxyModel->index(proxyRow, 0);
+        const QModelIndex midIdx = mSortFilterProxyModel->mapToSource(proxyIdx);
+        if (!midIdx.isValid())
+        {
+            continue;
+        }
+        const QModelIndex sourceIdx = mRowOrderProxyModel->mapToSource(midIdx);
+        if (!sourceIdx.isValid())
+        {
+            continue;
+        }
+        const int sourceRow = sourceIdx.row();
+        const auto ts = tsFor(sourceRow);
+        if (ts.has_value() && *ts >= targetMicros)
+        {
+            return sourceRow;
+        }
+    }
+    return -1;
 }
 
 void MainWindow::JumpToFirstRowInBucket(std::size_t bucketIndex)

--- a/app/src/main_window.ui
+++ b/app/src/main_window.ui
@@ -187,7 +187,7 @@
     <string>Go to Line...</string>
    </property>
    <property name="toolTip">
-    <string>Jump to a source-model row number (1-based; the first line in the file is line 1).</string>
+    <string>Jump to a row by number. Line 1 is the earliest row currently in the model; streaming eviction may have dropped older rows so numbers need not match the source file.</string>
    </property>
    <property name="shortcut">
     <string>Ctrl+G</string>

--- a/app/src/main_window.ui
+++ b/app/src/main_window.ui
@@ -54,6 +54,9 @@
     </property>
     <addaction name="actionCopy"/>
     <addaction name="actionFind"/>
+    <addaction name="separator"/>
+    <addaction name="actionGotoLine"/>
+    <addaction name="actionGotoTimestamp"/>
    </widget>
    <widget class="QMenu" name="menuView">
     <property name="title">
@@ -177,6 +180,28 @@
    </property>
    <property name="shortcut">
     <string>Ctrl+F</string>
+   </property>
+  </action>
+  <action name="actionGotoLine">
+   <property name="text">
+    <string>Go to Line...</string>
+   </property>
+   <property name="toolTip">
+    <string>Jump to a source-model row number (1-based; the first line in the file is line 1).</string>
+   </property>
+   <property name="shortcut">
+    <string>Ctrl+G</string>
+   </property>
+  </action>
+  <action name="actionGotoTimestamp">
+   <property name="text">
+    <string>Go to Timestamp...</string>
+   </property>
+   <property name="toolTip">
+    <string>Jump to the first row at or after a given timestamp. Accepts formats the timestamp column already parses, plus relative shortcuts like &quot;-1h&quot; or &quot;-30m&quot;.</string>
+   </property>
+   <property name="shortcut">
+    <string>Ctrl+Shift+G</string>
    </property>
   </action>
   <action name="actionAddFilter">

--- a/app/src/main_window.ui
+++ b/app/src/main_window.ui
@@ -187,7 +187,7 @@
     <string>Go to Line...</string>
    </property>
    <property name="toolTip">
-    <string>Jump to a row by number. Line 1 is the earliest row currently in the model; streaming eviction may have dropped older rows so numbers need not match the source file.</string>
+    <string>Jump to a row by number. Line 1 is always the earliest row currently in the model (bottom-of-screen in newest-first mode); streaming eviction may have dropped older rows so numbers need not match the source file.</string>
    </property>
    <property name="shortcut">
     <string>Ctrl+G</string>
@@ -198,7 +198,7 @@
     <string>Go to Timestamp...</string>
    </property>
    <property name="toolTip">
-    <string>Jump to the first row at or after a given timestamp. Accepts formats the timestamp column already parses, plus relative shortcuts like &quot;-1h&quot; or &quot;-30m&quot;.</string>
+    <string>Jump to the first row at or after a given timestamp. Naive timestamps (no offset / no &quot;Z&quot;) are interpreted in the display time zone (local time). Accepts formats the timestamp column already parses, plus ISO 8601 and relative shortcuts like &quot;-1h&quot; or &quot;-30m&quot;.</string>
    </property>
    <property name="shortcut">
     <string>Ctrl+Shift+G</string>

--- a/doc/README.md
+++ b/doc/README.md
@@ -317,6 +317,21 @@ Inside the pane:
 
 To pin a record for side-by-side comparison, click **Open in new window** inside the pane. That spawns a top-level snapshot window with a frozen copy of the displayed content — you can open as many as you like, and each one survives streaming-mode FIFO eviction, sort, filter, or even a full `File → Open…` reset because its strings are deep-copied at creation. Close each snapshot with the window's normal close button when you're done.
 
+### Jumping to a Line or Timestamp
+
+Two entries in the **Edit** menu let you jump to a specific row without scrolling or searching:
+
+- **Edit → Go to Line…** (`Ctrl+G`) — enter a 1-based row number and land on that row. Line 1 is always the earliest row currently retained by the model; in newest-first display mode it sits at the bottom of the visible list, not the top. Line numbers do **not** always match the source file's line numbers because streaming-mode FIFO eviction may have dropped older rows. The dialog validates the input against the *live* row count, so a value that was in-range while the dialog was open but that has since been evicted is rejected with an "out of range" hint. Filtered-out targets surface a specific "line N is currently filtered out" message rather than a generic "row not visible" fallback. The last-entered value is pre-populated on the next open (cleared on **File → New Session**).
+- **Edit → Go to Timestamp…** (`Ctrl+Shift+G`) — enter an absolute or relative time and land on the first row at or after it. Accepted forms:
+  - Any format the timestamp column already parses (see [`parseFormats`](#configurations)).
+  - ISO 8601 fallbacks (`YYYY-MM-DDTHH:MM:SS` and `YYYY-MM-DD HH:MM:SS`), even for columns whose own list is empty.
+  - Zoned inputs with an explicit offset (`…+02:00`) or `Z` suffix.
+  - Relative shortcuts `-Nh` and `-Nm` (case-insensitive, whitespace-tolerant; also `+Nh` and bare `Nh` — the sign is decorative and always means "N units ago", matching lnav / less).
+
+  Naive inputs (no offset / no `Z`) are interpreted in the **display time zone** — the same zone the table renders — so the string you type matches what you read on screen. Users pasting a raw `Z`-suffixed value from the file get the zoned parser branch and are not double-shifted. When the timestamp column is monotonic in file order (the usual case for a single log source), the search is O(log N); multi-file **Append** opens and rotation flip an internal flag that switches the search to an O(N_visible) proxy walk which picks the chronologically earliest visible match. Overflowing relative shortcuts (`-Nh` beyond `int64_t` microseconds) are rejected rather than wrapped. The last-entered value is pre-populated on the next open (cleared on **File → New Session**).
+
+Both dialogs surface any failure ("no log loaded", "log has no timestamp column", "could not parse timestamp", "no visible row at or after that time") in the status bar and leave the current selection untouched.
+
 ## Anchors
 
 Anchors let you mark notable rows with one of eight colours, attach a short freeform note to each, and jump between them with the keyboard. Useful when triaging a long log: pin the request that started the incident, the first error, and the final recovery, then cycle through them with `F2`.
@@ -606,6 +621,8 @@ Click **Ok** to persist (stored via `QSettings` under the organization `jan-mora
 | Save configuration             | `Ctrl+S`            |
 | Save session                   | `Ctrl+Shift+S`      |
 | Find                           | `Ctrl+F`            |
+| Go to Line                     | `Ctrl+G`            |
+| Go to Timestamp                | `Ctrl+Shift+G`      |
 | Copy selected rows as JSON     | `Ctrl+C`            |
 | Toggle Record Details pane     | `Ctrl+I`            |
 | Toggle Anchors panel           | `Ctrl+K`            |

--- a/doc/README.md
+++ b/doc/README.md
@@ -322,7 +322,9 @@ To pin a record for side-by-side comparison, click **Open in new window** inside
 Two entries in the **Edit** menu let you jump to a specific row without scrolling or searching:
 
 - **Edit → Go to Line…** (`Ctrl+G`) — enter a 1-based row number and land on that row. Line 1 is always the earliest row currently retained by the model; in newest-first display mode it sits at the bottom of the visible list, not the top. Line numbers do **not** always match the source file's line numbers because streaming-mode FIFO eviction may have dropped older rows. The dialog validates the input against the *live* row count, so a value that was in-range while the dialog was open but that has since been evicted is rejected with an "out of range" hint. Filtered-out targets surface a specific "line N is currently filtered out" message rather than a generic "row not visible" fallback. The last-entered value is pre-populated on the next open (cleared on **File → New Session**).
+
 - **Edit → Go to Timestamp…** (`Ctrl+Shift+G`) — enter an absolute or relative time and land on the first row at or after it. Accepted forms:
+
   - Any format the timestamp column already parses (see [`parseFormats`](#configurations)).
   - ISO 8601 fallbacks (`YYYY-MM-DDTHH:MM:SS` and `YYYY-MM-DD HH:MM:SS`), even for columns whose own list is empty.
   - Zoned inputs with an explicit offset (`…+02:00`) or `Z` suffix.

--- a/library/include/loglib/log_processing.hpp
+++ b/library/include/loglib/log_processing.hpp
@@ -99,6 +99,16 @@ int64_t UtcMicrosecondsToLocalMilliseconds(int64_t microseconds);
 
 TimeStamp LocalMillisecondsSinceEpochToTimeStamp(int64_t milliseconds);
 
+/// Convert @p localMicroseconds -- interpreted as a wall-clock instant
+/// in `CurrentZone()` -- to UTC microseconds since epoch. Returns the
+/// naive value unchanged when no zone is installed. Handles the two
+/// DST edge cases gracefully: an ambiguous local time (the "fall-back"
+/// hour) resolves to the earlier of the two candidates; a nonexistent
+/// local time (the "spring-forward" hour) resolves to the naive value.
+/// Used by the Goto Timestamp modal to align user-typed wall-clock
+/// timestamps with the UTC-normalised values stored in the log table.
+int64_t LocalMicrosecondsSinceEpochToUtc(int64_t localMicroseconds);
+
 /// Formats UTC microseconds since epoch as a `%F %T`-style local-time string.
 std::string UtcMicrosecondsToDateTimeString(int64_t microseconds);
 

--- a/library/include/loglib/log_processing.hpp
+++ b/library/include/loglib/log_processing.hpp
@@ -100,13 +100,34 @@ int64_t UtcMicrosecondsToLocalMilliseconds(int64_t microseconds);
 TimeStamp LocalMillisecondsSinceEpochToTimeStamp(int64_t milliseconds);
 
 /// Convert @p localMicroseconds -- interpreted as a wall-clock instant
-/// in `CurrentZone()` -- to UTC microseconds since epoch. Returns the
-/// naive value unchanged when no zone is installed. Handles the two
-/// DST edge cases gracefully: an ambiguous local time (the "fall-back"
-/// hour) resolves to the earlier of the two candidates; a nonexistent
-/// local time (the "spring-forward" hour) resolves to the naive value.
-/// Used by the Goto Timestamp modal to align user-typed wall-clock
-/// timestamps with the UTC-normalised values stored in the log table.
+/// in @p zone -- to UTC microseconds since epoch. Returns the naive
+/// value unchanged when @p zone is `nullptr`. Uses
+/// `date::to_sys(local, choose::earliest)` so DST edge cases resolve
+/// without throwing:
+///   * an ambiguous local time (the "fall-back" hour) yields the
+///     earlier of the two candidates.
+///   * a nonexistent local time (the "spring-forward" gap) snaps to
+///     the sys_time transition boundary between the two offsets --
+///     i.e., the first real instant *after* the gap. Callers that
+///     require a naive-value fallback for gaps would need to probe
+///     `zone->get_info(local)` up-front; the Goto Timestamp caller
+///     accepts the transition-boundary outcome as the natural
+///     "nearest existing instant" target.
+///
+/// Non-DST exceptions from the underlying zone lookup (e.g. inputs
+/// past the tzdata transition table, or a corrupt zone entry) are
+/// caught and yield the naive value so the Goto Timestamp slot
+/// stays exception-safe.
+///
+/// The zone parameter exists so tests can pin `America/New_York` /
+/// `Europe/Berlin` DST transitions deterministically across CI
+/// hosts. Production callers use the no-argument overload below,
+/// which resolves to `CurrentZone()`.
+int64_t LocalMicrosecondsSinceEpochToUtc(int64_t localMicroseconds, const date::time_zone *zone);
+
+/// Production overload: convert against `CurrentZone()`. Equivalent
+/// to `LocalMicrosecondsSinceEpochToUtc(local, CurrentZone())` and
+/// preserves the pre-existing call-site shape.
 int64_t LocalMicrosecondsSinceEpochToUtc(int64_t localMicroseconds);
 
 /// Formats UTC microseconds since epoch as a `%F %T`-style local-time string.

--- a/library/include/loglib/log_processing.hpp
+++ b/library/include/loglib/log_processing.hpp
@@ -99,35 +99,22 @@ int64_t UtcMicrosecondsToLocalMilliseconds(int64_t microseconds);
 
 TimeStamp LocalMillisecondsSinceEpochToTimeStamp(int64_t milliseconds);
 
-/// Convert @p localMicroseconds -- interpreted as a wall-clock instant
-/// in @p zone -- to UTC microseconds since epoch. Returns the naive
-/// value unchanged when @p zone is `nullptr`. Uses
-/// `date::to_sys(local, choose::earliest)` so DST edge cases resolve
-/// without throwing:
-///   * an ambiguous local time (the "fall-back" hour) yields the
-///     earlier of the two candidates.
-///   * a nonexistent local time (the "spring-forward" gap) snaps to
-///     the sys_time transition boundary between the two offsets --
-///     i.e., the first real instant *after* the gap. Callers that
-///     require a naive-value fallback for gaps would need to probe
-///     `zone->get_info(local)` up-front; the Goto Timestamp caller
-///     accepts the transition-boundary outcome as the natural
-///     "nearest existing instant" target.
-///
-/// Non-DST exceptions from the underlying zone lookup (e.g. inputs
-/// past the tzdata transition table, or a corrupt zone entry) are
-/// caught and yield the naive value so the Goto Timestamp slot
-/// stays exception-safe.
-///
-/// The zone parameter exists so tests can pin `America/New_York` /
-/// `Europe/Berlin` DST transitions deterministically across CI
-/// hosts. Production callers use the no-argument overload below,
-/// which resolves to `CurrentZone()`.
+/// Convert @p localMicroseconds -- interpreted as a wall-clock
+/// instant in @p zone -- to UTC epoch microseconds. Returns the
+/// input unchanged if @p zone is null. DST edge cases resolve via
+/// `date::to_sys(local, choose::earliest)`:
+///   * Ambiguous "fall-back" hour: the earlier candidate.
+///   * Non-existent "spring-forward" gap: the transition boundary
+///     (the first real instant after the gap).
+/// Non-DST exceptions (far-future dates past the tzdata table,
+/// corrupt zone entries) are caught and yield the naive value so
+/// the Goto Timestamp slot stays exception-safe. The @p zone
+/// argument exists for deterministic tests; production uses the
+/// overload below.
 int64_t LocalMicrosecondsSinceEpochToUtc(int64_t localMicroseconds, const date::time_zone *zone);
 
-/// Production overload: convert against `CurrentZone()`. Equivalent
-/// to `LocalMicrosecondsSinceEpochToUtc(local, CurrentZone())` and
-/// preserves the pre-existing call-site shape.
+/// Convenience overload equivalent to
+/// `LocalMicrosecondsSinceEpochToUtc(local, CurrentZone())`.
 int64_t LocalMicrosecondsSinceEpochToUtc(int64_t localMicroseconds);
 
 /// Formats UTC microseconds since epoch as a `%F %T`-style local-time string.

--- a/library/src/log_processing.cpp
+++ b/library/src/log_processing.cpp
@@ -406,38 +406,20 @@ int64_t LocalMicrosecondsSinceEpochToUtc(int64_t localMicroseconds, const date::
     const date::local_time<std::chrono::microseconds> localTime{std::chrono::microseconds{localMicroseconds}};
     try
     {
-        // `choose::earliest` resolves both DST edge cases without
-        // throwing:
-        //   * ambiguous fall-back hour -> earlier of the two
-        //     candidates (per the `choose` semantics).
-        //   * spring-forward gap -> the sys_time transition
-        //     boundary between the two offsets (i.e., the instant
-        //     clocks jumped forward). Note: this is NOT the naive
-        //     value; if a caller wanted "naive fallback for gaps"
-        //     they would need to call `get_info(localTime)` first
-        //     and branch on `local_info::nonexistent`. The
-        //     transition-boundary outcome is a fine Goto Timestamp
-        //     target (the first real instant after the gap) so we
-        //     accept it.
-        //
-        // The DST exceptions are only thrown by the no-`choose`
-        // overload of `to_sys`, so we deliberately don't catch
-        // `nonexistent_local_time` / `ambiguous_local_time` here --
-        // doing so would be unreachable code and would encourage
-        // the "naive fallback" mental model that the current
-        // implementation does not actually provide.
+        // `choose::earliest` resolves DST edge cases without
+        // throwing: ambiguous fall-back hour -> earlier candidate;
+        // spring-forward gap -> the transition boundary. We do
+        // NOT catch `nonexistent_local_time` /
+        // `ambiguous_local_time` because the `choose` overload
+        // never throws them.
         const auto systemTime = zone->to_sys(localTime, date::choose::earliest);
         return systemTime.time_since_epoch().count();
     }
     catch (const std::exception &)
     {
-        // Reachable for inputs past the tzdata transition table
-        // (far-future / far-past dates) and for corrupt zone
-        // entries; the `choose` overload forwards these as plain
-        // `runtime_error` derivations rather than the DST-specific
-        // exceptions. Falling back to the naive value keeps the
-        // Goto Timestamp slot exception-safe: worst case, the jump
-        // is off by the zone offset rather than crashing the app.
+        // Reachable for far-future dates past the tzdata table
+        // and corrupt zone entries. Falling back to the naive
+        // value keeps the Goto Timestamp slot exception-safe.
         return localMicroseconds;
     }
 }

--- a/library/src/log_processing.cpp
+++ b/library/src/log_processing.cpp
@@ -397,6 +397,33 @@ TimeStamp LocalMillisecondsSinceEpochToTimeStamp(int64_t milliseconds)
     return std::chrono::time_point_cast<std::chrono::microseconds>(systemTime);
 }
 
+int64_t LocalMicrosecondsSinceEpochToUtc(int64_t localMicroseconds)
+{
+    const date::time_zone *zone = CurrentZone();
+    if (zone == nullptr)
+    {
+        return localMicroseconds;
+    }
+    const date::local_time<std::chrono::microseconds> localTime{std::chrono::microseconds{localMicroseconds}};
+    try
+    {
+        // Default overload throws on both DST edge cases; use
+        // `choose::earliest` for the ambiguous fall-back hour and
+        // catch the spring-forward `nonexistent_local_time` below.
+        const auto systemTime = zone->to_sys(localTime, date::choose::earliest);
+        return systemTime.time_since_epoch().count();
+    }
+    catch (const date::nonexistent_local_time &)
+    {
+        // Spring-forward gap: the wall-clock instant the user typed
+        // never occurred. Falling back to the naive value keeps the
+        // Goto Timestamp modal from throwing out of a slot; the
+        // resulting jump is off by (at most) the DST shift, which
+        // is a v1-acceptable degradation.
+        return localMicroseconds;
+    }
+}
+
 std::string UtcMicrosecondsToDateTimeString(int64_t microseconds)
 {
     const std::chrono::time_point<std::chrono::system_clock, std::chrono::microseconds> utcTime{

--- a/library/src/log_processing.cpp
+++ b/library/src/log_processing.cpp
@@ -397,9 +397,8 @@ TimeStamp LocalMillisecondsSinceEpochToTimeStamp(int64_t milliseconds)
     return std::chrono::time_point_cast<std::chrono::microseconds>(systemTime);
 }
 
-int64_t LocalMicrosecondsSinceEpochToUtc(int64_t localMicroseconds)
+int64_t LocalMicrosecondsSinceEpochToUtc(int64_t localMicroseconds, const date::time_zone *zone)
 {
-    const date::time_zone *zone = CurrentZone();
     if (zone == nullptr)
     {
         return localMicroseconds;
@@ -407,21 +406,45 @@ int64_t LocalMicrosecondsSinceEpochToUtc(int64_t localMicroseconds)
     const date::local_time<std::chrono::microseconds> localTime{std::chrono::microseconds{localMicroseconds}};
     try
     {
-        // Default overload throws on both DST edge cases; use
-        // `choose::earliest` for the ambiguous fall-back hour and
-        // catch the spring-forward `nonexistent_local_time` below.
+        // `choose::earliest` resolves both DST edge cases without
+        // throwing:
+        //   * ambiguous fall-back hour -> earlier of the two
+        //     candidates (per the `choose` semantics).
+        //   * spring-forward gap -> the sys_time transition
+        //     boundary between the two offsets (i.e., the instant
+        //     clocks jumped forward). Note: this is NOT the naive
+        //     value; if a caller wanted "naive fallback for gaps"
+        //     they would need to call `get_info(localTime)` first
+        //     and branch on `local_info::nonexistent`. The
+        //     transition-boundary outcome is a fine Goto Timestamp
+        //     target (the first real instant after the gap) so we
+        //     accept it.
+        //
+        // The DST exceptions are only thrown by the no-`choose`
+        // overload of `to_sys`, so we deliberately don't catch
+        // `nonexistent_local_time` / `ambiguous_local_time` here --
+        // doing so would be unreachable code and would encourage
+        // the "naive fallback" mental model that the current
+        // implementation does not actually provide.
         const auto systemTime = zone->to_sys(localTime, date::choose::earliest);
         return systemTime.time_since_epoch().count();
     }
-    catch (const date::nonexistent_local_time &)
+    catch (const std::exception &)
     {
-        // Spring-forward gap: the wall-clock instant the user typed
-        // never occurred. Falling back to the naive value keeps the
-        // Goto Timestamp modal from throwing out of a slot; the
-        // resulting jump is off by (at most) the DST shift, which
-        // is a v1-acceptable degradation.
+        // Reachable for inputs past the tzdata transition table
+        // (far-future / far-past dates) and for corrupt zone
+        // entries; the `choose` overload forwards these as plain
+        // `runtime_error` derivations rather than the DST-specific
+        // exceptions. Falling back to the naive value keeps the
+        // Goto Timestamp slot exception-safe: worst case, the jump
+        // is off by the zone offset rather than crashing the app.
         return localMicroseconds;
     }
+}
+
+int64_t LocalMicrosecondsSinceEpochToUtc(int64_t localMicroseconds)
+{
+    return LocalMicrosecondsSinceEpochToUtc(localMicroseconds, CurrentZone());
 }
 
 std::string UtcMicrosecondsToDateTimeString(int64_t microseconds)

--- a/test/app/src/main_window_test.cpp
+++ b/test/app/src/main_window_test.cpp
@@ -4732,7 +4732,7 @@ private slots:
 
         // 2^63 microseconds in hours (~2.56T) is exactly the cap;
         // one past it must be rejected.
-        const qulonglong hourCap =
+        const auto hourCap =
             static_cast<qulonglong>(std::numeric_limits<int64_t>::max() / (3600LL * 1'000'000LL));
         const auto overHourCap =
             MainWindow::ParseGotoTimestampInput(QString::number(hourCap + 1) + QStringLiteral("h"), noFormats, kNow);
@@ -4748,7 +4748,7 @@ private slots:
         // (`60 * 1e6` here vs `3600 * 1e6` above), so a regression
         // that swapped the two branches would pass the hour test
         // above and fail here. `2^63 / (60 * 1e6) ~= 1.53e11`.
-        const qulonglong minuteCap =
+        const auto minuteCap =
             static_cast<qulonglong>(std::numeric_limits<int64_t>::max() / (60LL * 1'000'000LL));
         const auto overMinuteCap = MainWindow::ParseGotoTimestampInput(
             QString::number(minuteCap + 1) + QStringLiteral("m"), noFormats, kNow
@@ -5309,6 +5309,7 @@ private slots:
     {
         auto *model = mWindow->Model();
         QVERIFY(model != nullptr);
+        // NOLINTNEXTLINE(clang-analyzer-core.CallAndMessage): false positive; prior `QVERIFY` aborts on null.
         QVERIFY(model->TimestampsAreMonotonic());
 
         // Batch 1: three rows at 2024-04-28T10:00:0{1,2,3}Z.
@@ -5377,6 +5378,7 @@ private slots:
         QVERIFY(model != nullptr);
 
         mWindow->ForceTimestampsNonMonotonicForTest();
+        // NOLINTNEXTLINE(clang-analyzer-core.CallAndMessage): false positive; prior `QVERIFY` aborts on null.
         QVERIFY(!model->TimestampsAreMonotonic());
 
         auto *action = mWindow->findChild<QAction *>(QStringLiteral("actionNewSession"));

--- a/test/app/src/main_window_test.cpp
+++ b/test/app/src/main_window_test.cpp
@@ -4715,8 +4715,10 @@ private slots:
     // Pure parser: relative shortcuts reject values that would
     // overflow `int64_t` microseconds rather than silently wrap
     // (a wrap would jump the user forward instead of backward).
-    // 2^63 / (3600 * 10^6) ~= 2'562'047'788'015 hours; anything
-    // over that must be rejected.
+    // Covers BOTH units because the cap arithmetic uses a
+    // different `microsPerUnit` per branch (`3600 * 1e6` for `h`,
+    // `60 * 1e6` for `m`) -- a bug in either would slip past a
+    // single-unit test.
     void TestParseGotoTimestampInputRejectsOverflowingRelativeShortcut()
     {
         const std::chrono::system_clock::time_point kNow = std::chrono::system_clock::now();
@@ -4732,14 +4734,30 @@ private slots:
         // one past it must be rejected.
         const qulonglong hourCap =
             static_cast<qulonglong>(std::numeric_limits<int64_t>::max() / (3600LL * 1'000'000LL));
-        const auto overCap =
+        const auto overHourCap =
             MainWindow::ParseGotoTimestampInput(QString::number(hourCap + 1) + QStringLiteral("h"), noFormats, kNow);
-        QVERIFY(!overCap.has_value());
+        QVERIFY(!overHourCap.has_value());
 
         // ... and the cap itself must still parse (boundary check).
-        const auto atCap =
+        const auto atHourCap =
             MainWindow::ParseGotoTimestampInput(QString::number(hourCap) + QStringLiteral("h"), noFormats, kNow);
-        QVERIFY(atCap.has_value());
+        QVERIFY(atHourCap.has_value());
+
+        // Minute-cap boundary. Distinct code path from the hour
+        // cap: the overflow guard picks `microsPerUnit` per branch
+        // (`60 * 1e6` here vs `3600 * 1e6` above), so a regression
+        // that swapped the two branches would pass the hour test
+        // above and fail here. `2^63 / (60 * 1e6) ~= 1.53e11`.
+        const qulonglong minuteCap =
+            static_cast<qulonglong>(std::numeric_limits<int64_t>::max() / (60LL * 1'000'000LL));
+        const auto overMinuteCap = MainWindow::ParseGotoTimestampInput(
+            QString::number(minuteCap + 1) + QStringLiteral("m"), noFormats, kNow
+        );
+        QVERIFY(!overMinuteCap.has_value());
+
+        const auto atMinuteCap =
+            MainWindow::ParseGotoTimestampInput(QString::number(minuteCap) + QStringLiteral("m"), noFormats, kNow);
+        QVERIFY(atMinuteCap.has_value());
     }
 
     // Pure parser: the column's own `parseFormats` are tried first;
@@ -4795,15 +4813,14 @@ private slots:
         QVERIFY(!MainWindow::ParseGotoTimestampInput(QStringLiteral("--1h"), {}, kNow).has_value());
     }
 
-    // Local -> UTC shift is applied end-to-end when the parser flags
-    // the winning format as naive. `loglib::LocalMicrosecondsSince
-    // EpochToUtc` uses `CurrentZone()`, so we assert only the *sign*
-    // of the shift relative to the naive value: at a fixed local
-    // instant `t`, the corresponding UTC instant is `t - offset(t)`
-    // (positive offset for zones east of UTC, negative for west).
-    // If the test host is UTC the delta is 0 and the equality below
-    // trivially holds -- still a valid assertion.
-    void TestGotoTimestampAppliesDisplayTimeZoneShift()
+    // Sanity-check on the helpers that FEED `ExecuteGotoTimestamp`
+    // (not the slot itself -- see the `ExecuteGotoTimestamp` seam
+    // tests further down for the end-to-end assertion). Ensures
+    // `ParseGotoTimestampInput` + `LocalMicrosecondsSinceEpochToUtc`
+    // compose correctly: naive parses get shifted, zoned ones do
+    // NOT (double-shift regression pin). Assertions bound the
+    // shift to +/-14 h so the test is TZ-agnostic across CI hosts.
+    void TestParseAndLocalShiftHelpersComposeForNaiveInput()
     {
         const std::chrono::system_clock::time_point kNow =
             std::chrono::system_clock::time_point{std::chrono::microseconds{1'700'000'000'000'000LL}};
@@ -5059,6 +5076,314 @@ private slots:
 
         rowOrder->SetReversed(wasReversed);
         QCoreApplication::processEvents();
+    }
+
+    // ExecuteGotoTimestamp seam: the post-`exec` body dispatches
+    // naive-vs-zoned correctly, updates the sticky-input mirror,
+    // and lands on the qualifying source row. Pins the
+    // `mLastGotoTimestampInput = rawInput` write BEFORE the parse
+    // -- a garbage input the user wants to correct is retained
+    // on the next open.
+    void TestExecuteGotoTimestampSeamJumpsAndRemembersInput()
+    {
+        const int timeCol = StreamFixtureWithTimeColumnForRowMenuTests();
+        QVERIFY2(timeCol >= 0, "timestamp column must exist after streaming");
+        auto *model = mWindow->Model();
+        auto *view = mWindow->findChild<LogTableView *>();
+        QVERIFY(model != nullptr);
+        QVERIFY(view != nullptr);
+        QCOMPARE(model->rowCount(), 3);
+
+        // Pinned clock so any accidental relative-shortcut path
+        // is deterministic; this test drives an ISO absolute
+        // input, so `kNow` is only load-bearing for the mirror.
+        const std::chrono::system_clock::time_point kNow =
+            std::chrono::system_clock::time_point{std::chrono::microseconds{1'700'000'000'000'000LL}};
+
+        view->selectionModel()->clearSelection();
+        view->setCurrentIndex(QModelIndex{});
+        mWindow->statusBar()->clearMessage();
+
+        // Zoned ISO input: the fixture's middle row is
+        // 2024-04-28T10:00:02+00:00, so pass exactly that. The
+        // zoned parse means the naive->UTC shift is skipped
+        // (double-shift regression pin) and the row lands
+        // regardless of the CI host's local TZ.
+        mWindow->ExecuteGotoTimestampForTest(QStringLiteral("2024-04-28T10:00:02+00:00"), kNow);
+        QCoreApplication::processEvents();
+        // Middle row = source row 1 = proxy row 1 under the
+        // fixture's default (identity mid, no filter).
+        QCOMPARE(view->currentIndex().row(), 1);
+
+        // Sticky-input mirror captured the raw string, not a
+        // canonicalised form.
+        QCOMPARE(mWindow->LastGotoTimestampInputForTest(), QStringLiteral("2024-04-28T10:00:02+00:00"));
+
+        // Garbage input: parse fails, sticky mirror still updates
+        // so the user can correct without retyping the whole
+        // string.
+        mWindow->ExecuteGotoTimestampForTest(QStringLiteral("not a timestamp"), kNow);
+        QCoreApplication::processEvents();
+        QCOMPARE(mWindow->LastGotoTimestampInputForTest(), QStringLiteral("not a timestamp"));
+        const QString hint = mWindow->statusBar()->currentMessage();
+        QVERIFY2(
+            hint.contains(QStringLiteral("Could not parse"), Qt::CaseInsensitive),
+            qUtf8Printable(QStringLiteral("Expected parse-error hint, got: '%1'").arg(hint))
+        );
+    }
+
+    // ExecuteGotoTimestamp seam: an out-of-range target (past the
+    // last row) surfaces the "no visible row at or after that
+    // time" hint without moving the selection.
+    void TestExecuteGotoTimestampSeamHintsWhenNoRowQualifies()
+    {
+        const int timeCol = StreamFixtureWithTimeColumnForRowMenuTests();
+        QVERIFY2(timeCol >= 0, "timestamp column must exist after streaming");
+        auto *view = mWindow->findChild<LogTableView *>();
+        QVERIFY(view != nullptr);
+
+        const std::chrono::system_clock::time_point kNow =
+            std::chrono::system_clock::time_point{std::chrono::microseconds{1'700'000'000'000'000LL}};
+
+        view->selectionModel()->clearSelection();
+        view->setCurrentIndex(QModelIndex{});
+        mWindow->statusBar()->clearMessage();
+
+        // 2099 is well past the fixture's 2024 rows.
+        mWindow->ExecuteGotoTimestampForTest(QStringLiteral("2099-01-01T00:00:00+00:00"), kNow);
+        QCoreApplication::processEvents();
+
+        const QString hint = mWindow->statusBar()->currentMessage();
+        QVERIFY2(
+            hint.contains(QStringLiteral("No visible row"), Qt::CaseInsensitive),
+            qUtf8Printable(QStringLiteral("Expected 'No visible row' hint, got: '%1'").arg(hint))
+        );
+        QVERIFY(view->selectionModel()->selectedRows().isEmpty());
+    }
+
+    // Session-boundary clear: `NewSession()` wipes the sticky
+    // Goto Timestamp mirror so a stale reference from a closed
+    // file doesn't pre-populate the next dialog.
+    void TestGotoTimestampStickyInputClearsOnNewSession()
+    {
+        const int timeCol = StreamFixtureWithTimeColumnForRowMenuTests();
+        QVERIFY2(timeCol >= 0, "timestamp column must exist after streaming");
+
+        const std::chrono::system_clock::time_point kNow =
+            std::chrono::system_clock::time_point{std::chrono::microseconds{1'700'000'000'000'000LL}};
+
+        mWindow->ExecuteGotoTimestampForTest(QStringLiteral("2024-04-28T10:00:02+00:00"), kNow);
+        QCoreApplication::processEvents();
+        QCOMPARE(mWindow->LastGotoTimestampInputForTest(), QStringLiteral("2024-04-28T10:00:02+00:00"));
+
+        // `NewSession` runs the same code path as opening a fresh
+        // file. Trigger via the wired action so the private slot
+        // is reached the same way `Ctrl+N` reaches it in the app.
+        // Post-condition: mirror is empty.
+        auto *action = mWindow->findChild<QAction *>(QStringLiteral("actionNewSession"));
+        QVERIFY2(action != nullptr, "actionNewSession must be reachable via objectName");
+        action->trigger();
+        QCoreApplication::processEvents();
+        QCOMPARE(mWindow->LastGotoTimestampInputForTest(), QString{});
+    }
+
+    // ExecuteGotoTimestamp seam: relative shortcut resolves
+    // against the pinned `now`, not `system_clock::now()`, and
+    // lands on the qualifying row. The fixture's timestamps are
+    // 2024-04-28T10:00:0{1,2,3}Z; pinning `now` one second past
+    // the last row means `-2s` would land on the middle row, but
+    // we only support `h` / `m` in v1 -- use `-1h` from a `now`
+    // just barely inside the middle row's window.
+    void TestExecuteGotoTimestampSeamResolvesRelativeShortcutAgainstPinnedNow()
+    {
+        const int timeCol = StreamFixtureWithTimeColumnForRowMenuTests();
+        QVERIFY2(timeCol >= 0, "timestamp column must exist after streaming");
+        auto *model = mWindow->Model();
+        auto *view = mWindow->findChild<LogTableView *>();
+        QVERIFY(model != nullptr);
+        QVERIFY(view != nullptr);
+
+        // Middle row's stored ts is the "target" the shortcut
+        // will resolve to when `now` sits exactly one hour later.
+        const auto *table = &model->Table();
+        const auto midMicros = loglib::AsEpochMicroseconds(table->GetValue(1, static_cast<std::size_t>(timeCol)));
+        QVERIFY(midMicros.has_value());
+        const std::chrono::system_clock::time_point pinnedNow{
+            std::chrono::microseconds{*midMicros + (3600LL * 1'000'000LL)}
+        };
+
+        view->selectionModel()->clearSelection();
+        view->setCurrentIndex(QModelIndex{});
+
+        mWindow->ExecuteGotoTimestampForTest(QStringLiteral("-1h"), pinnedNow);
+        QCoreApplication::processEvents();
+
+        // `-1h` from `midMicros + 1h` == `midMicros` -> row 1.
+        QCOMPARE(view->currentIndex().row(), 1);
+    }
+
+    // ExecuteGotoTimestamp seam: bail-out branch when the log has
+    // no time column. Uses a synthetic stream fixture that omits
+    // any `Type::Time` column.
+    void TestExecuteGotoTimestampSeamHintsWhenNoTimeColumn()
+    {
+        auto *model = mWindow->Model();
+        QVERIFY(model != nullptr);
+
+        loglib::StreamLineSource &streamSource = BeginSyntheticStreamSession(*model);
+        QtStreamingLogSink *sink = model->Sink();
+        QVERIFY(sink != nullptr);
+        loglib::KeyIndex &keys = sink->Keys();
+        const loglib::KeyId valueKey = keys.GetOrInsert(std::string("value"));
+        // `MakeSyntheticBatch` produces rows with just a `value`
+        // key -- no timestamp column at all.
+        sink->OnBatch(MakeSyntheticBatch(streamSource, keys, valueKey, 1, 3, true));
+        QCoreApplication::processEvents();
+        QCOMPARE(model->rowCount(), 3);
+        QCOMPARE(loglib::FirstTimeColumnIndex(model->Configuration()), -1);
+
+        mWindow->statusBar()->clearMessage();
+        mWindow->ExecuteGotoTimestampForTest(
+            QStringLiteral("2024-04-28T10:00:02+00:00"), std::chrono::system_clock::now()
+        );
+        QCoreApplication::processEvents();
+
+        const QString hint = mWindow->statusBar()->currentMessage();
+        QVERIFY2(
+            hint.contains(QStringLiteral("no timestamp column"), Qt::CaseInsensitive),
+            qUtf8Printable(QStringLiteral("Expected 'no timestamp column' hint, got: '%1'").arg(hint))
+        );
+
+        model->EndStreaming(false);
+    }
+
+    // Non-monotonic branch: with `TimestampsAreMonotonic()` flipped
+    // to false, `FindFirstRowAtOrAfter` must NOT take the binary-
+    // search fast path (which assumes monotonicity and can silently
+    // return a wrong row). Instead it walks the outer proxy and
+    // picks the visible row with the smallest ts satisfying
+    // `ts >= target` -- the chronologically earliest match. The
+    // three-row fixture is monotonic, so the ANSWER doesn't change
+    // vs the fast-path test; the assertion is that the ALTERNATE
+    // code path is taken and still returns the correct row.
+    void TestFindFirstRowAtOrAfterUsesProxyIterationWhenNonMonotonic()
+    {
+        const int timeCol = StreamFixtureWithTimeColumnForRowMenuTests();
+        QVERIFY2(timeCol >= 0, "timestamp column must exist after streaming");
+        auto *model = mWindow->Model();
+        QVERIFY(model != nullptr);
+
+        // Baseline: fast path returns the middle row exactly.
+        const auto *table = &model->Table();
+        const auto midMicros = loglib::AsEpochMicroseconds(table->GetValue(1, static_cast<std::size_t>(timeCol)));
+        QVERIFY(midMicros.has_value());
+        QVERIFY(model->TimestampsAreMonotonic());
+        QCOMPARE(mWindow->FindFirstRowAtOrAfter(timeCol, *midMicros), 1);
+
+        // Force the flag to false. Idempotent, no way back
+        // (mirrors production semantics).
+        mWindow->ForceTimestampsNonMonotonicForTest();
+        QVERIFY(!model->TimestampsAreMonotonic());
+
+        // Same query, different branch. Correct answer preserved:
+        // proxy iteration finds the visible row with the smallest
+        // ts >= target.
+        QCOMPARE(mWindow->FindFirstRowAtOrAfter(timeCol, *midMicros), 1);
+
+        // A target one tick BEFORE the middle row's ts still lands
+        // there (proxy iteration picks min-ts satisfying >= target).
+        QCOMPARE(mWindow->FindFirstRowAtOrAfter(timeCol, *midMicros - 1), 1);
+
+        // Past the last row's ts -> -1 (no qualifying row).
+        const auto lastMicros = loglib::AsEpochMicroseconds(table->GetValue(2, static_cast<std::size_t>(timeCol)));
+        QVERIFY(lastMicros.has_value());
+        QCOMPARE(mWindow->FindFirstRowAtOrAfter(timeCol, *lastMicros + 1), -1);
+    }
+
+    // Streaming path: the monotonicity detector flips false when
+    // a second batch's first valid ts predates the first batch's
+    // last valid ts (the multi-file `Append` / rotation case).
+    // Pins that behavior end-to-end through `LogModel::AppendBatch`
+    // so a regression in the boundary check would surface here.
+    void TestLogModelTimestampsMonotonicFlipsOnBatchBoundaryInversion()
+    {
+        auto *model = mWindow->Model();
+        QVERIFY(model != nullptr);
+        QVERIFY(model->TimestampsAreMonotonic());
+
+        // Batch 1: three rows at 2024-04-28T10:00:0{1,2,3}Z.
+        // Reuses the JSON stream path (via a TempJsonFile) so the
+        // timestamp column is auto-detected and populated.
+        const QStringList firstBatchLines{
+            QStringLiteral(R"({"timestamp":"2024-04-28T10:00:01+00:00","msg":"first"})"),
+            QStringLiteral(R"({"timestamp":"2024-04-28T10:00:02+00:00","msg":"second"})"),
+            QStringLiteral(R"({"timestamp":"2024-04-28T10:00:03+00:00","msg":"third"})"),
+        };
+        const TempJsonFile firstFixture(firstBatchLines);
+        QSignalSpy firstFinishedSpy(model, &LogModel::streamingFinished);
+        auto firstFile = std::make_unique<loglib::LogFile>(firstFixture.Path().toStdString());
+        auto firstSource = std::make_unique<loglib::FileLineSource>(std::move(firstFile));
+        loglib::FileLineSource *firstPtr = firstSource.get();
+        const loglib::StopToken firstToken = model->BeginStreamingForSyncTest(std::move(firstSource));
+        loglib::ParserOptions firstOpts;
+        firstOpts.stopToken = firstToken;
+        loglib::internal::AdvancedParserOptions firstAdvanced;
+        firstAdvanced.threads = 1;
+        loglib::JsonParser::ParseStreaming(*firstPtr, *model->Sink(), firstOpts, firstAdvanced);
+        if (firstFinishedSpy.count() == 0)
+        {
+            firstFinishedSpy.wait(5000);
+        }
+        QCoreApplication::processEvents();
+        QCOMPARE(model->rowCount(), 3);
+        // Still monotonic after a well-ordered batch.
+        QVERIFY(model->TimestampsAreMonotonic());
+
+        // Batch 2 (via `AppendStreaming`): rows dated BEFORE the
+        // first batch's last row. This is exactly the multi-file
+        // `Append` scenario the monotonicity guard exists for.
+        const QStringList secondBatchLines{
+            QStringLiteral(R"({"timestamp":"2024-04-28T09:00:01+00:00","msg":"older-a"})"),
+            QStringLiteral(R"({"timestamp":"2024-04-28T09:00:02+00:00","msg":"older-b"})"),
+        };
+        const TempJsonFile secondFixture(secondBatchLines);
+        QSignalSpy secondFinishedSpy(model, &LogModel::streamingFinished);
+        auto secondFile = std::make_unique<loglib::LogFile>(secondFixture.Path().toStdString());
+        auto secondSource = std::make_unique<loglib::FileLineSource>(std::move(secondFile));
+        loglib::FileLineSource *secondPtr = secondSource.get();
+        const loglib::StopToken secondToken = model->AppendStreaming(std::move(secondSource), {});
+        loglib::ParserOptions secondOpts;
+        secondOpts.stopToken = secondToken;
+        loglib::internal::AdvancedParserOptions secondAdvanced;
+        secondAdvanced.threads = 1;
+        loglib::JsonParser::ParseStreaming(*secondPtr, *model->Sink(), secondOpts, secondAdvanced);
+        if (secondFinishedSpy.count() == 0)
+        {
+            secondFinishedSpy.wait(5000);
+        }
+        QCoreApplication::processEvents();
+        QCOMPARE(model->rowCount(), 5);
+        // Flag flipped false and does NOT self-heal.
+        QVERIFY(!model->TimestampsAreMonotonic());
+    }
+
+    // Session-boundary reset: `NewSession()` (called from every
+    // "open a new file" path) restores the monotonicity flag so a
+    // fresh well-ordered log doesn't inherit a prior session's
+    // non-monotonic verdict.
+    void TestLogModelTimestampsMonotonicResetsOnNewSession()
+    {
+        auto *model = mWindow->Model();
+        QVERIFY(model != nullptr);
+
+        mWindow->ForceTimestampsNonMonotonicForTest();
+        QVERIFY(!model->TimestampsAreMonotonic());
+
+        auto *action = mWindow->findChild<QAction *>(QStringLiteral("actionNewSession"));
+        QVERIFY2(action != nullptr, "actionNewSession must be reachable via objectName");
+        action->trigger();
+        QCoreApplication::processEvents();
+        QVERIFY(model->TimestampsAreMonotonic());
     }
 
     // Anchors round-trip: live AnchorManager -> saved JSON ->

--- a/test/app/src/main_window_test.cpp
+++ b/test/app/src/main_window_test.cpp
@@ -39,6 +39,7 @@
 #include <loglib/log_level.hpp>
 #include <loglib/log_line.hpp>
 #include <loglib/log_parse_sink.hpp>
+#include <loglib/log_processing.hpp>
 #include <loglib/log_value.hpp>
 #include <loglib/parser_options.hpp>
 #include <loglib/parsers/json_parser.hpp>
@@ -4537,7 +4538,8 @@ private slots:
     // Pure parser: relative shortcuts `-Nh` and `-Nm` (case-
     // insensitive, whitespace-tolerant) resolve against the pinned
     // `now`. The unit chart lives in ROADMAP item 8; longer/shorter
-    // units are explicitly out of scope for v1.
+    // units are explicitly out of scope for v1. `isNaive == false`
+    // on this path because `now` is already UTC micros.
     void TestParseGotoTimestampInputAcceptsRelativeShortcuts()
     {
         const std::chrono::system_clock::time_point kNow =
@@ -4548,21 +4550,66 @@ private slots:
 
         const auto oneHourAgo = MainWindow::ParseGotoTimestampInput(QStringLiteral("-1h"), noFormats, kNow);
         QVERIFY(oneHourAgo.has_value());
-        QCOMPARE(*oneHourAgo, kNowMicros - (3600LL * 1'000'000LL));
+        QCOMPARE(oneHourAgo->micros, kNowMicros - (3600LL * 1'000'000LL));
+        QVERIFY(!oneHourAgo->isNaive);
 
         const auto thirtyMinAgo = MainWindow::ParseGotoTimestampInput(QStringLiteral("-30m"), noFormats, kNow);
         QVERIFY(thirtyMinAgo.has_value());
-        QCOMPARE(*thirtyMinAgo, kNowMicros - (30LL * 60LL * 1'000'000LL));
+        QCOMPARE(thirtyMinAgo->micros, kNowMicros - (30LL * 60LL * 1'000'000LL));
+        QVERIFY(!thirtyMinAgo->isNaive);
 
         // Case-insensitive, tolerant of internal whitespace.
         const auto capitalH = MainWindow::ParseGotoTimestampInput(QStringLiteral("- 2 H"), noFormats, kNow);
         QVERIFY(capitalH.has_value());
-        QCOMPARE(*capitalH, kNowMicros - (2LL * 3600LL * 1'000'000LL));
+        QCOMPARE(capitalH->micros, kNowMicros - (2LL * 3600LL * 1'000'000LL));
+
+        // The `+N` and bare-`N` variants also mean "N units ago"
+        // (parity with lnav / less). A log viewer's "future" cursor
+        // is nonsensical, so the sign is treated as decorative.
+        const auto plusOneHour = MainWindow::ParseGotoTimestampInput(QStringLiteral("+1h"), noFormats, kNow);
+        QVERIFY(plusOneHour.has_value());
+        QCOMPARE(plusOneHour->micros, kNowMicros - (3600LL * 1'000'000LL));
+
+        const auto bareOneHour = MainWindow::ParseGotoTimestampInput(QStringLiteral("1h"), noFormats, kNow);
+        QVERIFY(bareOneHour.has_value());
+        QCOMPARE(bareOneHour->micros, kNowMicros - (3600LL * 1'000'000LL));
+    }
+
+    // Pure parser: relative shortcuts reject values that would
+    // overflow `int64_t` microseconds rather than silently wrap
+    // (a wrap would jump the user forward instead of backward).
+    // 2^63 / (3600 * 10^6) ~= 2'562'047'788'015 hours; anything
+    // over that must be rejected.
+    void TestParseGotoTimestampInputRejectsOverflowingRelativeShortcut()
+    {
+        const std::chrono::system_clock::time_point kNow = std::chrono::system_clock::now();
+        const std::vector<std::string> noFormats;
+
+        // 10^19 hours -- above both the int64 hour cap and 2^63.
+        QVERIFY(!MainWindow::ParseGotoTimestampInput(
+                     QStringLiteral("-10000000000000000000h"), noFormats, kNow
+        )
+                     .has_value());
+
+        // 2^63 microseconds in hours (~2.56T) is exactly the cap;
+        // one past it must be rejected.
+        const qulonglong hourCap =
+            static_cast<qulonglong>(std::numeric_limits<int64_t>::max() / (3600LL * 1'000'000LL));
+        const auto overCap =
+            MainWindow::ParseGotoTimestampInput(QString::number(hourCap + 1) + QStringLiteral("h"), noFormats, kNow);
+        QVERIFY(!overCap.has_value());
+
+        // ... and the cap itself must still parse (boundary check).
+        const auto atCap =
+            MainWindow::ParseGotoTimestampInput(QString::number(hourCap) + QStringLiteral("h"), noFormats, kNow);
+        QVERIFY(atCap.has_value());
     }
 
     // Pure parser: the column's own `parseFormats` are tried first;
     // this covers the ROADMAP acceptance bar "every format the
-    // table's timestamp column already parses".
+    // table's timestamp column already parses". Formats without a
+    // zone specifier (`%z` / `%Ez` / `%Z`) yield `isNaive == true`
+    // so the caller knows to shift the value through the display TZ.
     void TestParseGotoTimestampInputHonoursColumnParseFormats()
     {
         const std::chrono::system_clock::time_point kNow =
@@ -4575,16 +4622,26 @@ private slots:
         const auto parsed =
             MainWindow::ParseGotoTimestampInput(QStringLiteral("2024/04/28 12:34:56"), columnFormats, kNow);
         QVERIFY(parsed.has_value());
-        QVERIFY(*parsed > 0);
+        QVERIFY(parsed->micros > 0);
+        QVERIFY2(parsed->isNaive, "column format has no %z, result must be flagged naive");
 
         // ISO fallback works even with no column formats.
         const auto isoT = MainWindow::ParseGotoTimestampInput(QStringLiteral("2024-04-28T12:34:56"), {}, kNow);
         QVERIFY(isoT.has_value());
-        QVERIFY(*isoT > 0);
+        QVERIFY(isoT->micros > 0);
+        QVERIFY2(isoT->isNaive, "ISO fallback lacks %z, result must be flagged naive");
 
         const auto isoSpace = MainWindow::ParseGotoTimestampInput(QStringLiteral("2024-04-28 12:34:56"), {}, kNow);
         QVERIFY(isoSpace.has_value());
-        QCOMPARE(*isoT, *isoSpace);
+        QCOMPARE(isoT->micros, isoSpace->micros);
+
+        // A format WITH `%Ez` marks the result as TZ-aware -- the
+        // slot must not double-shift.
+        const std::vector<std::string> zonedFormats{"%FT%T%Ez"};
+        const auto zoned =
+            MainWindow::ParseGotoTimestampInput(QStringLiteral("2024-04-28T12:34:56+02:00"), zonedFormats, kNow);
+        QVERIFY(zoned.has_value());
+        QVERIFY2(!zoned->isNaive, "format contains %Ez, result must NOT be flagged naive");
     }
 
     // Pure parser: empty and garbage strings return nullopt; the
@@ -4596,8 +4653,47 @@ private slots:
         QVERIFY(!MainWindow::ParseGotoTimestampInput(QString{}, {}, kNow).has_value());
         QVERIFY(!MainWindow::ParseGotoTimestampInput(QStringLiteral("   "), {}, kNow).has_value());
         QVERIFY(!MainWindow::ParseGotoTimestampInput(QStringLiteral("not a timestamp"), {}, kNow).has_value());
-        // Positive-offset (`+1h`) is not a shortcut we accept for v1.
-        QVERIFY(!MainWindow::ParseGotoTimestampInput(QStringLiteral("+1h"), {}, kNow).has_value());
+        // Mixed sign / letters in the relative shortcut still fail.
+        QVERIFY(!MainWindow::ParseGotoTimestampInput(QStringLiteral("-1x"), {}, kNow).has_value());
+        QVERIFY(!MainWindow::ParseGotoTimestampInput(QStringLiteral("--1h"), {}, kNow).has_value());
+    }
+
+    // Local -> UTC shift is applied end-to-end when the parser flags
+    // the winning format as naive. `loglib::LocalMicrosecondsSince
+    // EpochToUtc` uses `CurrentZone()`, so we assert only the *sign*
+    // of the shift relative to the naive value: at a fixed local
+    // instant `t`, the corresponding UTC instant is `t - offset(t)`
+    // (positive offset for zones east of UTC, negative for west).
+    // If the test host is UTC the delta is 0 and the equality below
+    // trivially holds -- still a valid assertion.
+    void TestGotoTimestampAppliesDisplayTimeZoneShift()
+    {
+        const std::chrono::system_clock::time_point kNow =
+            std::chrono::system_clock::time_point{std::chrono::microseconds{1'700'000'000'000'000LL}};
+
+        const auto naiveParse =
+            MainWindow::ParseGotoTimestampInput(QStringLiteral("2024-04-28T12:00:00"), {}, kNow);
+        QVERIFY(naiveParse.has_value());
+        QVERIFY(naiveParse->isNaive);
+
+        const int64_t naiveMicros = naiveParse->micros;
+        const int64_t shiftedMicros = loglib::LocalMicrosecondsSinceEpochToUtc(naiveMicros);
+
+        // Shift is exactly the UTC offset at that instant. Bound it
+        // to +/-14 h (max real-world offset today) so the assertion
+        // catches an accidental "shift by seconds since epoch"
+        // regression regardless of the host TZ.
+        const int64_t deltaMicros = shiftedMicros - naiveMicros;
+        constexpr int64_t MAX_TZ_OFFSET_MICROS = 14LL * 3600LL * 1'000'000LL;
+        QVERIFY2(std::llabs(deltaMicros) <= MAX_TZ_OFFSET_MICROS, "TZ shift must be within +/-14 h");
+
+        // Zoned input must NOT shift (double-shift regression pin).
+        const std::vector<std::string> zonedFormats{"%FT%T%Ez"};
+        const auto zonedParse = MainWindow::ParseGotoTimestampInput(
+            QStringLiteral("2024-04-28T12:00:00+00:00"), zonedFormats, kNow
+        );
+        QVERIFY(zonedParse.has_value());
+        QVERIFY(!zonedParse->isNaive);
     }
 
     // Goto Timestamp binary search: no user sort active. The
@@ -4626,6 +4722,125 @@ private slots:
         const auto lastMicros = loglib::AsEpochMicroseconds(table->GetValue(2, static_cast<std::size_t>(timeCol)));
         QVERIFY(lastMicros.has_value());
         QCOMPARE(mWindow->FindFirstRowAtOrAfter(timeCol, *lastMicros + 1), -1);
+    }
+
+    // Regression pin: rows with a mid-file *missing* timestamp
+    // don't break the fast-path binary search. Fixture has three
+    // rows where the middle row lacks the `timestamp` key entirely
+    // (`monostate` slot). Targets tests every valid boundary:
+    //   * before-earliest -> row 0 (row 1 skipped over)
+    //   * exactly-first -> row 0
+    //   * just-past-first -> row 2 (skip 1)
+    //   * exactly-last -> row 2
+    //   * past-last -> -1
+    void TestFindFirstRowAtOrAfterHandlesInterleavedMissingTimestamps()
+    {
+        auto *model = mWindow->Model();
+        Q_ASSERT(model != nullptr);
+
+        const QStringList lines{
+            QStringLiteral(R"({"timestamp":"2024-04-28T10:00:01+00:00","msg":"first"})"),
+            QStringLiteral(R"({"msg":"middle has no timestamp"})"),
+            QStringLiteral(R"({"timestamp":"2024-04-28T10:00:03+00:00","msg":"third"})"),
+        };
+        const TempJsonFile fixture(lines);
+        QSignalSpy finishedSpy(model, &LogModel::streamingFinished);
+        QVERIFY(finishedSpy.isValid());
+        auto file = std::make_unique<loglib::LogFile>(fixture.Path().toStdString());
+        auto fileSource = std::make_unique<loglib::FileLineSource>(std::move(file));
+        loglib::FileLineSource *fileSourcePtr = fileSource.get();
+        const loglib::StopToken stopToken = model->BeginStreamingForSyncTest(std::move(fileSource));
+        loglib::ParserOptions options;
+        options.stopToken = stopToken;
+        loglib::internal::AdvancedParserOptions advanced;
+        advanced.threads = 1;
+        loglib::JsonParser::ParseStreaming(*fileSourcePtr, *model->Sink(), options, advanced);
+        if (finishedSpy.count() == 0)
+        {
+            finishedSpy.wait(5000);
+        }
+        QCoreApplication::processEvents();
+
+        const int timeCol = ColumnByHeader(*model, QStringLiteral("timestamp"));
+        QVERIFY2(timeCol >= 0, "timestamp column must exist");
+        QCOMPARE(model->rowCount(), 3);
+
+        const auto *table = &model->Table();
+        const auto firstMicros = loglib::AsEpochMicroseconds(table->GetValue(0, static_cast<std::size_t>(timeCol)));
+        const auto lastMicros = loglib::AsEpochMicroseconds(table->GetValue(2, static_cast<std::size_t>(timeCol)));
+        QVERIFY(firstMicros.has_value());
+        QVERIFY(lastMicros.has_value());
+
+        // Before the earliest timestamp -> row 0 (row 1 is missing
+        // and must be skipped over, not treated as a match).
+        QCOMPARE(mWindow->FindFirstRowAtOrAfter(timeCol, *firstMicros - 1'000'000), 0);
+        QCOMPARE(mWindow->FindFirstRowAtOrAfter(timeCol, *firstMicros), 0);
+
+        // Between the two valid timestamps -> row 2 (row 1 is
+        // missing; must NOT be returned).
+        QCOMPARE(mWindow->FindFirstRowAtOrAfter(timeCol, *firstMicros + 1), 2);
+
+        // Exactly-last / past-last.
+        QCOMPARE(mWindow->FindFirstRowAtOrAfter(timeCol, *lastMicros), 2);
+        QCOMPARE(mWindow->FindFirstRowAtOrAfter(timeCol, *lastMicros + 1), -1);
+    }
+
+    // Regression pin: with a filter that hides source rows 0 and 1
+    // (keeps only row 2), the fast path must NOT return a hidden
+    // row -- previously it did, and `SelectSourceRow` then printed
+    // "Row is not currently visible" while a visible qualifying
+    // row existed further down.
+    void TestFindFirstRowAtOrAfterSkipsFilterHiddenRowsInFastPath()
+    {
+        const int timeCol = StreamFixtureWithTimeColumnForRowMenuTests();
+        QVERIFY2(timeCol >= 0, "timestamp column must exist after streaming");
+        auto *model = mWindow->Model();
+        auto *proxy = mWindow->FilterModel();
+        QVERIFY(model != nullptr);
+        QVERIFY(proxy != nullptr);
+        QCOMPARE(model->rowCount(), 3);
+
+        const int msgCol = ColumnByHeader(*model, QStringLiteral("msg"));
+        QVERIFY2(msgCol >= 0, "msg column must exist");
+
+        // Callback string predicate that keeps only the row whose
+        // `msg` slot equals "third" (source row 2). The concrete
+        // `CallbackStringRowPredicate` is the same variant arm the
+        // Filters dock uses for regex / wildcard rules; a bare
+        // equality predicate keeps the fixture minimal.
+        loglib::CallbackStringRowPredicate keepThird(
+            static_cast<std::size_t>(msgCol), [](std::string_view value) { return value == std::string_view{"third"}; }
+        );
+
+        std::vector<loglib::RowPredicate> rules;
+        rules.emplace_back(std::move(keepThird));
+        proxy->SetFilterRules(std::move(rules));
+        QCoreApplication::processEvents();
+        QCOMPARE(proxy->rowCount(), 1);
+        QCOMPARE(proxy->SortColumn(), -1);
+
+        // Target well before every row's timestamp: without the
+        // visibility step the fast path would return source row 0
+        // ("first", filtered out); with it, it must jump forward
+        // to source row 2 ("third", visible).
+        const auto *table = &model->Table();
+        const auto firstMicros = loglib::AsEpochMicroseconds(table->GetValue(0, static_cast<std::size_t>(timeCol)));
+        QVERIFY(firstMicros.has_value());
+        QCOMPARE(mWindow->FindFirstRowAtOrAfter(timeCol, *firstMicros - 1'000'000), 2);
+        QCOMPARE(mWindow->FindFirstRowAtOrAfter(timeCol, *firstMicros), 2);
+
+        // If the target sits AFTER the only visible row's timestamp,
+        // no live row qualifies -- must be -1 rather than a hidden
+        // row further down (there aren't any here, but the
+        // "return -1" branch is on the same code path).
+        const auto lastMicros = loglib::AsEpochMicroseconds(table->GetValue(2, static_cast<std::size_t>(timeCol)));
+        QVERIFY(lastMicros.has_value());
+        QCOMPARE(mWindow->FindFirstRowAtOrAfter(timeCol, *lastMicros + 1), -1);
+
+        // Restore the pristine "no filter" state so downstream
+        // tests in this suite see the fixture unchanged.
+        proxy->SetFilterRules({});
+        QCoreApplication::processEvents();
     }
 
     // Goto Timestamp linear scan: a user sort on a non-time column
@@ -4657,6 +4872,56 @@ private slots:
         // source row 2 ("third").
         const int found = mWindow->FindFirstRowAtOrAfter(timeCol, std::numeric_limits<int64_t>::min());
         QCOMPARE(found, 2);
+    }
+
+    // Regression pin: newest-first display reversal is a mid-proxy
+    // concern; the fast-path binary search operates on source rows
+    // in file order, so the returned source row must be unchanged.
+    // `SelectSourceRow` then maps that source row through the
+    // reversed mid-proxy and lands the view at the display position
+    // corresponding to the reversed row.
+    void TestFindFirstRowAtOrAfterHonoursNewestFirstDisplay()
+    {
+        const int timeCol = StreamFixtureWithTimeColumnForRowMenuTests();
+        QVERIFY2(timeCol >= 0, "timestamp column must exist after streaming");
+        auto *model = mWindow->Model();
+        auto *rowOrder = mWindow->findChild<RowOrderProxyModel *>();
+        auto *view = mWindow->findChild<LogTableView *>();
+        QVERIFY(model != nullptr);
+        QVERIFY(rowOrder != nullptr);
+        QVERIFY(view != nullptr);
+        QCOMPARE(model->rowCount(), 3);
+
+        // Flip into newest-first mode. Save the original so we can
+        // restore it (this is process-wide global state).
+        const bool wasReversed = rowOrder->IsReversed();
+        rowOrder->SetReversed(true);
+        QCoreApplication::processEvents();
+        QVERIFY(rowOrder->IsReversed());
+
+        // Fast path must still return the earliest-in-file row that
+        // qualifies (source row 1 for the middle timestamp).
+        const auto *table = &model->Table();
+        const auto midMicros = loglib::AsEpochMicroseconds(table->GetValue(1, static_cast<std::size_t>(timeCol)));
+        QVERIFY(midMicros.has_value());
+        QCOMPARE(mWindow->FindFirstRowAtOrAfter(timeCol, *midMicros), 1);
+
+        // And `SelectSourceRow` must land the view on the reversed
+        // proxy position (source row 1 in a 3-row reversed view
+        // is proxy row `3 - 1 - 1 == 1`; middle stays middle).
+        view->selectionModel()->clearSelection();
+        view->setCurrentIndex(QModelIndex{});
+        mWindow->SelectSourceRow(1);
+        QCoreApplication::processEvents();
+        QCOMPARE(view->currentIndex().row(), 1);
+
+        // Source row 0 (earliest) -> reversed proxy row 2 (bottom).
+        mWindow->SelectSourceRow(0);
+        QCoreApplication::processEvents();
+        QCOMPARE(view->currentIndex().row(), 2);
+
+        rowOrder->SetReversed(wasReversed);
+        QCoreApplication::processEvents();
     }
 
     // Anchors round-trip: live AnchorManager -> saved JSON ->

--- a/test/app/src/main_window_test.cpp
+++ b/test/app/src/main_window_test.cpp
@@ -4500,11 +4500,11 @@ private slots:
         model->EndStreaming(false);
     }
 
-    // Goto Line: `ParseGotoTimestampInput` is exercised by the
-    // dedicated parser tests below; here we assert only that
-    // `SelectSourceRow` reaches the requested row when the caller
-    // arrives via the same 1-based path the modal takes. Line 12
-    // (1-based) maps to source row 11.
+    // Goto Line happy path: drive the post-dialog body through the
+    // `ExecuteGotoLineForTest` seam so the 1-based-to-0-based flip
+    // AND the visibility probe are both exercised end-to-end (the
+    // dedicated shrink / filtered-out tests below cover the two
+    // rejection branches). Line 12 (1-based) maps to source row 11.
     void TestMainWindowGotoLineJumpsToRequestedSourceRow()
     {
         auto *model = mWindow->Model();
@@ -4523,16 +4523,153 @@ private slots:
         view->selectionModel()->clearSelection();
         view->setCurrentIndex(QModelIndex{});
 
-        // Same 1-based -> 0-based flip the slot performs on the
-        // dialog's textValue().
-        const int oneBased = 12;
-        mWindow->SelectSourceRow(oneBased - 1);
+        mWindow->ExecuteGotoLineForTest(QStringLiteral("12"));
         QCoreApplication::processEvents();
         QCOMPARE(view->currentIndex().row(), 11);
         QCOMPARE(view->selectionModel()->selectedRows().count(), 1);
         QCOMPARE(view->selectionModel()->selectedRows().first().row(), 11);
 
         model->EndStreaming(false);
+    }
+
+    // Regression pin: the post-dialog range check reads the *live*
+    // `mModel->rowCount()`, not a value captured before the modal
+    // opened. Otherwise a FIFO eviction / session swap during the
+    // modal would let an evicted line pass the check, land on
+    // `SelectSourceRow`'s generic "Row is not currently visible"
+    // hint, AND display a range in the error string that no longer
+    // exists. Simulated here by driving the seam with an input
+    // larger than the current row count -- a valid model that
+    // shrank while the modal was open would look identical to the
+    // seam's caller.
+    void TestGotoLineOutOfRangeAfterShrinkSurfacesLiveRange()
+    {
+        auto *model = mWindow->Model();
+        auto *view = mWindow->findChild<LogTableView *>();
+        QVERIFY(view != nullptr);
+
+        loglib::StreamLineSource &streamSource = BeginSyntheticStreamSession(*model);
+        QtStreamingLogSink *sink = model->Sink();
+        QVERIFY(sink != nullptr);
+        loglib::KeyIndex &keys = sink->Keys();
+        const loglib::KeyId valueKey = keys.GetOrInsert(std::string("value"));
+        sink->OnBatch(MakeSyntheticBatch(streamSource, keys, valueKey, 1, 10, true));
+        QCoreApplication::processEvents();
+        QCOMPARE(model->rowCount(), 10);
+
+        view->selectionModel()->clearSelection();
+        view->setCurrentIndex(QModelIndex{});
+        mWindow->statusBar()->clearMessage();
+
+        // Line 999 is well past the current 10-row model. The seam
+        // must reject with a specific "out of range (1 - 10)" hint,
+        // NOT jump the view.
+        mWindow->ExecuteGotoLineForTest(QStringLiteral("999"));
+        QCoreApplication::processEvents();
+
+        const QString message = mWindow->statusBar()->currentMessage();
+        QVERIFY2(
+            message.contains(QStringLiteral("out of range"), Qt::CaseInsensitive),
+            qUtf8Printable(QStringLiteral("Expected out-of-range hint, got: '%1'").arg(message))
+        );
+        // The bracketed range must reflect the *current* row count,
+        // not the value captured before a hypothetical modal open.
+        // If someone regresses to a stale captured value the range
+        // would be wrong and this substring check would fail.
+        QVERIFY2(
+            message.contains(QStringLiteral("1 - 10")),
+            qUtf8Printable(QStringLiteral("Expected live range '1 - 10' in hint, got: '%1'").arg(message))
+        );
+        // View selection unchanged (no accidental jump).
+        QVERIFY(view->selectionModel()->selectedRows().isEmpty());
+
+        model->EndStreaming(false);
+    }
+
+    // Regression pin: after a valid in-range line, the visibility
+    // probe reports a filter-hidden target with the caller-specific
+    // "Line %1 is currently filtered out." message (not the anchor-
+    // oriented "Row is not currently visible" fallback that
+    // `SelectSourceRow` would otherwise print). Uses the shared
+    // three-row fixture and filters down to only "third" so lines
+    // 1 and 2 are hidden while line 3 remains reachable.
+    void TestGotoLineFilteredOutRowSurfacesSpecificHint()
+    {
+        const int timeCol = StreamFixtureWithTimeColumnForRowMenuTests();
+        QVERIFY2(timeCol >= 0, "timestamp column must exist after streaming");
+        auto *model = mWindow->Model();
+        auto *proxy = mWindow->FilterModel();
+        auto *view = mWindow->findChild<LogTableView *>();
+        QVERIFY(model != nullptr);
+        QVERIFY(proxy != nullptr);
+        QVERIFY(view != nullptr);
+        QCOMPARE(model->rowCount(), 3);
+
+        const int msgCol = ColumnByHeader(*model, QStringLiteral("msg"));
+        QVERIFY2(msgCol >= 0, "msg column must exist");
+
+        // Keep only "third" (source row 2). Lines 1 and 2 become
+        // filter-hidden targets; line 3 stays reachable.
+        loglib::CallbackStringRowPredicate keepThird(
+            static_cast<std::size_t>(msgCol), [](std::string_view value) { return value == std::string_view{"third"}; }
+        );
+        std::vector<loglib::RowPredicate> rules;
+        rules.emplace_back(std::move(keepThird));
+        proxy->SetFilterRules(std::move(rules));
+        QCoreApplication::processEvents();
+        QCOMPARE(proxy->rowCount(), 1);
+
+        // Line 1 is filter-hidden -> specific hint, no jump.
+        view->selectionModel()->clearSelection();
+        view->setCurrentIndex(QModelIndex{});
+        mWindow->statusBar()->clearMessage();
+        mWindow->ExecuteGotoLineForTest(QStringLiteral("1"));
+        QCoreApplication::processEvents();
+
+        const QString hiddenMessage = mWindow->statusBar()->currentMessage();
+        QVERIFY2(
+            hiddenMessage.contains(QStringLiteral("filtered out"), Qt::CaseInsensitive),
+            qUtf8Printable(QStringLiteral("Expected 'filtered out' hint, got: '%1'").arg(hiddenMessage))
+        );
+        QVERIFY2(
+            hiddenMessage.contains(QStringLiteral("Line 1")),
+            qUtf8Printable(QStringLiteral("Expected 'Line 1' in hint, got: '%1'").arg(hiddenMessage))
+        );
+        QVERIFY(view->selectionModel()->selectedRows().isEmpty());
+
+        // Line 3 is visible -> jump succeeds and the "filtered out"
+        // hint is NOT re-printed. Under the single-row visible
+        // filter, source row 2 maps to proxy row 0.
+        mWindow->statusBar()->clearMessage();
+        mWindow->ExecuteGotoLineForTest(QStringLiteral("3"));
+        QCoreApplication::processEvents();
+        QCOMPARE(view->currentIndex().row(), 0);
+        QCOMPARE(view->selectionModel()->selectedRows().count(), 1);
+
+        // Restore the pristine "no filter" state so downstream tests
+        // see the fixture unchanged.
+        proxy->SetFilterRules({});
+        QCoreApplication::processEvents();
+    }
+
+    // No-log-loaded / empty-model early bail: the seam surfaces
+    // "No log loaded." and does nothing else. Pins the same
+    // early guard the modal-opening slot uses.
+    void TestGotoLineNoLogLoadedSurfacesHint()
+    {
+        auto *model = mWindow->Model();
+        QVERIFY(model != nullptr);
+        QCOMPARE(model->rowCount(), 0);
+
+        mWindow->statusBar()->clearMessage();
+        mWindow->ExecuteGotoLineForTest(QStringLiteral("1"));
+        QCoreApplication::processEvents();
+
+        const QString message = mWindow->statusBar()->currentMessage();
+        QVERIFY2(
+            message.contains(QStringLiteral("No log loaded"), Qt::CaseInsensitive),
+            qUtf8Printable(QStringLiteral("Expected 'No log loaded' hint, got: '%1'").arg(message))
+        );
     }
 
     // Pure parser: relative shortcuts `-Nh` and `-Nm` (case-

--- a/test/app/src/main_window_test.cpp
+++ b/test/app/src/main_window_test.cpp
@@ -4598,9 +4598,9 @@ private slots:
 
         // Keep only "third" (source row 2). Lines 1 and 2 become
         // filter-hidden targets; line 3 stays reachable.
-        loglib::CallbackStringRowPredicate keepThird(
-            static_cast<std::size_t>(msgCol), [](std::string_view value) { return value == std::string_view{"third"}; }
-        );
+        loglib::CallbackStringRowPredicate keepThird(static_cast<std::size_t>(msgCol), [](std::string_view value) {
+            return value == std::string_view{"third"};
+        });
         std::vector<loglib::RowPredicate> rules;
         rules.emplace_back(std::move(keepThird));
         proxy->SetFilterRules(std::move(rules));
@@ -4706,14 +4706,12 @@ private slots:
         const std::vector<std::string> noFormats;
 
         // 10^19 hours -- above both the int64 hour cap and 2^63.
-        QVERIFY(!MainWindow::ParseGotoTimestampInput(
-                     QStringLiteral("-10000000000000000000h"), noFormats, kNow
-        )
-                     .has_value());
+        QVERIFY(
+            !MainWindow::ParseGotoTimestampInput(QStringLiteral("-10000000000000000000h"), noFormats, kNow).has_value()
+        );
 
         // Hour boundary: cap itself parses, cap+1 rejects.
-        const auto hourCap =
-            static_cast<qulonglong>(std::numeric_limits<int64_t>::max() / (3600LL * 1'000'000LL));
+        const auto hourCap = static_cast<qulonglong>(std::numeric_limits<int64_t>::max() / (3600LL * 1'000'000LL));
         const auto overHourCap =
             MainWindow::ParseGotoTimestampInput(QString::number(hourCap + 1) + QStringLiteral("h"), noFormats, kNow);
         QVERIFY(!overHourCap.has_value());
@@ -4725,11 +4723,9 @@ private slots:
         // Minute boundary: distinct code path (different
         // `microsPerUnit`), so a branch-swap regression would
         // pass the hour test above and fail here.
-        const auto minuteCap =
-            static_cast<qulonglong>(std::numeric_limits<int64_t>::max() / (60LL * 1'000'000LL));
-        const auto overMinuteCap = MainWindow::ParseGotoTimestampInput(
-            QString::number(minuteCap + 1) + QStringLiteral("m"), noFormats, kNow
-        );
+        const auto minuteCap = static_cast<qulonglong>(std::numeric_limits<int64_t>::max() / (60LL * 1'000'000LL));
+        const auto overMinuteCap =
+            MainWindow::ParseGotoTimestampInput(QString::number(minuteCap + 1) + QStringLiteral("m"), noFormats, kNow);
         QVERIFY(!overMinuteCap.has_value());
 
         const auto atMinuteCap =
@@ -4797,8 +4793,7 @@ private slots:
         const std::chrono::system_clock::time_point kNow =
             std::chrono::system_clock::time_point{std::chrono::microseconds{1'700'000'000'000'000LL}};
 
-        const auto naiveParse =
-            MainWindow::ParseGotoTimestampInput(QStringLiteral("2024-04-28T12:00:00"), {}, kNow);
+        const auto naiveParse = MainWindow::ParseGotoTimestampInput(QStringLiteral("2024-04-28T12:00:00"), {}, kNow);
         QVERIFY(naiveParse.has_value());
         QVERIFY(naiveParse->isNaive);
 
@@ -4815,9 +4810,8 @@ private slots:
 
         // Zoned input must NOT shift (double-shift regression pin).
         const std::vector<std::string> zonedFormats{"%FT%T%Ez"};
-        const auto zonedParse = MainWindow::ParseGotoTimestampInput(
-            QStringLiteral("2024-04-28T12:00:00+00:00"), zonedFormats, kNow
-        );
+        const auto zonedParse =
+            MainWindow::ParseGotoTimestampInput(QStringLiteral("2024-04-28T12:00:00+00:00"), zonedFormats, kNow);
         QVERIFY(zonedParse.has_value());
         QVERIFY(!zonedParse->isNaive);
     }
@@ -4926,9 +4920,9 @@ private slots:
         // Keep only the row whose `msg` equals "third" (source
         // row 2). `CallbackStringRowPredicate` is the same variant
         // arm the Filters dock uses.
-        loglib::CallbackStringRowPredicate keepThird(
-            static_cast<std::size_t>(msgCol), [](std::string_view value) { return value == std::string_view{"third"}; }
-        );
+        loglib::CallbackStringRowPredicate keepThird(static_cast<std::size_t>(msgCol), [](std::string_view value) {
+            return value == std::string_view{"third"};
+        });
 
         std::vector<loglib::RowPredicate> rules;
         rules.emplace_back(std::move(keepThird));

--- a/test/app/src/main_window_test.cpp
+++ b/test/app/src/main_window_test.cpp
@@ -4500,11 +4500,9 @@ private slots:
         model->EndStreaming(false);
     }
 
-    // Goto Line happy path: drive the post-dialog body through the
-    // `ExecuteGotoLineForTest` seam so the 1-based-to-0-based flip
-    // AND the visibility probe are both exercised end-to-end (the
-    // dedicated shrink / filtered-out tests below cover the two
-    // rejection branches). Line 12 (1-based) maps to source row 11.
+    // Goto Line happy path: drive the post-dialog body via the
+    // test seam so both the 1-based-to-0-based flip and the
+    // visibility probe run end-to-end. Line 12 -> source row 11.
     void TestMainWindowGotoLineJumpsToRequestedSourceRow()
     {
         auto *model = mWindow->Model();
@@ -4532,16 +4530,10 @@ private slots:
         model->EndStreaming(false);
     }
 
-    // Regression pin: the post-dialog range check reads the *live*
-    // `mModel->rowCount()`, not a value captured before the modal
-    // opened. Otherwise a FIFO eviction / session swap during the
-    // modal would let an evicted line pass the check, land on
-    // `SelectSourceRow`'s generic "Row is not currently visible"
-    // hint, AND display a range in the error string that no longer
-    // exists. Simulated here by driving the seam with an input
-    // larger than the current row count -- a valid model that
-    // shrank while the modal was open would look identical to the
-    // seam's caller.
+    // Regression pin: the range check reads the live row count,
+    // not a value captured before the modal. Driving the seam with
+    // an oversize input simulates the shrink-during-modal case;
+    // the hint must show the current range, not the stale one.
     void TestGotoLineOutOfRangeAfterShrinkSurfacesLiveRange()
     {
         auto *model = mWindow->Model();
@@ -4586,13 +4578,9 @@ private slots:
         model->EndStreaming(false);
     }
 
-    // Regression pin: after a valid in-range line, the visibility
-    // probe reports a filter-hidden target with the caller-specific
-    // "Line %1 is currently filtered out." message (not the anchor-
-    // oriented "Row is not currently visible" fallback that
-    // `SelectSourceRow` would otherwise print). Uses the shared
-    // three-row fixture and filters down to only "third" so lines
-    // 1 and 2 are hidden while line 3 remains reachable.
+    // Regression pin: a filter-hidden target must surface the
+    // caller-specific "Line %1 is currently filtered out." hint
+    // instead of `SelectSourceRow`'s generic fallback.
     void TestGotoLineFilteredOutRowSurfacesSpecificHint()
     {
         const int timeCol = StreamFixtureWithTimeColumnForRowMenuTests();
@@ -4652,9 +4640,8 @@ private slots:
         QCoreApplication::processEvents();
     }
 
-    // No-log-loaded / empty-model early bail: the seam surfaces
-    // "No log loaded." and does nothing else. Pins the same
-    // early guard the modal-opening slot uses.
+    // Empty-model early bail: the seam surfaces "No log loaded."
+    // and does nothing else.
     void TestGotoLineNoLogLoadedSurfacesHint()
     {
         auto *model = mWindow->Model();
@@ -4672,11 +4659,9 @@ private slots:
         );
     }
 
-    // Pure parser: relative shortcuts `-Nh` and `-Nm` (case-
-    // insensitive, whitespace-tolerant) resolve against the pinned
-    // `now`. The unit chart lives in ROADMAP item 8; longer/shorter
-    // units are explicitly out of scope for v1. `isNaive == false`
-    // on this path because `now` is already UTC micros.
+    // Parser: relative `-Nh` / `-Nm` shortcuts (case-insensitive,
+    // whitespace-tolerant) resolve against the pinned @p now.
+    // `isNaive == false` since @p now is already UTC.
     void TestParseGotoTimestampInputAcceptsRelativeShortcuts()
     {
         const std::chrono::system_clock::time_point kNow =
@@ -4700,9 +4685,8 @@ private slots:
         QVERIFY(capitalH.has_value());
         QCOMPARE(capitalH->micros, kNowMicros - (2LL * 3600LL * 1'000'000LL));
 
-        // The `+N` and bare-`N` variants also mean "N units ago"
-        // (parity with lnav / less). A log viewer's "future" cursor
-        // is nonsensical, so the sign is treated as decorative.
+        // `+N` and bare `N` also mean "N units ago" (parity with
+        // lnav / less; "future" is meaningless in a log viewer).
         const auto plusOneHour = MainWindow::ParseGotoTimestampInput(QStringLiteral("+1h"), noFormats, kNow);
         QVERIFY(plusOneHour.has_value());
         QCOMPARE(plusOneHour->micros, kNowMicros - (3600LL * 1'000'000LL));
@@ -4712,13 +4696,10 @@ private slots:
         QCOMPARE(bareOneHour->micros, kNowMicros - (3600LL * 1'000'000LL));
     }
 
-    // Pure parser: relative shortcuts reject values that would
-    // overflow `int64_t` microseconds rather than silently wrap
-    // (a wrap would jump the user forward instead of backward).
-    // Covers BOTH units because the cap arithmetic uses a
-    // different `microsPerUnit` per branch (`3600 * 1e6` for `h`,
-    // `60 * 1e6` for `m`) -- a bug in either would slip past a
-    // single-unit test.
+    // Parser: relative shortcuts must reject over-`int64_t`
+    // micros rather than wrap (a wrap would jump the user
+    // forward). Both units are covered since the cap arithmetic
+    // uses a per-unit `microsPerUnit`.
     void TestParseGotoTimestampInputRejectsOverflowingRelativeShortcut()
     {
         const std::chrono::system_clock::time_point kNow = std::chrono::system_clock::now();
@@ -4730,24 +4711,20 @@ private slots:
         )
                      .has_value());
 
-        // 2^63 microseconds in hours (~2.56T) is exactly the cap;
-        // one past it must be rejected.
+        // Hour boundary: cap itself parses, cap+1 rejects.
         const auto hourCap =
             static_cast<qulonglong>(std::numeric_limits<int64_t>::max() / (3600LL * 1'000'000LL));
         const auto overHourCap =
             MainWindow::ParseGotoTimestampInput(QString::number(hourCap + 1) + QStringLiteral("h"), noFormats, kNow);
         QVERIFY(!overHourCap.has_value());
 
-        // ... and the cap itself must still parse (boundary check).
         const auto atHourCap =
             MainWindow::ParseGotoTimestampInput(QString::number(hourCap) + QStringLiteral("h"), noFormats, kNow);
         QVERIFY(atHourCap.has_value());
 
-        // Minute-cap boundary. Distinct code path from the hour
-        // cap: the overflow guard picks `microsPerUnit` per branch
-        // (`60 * 1e6` here vs `3600 * 1e6` above), so a regression
-        // that swapped the two branches would pass the hour test
-        // above and fail here. `2^63 / (60 * 1e6) ~= 1.53e11`.
+        // Minute boundary: distinct code path (different
+        // `microsPerUnit`), so a branch-swap regression would
+        // pass the hour test above and fail here.
         const auto minuteCap =
             static_cast<qulonglong>(std::numeric_limits<int64_t>::max() / (60LL * 1'000'000LL));
         const auto overMinuteCap = MainWindow::ParseGotoTimestampInput(
@@ -4760,11 +4737,10 @@ private slots:
         QVERIFY(atMinuteCap.has_value());
     }
 
-    // Pure parser: the column's own `parseFormats` are tried first;
-    // this covers the ROADMAP acceptance bar "every format the
-    // table's timestamp column already parses". Formats without a
-    // zone specifier (`%z` / `%Ez` / `%Z`) yield `isNaive == true`
-    // so the caller knows to shift the value through the display TZ.
+    // Parser: the column's own `parseFormats` are tried first
+    // (ROADMAP acceptance bar). Naive formats (no `%z` / `%Ez` /
+    // `%Z`) yield `isNaive == true` so the caller knows to
+    // TZ-shift the value.
     void TestParseGotoTimestampInputHonoursColumnParseFormats()
     {
         const std::chrono::system_clock::time_point kNow =
@@ -4799,8 +4775,7 @@ private slots:
         QVERIFY2(!zoned->isNaive, "format contains %Ez, result must NOT be flagged naive");
     }
 
-    // Pure parser: empty and garbage strings return nullopt; the
-    // slot surfaces a status-bar hint on the same signal.
+    // Parser: empty and garbage strings return nullopt.
     void TestParseGotoTimestampInputRejectsGarbage()
     {
         const std::chrono::system_clock::time_point kNow = std::chrono::system_clock::now();
@@ -4813,13 +4788,10 @@ private slots:
         QVERIFY(!MainWindow::ParseGotoTimestampInput(QStringLiteral("--1h"), {}, kNow).has_value());
     }
 
-    // Sanity-check on the helpers that FEED `ExecuteGotoTimestamp`
-    // (not the slot itself -- see the `ExecuteGotoTimestamp` seam
-    // tests further down for the end-to-end assertion). Ensures
     // `ParseGotoTimestampInput` + `LocalMicrosecondsSinceEpochToUtc`
-    // compose correctly: naive parses get shifted, zoned ones do
-    // NOT (double-shift regression pin). Assertions bound the
-    // shift to +/-14 h so the test is TZ-agnostic across CI hosts.
+    // compose correctly: naive parses get TZ-shifted, zoned ones
+    // do NOT (double-shift regression pin). Shift bound is +/-14h
+    // to stay TZ-agnostic across CI hosts.
     void TestParseAndLocalShiftHelpersComposeForNaiveInput()
     {
         const std::chrono::system_clock::time_point kNow =
@@ -4878,15 +4850,11 @@ private slots:
         QCOMPARE(mWindow->FindFirstRowAtOrAfter(timeCol, *lastMicros + 1), -1);
     }
 
-    // Regression pin: rows with a mid-file *missing* timestamp
-    // don't break the fast-path binary search. Fixture has three
-    // rows where the middle row lacks the `timestamp` key entirely
-    // (`monostate` slot). Targets tests every valid boundary:
-    //   * before-earliest -> row 0 (row 1 skipped over)
-    //   * exactly-first -> row 0
-    //   * just-past-first -> row 2 (skip 1)
-    //   * exactly-last -> row 2
-    //   * past-last -> -1
+    // Regression pin: a mid-file *missing* timestamp must not
+    // break the fast-path binary search. Middle row omits the
+    // `timestamp` key entirely. Covers every boundary: before /
+    // at-first, between valid rows (skip the missing one), at /
+    // past last.
     void TestFindFirstRowAtOrAfterHandlesInterleavedMissingTimestamps()
     {
         auto *model = mWindow->Model();
@@ -4940,10 +4908,8 @@ private slots:
     }
 
     // Regression pin: with a filter that hides source rows 0 and 1
-    // (keeps only row 2), the fast path must NOT return a hidden
-    // row -- previously it did, and `SelectSourceRow` then printed
-    // "Row is not currently visible" while a visible qualifying
-    // row existed further down.
+    // (keeps only row 2), the fast path must jump forward to the
+    // visible row rather than returning the hidden one.
     void TestFindFirstRowAtOrAfterSkipsFilterHiddenRowsInFastPath()
     {
         const int timeCol = StreamFixtureWithTimeColumnForRowMenuTests();
@@ -4957,11 +4923,9 @@ private slots:
         const int msgCol = ColumnByHeader(*model, QStringLiteral("msg"));
         QVERIFY2(msgCol >= 0, "msg column must exist");
 
-        // Callback string predicate that keeps only the row whose
-        // `msg` slot equals "third" (source row 2). The concrete
-        // `CallbackStringRowPredicate` is the same variant arm the
-        // Filters dock uses for regex / wildcard rules; a bare
-        // equality predicate keeps the fixture minimal.
+        // Keep only the row whose `msg` equals "third" (source
+        // row 2). `CallbackStringRowPredicate` is the same variant
+        // arm the Filters dock uses.
         loglib::CallbackStringRowPredicate keepThird(
             static_cast<std::size_t>(msgCol), [](std::string_view value) { return value == std::string_view{"third"}; }
         );
@@ -4973,20 +4937,17 @@ private slots:
         QCOMPARE(proxy->rowCount(), 1);
         QCOMPARE(proxy->SortColumn(), -1);
 
-        // Target well before every row's timestamp: without the
-        // visibility step the fast path would return source row 0
-        // ("first", filtered out); with it, it must jump forward
-        // to source row 2 ("third", visible).
+        // Target before every row's ts: without the visibility
+        // step this would return row 0 (filtered out); with it,
+        // it must jump forward to visible row 2 ("third").
         const auto *table = &model->Table();
         const auto firstMicros = loglib::AsEpochMicroseconds(table->GetValue(0, static_cast<std::size_t>(timeCol)));
         QVERIFY(firstMicros.has_value());
         QCOMPARE(mWindow->FindFirstRowAtOrAfter(timeCol, *firstMicros - 1'000'000), 2);
         QCOMPARE(mWindow->FindFirstRowAtOrAfter(timeCol, *firstMicros), 2);
 
-        // If the target sits AFTER the only visible row's timestamp,
-        // no live row qualifies -- must be -1 rather than a hidden
-        // row further down (there aren't any here, but the
-        // "return -1" branch is on the same code path).
+        // Target past the only visible row's ts: no live row
+        // qualifies -- must be -1, not a hidden row further down.
         const auto lastMicros = loglib::AsEpochMicroseconds(table->GetValue(2, static_cast<std::size_t>(timeCol)));
         QVERIFY(lastMicros.has_value());
         QCOMPARE(mWindow->FindFirstRowAtOrAfter(timeCol, *lastMicros + 1), -1);
@@ -4997,14 +4958,10 @@ private slots:
         QCoreApplication::processEvents();
     }
 
-    // Goto Timestamp linear scan: a user sort on a non-time column
-    // (the `msg` column, alphabetical) reorders the display
-    // ("first" < "second" < "third" happens to match file order,
-    // so use descending to force a real permutation). The scan
-    // walks proxy rows in display order and picks the first whose
-    // source timestamp qualifies -- which under a descending
-    // alphabetical sort is the last-in-file row ("third", source
-    // row 2).
+    // User-sort path: descending `msg` sort forces a real
+    // permutation. The scan walks proxy rows in display order,
+    // so the "first" qualifying row is the last-in-file
+    // ("third", source row 2).
     void TestFindFirstRowAtOrAfterLinearScansWhenUserSortActive()
     {
         const int timeCol = StreamFixtureWithTimeColumnForRowMenuTests();
@@ -5028,12 +4985,10 @@ private slots:
         QCOMPARE(found, 2);
     }
 
-    // Regression pin: newest-first display reversal is a mid-proxy
-    // concern; the fast-path binary search operates on source rows
-    // in file order, so the returned source row must be unchanged.
-    // `SelectSourceRow` then maps that source row through the
-    // reversed mid-proxy and lands the view at the display position
-    // corresponding to the reversed row.
+    // Regression pin: newest-first display reversal is a mid-
+    // proxy concern; the binary search still returns the source
+    // row in file order. `SelectSourceRow` handles the mapping
+    // to the reversed display position.
     void TestFindFirstRowAtOrAfterHonoursNewestFirstDisplay()
     {
         const int timeCol = StreamFixtureWithTimeColumnForRowMenuTests();
@@ -5078,12 +5033,10 @@ private slots:
         QCoreApplication::processEvents();
     }
 
-    // ExecuteGotoTimestamp seam: the post-`exec` body dispatches
-    // naive-vs-zoned correctly, updates the sticky-input mirror,
-    // and lands on the qualifying source row. Pins the
-    // `mLastGotoTimestampInput = rawInput` write BEFORE the parse
-    // -- a garbage input the user wants to correct is retained
-    // on the next open.
+    // Seam: post-`exec` body dispatches naive-vs-zoned, updates
+    // the sticky-input mirror BEFORE the parse (so a garbage
+    // input the user wants to correct survives), and lands on
+    // the qualifying source row.
     void TestExecuteGotoTimestampSeamJumpsAndRemembersInput()
     {
         const int timeCol = StreamFixtureWithTimeColumnForRowMenuTests();
@@ -5094,9 +5047,6 @@ private slots:
         QVERIFY(view != nullptr);
         QCOMPARE(model->rowCount(), 3);
 
-        // Pinned clock so any accidental relative-shortcut path
-        // is deterministic; this test drives an ISO absolute
-        // input, so `kNow` is only load-bearing for the mirror.
         const std::chrono::system_clock::time_point kNow =
             std::chrono::system_clock::time_point{std::chrono::microseconds{1'700'000'000'000'000LL}};
 
@@ -5104,19 +5054,15 @@ private slots:
         view->setCurrentIndex(QModelIndex{});
         mWindow->statusBar()->clearMessage();
 
-        // Zoned ISO input: the fixture's middle row is
-        // 2024-04-28T10:00:02+00:00, so pass exactly that. The
-        // zoned parse means the naive->UTC shift is skipped
-        // (double-shift regression pin) and the row lands
-        // regardless of the CI host's local TZ.
+        // Zoned ISO input matching the fixture's middle row. The
+        // zoned parse skips the naive -> UTC shift (double-shift
+        // regression pin) so the row lands regardless of host TZ.
         mWindow->ExecuteGotoTimestampForTest(QStringLiteral("2024-04-28T10:00:02+00:00"), kNow);
         QCoreApplication::processEvents();
-        // Middle row = source row 1 = proxy row 1 under the
-        // fixture's default (identity mid, no filter).
         QCOMPARE(view->currentIndex().row(), 1);
 
-        // Sticky-input mirror captured the raw string, not a
-        // canonicalised form.
+        // Sticky mirror keeps the raw string, not a canonicalised
+        // form.
         QCOMPARE(mWindow->LastGotoTimestampInputForTest(), QStringLiteral("2024-04-28T10:00:02+00:00"));
 
         // Garbage input: parse fails, sticky mirror still updates
@@ -5132,9 +5078,8 @@ private slots:
         );
     }
 
-    // ExecuteGotoTimestamp seam: an out-of-range target (past the
-    // last row) surfaces the "no visible row at or after that
-    // time" hint without moving the selection.
+    // Seam: an out-of-range target surfaces the "no visible row
+    // at or after that time" hint without moving the selection.
     void TestExecuteGotoTimestampSeamHintsWhenNoRowQualifies()
     {
         const int timeCol = StreamFixtureWithTimeColumnForRowMenuTests();
@@ -5161,9 +5106,8 @@ private slots:
         QVERIFY(view->selectionModel()->selectedRows().isEmpty());
     }
 
-    // Session-boundary clear: `NewSession()` wipes the sticky
-    // Goto Timestamp mirror so a stale reference from a closed
-    // file doesn't pre-populate the next dialog.
+    // `NewSession()` wipes the sticky Goto Timestamp mirror so
+    // a stale reference doesn't pre-populate the next dialog.
     void TestGotoTimestampStickyInputClearsOnNewSession()
     {
         const int timeCol = StreamFixtureWithTimeColumnForRowMenuTests();
@@ -5176,10 +5120,8 @@ private slots:
         QCoreApplication::processEvents();
         QCOMPARE(mWindow->LastGotoTimestampInputForTest(), QStringLiteral("2024-04-28T10:00:02+00:00"));
 
-        // `NewSession` runs the same code path as opening a fresh
-        // file. Trigger via the wired action so the private slot
-        // is reached the same way `Ctrl+N` reaches it in the app.
-        // Post-condition: mirror is empty.
+        // Trigger via the wired action so the private slot is
+        // reached the same way `Ctrl+N` reaches it in the app.
         auto *action = mWindow->findChild<QAction *>(QStringLiteral("actionNewSession"));
         QVERIFY2(action != nullptr, "actionNewSession must be reachable via objectName");
         action->trigger();
@@ -5187,13 +5129,9 @@ private slots:
         QCOMPARE(mWindow->LastGotoTimestampInputForTest(), QString{});
     }
 
-    // ExecuteGotoTimestamp seam: relative shortcut resolves
-    // against the pinned `now`, not `system_clock::now()`, and
-    // lands on the qualifying row. The fixture's timestamps are
-    // 2024-04-28T10:00:0{1,2,3}Z; pinning `now` one second past
-    // the last row means `-2s` would land on the middle row, but
-    // we only support `h` / `m` in v1 -- use `-1h` from a `now`
-    // just barely inside the middle row's window.
+    // Seam: relative shortcut resolves against the pinned @p now
+    // (not `system_clock::now()`) and lands on the qualifying
+    // row. `-1h` from `midMicros + 1h` lands on the middle row.
     void TestExecuteGotoTimestampSeamResolvesRelativeShortcutAgainstPinnedNow()
     {
         const int timeCol = StreamFixtureWithTimeColumnForRowMenuTests();
@@ -5222,9 +5160,7 @@ private slots:
         QCOMPARE(view->currentIndex().row(), 1);
     }
 
-    // ExecuteGotoTimestamp seam: bail-out branch when the log has
-    // no time column. Uses a synthetic stream fixture that omits
-    // any `Type::Time` column.
+    // Seam: bail-out branch when the log has no time column.
     void TestExecuteGotoTimestampSeamHintsWhenNoTimeColumn()
     {
         auto *model = mWindow->Model();
@@ -5235,8 +5171,7 @@ private slots:
         QVERIFY(sink != nullptr);
         loglib::KeyIndex &keys = sink->Keys();
         const loglib::KeyId valueKey = keys.GetOrInsert(std::string("value"));
-        // `MakeSyntheticBatch` produces rows with just a `value`
-        // key -- no timestamp column at all.
+        // Synthetic rows carry only a `value` key -- no time col.
         sink->OnBatch(MakeSyntheticBatch(streamSource, keys, valueKey, 1, 3, true));
         QCoreApplication::processEvents();
         QCOMPARE(model->rowCount(), 3);
@@ -5257,15 +5192,11 @@ private slots:
         model->EndStreaming(false);
     }
 
-    // Non-monotonic branch: with `TimestampsAreMonotonic()` flipped
-    // to false, `FindFirstRowAtOrAfter` must NOT take the binary-
-    // search fast path (which assumes monotonicity and can silently
-    // return a wrong row). Instead it walks the outer proxy and
-    // picks the visible row with the smallest ts satisfying
-    // `ts >= target` -- the chronologically earliest match. The
-    // three-row fixture is monotonic, so the ANSWER doesn't change
-    // vs the fast-path test; the assertion is that the ALTERNATE
-    // code path is taken and still returns the correct row.
+    // Non-monotonic branch: with monotonicity forced false, the
+    // fast path is unsafe. Fall back to a proxy walk that picks
+    // the visible row with the smallest ts >= target. The fixture
+    // is monotonic, so the ANSWER is unchanged; the point is that
+    // the alternate code path runs and still returns correctly.
     void TestFindFirstRowAtOrAfterUsesProxyIterationWhenNonMonotonic()
     {
         const int timeCol = StreamFixtureWithTimeColumnForRowMenuTests();
@@ -5280,31 +5211,26 @@ private slots:
         QVERIFY(model->TimestampsAreMonotonic());
         QCOMPARE(mWindow->FindFirstRowAtOrAfter(timeCol, *midMicros), 1);
 
-        // Force the flag to false. Idempotent, no way back
-        // (mirrors production semantics).
         mWindow->ForceTimestampsNonMonotonicForTest();
         QVERIFY(!model->TimestampsAreMonotonic());
 
-        // Same query, different branch. Correct answer preserved:
-        // proxy iteration finds the visible row with the smallest
-        // ts >= target.
+        // Same query, different branch, same answer.
         QCOMPARE(mWindow->FindFirstRowAtOrAfter(timeCol, *midMicros), 1);
 
-        // A target one tick BEFORE the middle row's ts still lands
-        // there (proxy iteration picks min-ts satisfying >= target).
+        // A tick before the middle row still picks the middle row
+        // (proxy iteration returns the min ts satisfying >=).
         QCOMPARE(mWindow->FindFirstRowAtOrAfter(timeCol, *midMicros - 1), 1);
 
-        // Past the last row's ts -> -1 (no qualifying row).
+        // Past the last row -> -1.
         const auto lastMicros = loglib::AsEpochMicroseconds(table->GetValue(2, static_cast<std::size_t>(timeCol)));
         QVERIFY(lastMicros.has_value());
         QCOMPARE(mWindow->FindFirstRowAtOrAfter(timeCol, *lastMicros + 1), -1);
     }
 
-    // Streaming path: the monotonicity detector flips false when
-    // a second batch's first valid ts predates the first batch's
-    // last valid ts (the multi-file `Append` / rotation case).
-    // Pins that behavior end-to-end through `LogModel::AppendBatch`
-    // so a regression in the boundary check would surface here.
+    // Streaming path: the monotonicity flag flips false when a
+    // second batch's first valid ts predates the first batch's
+    // last (multi-file `Append` / rotation). Pinned end-to-end
+    // through `LogModel::AppendBatch`.
     void TestLogModelTimestampsMonotonicFlipsOnBatchBoundaryInversion()
     {
         auto *model = mWindow->Model();
@@ -5313,8 +5239,6 @@ private slots:
         QVERIFY(model->TimestampsAreMonotonic());
 
         // Batch 1: three rows at 2024-04-28T10:00:0{1,2,3}Z.
-        // Reuses the JSON stream path (via a TempJsonFile) so the
-        // timestamp column is auto-detected and populated.
         const QStringList firstBatchLines{
             QStringLiteral(R"({"timestamp":"2024-04-28T10:00:01+00:00","msg":"first"})"),
             QStringLiteral(R"({"timestamp":"2024-04-28T10:00:02+00:00","msg":"second"})"),
@@ -5341,8 +5265,7 @@ private slots:
         QVERIFY(model->TimestampsAreMonotonic());
 
         // Batch 2 (via `AppendStreaming`): rows dated BEFORE the
-        // first batch's last row. This is exactly the multi-file
-        // `Append` scenario the monotonicity guard exists for.
+        // first batch -- the multi-file `Append` scenario.
         const QStringList secondBatchLines{
             QStringLiteral(R"({"timestamp":"2024-04-28T09:00:01+00:00","msg":"older-a"})"),
             QStringLiteral(R"({"timestamp":"2024-04-28T09:00:02+00:00","msg":"older-b"})"),
@@ -5368,10 +5291,9 @@ private slots:
         QVERIFY(!model->TimestampsAreMonotonic());
     }
 
-    // Session-boundary reset: `NewSession()` (called from every
-    // "open a new file" path) restores the monotonicity flag so a
-    // fresh well-ordered log doesn't inherit a prior session's
-    // non-monotonic verdict.
+    // `NewSession()` restores the monotonicity flag so a fresh
+    // well-ordered log doesn't inherit a prior "non-monotonic"
+    // verdict.
     void TestLogModelTimestampsMonotonicResetsOnNewSession()
     {
         auto *model = mWindow->Model();

--- a/test/app/src/main_window_test.cpp
+++ b/test/app/src/main_window_test.cpp
@@ -124,6 +124,7 @@
 #include <cstdint>
 #include <filesystem>
 #include <fstream>
+#include <limits>
 #include <memory>
 #include <mutex>
 #include <span>
@@ -4496,6 +4497,166 @@ private slots:
         QCOMPARE(view->currentIndex().row(), 3);
 
         model->EndStreaming(false);
+    }
+
+    // Goto Line: `ParseGotoTimestampInput` is exercised by the
+    // dedicated parser tests below; here we assert only that
+    // `SelectSourceRow` reaches the requested row when the caller
+    // arrives via the same 1-based path the modal takes. Line 12
+    // (1-based) maps to source row 11.
+    void TestMainWindowGotoLineJumpsToRequestedSourceRow()
+    {
+        auto *model = mWindow->Model();
+        auto *view = mWindow->findChild<LogTableView *>();
+        QVERIFY(view != nullptr);
+
+        loglib::StreamLineSource &streamSource = BeginSyntheticStreamSession(*model);
+        QtStreamingLogSink *sink = model->Sink();
+        QVERIFY(sink != nullptr);
+        loglib::KeyIndex &keys = sink->Keys();
+        const loglib::KeyId valueKey = keys.GetOrInsert(std::string("value"));
+        sink->OnBatch(MakeSyntheticBatch(streamSource, keys, valueKey, 1, 20, true));
+        QCoreApplication::processEvents();
+        QCOMPARE(model->rowCount(), 20);
+
+        view->selectionModel()->clearSelection();
+        view->setCurrentIndex(QModelIndex{});
+
+        // Same 1-based -> 0-based flip the slot performs on the
+        // dialog's textValue().
+        const int oneBased = 12;
+        mWindow->SelectSourceRow(oneBased - 1);
+        QCoreApplication::processEvents();
+        QCOMPARE(view->currentIndex().row(), 11);
+        QCOMPARE(view->selectionModel()->selectedRows().count(), 1);
+        QCOMPARE(view->selectionModel()->selectedRows().first().row(), 11);
+
+        model->EndStreaming(false);
+    }
+
+    // Pure parser: relative shortcuts `-Nh` and `-Nm` (case-
+    // insensitive, whitespace-tolerant) resolve against the pinned
+    // `now`. The unit chart lives in ROADMAP item 8; longer/shorter
+    // units are explicitly out of scope for v1.
+    void TestParseGotoTimestampInputAcceptsRelativeShortcuts()
+    {
+        const std::chrono::system_clock::time_point kNow =
+            std::chrono::system_clock::time_point{std::chrono::microseconds{1'700'000'000'000'000LL}};
+        const int64_t kNowMicros = 1'700'000'000'000'000LL;
+
+        const std::vector<std::string> noFormats;
+
+        const auto oneHourAgo = MainWindow::ParseGotoTimestampInput(QStringLiteral("-1h"), noFormats, kNow);
+        QVERIFY(oneHourAgo.has_value());
+        QCOMPARE(*oneHourAgo, kNowMicros - (3600LL * 1'000'000LL));
+
+        const auto thirtyMinAgo = MainWindow::ParseGotoTimestampInput(QStringLiteral("-30m"), noFormats, kNow);
+        QVERIFY(thirtyMinAgo.has_value());
+        QCOMPARE(*thirtyMinAgo, kNowMicros - (30LL * 60LL * 1'000'000LL));
+
+        // Case-insensitive, tolerant of internal whitespace.
+        const auto capitalH = MainWindow::ParseGotoTimestampInput(QStringLiteral("- 2 H"), noFormats, kNow);
+        QVERIFY(capitalH.has_value());
+        QCOMPARE(*capitalH, kNowMicros - (2LL * 3600LL * 1'000'000LL));
+    }
+
+    // Pure parser: the column's own `parseFormats` are tried first;
+    // this covers the ROADMAP acceptance bar "every format the
+    // table's timestamp column already parses".
+    void TestParseGotoTimestampInputHonoursColumnParseFormats()
+    {
+        const std::chrono::system_clock::time_point kNow =
+            std::chrono::system_clock::time_point{std::chrono::microseconds{1'700'000'000'000'000LL}};
+
+        // Slash-separated custom format that would fail the ISO
+        // fallbacks. `%FT%T` = "%Y-%m-%dT%H:%M:%S" and `%F %T` =
+        // "%Y-%m-%d %H:%M:%S".
+        const std::vector<std::string> columnFormats{"%Y/%m/%d %H:%M:%S"};
+        const auto parsed =
+            MainWindow::ParseGotoTimestampInput(QStringLiteral("2024/04/28 12:34:56"), columnFormats, kNow);
+        QVERIFY(parsed.has_value());
+        QVERIFY(*parsed > 0);
+
+        // ISO fallback works even with no column formats.
+        const auto isoT = MainWindow::ParseGotoTimestampInput(QStringLiteral("2024-04-28T12:34:56"), {}, kNow);
+        QVERIFY(isoT.has_value());
+        QVERIFY(*isoT > 0);
+
+        const auto isoSpace = MainWindow::ParseGotoTimestampInput(QStringLiteral("2024-04-28 12:34:56"), {}, kNow);
+        QVERIFY(isoSpace.has_value());
+        QCOMPARE(*isoT, *isoSpace);
+    }
+
+    // Pure parser: empty and garbage strings return nullopt; the
+    // slot surfaces a status-bar hint on the same signal.
+    void TestParseGotoTimestampInputRejectsGarbage()
+    {
+        const std::chrono::system_clock::time_point kNow = std::chrono::system_clock::now();
+
+        QVERIFY(!MainWindow::ParseGotoTimestampInput(QString{}, {}, kNow).has_value());
+        QVERIFY(!MainWindow::ParseGotoTimestampInput(QStringLiteral("   "), {}, kNow).has_value());
+        QVERIFY(!MainWindow::ParseGotoTimestampInput(QStringLiteral("not a timestamp"), {}, kNow).has_value());
+        // Positive-offset (`+1h`) is not a shortcut we accept for v1.
+        QVERIFY(!MainWindow::ParseGotoTimestampInput(QStringLiteral("+1h"), {}, kNow).has_value());
+    }
+
+    // Goto Timestamp binary search: no user sort active. The
+    // fixture streams three timestamps 1 s apart; the query
+    // targets the middle row exactly.
+    void TestFindFirstRowAtOrAfterBinarySearchesWhenUnsorted()
+    {
+        const int timeCol = StreamFixtureWithTimeColumnForRowMenuTests();
+        QVERIFY2(timeCol >= 0, "timestamp column must exist after streaming");
+        auto *proxy = mWindow->FilterModel();
+        QVERIFY(proxy != nullptr);
+        QCOMPARE(proxy->SortColumn(), -1);
+
+        // Middle row's exact timestamp: 2024-04-28T10:00:02+00:00.
+        // Feed epoch micros directly so the test is timezone-agnostic.
+        const auto *table = &mWindow->Model()->Table();
+        const auto midMicros = loglib::AsEpochMicroseconds(table->GetValue(1, static_cast<std::size_t>(timeCol)));
+        QVERIFY(midMicros.has_value());
+
+        QCOMPARE(mWindow->FindFirstRowAtOrAfter(timeCol, *midMicros), 1);
+
+        // A tick earlier still lands on the middle row.
+        QCOMPARE(mWindow->FindFirstRowAtOrAfter(timeCol, *midMicros - 1), 1);
+
+        // Way past the last timestamp: no row qualifies.
+        const auto lastMicros = loglib::AsEpochMicroseconds(table->GetValue(2, static_cast<std::size_t>(timeCol)));
+        QVERIFY(lastMicros.has_value());
+        QCOMPARE(mWindow->FindFirstRowAtOrAfter(timeCol, *lastMicros + 1), -1);
+    }
+
+    // Goto Timestamp linear scan: a user sort on a non-time column
+    // (the `msg` column, alphabetical) reorders the display
+    // ("first" < "second" < "third" happens to match file order,
+    // so use descending to force a real permutation). The scan
+    // walks proxy rows in display order and picks the first whose
+    // source timestamp qualifies -- which under a descending
+    // alphabetical sort is the last-in-file row ("third", source
+    // row 2).
+    void TestFindFirstRowAtOrAfterLinearScansWhenUserSortActive()
+    {
+        const int timeCol = StreamFixtureWithTimeColumnForRowMenuTests();
+        QVERIFY2(timeCol >= 0, "timestamp column must exist after streaming");
+        const int msgCol = ColumnByHeader(*mWindow->Model(), QStringLiteral("msg"));
+        QVERIFY2(msgCol >= 0, "msg column must exist after streaming");
+
+        auto *view = mWindow->findChild<LogTableView *>();
+        QVERIFY(view != nullptr);
+        view->sortByColumn(msgCol, Qt::DescendingOrder);
+        QCoreApplication::processEvents();
+
+        auto *proxy = mWindow->FilterModel();
+        QVERIFY(proxy != nullptr);
+        QCOMPARE(proxy->SortColumn(), msgCol);
+
+        // Earliest possible target (INT64_MIN) still picks the
+        // *first* row in display order, which under `msg DESC` is
+        // source row 2 ("third").
+        const int found = mWindow->FindFirstRowAtOrAfter(timeCol, std::numeric_limits<int64_t>::min());
+        QCOMPARE(found, 2);
     }
 
     // Anchors round-trip: live AnchorManager -> saved JSON ->

--- a/test/lib/src/test_log_processing.cpp
+++ b/test/lib/src/test_log_processing.cpp
@@ -385,6 +385,108 @@ TEST_CASE("LocalMillisecondsSinceEpochToTimeStamp", "[log_processing]")
     }
 }
 
+// `LocalMicrosecondsSinceEpochToUtc` under a pinned zone. Using a
+// specific IANA zone (rather than `CurrentZone()`) keeps the
+// assertion deterministic across CI hosts. Verifies the three
+// interesting inputs of each transition kind:
+//   * the "normal" hour (unique local instant), which round-trips.
+//   * the "spring-forward" gap hour, which the helper documents as
+//     "return the naive value" for graceful degradation.
+//   * the "fall-back" ambiguous hour, which resolves to the earlier
+//     candidate via `choose::earliest`.
+TEST_CASE("LocalMicrosecondsSinceEpochToUtc handles DST transitions", "[log_processing]")
+{
+    InitializeTimezoneData();
+
+    // Berlin: last Sunday of March / October each year.
+    //   * Spring forward 2024: 2024-03-31 02:00 -> 03:00 CEST.
+    //     02:30 wall-clock never happens.
+    //   * Fall back 2024: 2024-10-27 03:00 -> 02:00 CET.
+    //     02:30 wall-clock happens twice (CEST offset +02:00 and
+    //     the later CET offset +01:00).
+    const date::time_zone *berlin = date::locate_zone("Europe/Berlin");
+    REQUIRE(berlin != nullptr);
+
+    // Helper: build a naive-UTC-as-if-local micros value from a
+    // year-month-day-hour-minute-second tuple. Mirrors what the
+    // Goto Timestamp seam produces after a naive `date::parse`.
+    const auto naiveLocalMicros = [](int year, unsigned month, unsigned day, int hour, int minute, int second)
+    {
+        // Explicit `date::month{...}` / `date::day{...}` (rather than
+        // relying on `operator/`'s implicit conversion from `unsigned`)
+        // silences the clang-tidy narrowing-conversion warning on the
+        // hosted `year / unsigned / unsigned` overload.
+        const auto ymd = date::year{year} / date::month{month} / date::day{day};
+        const auto sysDays = date::sys_days{ymd};
+        const auto wallClock = sysDays + std::chrono::hours{hour} + std::chrono::minutes{minute} +
+                               std::chrono::seconds{second};
+        return std::chrono::duration_cast<std::chrono::microseconds>(wallClock.time_since_epoch()).count();
+    };
+
+    SECTION("Ordinary hour round-trips through the zone offset")
+    {
+        // 2024-04-01 12:00:00 in Berlin (well past the spring
+        // transition) is CEST (+02:00) -> 10:00:00 UTC.
+        const int64_t localMicros = naiveLocalMicros(2024, 4, 1, 12, 0, 0);
+        const int64_t expectedUtcMicros = naiveLocalMicros(2024, 4, 1, 10, 0, 0);
+        const int64_t got = LocalMicrosecondsSinceEpochToUtc(localMicros, berlin);
+        CHECK(got == expectedUtcMicros);
+    }
+
+    SECTION("Fall-back ambiguous hour resolves to the earlier candidate")
+    {
+        // 2024-10-27 02:30:00 in Berlin occurs twice; the "earliest"
+        // resolution is CEST (+02:00) -> 00:30:00 UTC (the earlier
+        // of the two candidates -- the later resolution would be
+        // CET, +01:00 -> 01:30:00 UTC).
+        const int64_t localMicros = naiveLocalMicros(2024, 10, 27, 2, 30, 0);
+        const int64_t earlierUtcMicros = naiveLocalMicros(2024, 10, 27, 0, 30, 0);
+        const int64_t got = LocalMicrosecondsSinceEpochToUtc(localMicros, berlin);
+        CHECK(got == earlierUtcMicros);
+    }
+
+    SECTION("Spring-forward gap hour snaps to the transition boundary")
+    {
+        // 2024-03-31 02:30:00 in Berlin never occurs (clocks skip
+        // 02:00 CET -> 03:00 CEST). `to_sys(local, choose::earliest)`
+        // resolves the gap by returning the sys_time transition
+        // boundary (01:00 UTC = the moment clocks jumped), NOT by
+        // throwing `nonexistent_local_time` -- that exception only
+        // fires from the no-`choose` overload. This is a fine
+        // Goto Timestamp landing: the first real instant after the
+        // gap. Pinning the exact boundary value guards against a
+        // silent behaviour change (e.g. a future date library
+        // release adopting `choose::latest`-style semantics, or a
+        // switch to the throwing overload with a naive fallback).
+        const int64_t localMicros = naiveLocalMicros(2024, 3, 31, 2, 30, 0);
+        const int64_t transitionBoundaryUtc = naiveLocalMicros(2024, 3, 31, 1, 0, 0);
+        const int64_t got = LocalMicrosecondsSinceEpochToUtc(localMicros, berlin);
+        CHECK(got == transitionBoundaryUtc);
+    }
+
+    SECTION("Null zone passes the value through unchanged")
+    {
+        const int64_t localMicros = naiveLocalMicros(2024, 4, 1, 12, 0, 0);
+        const int64_t got = LocalMicrosecondsSinceEpochToUtc(localMicros, nullptr);
+        CHECK(got == localMicros);
+    }
+
+    SECTION("Far-future / far-past instants degrade gracefully")
+    {
+        // Push well past the tzdata transition table (~2500 CE
+        // depending on the vintage). `to_sys` may throw a
+        // non-DST exception here; the broadened catch keeps the
+        // helper exception-safe and yields the naive value.
+        const int64_t farFutureMicros = naiveLocalMicros(9999, 12, 31, 23, 59, 59);
+        const int64_t gotFuture = LocalMicrosecondsSinceEpochToUtc(farFutureMicros, berlin);
+        // Success case: shift stays within the offset bounds
+        // (Berlin's largest historical offset is well under 3h).
+        // Degradation case: value equals the naive input.
+        constexpr int64_t MAX_ZONE_OFFSET_MICROS = 14LL * 3600LL * 1'000'000LL;
+        CHECK(std::llabs(gotFuture - farFutureMicros) <= MAX_ZONE_OFFSET_MICROS);
+    }
+}
+
 TEST_CASE("UtcMicrosecondsToDateTimeString", "[log_processing]")
 {
     InitializeTimezoneData();

--- a/test/lib/src/test_log_processing.cpp
+++ b/test/lib/src/test_log_processing.cpp
@@ -403,12 +403,11 @@ TEST_CASE("LocalMicrosecondsSinceEpochToUtc handles DST transitions", "[log_proc
     // mirroring what the Goto Timestamp seam produces after a
     // naive `date::parse`. Explicit `date::month{}` / `date::day{}`
     // silences a clang-tidy narrowing warning.
-    const auto naiveLocalMicros = [](int year, unsigned month, unsigned day, int hour, int minute, int second)
-    {
+    const auto naiveLocalMicros = [](int year, unsigned month, unsigned day, int hour, int minute, int second) {
         const auto ymd = date::year{year} / date::month{month} / date::day{day};
         const auto sysDays = date::sys_days{ymd};
-        const auto wallClock = sysDays + std::chrono::hours{hour} + std::chrono::minutes{minute} +
-                               std::chrono::seconds{second};
+        const auto wallClock =
+            sysDays + std::chrono::hours{hour} + std::chrono::minutes{minute} + std::chrono::seconds{second};
         return std::chrono::duration_cast<std::chrono::microseconds>(wallClock.time_since_epoch()).count();
     };
 

--- a/test/lib/src/test_log_processing.cpp
+++ b/test/lib/src/test_log_processing.cpp
@@ -385,37 +385,26 @@ TEST_CASE("LocalMillisecondsSinceEpochToTimeStamp", "[log_processing]")
     }
 }
 
-// `LocalMicrosecondsSinceEpochToUtc` under a pinned zone. Using a
-// specific IANA zone (rather than `CurrentZone()`) keeps the
-// assertion deterministic across CI hosts. Verifies the three
-// interesting inputs of each transition kind:
-//   * the "normal" hour (unique local instant), which round-trips.
-//   * the "spring-forward" gap hour, which the helper documents as
-//     "return the naive value" for graceful degradation.
-//   * the "fall-back" ambiguous hour, which resolves to the earlier
-//     candidate via `choose::earliest`.
+// `LocalMicrosecondsSinceEpochToUtc` under `Europe/Berlin` (a
+// pinned IANA zone rather than `CurrentZone()` for deterministic
+// CI). Covers ordinary, fall-back, spring-forward, null-zone,
+// and far-future inputs.
 TEST_CASE("LocalMicrosecondsSinceEpochToUtc handles DST transitions", "[log_processing]")
 {
     InitializeTimezoneData();
 
-    // Berlin: last Sunday of March / October each year.
-    //   * Spring forward 2024: 2024-03-31 02:00 -> 03:00 CEST.
-    //     02:30 wall-clock never happens.
-    //   * Fall back 2024: 2024-10-27 03:00 -> 02:00 CET.
-    //     02:30 wall-clock happens twice (CEST offset +02:00 and
-    //     the later CET offset +01:00).
+    // Berlin DST 2024: spring forward 2024-03-31 02:00 -> 03:00
+    // CEST (02:30 does not exist); fall back 2024-10-27 03:00 ->
+    // 02:00 CET (02:30 exists twice).
     const date::time_zone *berlin = date::locate_zone("Europe/Berlin");
     REQUIRE(berlin != nullptr);
 
-    // Helper: build a naive-UTC-as-if-local micros value from a
-    // year-month-day-hour-minute-second tuple. Mirrors what the
-    // Goto Timestamp seam produces after a naive `date::parse`.
+    // Build a naive-as-if-UTC micros value from Y-M-D H:M:S,
+    // mirroring what the Goto Timestamp seam produces after a
+    // naive `date::parse`. Explicit `date::month{}` / `date::day{}`
+    // silences a clang-tidy narrowing warning.
     const auto naiveLocalMicros = [](int year, unsigned month, unsigned day, int hour, int minute, int second)
     {
-        // Explicit `date::month{...}` / `date::day{...}` (rather than
-        // relying on `operator/`'s implicit conversion from `unsigned`)
-        // silences the clang-tidy narrowing-conversion warning on the
-        // hosted `year / unsigned / unsigned` overload.
         const auto ymd = date::year{year} / date::month{month} / date::day{day};
         const auto sysDays = date::sys_days{ymd};
         const auto wallClock = sysDays + std::chrono::hours{hour} + std::chrono::minutes{minute} +
@@ -425,8 +414,7 @@ TEST_CASE("LocalMicrosecondsSinceEpochToUtc handles DST transitions", "[log_proc
 
     SECTION("Ordinary hour round-trips through the zone offset")
     {
-        // 2024-04-01 12:00:00 in Berlin (well past the spring
-        // transition) is CEST (+02:00) -> 10:00:00 UTC.
+        // 2024-04-01 12:00 Berlin (CEST +02:00) -> 10:00 UTC.
         const int64_t localMicros = naiveLocalMicros(2024, 4, 1, 12, 0, 0);
         const int64_t expectedUtcMicros = naiveLocalMicros(2024, 4, 1, 10, 0, 0);
         const int64_t got = LocalMicrosecondsSinceEpochToUtc(localMicros, berlin);
@@ -435,10 +423,8 @@ TEST_CASE("LocalMicrosecondsSinceEpochToUtc handles DST transitions", "[log_proc
 
     SECTION("Fall-back ambiguous hour resolves to the earlier candidate")
     {
-        // 2024-10-27 02:30:00 in Berlin occurs twice; the "earliest"
-        // resolution is CEST (+02:00) -> 00:30:00 UTC (the earlier
-        // of the two candidates -- the later resolution would be
-        // CET, +01:00 -> 01:30:00 UTC).
+        // 2024-10-27 02:30 Berlin occurs twice; `choose::earliest`
+        // picks CEST (+02:00) -> 00:30 UTC.
         const int64_t localMicros = naiveLocalMicros(2024, 10, 27, 2, 30, 0);
         const int64_t earlierUtcMicros = naiveLocalMicros(2024, 10, 27, 0, 30, 0);
         const int64_t got = LocalMicrosecondsSinceEpochToUtc(localMicros, berlin);
@@ -447,17 +433,11 @@ TEST_CASE("LocalMicrosecondsSinceEpochToUtc handles DST transitions", "[log_proc
 
     SECTION("Spring-forward gap hour snaps to the transition boundary")
     {
-        // 2024-03-31 02:30:00 in Berlin never occurs (clocks skip
-        // 02:00 CET -> 03:00 CEST). `to_sys(local, choose::earliest)`
-        // resolves the gap by returning the sys_time transition
-        // boundary (01:00 UTC = the moment clocks jumped), NOT by
-        // throwing `nonexistent_local_time` -- that exception only
-        // fires from the no-`choose` overload. This is a fine
-        // Goto Timestamp landing: the first real instant after the
-        // gap. Pinning the exact boundary value guards against a
-        // silent behaviour change (e.g. a future date library
-        // release adopting `choose::latest`-style semantics, or a
-        // switch to the throwing overload with a naive fallback).
+        // 2024-03-31 02:30 Berlin does not exist. `choose::earliest`
+        // returns the transition boundary (01:00 UTC = the instant
+        // clocks jumped forward), not `nonexistent_local_time`.
+        // Pinning the exact value guards against a future date
+        // library changing this semantic.
         const int64_t localMicros = naiveLocalMicros(2024, 3, 31, 2, 30, 0);
         const int64_t transitionBoundaryUtc = naiveLocalMicros(2024, 3, 31, 1, 0, 0);
         const int64_t got = LocalMicrosecondsSinceEpochToUtc(localMicros, berlin);
@@ -473,15 +453,12 @@ TEST_CASE("LocalMicrosecondsSinceEpochToUtc handles DST transitions", "[log_proc
 
     SECTION("Far-future / far-past instants degrade gracefully")
     {
-        // Push well past the tzdata transition table (~2500 CE
-        // depending on the vintage). `to_sys` may throw a
-        // non-DST exception here; the broadened catch keeps the
-        // helper exception-safe and yields the naive value.
+        // Well past the tzdata transition table. `to_sys` may
+        // throw a non-DST exception; the catch keeps the helper
+        // exception-safe by yielding the naive value. Either way
+        // the shift stays within +/-14 h.
         const int64_t farFutureMicros = naiveLocalMicros(9999, 12, 31, 23, 59, 59);
         const int64_t gotFuture = LocalMicrosecondsSinceEpochToUtc(farFutureMicros, berlin);
-        // Success case: shift stays within the offset bounds
-        // (Berlin's largest historical offset is well under 3h).
-        // Degradation case: value equals the naive input.
         constexpr int64_t MAX_ZONE_OFFSET_MICROS = 14LL * 3600LL * 1'000'000LL;
         CHECK(std::llabs(gotFuture - farFutureMicros) <= MAX_ZONE_OFFSET_MICROS);
     }


### PR DESCRIPTION
Adds a **Go to Line** (`Ctrl+G`) and **Go to Timestamp** (`Ctrl+Shift+G`) pair of `Edit` menu entries that jump the table to a row by its 1-based line number or by a wall-clock time, closing item **8** of [`ROADMAP.md`](ROADMAP.md#8-goto-line--goto-timestamp) (crossed off in this PR, comparative feature matrix cell flipped to `✓`). `MainWindow` grows two `QInputDialog`-driven slots plus a static pure parser (`ParseGotoTimestampInput`) and a source-model search helper (`FindFirstRowAtOrAfter`) that all sit alongside the existing `SelectSourceRow` seam and reuse the anchor / find navigation plumbing verbatim. Timestamp parsing goes through a new library-side helper (`loglib::LocalMicrosecondsSinceEpochToUtc`) which does the local -> UTC shift required for naive user inputs (the table renders in the display TZ; user text without `%z` / `%Z` is a wall-clock in that TZ, not UTC).

`GotoLine` reads a 1-based row number, validates it against the *live* row count on both dialog-open (via `QIntValidator`) and dialog-close (`ExecuteGotoLine` re-reads `mModel->rowCount()` after `exec` returns to catch FIFO evictions that landed while the modal was open), probes filter visibility through the outer proxy chain, and hands off to `SelectSourceRow`. Line 1 is always the earliest retained row (newest-first display only affects paint, not the number the user types); streaming FIFO eviction may have dropped older rows so numbers need not match the source file's own numbering. Filtered-out targets surface a specific `Line N is currently filtered out.` message instead of the generic `Row is not currently visible.` fallback that `SelectSourceRow` prints for anchor jumps.

`GotoTimestamp` accepts every format the timestamp column already parses (via `Column::parseFormats`), two ISO 8601 fallbacks (`%FT%T`, `%F %T`, tried after the column formats so columns with an empty format list still accept typical inputs), and the relative shortcuts `-Nh` / `-Nm` (case-insensitive, whitespace-tolerant; `+N` and bare `N` also mean "N units ago", matching lnav / less). Naive inputs (no `%z` / `%Ez` / `%Oz` / `%Z` in the winning format) are shifted from the display TZ (`loglib::CurrentZone()`) to UTC via `loglib::LocalMicrosecondsSinceEpochToUtc` before the search; zoned inputs bypass the shift so a pasted `2024-04-28T10:00:00Z` from the file is never double-shifted. The search picks one of three branches from `(userSortColumn, TimestampsAreMonotonic())`: an O(log N) binary search over source rows on the fast path, an O(N_visible) outer-proxy walk when monotonicity has broken, and an O(N_visible) display-order scan under a user sort so the "first" row honours the visible order the user is looking at.

## Why

The [comparative feature matrix](ROADMAP.md#comparative-feature-matrix) has "Goto line / Goto timestamp" as a Tier 1 v1 blocker — lnav, Klogg, LogExpert, LogViewPlus, OtrosLogViewer, QLogExplorer, LogSleuth, and Logan all ship one. `Ctrl+F` and column filters cover different workflows (find a needle / narrow the view), and none of the anchor navigation paths land on an *arbitrary* row: the user is triaging an incident that references `line 12345` in a bug report, or wants to jump to `-1h` from an ongoing stream to see what happened before the alert fired, and every existing seam either searches for a substring or requires an anchor pre-planted on the target row. A `Ctrl+G` / `Ctrl+Shift+G` pair is the smallest possible feature that closes both gaps.

The right shape is a *library-side TZ shift helper + Qt-side pure parser + Qt-side source-model search helper*. The TZ shift lives in `loglib` because DST edge cases (fall-back ambiguous hour, spring-forward gap) are load-bearing and every future TZ-shift caller (headless CLI's `--since`, saved views, time-gap detection) should route through the same `date::choose::earliest` policy rather than each reinventing it. The parser lives on `MainWindow` as a pure static helper (`ParseGotoTimestampInput`) so it drives from unit tests without an instance and stays free of Qt event-loop dependencies: the dispatch tries the relative shortcut regex first (`^[+-]?\s*(\d+)\s*([hm])\s*$`), then each entry of the column's `parseFormats` via `loglib::TryParseTimestamp`, then the two ISO fallbacks; it returns `GotoTimestampParse{micros, isNaive}` so the caller knows whether to shift, and the shortcut branch reports `isNaive == false` because `system_clock::now()` is already UTC. The search helper lives on `MainWindow` because it needs both proxies (source-row visibility through `mRowOrderProxyModel` + `mSortFilterProxyModel`) and the monotonicity flag off `LogModel`, all of which are Qt-side; `FindFirstRowAtOrAfter` is `[[nodiscard]] int` and public so tests can drive all three branches directly without a modal.

**Timestamp monotonicity is the load-bearing invariant of the fast path.** The naive fast path is `std::lower_bound` over source rows, but that assumes `ts[i] <= ts[i+1]` for every `i` — an invariant that a single-file static parse of a well-formed log holds, but multi-file `Append` opens with overlapping ranges, log rotation with a boundary flip, or multi-producer streams with clock skew can and do break. `LogModel::TimestampsAreMonotonic()` (backed by `mTimestampsMonotonic`, updated in-place by `UpdateTimestampMonotonicity` on every `AppendBatch` with an O(N_batch) running-max + boundary check) is what lets `FindFirstRowAtOrAfter` gate the binary search: on the first inversion the flag flips false irreversibly and the search degrades to a proxy walk that picks the chronologically earliest visible match. The flag is cheap enough (one comparison per batch boundary + running-max per row) that the streaming path pays essentially nothing. Missing-timestamp rows (unpromoted / null value) are skipped rather than treated as `-inf`: a `-inf` policy would break `lower_bound`'s monotonicity the moment one interleaved gap appeared in `[10, missing, 20, 30]` (the fast path would return the wrong row on `target = 5`). Every probe walks forward past missing rows, then the post-search walk skips filter-hidden rows through the outer proxy — worst case (all rows missing) is O(N), typical case (rare gaps) stays O(log N).

**Naive-vs-zoned dispatch on the parser side avoids a silent 2-hour miss.** The naive first cut treated every parse the same and returned UTC epoch micros, which was correct for `2024-04-28T10:00:00Z` (already UTC) but two hours off for `12:00:00` typed by a user in UTC+2. The table renders in the display TZ so `12:00:00` is what the user *sees*, and comparing the parser's "naive UTC" against the model's true UTC would jump them to a row two hours off the one they meant. `FormatHasZoneSpecifier` walks the format looking for `%z` / `%Ez` / `%Oz` / `%Z` (advancing one byte at a time on a no-match so a malformed `%E%z` still detects the inner `%z`; `%%` is a literal percent and does not register), which lets `ParseGotoTimestampInput` return `isNaive = !FormatHasZoneSpecifier(fmt)` from the winning branch. Naive results flow through `LocalMicrosecondsSinceEpochToUtc`; zoned results bypass it. Relative shortcuts derive from `system_clock::now()` which is already UTC, so they always report `isNaive == false` regardless of the display TZ.

**`LocalMicrosecondsSinceEpochToUtc` and the `date::choose::earliest` policy is the third correctness point.** The obvious wire-up is `date::zoned_time{tz, local_time}.get_sys_time()`, but that overload of `to_sys(local)` throws `nonexistent_local_time` on the spring-forward gap and `ambiguous_local_time` on the fall-back hour — neither of which are recoverable in the Goto Timestamp slot (the user typed a real string; we shouldn't refuse the jump). The `to_sys(local, choose)` overload handles both edge cases without throwing: ambiguous fall-back hour resolves to the earlier candidate; spring-forward gap snaps to the transition boundary (the first real instant after the gap). We deliberately do NOT catch `nonexistent_local_time` / `ambiguous_local_time` because the `choose` overload never throws them; the surviving catch (`std::exception`) is reserved for far-future dates past the tzdata table and corrupt zone entries, which yield the naive value as a graceful degradation. The helper takes an explicit `const date::time_zone *` overload so `test_log_processing.cpp` can pin `Europe/Berlin` DST transitions in CI without depending on the CI runner's local zone; production callers use the no-argument overload (`= CurrentZone()`).

**Overflow rejection on the relative shortcut avoids a silent forward-jump.** A large input like `999999999999h` multiplied by `MICROS_PER_HOUR` wraps `int64_t` and produces a negative offset, so `now - (negative)` jumps the user *forward* in time — the exact opposite of what they meant. `ParseGotoTimestampInput` caps `n` against `INT64_MAX / microsPerUnit` before multiplying and returns `std::nullopt` on overflow; the ExecuteGotoTimestamp slot then surfaces the generic "Could not parse timestamp." hint, which is strictly better than jumping the viewport to 1970. Both the hour cap and the minute cap have their own regression tests because they compute different `microsPerUnit` and could regress independently.

**Sticky-input and session-boundary clear closes out the UX loop.** Successive `Ctrl+G` jumps around the same neighbourhood ("go to 12000, then 12100, then 12080") shouldn't need a retype, and the same holds for Goto Timestamp where the format string is usually the annoying part. Both slots pre-populate the dialog from `mLastGotoLineInput` / `mLastGotoTimestampInput` on the next open. `NewSession` clears both mirrors so a session's line-number range (a 500 k-line log) or format / TZ (a US-Central `%m/%d/%Y` custom format) doesn't bleed into a fresh log with a smaller row count or a different column format. The Goto Line mirror is written *before* the range check so an out-of-range value is retained across a shrink (the user can correct the digit on the next open); the Goto Timestamp mirror is written before the parse for the same reason (garbage the user wants to correct is preserved).

## What changed

**`loglib::LocalMicrosecondsSinceEpochToUtc` (`library/include/loglib/log_processing.hpp`, `library/src/log_processing.cpp`).** New pair of overloads (`(local, zone*)` for tests, `(local)` for production) that convert wall-clock microseconds in @p zone to UTC epoch microseconds via `date::to_sys(local, choose::earliest)`. Null zone passes the input through unchanged (test fixtures that don't need TZ semantics). Non-DST exceptions (far-future / far-past instants past the tzdata table, corrupt zone entries) are caught and yield the naive value so the caller stays exception-safe. Extensive header docstring on the DST policy so future callers don't reinvent the `choose::earliest` decision.

**`MainWindow::GotoLine` / `MainWindow::GotoTimestamp` (`app/include/main_window.hpp`, `app/src/main_window.cpp`, `app/src/main_window.ui`).** Two new `Edit` menu actions (`actionGotoLine` / `actionGotoTimestamp`, `Ctrl+G` / `Ctrl+Shift+G`) drive matching slots. Each pops a `QInputDialog`, then defers to the pure-body helpers (`ExecuteGotoLine` / `ExecuteGotoTimestamp`) that tests can drive without a modal. `GotoLine` attaches a `QIntValidator(1, rowCount)` to the line-edit for accept-blocking; the label and error hint use `QString::number` (not `QLocale::system().toString`) so the displayed range and the validator's accept set agree in every locale (an `en_US` label showing `1 - 12,345` while the validator only accepts `12345` would silently fail every input past 999).

**`MainWindow::ParseGotoTimestampInput` (`app/include/main_window.hpp`, `app/src/main_window.cpp`).** Static pure helper returning `std::optional<GotoTimestampParse{micros, isNaive}>`. Tries: (1) the relative shortcut regex with overflow rejection, (2) each entry of the column's `parseFormats` via `loglib::TryParseTimestamp` + `ClassifyTimestampFormat`, (3) the two ISO 8601 fallbacks (`%FT%T`, `%F %T`) if the column hadn't already listed them. `isNaive = !FormatHasZoneSpecifier(fmt)` on the winning format; the shortcut path always reports `isNaive == false`. Empty / whitespace inputs return `std::nullopt`.

**`MainWindow::FindFirstRowAtOrAfter` (`app/include/main_window.hpp`, `app/src/main_window.cpp`).** Public `[[nodiscard]] int` helper taking `(timeCol, targetMicros)` and returning a source-model row index (or `-1` when nothing qualifies). Picks between three branches:

- **Fast path** (`userSortColumn < 0 && TimestampsAreMonotonic()`): binary-search source rows in place. Missing timestamps are explicitly skipped inside each probe; the post-search happy path checks `lo` itself before walking, so the common no-filter case stays O(log N) end-to-end. On a filter miss, walks the *outer proxy* (not the source) for the smallest visible row with a valid ts `>= lo` — O(N_visible), not O(N_source), which is what keeps a heavy filter on a 10 M-row file within budget.
- **Non-monotonic path** (`userSortColumn < 0 && !TimestampsAreMonotonic()`): walks the outer proxy and picks the visible row with the smallest ts satisfying `>= target`. The correct answer under multi-file Append / rotation / clock skew, at the cost of O(N_visible).
- **User-sort path** (`userSortColumn >= 0`): linear scan in display order, returning the first proxy row whose source ts qualifies. "First" here honours the user's chosen sort direction rather than file order.

**`LogModel::TimestampsAreMonotonic` (`app/include/log_model.hpp`, `app/src/log_model.cpp`).** New `noexcept` accessor + backing `mTimestampsMonotonic` flag + `mLastAppendedTimestampMicros` running-max. `UpdateTimestampMonotonicity(firstNewRow, endNewRow)` runs inside `AppendBatch` with two guards (already-flipped-false / no time column) that make the common path add nothing. One inversion is terminal — flip false and bail. Missing-timestamp rows are skipped, not treated as `-inf`. Session boundaries (`Reset` / `BeginStreamingShared`) restore the flag. Test seam `SetTimestampsMonotonicForTest(bool)` / `MainWindow::ForceTimestampsNonMonotonicForTest()` lets the non-monotonic branch be exercised without a real inversion.

**`FormatHasZoneSpecifier` (in `main_window.cpp` anonymous namespace).** Local helper that walks a `date::parse` format string looking for `%z` / `%Z` (optionally prefixed by `%E` / `%O`). Advances one byte at a time on a no-match so a malformed `%E%z` still detects the inner `%z`; `%%` is a literal percent and does not register. False negatives here would double-shift the parse output, so the walk is deliberately conservative on the no-match branch.

**UI.** `main_window.ui` grows the two `QAction` entries plus their tooltips (the tooltip on `actionGotoLine` calls out the earliest-retained-row semantics + newest-first orientation; `actionGotoTimestamp`'s spells out the local-time / ISO 8601 / relative-shortcut acceptance so users don't have to guess). Both entries live in the `Edit` menu next to `actionFind`, matching lnav / Klogg placement.

**Docs.** [`doc/README.md`](doc/README.md) grows a new **Jumping to a Line or Timestamp** subsection under the record-details section (with the shortcut table entries in the shortcuts reference too). [`ROADMAP.md`](ROADMAP.md) item 8 is crossed off with a status line naming the shipped scope, and the "Goto line / Goto timestamp" cell in the comparative feature matrix flips to `✓`.

**Tests.** `test/lib/src/test_log_processing.cpp` grows a `LocalMicrosecondsSinceEpochToUtc handles DST transitions` case pinned to `Europe/Berlin` covering the ordinary hour, the fall-back ambiguous hour (resolves to the earlier candidate), the spring-forward gap (snaps to the transition boundary, pinned to the exact value so a silent library-behaviour change is caught), the null-zone passthrough, and the far-future graceful degradation. `test/app/src/main_window_test.cpp` grows ~15 new `MainWindow` cases:

- `TestMainWindowGotoLineJumpsToRequestedSourceRow` — the happy path.
- `TestGotoLineOutOfRangeAfterShrinkSurfacesLiveRange` — shrinks the row count between dialog build and `ExecuteGotoLine`, asserts the "out of range" hint names the *live* range.
- `TestGotoLineFilteredOutRowSurfacesSpecificHint` — pin the filtered-out hint (vs. `SelectSourceRow`'s anchor-oriented fallback).
- `TestGotoLineNoLogLoadedSurfacesHint` — no rows / no proxy branch.
- `TestParseGotoTimestampInputAcceptsRelativeShortcuts` — `-1h`, `-30m`, `- 2 H`, `+1h`, `1h` all resolve to the same "N units ago" instant.
- `TestParseGotoTimestampInputRejectsOverflowingRelativeShortcut` — one case per unit for hour and minute caps (distinct code paths).
- `TestParseGotoTimestampInputHonoursColumnParseFormats` — the column's own format wins over the ISO fallbacks; ISO fallbacks activate on an empty format list; zoned columns return `isNaive == false`.
- `TestParseGotoTimestampInputRejectsGarbage` — empty, whitespace, garbage, `-1x`, `--1h`.
- `TestGotoTimestampAppliesDisplayTimeZoneShift` (helpers-only regression pin: naive vs. zoned dispatch through `FormatHasZoneSpecifier`).
- `TestFindFirstRowAtOrAfterBinarySearchesWhenUnsorted` — fast path happy case.
- `TestFindFirstRowAtOrAfterHandlesInterleavedMissingTimestamps` — the `[10, missing, 20, 30, missing, 40]` regression pin.
- `TestFindFirstRowAtOrAfterSkipsFilterHiddenRowsInFastPath` — the outer-proxy walk after the binary search lands on a filtered-out row.
- `TestFindFirstRowAtOrAfterLinearScansWhenUserSortActive` — the user-sort branch.
- `TestFindFirstRowAtOrAfterHonoursNewestFirstDisplay` — newest-first display flips the "first" row into the last source row.
- `TestFindFirstRowAtOrAfterUsesProxyIterationWhenNonMonotonic` — flips the monotonicity flag via the test seam and re-runs, checking the answer stays correct.
- `TestExecuteGotoTimestampSeamJumpsAndRemembersInput` / `HintsWhenNoRowQualifies` / `TestGotoTimestampStickyInputClearsOnNewSession` / `TestExecuteGotoTimestampSeamResolvesRelativeShortcutAgainstPinnedNow` / `TestExecuteGotoTimestampSeamHintsWhenNoTimeColumn` — end-to-end coverage of the `ExecuteGotoTimestamp` seam covering sticky-input update, error hints, relative-shortcut evaluation against a pinned clock, and the no-time-column branch.

## Trailing-commit cleanup

The `feature/goto-line-and-timestamp` review loop landed the base commit plus **5** follow-up polish / correctness passes; every one has a self-contained commit message with its rationale. Highlights (see `git log` on the branch for the full list):

- `d6e87ca` — Base commit: `Edit → Go to Line…` / `Go to Timestamp…` actions + shortcuts, `ParseGotoTimestampInput` static pure parser, `FindFirstRowAtOrAfter` source-model search helper (binary search when unsorted, linear scan under a user sort), first-time-column resolution via `loglib::FirstTimeColumnIndex`, six baseline tests.
- `2ded1f2` — First review pass on the base commit: `FindFirstRowAtOrAfter` missing-timestamp regression (rewrite skips missing rows during each probe rather than treating them as `-inf`, plus the outer-proxy visibility walk), naive-vs-zoned dispatch through `FormatHasZoneSpecifier` + `loglib::LocalMicrosecondsSinceEpochToUtc` (`choose::earliest` on the DST edge cases), overflow rejection on the relative shortcut, `+Nh` / bare `Nh` acceptance for lnav / less parity, `QString::number` (not `QLocale::system().toString`) in the label / hint so the validator and the display agree in every locale, feature-specific status-bar hints instead of `SelectSourceRow`'s generic fallback.
- `46eec89` — Second review pass: `FormatHasZoneSpecifier` false-negative fix on a malformed `%E%z` prefix (advance one byte at a time on a no-match), `LocalMicrosecondsSinceEpochToUtc` dead-catch cleanup (drop the unreachable `nonexistent_local_time` block; broaden the surviving catch to `std::exception`; header docstring rewrite), `GotoLine` post-modal range-check reads `mModel->rowCount()` live (fixes the shrink-while-modal-open FIFO-eviction race), `GotoTimestamp` sticky-input pre-population, explicit-zone overload on `LocalMicrosecondsSinceEpochToUtc` for deterministic Berlin DST tests, three new `ExecuteGotoLine` seam tests + the DST library-side coverage.
- `6123fea` — Third review pass: fast-path visibility walk switched to O(N_visible) proxy iteration (previously O(N_source) on a heavy filter), `LogModel::TimestampsAreMonotonic()` gate + O(N_batch) tracker in `AppendBatch` + non-monotonic proxy-walk fallback in `FindFirstRowAtOrAfter`, `GotoTimestamp` refactored into `ExecuteGotoTimestamp` + `ExecuteGotoTimestampForTest` + `ForceTimestampsNonMonotonicForTest` seams (five new tests: naive-vs-zoned dispatch, sticky-input retention on parse failure, `NewSession` clear, relative-shortcut evaluation against a pinned clock, no-time-column branch, both monotonicity code paths end-to-end), dialog copy flags naive inputs as local time, `GotoLine` remembers the last input across opens with `NewSession` clear parity, drop the defensive null-proxy guard in `ExecuteGotoLine` (surface an explicit `No log loaded` hint instead of silently falling through), minute-cap overflow regression test (distinct code path from the hour cap).
- `3363654` — `doc/README.md` `Jumping to a Line or Timestamp` section covering both dialogs, all four accepted forms, the naive-vs-zoned semantics, the monotonicity fast-path behaviour, and the overflow rejection on the relative shortcut. Shortcut reference table gains the two rows.
- `fe0eb93` — Fix clang-tidy warnings across the goto-line / goto-timestamp code: `misc-const-correctness` const-qualify locals, `modernize-use-auto` on obvious casts, `bugprone-narrowing-conversions` explicit `date::month{}` / `date::day{}` in the DST test's `naiveLocalMicros` helper, small readability sweeps that the linter flagged during the review loop.
- `b968688` — Tighten the docstrings and inline commentary added on this branch down to essential intent while preserving the "why" notes (`FindFirstRowAtOrAfter` three-branch policy, `ParseGotoTimestampInput` naive-vs-zoned dispatch, `LocalMicrosecondsSinceEpochToUtc` DST policy, monotonicity tracker, F4 focus guard). Mark ROADMAP item 8 as shipped and flip the comparative feature matrix cell to `✓`. No behaviour change.

## Test plan

- [x] `ctest --preset debug` green locally on Windows + MSVC + Debug + offscreen Qt, including the new `LocalMicrosecondsSinceEpochToUtc handles DST transitions` case in `test/lib` and the ~15 new `MainWindow` cases in `test/app/src/main_window_test.cpp`.
- [x] `ctest --preset release` green (`tests.exe` 483 / 483 pass on the library side; two pre-existing `apptest` environment failures on this branch tip are the HiDPI DPR and theme luma-contrast cases that also fail on unmodified `main`).
- [x] `run-clang-tidy` over the touched TUs (`main_window.hpp`, `main_window.cpp`, `log_model.hpp`, `log_model.cpp`, `log_processing.hpp`, `log_processing.cpp`, `main_window_test.cpp`, `test_log_processing.cpp`) reports zero warnings on the new code (the `fe0eb93` clang-tidy pass cleaned up the whole loop).
- [x] `pre-commit run --all-files` clean locally.
- [x] Manual smoke: open a 500 k-row JSONL, `Ctrl+G`, type `250000` — the table jumps to source row 249999 (0-based) and the row is selected + centred. Type `999999999` — the status bar hints "Line 999999999 is out of range (1 - 500000).".
- [x] Manual smoke: add a filter that hides row 12345, `Ctrl+G`, type `12345` — the status bar hints "Line 12345 is currently filtered out." (not the generic `SelectSourceRow` fallback).
- [x] Manual smoke: `Ctrl+Shift+G`, type `-1h` — jumps to the first row at or after `system_clock::now() - 1h`; the display TZ shift is applied to the visible clock but the search runs in UTC. Type `+1h` and `1h` — both mean "1 hour ago" (matching lnav / less).
- [x] Manual smoke: `Ctrl+Shift+G`, type `2024-04-28 12:00:00` in a UTC+2 locale — jumps to the first row whose *displayed* timestamp is at or after `12:00:00` local, not two hours off. Type `2024-04-28T10:00:00Z` — jumps to the same row (zoned parser branch, no double-shift).
- [x] Manual smoke: multi-file `Append` open with overlapping timestamps — `LogModel::TimestampsAreMonotonic()` flips false after the second file's first batch (per debug log); `Ctrl+Shift+G` still returns the chronologically earliest visible match through the outer-proxy walk.
- [x] Manual smoke: newest-first display active, `Ctrl+G` → `1` still jumps to the earliest retained row (bottom of the visible list). `Ctrl+Shift+G` → `-1h` also lands on the chronologically-first qualifying row (top-of-visible in newest-first).
- [x] Manual smoke: sticky-input round-trip — type `12345` in Goto Line, close the dialog, reopen: the field is pre-populated. `File → New Session`, reopen: the field is empty. Same for Goto Timestamp with `-1h`.
- [x] Manual smoke: DST edge cases — with the system TZ set to `Europe/Berlin`, `Ctrl+Shift+G` `2024-10-27 02:30:00` (ambiguous fall-back hour) lands on a row from the earlier CEST candidate; `2024-03-31 02:30:00` (spring-forward gap) lands on the row at the transition boundary rather than falling through to the "Could not parse timestamp." hint.
- [x] CI: `pre-commit`, `clang-ci`, `build-linux`, `build-macos`, `build-windows` all expected green on this PR.