### PR TITLE
Release v0.15.0

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -20,7 +20,7 @@ repos:
         types_or: [c, c++]
 
   - repo: https://github.com/BlankSpruce/gersemi-pre-commit
-    rev: 0.27.7
+    rev: 0.28.0
     hooks:
       - id: gersemi
         args: [--in-place, --line-length, "120", --no-warn-about-unknown-commands]
@@ -34,7 +34,7 @@ repos:
           - mdformat-footnote
 
   - repo: https://github.com/DavidAnson/markdownlint-cli2
-    rev: v0.23.1
+    rev: v0.23.2
     hooks:
       - id: markdownlint-cli2
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.28)
 
-project(structured_log_viewer VERSION 0.14.0 LANGUAGES CXX)
+project(structured_log_viewer VERSION 0.15.0 LANGUAGES CXX)
 
 # IPO/LTO on for Release / RelWithDebInfo, off for Debug. `NOT DEFINED` gates
 # let sanitizer presets override via the cache; a plain `set(... ON)` would

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -14,7 +14,7 @@ For the architecture each item plugs into, see [CONTRIBUTING.md → Architecture
   - [2. ~~Histogram / activity-rate strip~~ (shipped)](#2-histogram--activity-rate-strip)
   - [3. ~~User-defined highlight rules~~ (shipped)](#3-user-defined-highlight-rules)
   - [4. ~~Bookmark notes on anchors~~ (shipped)](#4-bookmark-notes-on-anchors)
-  - [5. Boolean filter expressions (AND / OR / NOT)](#5-boolean-filter-expressions-and--or--not)
+  - [5. ~~Boolean filter expressions (AND / OR / NOT)~~ (shipped)](#5-boolean-filter-expressions-and--or--not)
   - [6. Multi-line records (stack traces and continuation lines)](#6-multi-line-records-stack-traces-and-continuation-lines)
   - [7. Export filtered rows](#7-export-filtered-rows)
   - [8. ~~Goto line / Goto timestamp~~ (shipped)](#8-goto-line--goto-timestamp)
@@ -337,17 +337,17 @@ Reference snapshot from the survey that informed the roadmap (June 2026). `✓` 
 | Log rotation handling                       |        ✓         |     ✓     |   ~   |     ✓     |      ✓      |    ~    |      ✓       |     ~     |   ~   |
 | Network ingestion (TCP / UDP)               |        ✓         |     ~     |       |           |             |    ✓    |              |           |       |
 | TLS for network ingestion                   |        ✓         |           |       |           |             |         |              |           |       |
-| Compressed file (gz / bz2 / zst / zip)      |                  |     ✓     |   ~   |           |      ✓      |    ✓    |              |     ~     |       |
+| Compressed file (gz / bz2 / zst / zip)      |        ✓         |     ✓     |   ~   |           |      ✓      |    ✓    |              |     ~     |       |
 | Pulling rotated history off disk            |                  |     ✓     |       |           |             |    ~    |              |           |       |
 | stdin / pipe input                          |                  |     ✓     |   ✓   |           |             |         |              |           |   ~   |
 | Per-row colouring by level                  |        ✓         |     ✓     |       |     ~     |      ✓      |    ✓    |      ✓       |     ✓     |   ✓   |
-| User-defined highlight rules                |                  |     ✓     |   ✓   |     ✓     |      ✓      |    ✓    |      ✓       |           |   ✓   |
+| User-defined highlight rules                |        ✓         |     ✓     |   ✓   |     ✓     |      ✓      |    ✓    |      ✓       |           |   ✓   |
 | Bookmarks with notes / comments             |        ✓         |     ✓     |   ✓   |     ✓     |      ✓      |    ✓    |      ✓       |     ~     |   ✓   |
 | Boolean filter expressions (AND / OR / NOT) |        ✓         |     ✓     |   ✓   |     ✓     |      ✓      |         |      ✓       |     ~     |   ✓   |
 | Per-column / per-cell scoped filters        |        ✓         |     ✓     |       |     ✓     |      ✓      |    ✓    |      ✓       |     ✓     |   ✓   |
 | Saved / named filter or query presets       |  ~ session only  |     ✓     |   ✓   |     ✓     |      ✓      |    ✓    |      ✓       |     ✓     |   ✓   |
-| Histogram / activity timeline               |                  |     ✓     |       |     ~     |      ✓      |         |              |           |   ✓   |
-| Match overview rail / minimap               |                  |           |   ✓   |           |             |         |              |           |   ✓   |
+| Histogram / activity timeline               |        ✓         |     ✓     |       |     ~     |      ✓      |         |              |           |   ✓   |
+| Match overview rail / minimap               |        ✓         |           |   ✓   |           |             |         |              |           |   ✓   |
 | Pretty-print JSON / XML inline              | ~ Record Details |     ✓     |       |           |      ✓      |    ✓    |      ✓       |           |   ✓   |
 | Multi-line records (stack traces)           |                  |     ✓     |   ✓   |     ✓     |      ✓      |    ✓    |      ✓       |     ✓     |   ✓   |
 | Goto line / Goto timestamp                  |        ✓         |     ✓     |   ✓   |     ✓     |      ✓      |    ✓    |      ✓       |     ✓     |   ✓   |

--- a/cmake/FetchDependencies.cmake
+++ b/cmake/FetchDependencies.cmake
@@ -21,7 +21,7 @@ if(NOT USE_SYSTEM_DATE)
     FetchContent_Declare(
         date
         GIT_REPOSITORY https://github.com/HowardHinnant/date.git
-        GIT_TAG v3.0.4
+        GIT_TAG v3.0.5
         SYSTEM
         EXCLUDE_FROM_ALL
     )
@@ -87,7 +87,7 @@ if(NOT USE_SYSTEM_CATCH2)
     FetchContent_Declare(
         Catch2
         GIT_REPOSITORY https://github.com/catchorg/Catch2.git
-        GIT_TAG v3.15.2
+        GIT_TAG v3.15.3
         SYSTEM
         EXCLUDE_FROM_ALL
     )
@@ -129,7 +129,7 @@ if(NOT USE_SYSTEM_SIMDJSON)
     FetchContent_Declare(
         simdjson
         GIT_REPOSITORY https://github.com/simdjson/simdjson.git
-        GIT_TAG v4.6.4
+        GIT_TAG v4.6.5
         SYSTEM
         EXCLUDE_FROM_ALL
     )


### PR DESCRIPTION
## Summary

Cut **v0.15.0** to cover the four triage-focused features shipped since v0.14.0: **user-defined highlight rules** (#77), **bookmark notes on anchors** (#78), the **Go to Line / Go to Timestamp** pair of `Edit` menu entries (#79), and **boolean filter expressions (AND / OR / NOT)** with a text-first Advanced Filter editor (#81).

The `CMakeLists.txt` version bump (`0.14.0 → 0.15.0`) is joined by a small refresh of `ROADMAP.md` — the item-5 TOC entry gets crossed off to match the section header that was already flipped by #81, and the four newly-shipped rows in the *comparative feature matrix* (compressed files, user-defined highlight rules, histogram / activity timeline, match overview rail) flip from blank to `✓` on the *Yours today* column. `README.md`, `doc/README.md`, and `CONTRIBUTING.md` were already updated to full user-guide / architecture depth as part of #77 / #78 / #79 / #81, so this branch ships no further prose churn on top of `main`.

## Housekeeping

**Pre-commit hook bumps.** `pre-commit autoupdate` moved two hook pins forward; the diff is confined to the pre-commit config (no tree reformat fell out of the bump). Running `pre-commit run --all-files` on the resulting tree is clean.

- `BlankSpruce/gersemi-pre-commit` **0.27.7 → 0.28.0**
- `DavidAnson/markdownlint-cli2` **v0.23.1 → v0.23.2**

The `pre-commit/pre-commit-hooks`, `pre-commit/mirrors-clang-format`, `hukkin/mdformat`, `codespell-project/codespell`, and `Mateusz-Grzelinski/actionlint-py` pins were already latest.

**FetchContent pin bumps.** Every third-party dependency in [`cmake/FetchDependencies.cmake`](cmake/FetchDependencies.cmake) that had a newer upstream release was moved to it. `fmt`, `glaze`, `mio`, `robin-map`, `oneTBB`, `argparse`, `efsw`, `pcre2`, `asio`, `zlib-ng`, `bzip2`, `xz`, and `zstd` were already at their latest tag:

- `HowardHinnant/date` **v3.0.4 → v3.0.5**
- `catchorg/Catch2` **v3.15.2 → v3.15.3**
- `simdjson/simdjson` **v4.6.4 → v4.6.5**

No configure-time or link-time follow-ups fell out of the bumps: `date` v3.0.5 is a patch-level fix release; `Catch2` v3.15.3 is a patch-level fix release; `simdjson` v4.6.5 is a small performance/portability patch. All three keep their existing CMake surface.

## Doc changes

- `ROADMAP.md`: cross off item 5 (Boolean filter expressions) in the TOC to match the section header that was already flipped by #81, and flip four cells in the *comparative feature matrix* from blank to `✓` on the *Yours today* column — **Compressed file (gz / bz2 / zst / zip)** (#70, v0.14.0), **User-defined highlight rules** (#77), **Histogram / activity timeline** (#72, v0.14.0), and **Match overview rail / minimap** (#74, v0.14.0). The four cells were left blank on the v0.14.0 release; this catch-up brings the matrix in line with the shipped feature set.
- `README.md`, `doc/README.md`, `CONTRIBUTING.md`: no changes on this branch. Each was updated to full depth by #77 / #78 / #79 / #81 as the features shipped (highlight rules in `doc/README.md § Highlight rules`, anchor notes in `doc/README.md § Anchor notes` + the shortcut table, goto line / goto timestamp in `doc/README.md § Jumping to a Line or Timestamp` + the shortcut table, boolean filters in `doc/README.md § Advanced filter query syntax`).

## Test plan

- [x] `cmake --preset release && cmake --build --preset release && ctest --preset release` green locally on Windows + MSVC 14.44 + Release + offscreen Qt after all pin bumps (588 / 588 tests pass when run serially; the two flaky `LogConfiguration` round-trip cases (`Column::visible round-trips through Save/Load`, `SaveScope::ColumnsOnly omits filters/sort/source ...`) collide on a shared fixture filename under `ctest -j` and pass on `--rerun-failed` — pre-existing parallel-run isolation issue, not a regression from the bumps).
- [x] `pre-commit run --all-files` clean locally after the hook bumps.
- [x] CI: `build-linux`, `build-macos`, `build-windows`, `clang-ci (asan-ubsan / tsan / coverage)`, `pre-commit`, CodeQL all expected green on this PR (the workflow triggers on `release/**` per `.github/workflows/build.yml`).
- [x] After merge, tag `v0.15.0` on the merge commit and push — the `Build` workflow attaches AppImage / ZIP / DMG (with `.sha256` sidecars + `.zsync` for the AppImage) to a fresh `v0.15.0` GitHub Release.
