### PR TITLE
Release v0.16.0

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.28)
 
-project(structured_log_viewer VERSION 0.15.0 LANGUAGES CXX)
+project(structured_log_viewer VERSION 0.16.0 LANGUAGES CXX)
 
 # IPO/LTO on for Release / RelWithDebInfo, off for Debug. `NOT DEFINED` gates
 # let sanitizer presets override via the cache; a plain `set(... ON)` would

--- a/cmake/FetchDependencies.cmake
+++ b/cmake/FetchDependencies.cmake
@@ -116,7 +116,7 @@ if(NOT USE_SYSTEM_GLAZE)
     FetchContent_Declare(
         glaze
         GIT_REPOSITORY https://github.com/stephenberry/glaze.git
-        GIT_TAG v7.9.1
+        GIT_TAG v8.0.0
         SYSTEM
         EXCLUDE_FROM_ALL
     )
@@ -129,7 +129,7 @@ if(NOT USE_SYSTEM_SIMDJSON)
     FetchContent_Declare(
         simdjson
         GIT_REPOSITORY https://github.com/simdjson/simdjson.git
-        GIT_TAG v4.6.5
+        GIT_TAG v4.6.6
         SYSTEM
         EXCLUDE_FROM_ALL
     )


### PR DESCRIPTION
## Summary

Cut **v0.16.0** to cover the three Tier 1 features shipped since v0.15.0: **multi-line records (stack traces and continuation lines)** (#83), the **Export Filtered Rows** action for JSON Lines / CSV / Source snapshot / Markdown (#84), and the **Full-session export bundle** (`.slvbundle`) (#86).

The `CMakeLists.txt` version bump (`0.15.0 → 0.16.0`) is the only in-tree change: `README.md`, `doc/README.md`, `ROADMAP.md`, and `CONTRIBUTING.md` were already updated to full user-guide / architecture depth as part of #83 / #84 / #86 (multi-line surface + authoring guidance in `doc/README.md § Multi-line records`, the `Ctrl+E` export flow in `doc/README.md § Exporting Filtered Rows`, and the `Ctrl+Shift+E` session bundle flow in `doc/README.md § Session bundles`; three Tier-1 items — #6 multi-line records, #7 export filtered rows, and #30 full-session export bundle — crossed off in `ROADMAP.md` and their comparative-feature-matrix rows flipped to `✓`), so this branch ships no further prose churn on top of `main`.

## Housekeeping

**Pre-commit hook bumps.** `pre-commit autoupdate` reports every hook pin already at its latest upstream tag on top of `main`, so `.pre-commit-config.yaml` is unchanged in this PR (`pre-commit/pre-commit-hooks` v6.0.0, `pre-commit/mirrors-clang-format` v22.1.8, `BlankSpruce/gersemi-pre-commit` 0.28.0, `hukkin/mdformat` 1.0.0, `DavidAnson/markdownlint-cli2` v0.23.2, `codespell-project/codespell` v2.4.3, `Mateusz-Grzelinski/actionlint-py` v1.7.12.24). Running `pre-commit run --all-files` on the resulting tree is clean.

**FetchContent pin bumps.** Two third-party dependencies in [`cmake/FetchDependencies.cmake`](cmake/FetchDependencies.cmake) had a newer upstream release and were moved to it. `date`, `fmt`, `Catch2`, `mio`, `robin-map`, `oneTBB`, `argparse`, `efsw`, `pcre2`, `asio`, `zlib-ng`, `bzip2`, `xz`, and `zstd` were already at their latest tag:

- `stephenberry/glaze` **v7.9.1 → v8.0.0**
- `simdjson/simdjson` **v4.6.5 → v4.6.6**

`glaze v8.0.0` is a major-version bump with several deliberate wire-format and reader-hardening breaks documented [upstream](https://github.com/stephenberry/glaze/releases/tag/v8.0.0): full UTF-8 validation on every read (previously incomplete), bounded reader recursion at 256 levels (previously unbounded — a hostile buffer could overflow the stack), out-of-range integer literals rejected instead of silently wrapped, truncated non-null-terminated input surfaced as `unexpected_end` (previously the documented non-error `end_reached`), and BEVE variants moved to the v2 wire format (adjacent form). Our four glaze surfaces — `LogConfiguration` (session state), `RegexTemplate` (built-in + user JSON), `Theme` (colour palettes), and `SessionBundleMetadata` — all go through `LogConfigOpts` / equivalent (`error_on_unknown_keys=false`, `prettify=true`, JSON-only, no variants, no `null_terminated=false`, no recursion anywhere near 256 levels), so the surface we depend on stays compatible; the 645-test suite passes clean after the bump. `simdjson v4.6.6` is a small [patch release](https://github.com/simdjson/simdjson/releases/tag/v4.6.6) (portability fix for [PR #2801](https://github.com/simdjson/simdjson/pull/2801)) with the same CMake surface.

## Doc changes

- `CMakeLists.txt`: `project(... VERSION 0.16.0 ...)`. No other prose changes on this branch — `README.md`, `doc/README.md`, `ROADMAP.md`, and `CONTRIBUTING.md` were already updated as part of #83 / #84 / #86.

## Test plan

- [x] `cmake --workflow --preset release` green locally on Windows + MSVC 14.44 + Release + offscreen Qt after both pin bumps (645 / 645 tests pass).
- [x] `pre-commit run --all-files` clean locally.
- [x] `pre-commit autoupdate` reports every hook pin already at its latest upstream tag.
- [x] CI: `build-linux`, `build-macos`, `build-windows`, `clang-ci (asan-ubsan / tsan / coverage)`, `pre-commit`, CodeQL all expected green on this PR (the workflow triggers on `release/**` per `.github/workflows/build.yml`).
- [x] After merge, tag `v0.16.0` on the merge commit and push — the `Build` workflow attaches AppImage / ZIP / DMG (with `.sha256` sidecars + `.zsync` for the AppImage) to a fresh `v0.16.0` GitHub Release.
